### PR TITLE
Set up the Go module, kind-based dev cluster, CI, and shared core library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # Integration tests added by later work packages use testcontainers, which
+      # needs Docker. The GitHub-hosted runner provides it; kind is never used in CI.
+      - name: lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
+      - name: vet
+        run: go vet ./...
+
+      - name: test
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Go build artifacts
+/bin/
+/dist/
+*.exe
+*.test
+*.out
+
+# Go workspace files
+go.work
+go.work.sum
+
+# Tilt
+.tiltbuild/
+tilt_modules/
+
+# Local environment overrides (.env.example files are tracked)
+.env
+!.env.example
+
+# Editors
+.idea/
+.vscode/
+*.swp
+.DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: 'decimal\.NewFromFloat'
+          msg: >-
+            Money and usage quantities never come from floats (roadmap/00-conventions.md
+            section 6). Construct decimals from strings or integers.
+        - pattern: '\.InexactFloat64'
+          msg: >-
+            Money and usage quantities never leave decimal form (roadmap/00-conventions.md
+            section 6). Use the internal/core/money helpers instead.
+
+formatters:
+  enable:
+    - gofumpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# One image per service, built from one file: pass CMD to pick the binary.
+#
+#   docker build --build-arg CMD=tally-reporting -t tally-reporting:dev .
+#
+# The result is a static binary on distroless, so dev and prod run the same
+# image (roadmap/00-conventions.md section 1).
+
+FROM golang:1.26.1-alpine AS build
+
+ARG CMD
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+# Fail early and clearly rather than letting ./cmd/ resolve to the directory.
+RUN test -n "${CMD}" || (echo "build argument CMD is required, e.g. --build-arg CMD=tally-reporting" >&2; exit 1)
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/service "./cmd/${CMD}"
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/service /service
+USER nonroot:nonroot
+ENTRYPOINT ["/service"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,145 @@
+# Tally development entry points.
+#
+# `make up` gives you a complete stack on kind, reachable over real HTTPS URLs
+# under *.tally.127-0-0-1.nip.io. `make dev` adds the rebuild-on-change loop.
+
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+# Add-on versions. The Kubernetes version is pinned in deploy/kind/kind.yaml,
+# which is the cluster's own configuration.
+ENVOY_GATEWAY_VERSION ?= v1.8.3
+CERT_MANAGER_VERSION ?= v1.21.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
+# Code generation and migration tools. They run from the module cache at these
+# versions; nothing has to be installed on the host. The configs they read
+# arrive with the Reporting API skeleton.
+GOOSE_VERSION ?= v3.27.3
+OAPI_CODEGEN_VERSION ?= v2.8.0
+SQLC_VERSION ?= v1.31.1
+
+CLUSTER_NAME ?= tally
+NAMESPACE ?= tally
+DEV_OVERLAY := deploy/kubernetes/overlays/dev
+SERVICES := tally-reporting
+
+# Every kubectl call names the cluster explicitly. Creating a kind cluster
+# switches the current context, but reusing an existing one does not, so an
+# unqualified kubectl would deploy Tally into whatever cluster happened to be
+# selected.
+KUBE_CONTEXT := kind-$(CLUSTER_NAME)
+KUBECTL := kubectl --context $(KUBE_CONTEXT)
+
+# Reaches TimescaleDB through the Gateway's TCP listener, which is the same path
+# a developer's psql takes.
+TALLY_DEV_DB_URL ?= postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable
+
+.PHONY: up down dev ca test lint fmt migrate generate images
+
+## up: create the kind cluster, install the add-ons, and deploy the dev overlay
+up:
+	@if ! kind get clusters | grep -qx '$(CLUSTER_NAME)'; then \
+		echo '==> creating kind cluster $(CLUSTER_NAME)'; \
+		kind create cluster --config deploy/kind/kind.yaml; \
+	else \
+		echo '==> kind cluster $(CLUSTER_NAME) already exists'; \
+	fi
+	@echo '==> installing cert-manager $(CERT_MANAGER_VERSION)'
+	$(KUBECTL) apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager --timeout=300s
+	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager-webhook --timeout=300s
+	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager-cainjector --timeout=300s
+	@echo '==> installing Envoy Gateway $(ENVOY_GATEWAY_VERSION)'
+	$(KUBECTL) apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/$(ENVOY_GATEWAY_VERSION)/install.yaml
+	$(KUBECTL) -n envoy-gateway-system rollout status deployment/envoy-gateway --timeout=300s
+	@echo '==> checking for the experimental Gateway API channel'
+	@$(KUBECTL) get crd tcproutes.gateway.networking.k8s.io >/dev/null 2>&1 || { \
+		echo 'ERROR: the TCPRoute CRD is missing, so Postgres cannot be routed.' >&2; \
+		echo '       Envoy Gateway $(ENVOY_GATEWAY_VERSION) is expected to bundle the' >&2; \
+		echo '       experimental Gateway API channel; a release that does not needs' >&2; \
+		echo '       experimental-install.yaml applied before it.' >&2; \
+		exit 1; \
+	}
+	@echo '==> installing the dev certificate authority'
+	$(KUBECTL) apply -f $(DEV_OVERLAY)/issuers.yaml
+	$(MAKE) images
+	@echo '==> loading images into the cluster'
+	@for service in $(SERVICES); do \
+		kind load docker-image "$$service:dev" --name '$(CLUSTER_NAME)'; \
+	done
+	@echo '==> applying the dev overlay'
+	$(KUBECTL) apply -k $(DEV_OVERLAY)
+	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/timescaledb --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/victoriametrics --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/otel-collector --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/reporting-api --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) wait gateway/tally --for=condition=Programmed --timeout=300s
+	@echo
+	@echo 'Stack is up:'
+	@echo '  https://api.tally.127-0-0-1.nip.io   Reporting API'
+	@echo '  https://vm.tally.127-0-0-1.nip.io    VictoriaMetrics'
+	@echo '  https://otlp.tally.127-0-0-1.nip.io  OTLP/HTTP'
+	@echo '  db.tally.127-0-0-1.nip.io:5432       TimescaleDB'
+	@echo
+	@echo 'Trust the dev CA with: make -s ca > tally-ca.crt'
+
+## images: build one container image per service
+images:
+	@for service in $(SERVICES); do \
+		echo "==> building $$service"; \
+		docker build --build-arg "CMD=$$service" -t "$$service:dev" .; \
+	done
+
+## down: delete the kind cluster
+down:
+	@if kind get clusters | grep -qx '$(CLUSTER_NAME)'; then \
+		kind delete cluster --name '$(CLUSTER_NAME)'; \
+	else \
+		echo 'kind cluster $(CLUSTER_NAME) does not exist'; \
+	fi
+
+## dev: rebuild and redeploy on change
+dev:
+	tilt up
+
+## ca: print the dev CA certificate, for curl --cacert and browser trust
+ca:
+	@$(KUBECTL) -n cert-manager get secret tally-dev-ca -o jsonpath='{.data.tls\.crt}' | base64 -d
+
+## test: run the test suite
+test:
+	go test ./...
+
+## lint: run golangci-lint
+lint:
+	golangci-lint run
+
+## fmt: format every Go file with gofumpt, through golangci-lint's formatter
+fmt:
+	golangci-lint fmt
+
+## migrate: apply the goose migration chains
+#
+# goose runs from the module cache at a pinned version rather than from a go.mod
+# tool directive: its CLI drags in drivers for ClickHouse, MSSQL, YDB, and half a
+# dozen other databases Tally will never speak, and none of them belong in this
+# module's dependency graph.
+migrate:
+	@if compgen -G 'migrations/reporting/*.sql' >/dev/null; then \
+		echo '==> migrating the reporting database'; \
+		go run github.com/pressly/goose/v3/cmd/goose@$(GOOSE_VERSION) \
+			-dir migrations/reporting postgres '$(TALLY_DEV_DB_URL)' up; \
+	else \
+		echo 'nothing to migrate yet'; \
+	fi
+
+## generate: run the code generators
+generate:
+	@if [[ -f api/reporting/oapi-codegen.yaml || -f sqlc.yaml ]]; then \
+		echo '==> generating'; \
+		test ! -f api/reporting/oapi-codegen.yaml || go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION) -config api/reporting/oapi-codegen.yaml api/reporting/openapi.yaml; \
+		test ! -f sqlc.yaml || go run github.com/sqlc-dev/sqlc/cmd/sqlc@$(SQLC_VERSION) generate; \
+	else \
+		echo 'nothing to generate yet'; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Tally development entry points.
 #
 # `make up` gives you a complete stack on kind, reachable over real HTTPS URLs
-# under *.tally.127-0-0-1.nip.io. `make dev` adds the rebuild-on-change loop.
+# under *.tally.127-0-0-1.nip.io:8443. `make dev` adds the rebuild-on-change
+# loop. The port suffix is there because kind publishes https on 8443 rather
+# than 443; deploy/kind/kind.yaml explains why.
 
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
@@ -77,10 +79,10 @@ up:
 	$(KUBECTL) -n $(NAMESPACE) wait gateway/tally --for=condition=Programmed --timeout=300s
 	@echo
 	@echo 'Stack is up:'
-	@echo '  https://api.tally.127-0-0-1.nip.io   Reporting API'
-	@echo '  https://vm.tally.127-0-0-1.nip.io    VictoriaMetrics'
-	@echo '  https://otlp.tally.127-0-0-1.nip.io  OTLP/HTTP'
-	@echo '  db.tally.127-0-0-1.nip.io:5432       TimescaleDB'
+	@echo '  https://api.tally.127-0-0-1.nip.io:8443   Reporting API'
+	@echo '  https://vm.tally.127-0-0-1.nip.io:8443    VictoriaMetrics'
+	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443  OTLP/HTTP'
+	@echo '  db.tally.127-0-0-1.nip.io:5432            TimescaleDB'
 	@echo
 	@echo 'Trust the dev CA with: make -s ca > tally-ca.crt'
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,20 +16,21 @@ docker_build(
 k8s_yaml(kustomize('deploy/kubernetes/overlays/dev'))
 
 # Every service is reachable through the Gateway, so no port-forward is
-# configured: the links below are the real URLs.
+# configured: the links below are the real URLs. They carry :8443 because kind
+# publishes https there rather than on 443 — see deploy/kind/kind.yaml.
 k8s_resource(
     'reporting-api',
     labels=['tally'],
-    links=[link('https://api.tally.127-0-0-1.nip.io/healthz', 'health')],
+    links=[link('https://api.tally.127-0-0-1.nip.io:8443/healthz', 'health')],
 )
 k8s_resource('timescaledb', labels=['infrastructure'])
 k8s_resource(
     'victoriametrics',
     labels=['infrastructure'],
-    links=[link('https://vm.tally.127-0-0-1.nip.io', 'UI')],
+    links=[link('https://vm.tally.127-0-0-1.nip.io:8443', 'UI')],
 )
 k8s_resource(
     'otel-collector',
     labels=['infrastructure'],
-    links=[link('https://otlp.tally.127-0-0-1.nip.io', 'OTLP/HTTP')],
+    links=[link('https://otlp.tally.127-0-0-1.nip.io:8443', 'OTLP/HTTP')],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,35 @@
+# Dev loop: rebuild the image on change, side-load it into kind, redeploy.
+#
+# Prerequisite: `make up` has created the cluster and installed the add-ons.
+# Tilt only owns what the dev overlay deploys.
+
+allow_k8s_contexts('kind-tally')
+
+docker_build(
+    'tally-reporting',
+    context='.',
+    build_args={'CMD': 'tally-reporting'},
+    # Only a Go change can alter the binary, so nothing else triggers a rebuild.
+    only=['go.mod', 'go.sum', 'cmd', 'internal', 'Dockerfile'],
+)
+
+k8s_yaml(kustomize('deploy/kubernetes/overlays/dev'))
+
+# Every service is reachable through the Gateway, so no port-forward is
+# configured: the links below are the real URLs.
+k8s_resource(
+    'reporting-api',
+    labels=['tally'],
+    links=[link('https://api.tally.127-0-0-1.nip.io/healthz', 'health')],
+)
+k8s_resource('timescaledb', labels=['infrastructure'])
+k8s_resource(
+    'victoriametrics',
+    labels=['infrastructure'],
+    links=[link('https://vm.tally.127-0-0-1.nip.io', 'UI')],
+)
+k8s_resource(
+    'otel-collector',
+    labels=['infrastructure'],
+    links=[link('https://otlp.tally.127-0-0-1.nip.io', 'OTLP/HTTP')],
+)

--- a/cmd/tally-reporting/.env.example
+++ b/cmd/tally-reporting/.env.example
@@ -1,0 +1,18 @@
+# Reporting API configuration.
+#
+# Every variable is read from the environment with the TALLY_ prefix
+# (roadmap/00-conventions.md section 8). Secrets also accept the *_FILE
+# convention, which is how the dev overlay mounts them from a Kubernetes Secret:
+# TALLY_DB_URL_FILE=/run/secrets/tally/db-url
+#
+# The placeholder binary reads TALLY_HTTP_PORT only. The remaining variables
+# arrive with the real service.
+
+# Log level: DEBUG, INFO, WARN, ERROR.
+TALLY_LOG_LEVEL=INFO
+
+# Port the HTTP server listens on.
+TALLY_HTTP_PORT=8080
+
+# Whether /metrics is served.
+TALLY_METRICS_ENABLED=true

--- a/cmd/tally-reporting/main.go
+++ b/cmd/tally-reporting/main.go
@@ -1,0 +1,51 @@
+// Command tally-reporting is a placeholder for the Reporting API.
+//
+// It answers the liveness and readiness probes and nothing else, which is what
+// the dev cluster needs to report every pod Ready and to prove the Gateway,
+// route, and certificate chain reaches an application pod. The real service,
+// with its chi router, configuration, OpenAPI contract, database pool, and
+// authentication, replaces this file wholesale.
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultPort       = "8080"
+	readHeaderTimeout = 5 * time.Second
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).With("service", "tally-reporting")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", respondOK)
+	mux.HandleFunc("GET /readyz", respondOK)
+
+	port := os.Getenv("TALLY_HTTP_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	server := &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+
+	logger.Info("listening", "port", port)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("server stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+func respondOK(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte("ok"))
+}

--- a/deploy/kind/kind.yaml
+++ b/deploy/kind/kind.yaml
@@ -1,0 +1,32 @@
+# Dev cluster for Tally.
+#
+# All traffic enters through the Gateway, so the node publishes exactly three
+# ports and nothing uses a per-service NodePort or a port-forward. The node
+# ports below are pinned to match the EnvoyProxy patch in the dev overlay
+# (deploy/kubernetes/overlays/dev/envoyproxy.yaml); change one and you must
+# change the other.
+#
+# The node image is held one Kubernetes minor behind kind's default on purpose:
+# Envoy Gateway v1.8 supports Kubernetes v1.32 to v1.35.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: tally
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
+    extraPortMappings:
+      # http: redirects to https
+      - containerPort: 30080
+        hostPort: 80
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # https: every service's real URL
+      - containerPort: 30443
+        hostPort: 443
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+      # postgres: psql and goose reach TimescaleDB through the Gateway
+      - containerPort: 30432
+        hostPort: 5432
+        listenAddress: "127.0.0.1"
+        protocol: TCP

--- a/deploy/kind/kind.yaml
+++ b/deploy/kind/kind.yaml
@@ -6,6 +6,17 @@
 # (deploy/kubernetes/overlays/dev/envoyproxy.yaml); change one and you must
 # change the other.
 #
+# The host side stays above 1024. Docker Desktop can only publish a privileged
+# port through the com.docker.vmnetd helper, which is not installed on every
+# Mac, and rootless Docker and Podman cannot publish one at all — binding 80 and
+# 443 makes `make up` fail outright on the machines this project is developed
+# on. Only the host binding moves: the node ports, the Envoy Service ports, and
+# the Gateway listeners all keep the standard numbers, so the prod overlay is
+# untouched by this. Two things follow from it: every dev URL carries a port
+# suffix (https://api.tally.127-0-0-1.nip.io:8443), and the http listener's
+# redirect has to name the https host port, which the dev overlay patches into
+# the http-to-https route.
+#
 # The node image is held one Kubernetes minor behind kind's default on purpose:
 # Envoy Gateway v1.8 supports Kubernetes v1.32 to v1.35.
 kind: Cluster
@@ -15,14 +26,17 @@ nodes:
   - role: control-plane
     image: kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
     extraPortMappings:
-      # http: redirects to https
+      # http: redirects to https on 8443. Deliberately not 8080 — that is the
+      # Reporting API's own port (cmd/tally-reporting/.env.example), and the
+      # cluster holds its host ports for as long as it exists, which would stop
+      # a local `go run ./cmd/tally-reporting` from ever binding.
       - containerPort: 30080
-        hostPort: 80
+        hostPort: 8081
         listenAddress: "127.0.0.1"
         protocol: TCP
       # https: every service's real URL
       - containerPort: 30443
-        hostPort: 443
+        hostPort: 8443
         listenAddress: "127.0.0.1"
         protocol: TCP
       # postgres: psql and goose reach TimescaleDB through the Gateway

--- a/deploy/kubernetes/base/gateway/certificate.yaml
+++ b/deploy/kubernetes/base/gateway/certificate.yaml
@@ -1,0 +1,16 @@
+# The wildcard certificate the https listener terminates with.
+#
+# Every overlay MUST patch two fields: dnsNames, to the domain it serves, and
+# issuerRef.name, to the issuer that signs there. The values below are
+# placeholders and are never served by any environment.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tally-wildcard
+spec:
+  secretName: tally-wildcard-tls
+  dnsNames:
+    - "*.tally.example.com"
+  issuerRef:
+    kind: ClusterIssuer
+    name: tally-ca

--- a/deploy/kubernetes/base/gateway/gateway.yaml
+++ b/deploy/kubernetes/base/gateway/gateway.yaml
@@ -1,0 +1,45 @@
+# One Gateway carries every ingress path into the stack: HTTP redirects to
+# HTTPS, HTTPS serves every service under a wildcard certificate, and a TCP
+# listener carries Postgres so psql and goose need no port-forward.
+#
+# Dev and prod share this file. Overlays change the hostnames the routes match,
+# the issuer that signs the certificate, and (in dev) the proxy Service type.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: tally
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: tally
+spec:
+  gatewayClassName: tally
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: tally-wildcard-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+        namespaces:
+          from: Same

--- a/deploy/kubernetes/base/gateway/kustomization.yaml
+++ b/deploy/kubernetes/base/gateway/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - gateway.yaml
+  - certificate.yaml
+  - redirect.yaml

--- a/deploy/kubernetes/base/gateway/redirect.yaml
+++ b/deploy/kubernetes/base/gateway/redirect.yaml
@@ -1,0 +1,17 @@
+# Everything arriving on the http listener is redirected to https, whatever the
+# hostname. This route carries no hostnames on purpose: it is the only route
+# attached to that listener, so it matches all of them.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-to-https
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/deploy/kubernetes/base/gateway/redirect.yaml
+++ b/deploy/kubernetes/base/gateway/redirect.yaml
@@ -1,6 +1,10 @@
 # Everything arriving on the http listener is redirected to https, whatever the
 # hostname. This route carries no hostnames on purpose: it is the only route
 # attached to that listener, so it matches all of them.
+#
+# No port is set here, so the redirect targets the scheme's default, 443. That
+# is right for prod; the dev overlay patches in the host port kind publishes,
+# because on a developer's machine https does not live on 443.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,12 @@
+# The deployment surface dev and prod share. One directory per component;
+# overlays change hostnames, the certificate issuer, and environment-specific
+# infrastructure, never the shape of what is deployed.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - gateway
+  - timescaledb
+  - victoriametrics
+  - otel-collector
+  - reporting-api

--- a/deploy/kubernetes/base/otel-collector/config.yaml
+++ b/deploy/kubernetes/base/otel-collector/config.yaml
@@ -1,0 +1,25 @@
+# OpenTelemetry Collector configuration.
+#
+# The collector is the universal middleware of the metrics pipeline: OTLP in,
+# Prometheus remote write into VictoriaMetrics out. The OpenStack pipeline adds
+# the receivers, processors, and per-cloud labelling it needs; this file is the
+# minimum that boots and accepts OTLP over both transports.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  prometheusremotewrite:
+    endpoint: http://victoriametrics:8428/api/v1/write
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheusremotewrite]

--- a/deploy/kubernetes/base/otel-collector/kustomization.yaml
+++ b/deploy/kubernetes/base/otel-collector/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - otel-collector.yaml
+
+configMapGenerator:
+  - name: otel-collector-config
+    files:
+      - config.yaml

--- a/deploy/kubernetes/base/otel-collector/otel-collector.yaml
+++ b/deploy/kubernetes/base/otel-collector/otel-collector.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app.kubernetes.io/name: otel-collector
+spec:
+  selector:
+    app.kubernetes.io/name: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app.kubernetes.io/name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.157.0
+          args:
+            - --config=/etc/otel/config.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: otel-collector-http
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - otlp.tally.example.com
+  rules:
+    - backendRefs:
+        - name: otel-collector
+          port: 4318
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: otel-collector-grpc
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - otlp-grpc.tally.example.com
+  rules:
+    - backendRefs:
+        - name: otel-collector
+          port: 4317

--- a/deploy/kubernetes/base/reporting-api/kustomization.yaml
+++ b/deploy/kubernetes/base/reporting-api/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - reporting-api.yaml

--- a/deploy/kubernetes/base/reporting-api/reporting-api.yaml
+++ b/deploy/kubernetes/base/reporting-api/reporting-api.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reporting-api
+  labels:
+    app.kubernetes.io/name: reporting-api
+spec:
+  selector:
+    app.kubernetes.io/name: reporting-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reporting-api
+  labels:
+    app.kubernetes.io/name: reporting-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reporting-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reporting-api
+    spec:
+      initContainers:
+        # The service is useless without its database, and crash-looping while
+        # Postgres initializes buries the real startup logs.
+        - name: wait-for-timescaledb
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - "until nc -z timescaledb 5432; do echo waiting for timescaledb; sleep 2; done"
+      containers:
+        - name: reporting-api
+          image: tally-reporting:dev
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: TALLY_HTTP_PORT
+              value: "8080"
+            # Secrets follow the *_FILE convention so they arrive as a mounted
+            # file rather than an environment value.
+            - name: TALLY_DB_URL_FILE
+              value: /run/secrets/tally/db-url
+          volumeMounts:
+            - name: db-credentials
+              mountPath: /run/secrets/tally
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: db-credentials
+          secret:
+            secretName: tally-db
+            items:
+              - key: db-url
+                path: db-url
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: reporting-api
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - api.tally.example.com
+  rules:
+    - backendRefs:
+        - name: reporting-api
+          port: 80

--- a/deploy/kubernetes/base/timescaledb/kustomization.yaml
+++ b/deploy/kubernetes/base/timescaledb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - timescaledb.yaml

--- a/deploy/kubernetes/base/timescaledb/timescaledb.yaml
+++ b/deploy/kubernetes/base/timescaledb/timescaledb.yaml
@@ -1,0 +1,91 @@
+# The Reporting API's database. It is reachable from outside the cluster through
+# the Gateway's TCP listener, which is what lets `make migrate` and psql run
+# against it without a port-forward.
+apiVersion: v1
+kind: Service
+metadata:
+  name: timescaledb
+  labels:
+    app.kubernetes.io/name: timescaledb
+spec:
+  selector:
+    app.kubernetes.io/name: timescaledb
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: timescaledb
+  labels:
+    app.kubernetes.io/name: timescaledb
+spec:
+  serviceName: timescaledb
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: timescaledb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: timescaledb
+    spec:
+      containers:
+        - name: timescaledb
+          image: timescale/timescaledb:latest-pg16
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: tally_reporting
+            - name: POSTGRES_USER
+              value: tally
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tally-db
+                  key: password
+            # The volume root holds lost+found, which Postgres refuses to
+            # initialize into, so the cluster lives one level down.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "tally", "-d", "tally_reporting"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "tally", "-d", "tally_reporting"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+---
+# TCP routing is by listener port, so the hostname a client uses is cosmetic:
+# anything reaching :5432 on the Gateway lands here.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: timescaledb
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: postgres
+  rules:
+    - backendRefs:
+        - name: timescaledb
+          port: 5432

--- a/deploy/kubernetes/base/victoriametrics/kustomization.yaml
+++ b/deploy/kubernetes/base/victoriametrics/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - victoriametrics.yaml
+
+# Generating the ConfigMap from the file means editing scrape.yaml re-rolls the
+# pod, rather than leaving it serving a stale config.
+configMapGenerator:
+  - name: victoriametrics-scrape
+    files:
+      - scrape.yaml

--- a/deploy/kubernetes/base/victoriametrics/scrape.yaml
+++ b/deploy/kubernetes/base/victoriametrics/scrape.yaml
@@ -1,0 +1,7 @@
+# VictoriaMetrics scrape configuration.
+#
+# Scrape targets arrive with the OpenStack metrics pipeline, which also attaches
+# the mandatory platform and cloud labels to every third-party exporter. Until
+# then this file exists so the ConfigMap, the mount, and the -promscrape.config
+# flag are wired and exercised.
+scrape_configs: []

--- a/deploy/kubernetes/base/victoriametrics/victoriametrics.yaml
+++ b/deploy/kubernetes/base/victoriametrics/victoriametrics.yaml
@@ -1,0 +1,89 @@
+# The metrics store. Retention is 13 months so a full billing year plus the
+# current month is always queryable.
+apiVersion: v1
+kind: Service
+metadata:
+  name: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+spec:
+  selector:
+    app.kubernetes.io/name: victoriametrics
+  ports:
+    - name: http
+      port: 8428
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: victoriametrics
+  labels:
+    app.kubernetes.io/name: victoriametrics
+spec:
+  serviceName: victoriametrics
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: victoriametrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: victoriametrics
+    spec:
+      containers:
+        - name: victoriametrics
+          image: victoriametrics/victoria-metrics:v1.148.0
+          args:
+            - -retentionPeriod=13
+            - -promscrape.config=/etc/vm/scrape.yaml
+            - -storageDataPath=/victoria-metrics-data
+          ports:
+            - name: http
+              containerPort: 8428
+          volumeMounts:
+            - name: scrape-config
+              mountPath: /etc/vm
+              readOnly: true
+            - name: data
+              mountPath: /victoria-metrics-data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: scrape-config
+          configMap:
+            name: victoriametrics-scrape
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: victoriametrics
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - vm.tally.example.com
+  rules:
+    - backendRefs:
+        - name: victoriametrics
+          port: 8428

--- a/deploy/kubernetes/overlays/dev/envoyproxy.yaml
+++ b/deploy/kubernetes/overlays/dev/envoyproxy.yaml
@@ -1,0 +1,27 @@
+# Pins the Envoy proxy Service to the node ports deploy/kind/kind.yaml publishes.
+# Without this, Envoy Gateway allocates node ports at random and the host port
+# mappings point at nothing.
+#
+# There is no per-port nodePort field on envoyService, so the ports go through a
+# strategic merge patch. Its merge key is the service port number.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: tally-proxy-config
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: NodePort
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              ports:
+                - port: 80
+                  nodePort: 30080
+                - port: 443
+                  nodePort: 30443
+                - port: 5432
+                  nodePort: 30432

--- a/deploy/kubernetes/overlays/dev/issuers.yaml
+++ b/deploy/kubernetes/overlays/dev/issuers.yaml
@@ -1,0 +1,39 @@
+# The dev certificate authority.
+#
+# Applied by `make up` with plain kubectl rather than through the overlay: the
+# CA Certificate must live in cert-manager's own namespace, and the overlay's
+# namespace transformer would move it into tally, where cert-manager would never
+# find the key it signs with.
+#
+# `make ca` prints the resulting CA certificate for `curl --cacert`.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: tally-selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tally-dev-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: tally-dev-ca
+  secretName: tally-dev-ca
+  duration: 87600h # 10 years: a dev CA that expires mid-sprint helps nobody
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: ClusterIssuer
+    name: tally-selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: tally-dev-ca
+spec:
+  ca:
+    secretName: tally-dev-ca

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -74,6 +74,18 @@ patches:
         path: /spec/issuerRef/name
         value: tally-dev-ca
 
+  # The browser follows the redirect on the host side, where https is published
+  # on 8443 rather than 443 (deploy/kind/kind.yaml), so the Location header has
+  # to carry that port. Without it the redirect points at a closed port.
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: http-to-https
+    patch: |
+      - op: add
+        path: /spec/rules/0/filters/0/requestRedirect/port
+        value: 8443
+
   # Point the Gateway at the proxy config that pins the node ports.
   - target:
       group: gateway.networking.k8s.io

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,0 +1,99 @@
+# The kind dev environment.
+#
+# Every service gets a real HTTPS URL under *.tally.127-0-0-1.nip.io. nip.io
+# resolves that wildcard to 127.0.0.1, so no /etc/hosts edit is needed, and the
+# self-signed CA in issuers.yaml signs the certificate the Gateway serves.
+#
+# issuers.yaml is deliberately not listed here; see the comment in that file.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tally
+
+resources:
+  - namespace.yaml
+  - ../../base
+  - envoyproxy.yaml
+
+# Dev credentials, in the clear on purpose: this database is reachable only
+# through a Gateway bound to 127.0.0.1 on the developer's own machine.
+secretGenerator:
+  - name: tally-db
+    literals:
+      - password=tally-dev-password
+      - db-url=postgres://tally:tally-dev-password@timescaledb:5432/tally_reporting?sslmode=disable
+
+patches:
+  # Route every service to its nip.io hostname.
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: reporting-api
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: api.tally.127-0-0-1.nip.io
+
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: victoriametrics
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: vm.tally.127-0-0-1.nip.io
+
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: otel-collector-http
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: otlp.tally.127-0-0-1.nip.io
+
+  - target:
+      group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: otel-collector-grpc
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: otlp-grpc.tally.127-0-0-1.nip.io
+
+  # Serve that domain, signed by the dev CA.
+  - target:
+      group: cert-manager.io
+      kind: Certificate
+      name: tally-wildcard
+    patch: |
+      - op: replace
+        path: /spec/dnsNames/0
+        value: "*.tally.127-0-0-1.nip.io"
+      - op: replace
+        path: /spec/issuerRef/name
+        value: tally-dev-ca
+
+  # Point the Gateway at the proxy config that pins the node ports.
+  - target:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: tally
+    patch: |
+      - op: add
+        path: /spec/infrastructure
+        value:
+          parametersRef:
+            group: gateway.envoyproxy.io
+            kind: EnvoyProxy
+            name: tally-proxy-config
+
+  # The image is built locally and side-loaded with `kind load`, so pulling it
+  # would only ever fail.
+  - target:
+      kind: Deployment
+      name: reporting-api
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Never

--- a/deploy/kubernetes/overlays/dev/namespace.yaml
+++ b/deploy/kubernetes/overlays/dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tally

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/b42labs/tally
 go 1.25.0
 
 toolchain go1.26.1
+
+require github.com/shopspring/decimal v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/b42labs/tally
+
+go 1.25.0
+
+toolchain go1.26.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=

--- a/internal/core/event/event.go
+++ b/internal/core/event/event.go
@@ -1,0 +1,222 @@
+// Package event carries the canonical event schema every platform is normalized
+// into: the wire types, their validation rules, and the categorization that
+// derives an event's effect from its type. It is the contract collectors write
+// against and the ingestion pipeline reads, so it holds no provider-specific
+// knowledge and does no I/O.
+//
+// The normative specification is roadmap/00-conventions.md section 4.
+package event
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Source names the pipeline an event came from.
+type Source string
+
+const (
+	// SourceCollector marks an event pushed by a provider-side collector. It is
+	// the default: an event that names no source is treated as a collector event.
+	SourceCollector Source = "collector"
+	// SourceReconciliation marks a synthetic event emitted by a server-side sync
+	// run to correct drift between a platform and the projection.
+	SourceReconciliation Source = "reconciliation"
+)
+
+// Category is the effect an event has on a resource.
+type Category string
+
+const (
+	// CategoryCreate starts a resource's life: it sets created_at and requires a
+	// full payload (state and size).
+	CategoryCreate Category = "create"
+	// CategoryUpdate changes a resource's state, size, or owner.
+	CategoryUpdate Category = "update"
+	// CategoryDelete ends a resource's life: it sets deleted_at and forces the
+	// state to "deleted".
+	CategoryDelete Category = "delete"
+)
+
+// eventIDMaxLen bounds event_id so it fits the database column and stays a
+// usable idempotency key.
+const eventIDMaxLen = 256
+
+var eventTypePattern = regexp.MustCompile(`^[a-z0-9_]+(\.[a-z0-9_]+)+$`)
+
+// PayloadEnvelope is the normalized payload every event carries. Collectors map
+// provider data into it so that projection, timeline, and metering never need
+// provider-specific code.
+//
+// Unknown fields survive a decode/encode round-trip untouched, which keeps an
+// event byte-faithful to what the provider sent even as this struct grows.
+type PayloadEnvelope struct {
+	// State is the resource state at or after the event. It is required on every
+	// event except a delete, where the core sets "deleted" itself.
+	State *string `json:"state,omitempty"`
+	// Size is the full replacement size object, required on create and on any
+	// size-changing event. Absent means the size did not change.
+	Size map[string]any `json:"size,omitempty"`
+	// Provider is free-form raw provider data, kept for debugging and audit. Core
+	// logic never reads it.
+	Provider map[string]any `json:"provider,omitempty"`
+
+	extra map[string]json.RawMessage
+}
+
+// UnmarshalJSON decodes the envelope, routing every field this struct does not
+// name into an unexported map so MarshalJSON can put it back.
+func (p *PayloadEnvelope) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*p = PayloadEnvelope{}
+	for key, value := range raw {
+		var err error
+		switch key {
+		case "state":
+			err = json.Unmarshal(value, &p.State)
+		case "size":
+			err = json.Unmarshal(value, &p.Size)
+		case "provider":
+			err = json.Unmarshal(value, &p.Provider)
+		default:
+			if p.extra == nil {
+				p.extra = make(map[string]json.RawMessage, len(raw))
+			}
+			p.extra[key] = value
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("payload field %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON encodes the named fields alongside every unknown field a previous
+// decode preserved.
+func (p PayloadEnvelope) MarshalJSON() ([]byte, error) {
+	out := make(map[string]json.RawMessage, len(p.extra)+3)
+	for key, value := range p.extra {
+		out[key] = value
+	}
+
+	set := func(key string, value any) error {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("payload field %q: %w", key, err)
+		}
+		out[key] = encoded
+		return nil
+	}
+	if p.State != nil {
+		if err := set("state", p.State); err != nil {
+			return nil, err
+		}
+	}
+	if p.Size != nil {
+		if err := set("size", p.Size); err != nil {
+			return nil, err
+		}
+	}
+	if p.Provider != nil {
+		if err := set("provider", p.Provider); err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(out)
+}
+
+// Event is an immutable lifecycle fact. The events table is the system's single
+// source of truth; everything else is derived from it and rebuildable.
+type Event struct {
+	EventID      string          `json:"event_id"`
+	Timestamp    time.Time       `json:"timestamp"`
+	EventType    string          `json:"event_type"`
+	Platform     string          `json:"platform"`
+	Cloud        string          `json:"cloud"`
+	ResourceType string          `json:"resource_type"`
+	ResourceID   string          `json:"resource_id"`
+	ProjectID    string          `json:"project_id"`
+	Source       Source          `json:"source"`
+	Payload      PayloadEnvelope `json:"payload"`
+}
+
+// Stored pairs an Event with the server-side timestamp that breaks ordering ties
+// between events sharing an instant.
+type Stored struct {
+	Event
+	ReceivedAt time.Time `json:"received_at"`
+}
+
+// Validate reports every rule the event breaks, joined into one error, so a
+// caller sees the whole picture rather than the first problem.
+func (e *Event) Validate() error {
+	var errs []error
+
+	if n := len(e.EventID); n < 1 || n > eventIDMaxLen {
+		errs = append(errs, fmt.Errorf("event_id: must be 1..%d characters, got %d", eventIDMaxLen, n))
+	}
+	if e.Timestamp.IsZero() {
+		errs = append(errs, errors.New("timestamp: must be set"))
+	}
+	if !eventTypePattern.MatchString(e.EventType) {
+		errs = append(errs, fmt.Errorf("event_type: %q must match %s", e.EventType, eventTypePattern))
+	}
+
+	for _, field := range []struct{ name, value string }{
+		{"platform", e.Platform},
+		{"cloud", e.Cloud},
+		{"resource_type", e.ResourceType},
+		{"resource_id", e.ResourceID},
+		{"project_id", e.ProjectID},
+	} {
+		if field.value == "" {
+			errs = append(errs, fmt.Errorf("%s: must not be empty", field.name))
+		}
+	}
+
+	switch e.Source {
+	case "", SourceCollector, SourceReconciliation:
+	default:
+		errs = append(errs, fmt.Errorf("source: %q must be %q or %q", e.Source, SourceCollector, SourceReconciliation))
+	}
+
+	switch Categorize(e.EventType) {
+	case CategoryCreate:
+		if e.Payload.State == nil {
+			errs = append(errs, errors.New("payload.state: required on create events"))
+		}
+		if e.Payload.Size == nil {
+			errs = append(errs, errors.New("payload.size: required on create events"))
+		}
+	case CategoryUpdate:
+		if e.Payload.State == nil {
+			errs = append(errs, errors.New("payload.state: required on every event except delete"))
+		}
+	case CategoryDelete:
+	}
+
+	return errors.Join(errs...)
+}
+
+// Categorize derives an event's effect from its type alone, which is what keeps
+// the core free of per-platform code. See roadmap/00-conventions.md section 4.2.
+func Categorize(eventType string) Category {
+	parts := strings.Split(eventType, ".")
+	if slices.Contains(parts, "create") {
+		return CategoryCreate
+	}
+	if slices.Contains(parts, "delete") {
+		return CategoryDelete
+	}
+	return CategoryUpdate
+}

--- a/internal/core/event/event_test.go
+++ b/internal/core/event/event_test.go
@@ -1,0 +1,277 @@
+package event_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+// validEvent is a fully populated create event. Tests mutate one field of a copy
+// to isolate the rule they exercise.
+func validEvent() event.Event {
+	state := "active"
+	return event.Event{
+		EventID:      "openstack-abc123",
+		Timestamp:    time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC),
+		EventType:    "compute.instance.create.end",
+		Platform:     "openstack",
+		Cloud:        "os-prod-eu1",
+		ResourceType: "instance",
+		ResourceID:   "i-1",
+		ProjectID:    "p-1",
+		Source:       event.SourceCollector,
+		Payload: event.PayloadEnvelope{
+			State: &state,
+			Size:  map[string]any{"vcpus": 4},
+		},
+	}
+}
+
+func TestValidateAcceptsCompleteCreateEvent(t *testing.T) {
+	e := validEvent()
+	if err := e.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestValidateZeroValueNamesEveryMissingField(t *testing.T) {
+	var e event.Event
+
+	err := e.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil, want an error")
+	}
+
+	// The zero value breaks every rule at once, and a caller fixing it should see
+	// the whole list rather than one field per attempt.
+	for _, field := range []string{
+		"event_id", "timestamp", "event_type", "platform", "cloud",
+		"resource_type", "resource_id", "project_id", "payload.state",
+	} {
+		if !strings.Contains(err.Error(), field) {
+			t.Errorf("Validate() error does not mention %q: %v", field, err)
+		}
+	}
+}
+
+func TestValidateEventIDLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{name: "empty", id: "", wantErr: true},
+		{name: "one character", id: "x"},
+		{name: "256 characters", id: strings.Repeat("x", 256)},
+		{name: "257 characters", id: strings.Repeat("x", 257), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validEvent()
+			e.EventID = tc.id
+
+			err := e.Validate()
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("Validate() = nil, want an error for a %d character id", len(tc.id))
+			case tc.wantErr && !strings.Contains(err.Error(), "event_id"):
+				t.Fatalf("Validate() error does not mention event_id: %v", err)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidateEventTypePattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		wantErr   bool
+	}{
+		{name: "dotted", eventType: "compute.instance.create.end"},
+		{name: "two segments", eventType: "sync.create"},
+		{name: "underscores", eventType: "load_balancer.create.end"},
+		{name: "single segment", eventType: "create", wantErr: true},
+		{name: "empty", eventType: "", wantErr: true},
+		{name: "uppercase", eventType: "Compute.Instance.Create.End", wantErr: true},
+		{name: "trailing dot", eventType: "compute.instance.", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validEvent()
+			e.EventType = tc.eventType
+			// Keep the payload complete so only the type rule can fail.
+			state := "active"
+			e.Payload.State = &state
+			e.Payload.Size = map[string]any{"vcpus": 4}
+
+			err := e.Validate()
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("Validate() = nil, want an error for %q", tc.eventType)
+			case tc.wantErr && !strings.Contains(err.Error(), "event_type"):
+				t.Fatalf("Validate() error does not mention event_type: %v", err)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidatePayloadRulesByCategory(t *testing.T) {
+	state := "active"
+	size := map[string]any{"vcpus": 4}
+
+	tests := []struct {
+		name      string
+		eventType string
+		state     *string
+		size      map[string]any
+		wantErr   string
+	}{
+		{name: "create with state and size", eventType: "compute.instance.create.end", state: &state, size: size},
+		{name: "create without size", eventType: "compute.instance.create.end", state: &state, wantErr: "payload.size"},
+		{name: "create without state", eventType: "compute.instance.create.end", size: size, wantErr: "payload.state"},
+		{name: "update with state and size", eventType: "compute.instance.resize.end", state: &state, size: size},
+		{name: "update without size is fine", eventType: "compute.instance.power_off.end", state: &state},
+		{name: "update without state", eventType: "compute.instance.power_off.end", wantErr: "payload.state"},
+		{name: "delete without state", eventType: "compute.instance.delete.end"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validEvent()
+			e.EventType = tc.eventType
+			e.Payload.State = tc.state
+			e.Payload.Size = tc.size
+
+			err := e.Validate()
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Validate() = nil, want an error mentioning %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Validate() error does not mention %q: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  event.Source
+		wantErr bool
+	}{
+		{name: "empty means collector", source: ""},
+		{name: "collector", source: event.SourceCollector},
+		{name: "reconciliation", source: event.SourceReconciliation},
+		{name: "anything else", source: event.Source("operator"), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validEvent()
+			e.Source = tc.source
+
+			err := e.Validate()
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("Validate() = nil, want an error for source %q", tc.source)
+			case tc.wantErr && !strings.Contains(err.Error(), "source"):
+				t.Fatalf("Validate() error does not mention source: %v", err)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestPayloadEnvelopePreservesUnknownFields(t *testing.T) {
+	const raw = `{"state":"active","note":"x","size":{"vcpus":4}}`
+
+	var p event.PayloadEnvelope
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("Unmarshal() = %v, want nil", err)
+	}
+	if p.State == nil || *p.State != "active" {
+		t.Fatalf("State = %v, want %q", p.State, "active")
+	}
+
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal() = %v, want nil", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		t.Fatalf("decoding round-tripped payload: %v", err)
+	}
+	if out["note"] != "x" {
+		t.Errorf("round-tripped payload lost the unknown field: %s", encoded)
+	}
+	if out["state"] != "active" {
+		t.Errorf("round-tripped payload lost state: %s", encoded)
+	}
+}
+
+func TestPayloadEnvelopeEmptyObject(t *testing.T) {
+	var p event.PayloadEnvelope
+	if err := json.Unmarshal([]byte(`{}`), &p); err != nil {
+		t.Fatalf("Unmarshal() = %v, want nil", err)
+	}
+
+	if p.State != nil {
+		t.Errorf("State = %v, want nil", *p.State)
+	}
+	if p.Size != nil {
+		t.Errorf("Size = %v, want nil", p.Size)
+	}
+	if p.Provider != nil {
+		t.Errorf("Provider = %v, want nil", p.Provider)
+	}
+}
+
+func TestPayloadEnvelopeMalformedJSON(t *testing.T) {
+	// The decoder's own syntax error travels to the caller unchanged, so a
+	// malformed payload is reported as malformed rather than as a field problem.
+	var p event.PayloadEnvelope
+	err := p.UnmarshalJSON([]byte(`{`))
+
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("UnmarshalJSON() = %v, want a *json.SyntaxError", err)
+	}
+}
+
+func TestCategorize(t *testing.T) {
+	tests := []struct {
+		eventType string
+		want      event.Category
+	}{
+		{eventType: "compute.instance.create.end", want: event.CategoryCreate},
+		{eventType: "sync.create", want: event.CategoryCreate},
+		{eventType: "compute.instance.delete.end", want: event.CategoryDelete},
+		{eventType: "sync.delete", want: event.CategoryDelete},
+		{eventType: "volume.transfer.accept.end", want: event.CategoryUpdate},
+		{eventType: "sync.update", want: event.CategoryUpdate},
+		{eventType: "compute.instance.power_off.end", want: event.CategoryUpdate},
+		{eventType: "", want: event.CategoryUpdate},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.eventType, func(t *testing.T) {
+			if got := event.Categorize(tc.eventType); got != tc.want {
+				t.Errorf("Categorize(%q) = %q, want %q", tc.eventType, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/core/ids/ids.go
+++ b/internal/core/ids/ids.go
@@ -1,0 +1,30 @@
+// Package ids derives event identifiers. Both functions are pure and stable
+// across processes and releases: the same inputs always produce the same id, so
+// re-delivering a notification or re-running a sync is a no-op at ingestion
+// rather than a duplicate.
+//
+// The normative specification is roadmap/00-conventions.md section 4.
+package ids
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// DeterministicEventID derives an event id for a provider that exposes no native
+// event or action id of its own. The timestamp is normalized to UTC first, so
+// the same instant expressed in different zones yields one id.
+func DeterministicEventID(platform, cloud, resourceID, eventType string, ts time.Time) string {
+	raw := cloud + ":" + resourceID + ":" + eventType + ":" + ts.UTC().Format(time.RFC3339Nano)
+	sum := sha256.Sum256([]byte(raw))
+	return platform + "-" + hex.EncodeToString(sum[:])
+}
+
+// SyntheticEventID derives the event id of a correction emitted by a sync run.
+// It is deterministic per run, which makes re-applying that run a no-op.
+func SyntheticEventID(syncRunID, cloud, resourceType, resourceID, kind string) string {
+	raw := syncRunID + ":" + cloud + ":" + resourceType + ":" + resourceID + ":" + kind
+	sum := sha256.Sum256([]byte(raw))
+	return "recon-" + hex.EncodeToString(sum[:])
+}

--- a/internal/core/ids/ids_test.go
+++ b/internal/core/ids/ids_test.go
@@ -1,0 +1,112 @@
+package ids_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/ids"
+)
+
+// The golden values below pin the hashing scheme. Changing either function
+// changes every id it ever produced, so a diff here is a migration, not a fix.
+const (
+	// sha256("os-prod-eu1:i-1:compute.instance.create.end:2026-03-01T12:00:00Z")
+	goldenDeterministicID = "openstack-56e3f54aefd66cdc729b86ddc7ad894b8010095a2edbde2881319b1de7522d4f"
+	// sha256("run-1:os-prod-eu1:instance:i-1:delete")
+	goldenSyntheticID = "recon-509cb64132d88d07e1f98c046807f1c26396b0b338245e15bc5349cfd0acbc0b"
+)
+
+func TestDeterministicEventIDIsGolden(t *testing.T) {
+	ts := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+
+	got := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", ts)
+	if got != goldenDeterministicID {
+		t.Errorf("DeterministicEventID() = %q, want %q", got, goldenDeterministicID)
+	}
+}
+
+func TestDeterministicEventIDShape(t *testing.T) {
+	ts := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+
+	got := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", ts)
+
+	prefix, hash, found := strings.Cut(got, "-")
+	if !found {
+		t.Fatalf("DeterministicEventID() = %q, want a platform prefix", got)
+	}
+	if prefix != "openstack" {
+		t.Errorf("prefix = %q, want %q", prefix, "openstack")
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+}
+
+func TestDeterministicEventIDNormalizesTimezone(t *testing.T) {
+	// The same instant written in two zones is one event, not two.
+	utc := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+	berlin := utc.In(time.FixedZone("CEST", 2*60*60))
+
+	inUTC := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", utc)
+	inBerlin := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", berlin)
+
+	if inUTC != inBerlin {
+		t.Errorf("id differs by timezone: %q (UTC) vs %q (+02:00)", inUTC, inBerlin)
+	}
+}
+
+func TestDeterministicEventIDIsStableAcrossCalls(t *testing.T) {
+	ts := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+
+	first := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", ts)
+	second := ids.DeterministicEventID("openstack", "os-prod-eu1", "i-1", "compute.instance.create.end", ts)
+
+	if first != second {
+		t.Errorf("id is not stable: %q then %q", first, second)
+	}
+}
+
+func TestSyntheticEventIDIsGolden(t *testing.T) {
+	got := ids.SyntheticEventID("run-1", "os-prod-eu1", "instance", "i-1", "delete")
+	if got != goldenSyntheticID {
+		t.Errorf("SyntheticEventID() = %q, want %q", got, goldenSyntheticID)
+	}
+}
+
+func TestSyntheticEventIDShape(t *testing.T) {
+	got := ids.SyntheticEventID("run-1", "os-prod-eu1", "instance", "i-1", "delete")
+
+	hash, found := strings.CutPrefix(got, "recon-")
+	if !found {
+		t.Fatalf("SyntheticEventID() = %q, want a %q prefix", got, "recon-")
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+}
+
+func TestSyntheticEventIDSeparatesKinds(t *testing.T) {
+	// A missed create and a missed delete for one resource in one run are two
+	// distinct corrections, so they must not collide.
+	create := ids.SyntheticEventID("run-1", "os-prod-eu1", "instance", "i-1", "create")
+	del := ids.SyntheticEventID("run-1", "os-prod-eu1", "instance", "i-1", "delete")
+
+	if create == del {
+		t.Errorf("ids collide across kinds: %q", create)
+	}
+}
+
+func TestIDsAcceptEmptyInput(t *testing.T) {
+	// Empty strings and the zero time are degenerate but must not panic: they
+	// reach these functions from providers with incomplete notifications.
+	deterministic := ids.DeterministicEventID("", "", "", "", time.Time{})
+	if _, hash, _ := strings.Cut(deterministic, "-"); len(hash) != 64 {
+		t.Errorf("DeterministicEventID() = %q, want a 64 character hash", deterministic)
+	}
+
+	synthetic := ids.SyntheticEventID("", "", "", "", "")
+	if hash, _ := strings.CutPrefix(synthetic, "recon-"); len(hash) != 64 {
+		t.Errorf("SyntheticEventID() = %q, want a 64 character hash", synthetic)
+	}
+}

--- a/internal/core/money/money.go
+++ b/internal/core/money/money.go
@@ -1,0 +1,60 @@
+// Package money holds the only rounding and division entry points in the system.
+// Money, prices, and usage quantities are decimals from end to end: floats never
+// touch them, which the forbidigo rules in .golangci.yml enforce.
+//
+// The normative specification is roadmap/00-conventions.md section 6.
+package money
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// moneyPlaces is the scale every monetary value is rounded and rendered at.
+	moneyPlaces = 2
+	// minutePlaces is the scale derived minute quantities are rounded at.
+	minutePlaces = 4
+	// divisionScale is the working precision every division runs at, set
+	// explicitly so no result depends on decimal.DivisionPrecision.
+	divisionScale = 28
+)
+
+// Round2 rounds to two decimal places, half away from zero. It is the single
+// rounding entry point: per-dimension costs are rounded here, and every
+// aggregate is a sum of already-rounded values, so a total always equals the sum
+// of its visible line items.
+func Round2(d decimal.Decimal) decimal.Decimal {
+	return d.Round(moneyPlaces)
+}
+
+// Minutes converts a duration in whole seconds to minutes, rounded to four
+// decimal places. Interval arithmetic is done in integer seconds; this is where
+// it becomes a billable quantity.
+func Minutes(seconds int64) decimal.Decimal {
+	return Div(decimal.NewFromInt(seconds), decimal.NewFromInt(60)).Round(minutePlaces)
+}
+
+// Div divides at an explicit working precision. Dividing by zero panics, as it
+// does in the underlying decimal package: no billing input can legitimately be a
+// zero divisor, so it is a caller bug rather than a condition to handle.
+func Div(a, b decimal.Decimal) decimal.Decimal {
+	return a.DivRound(b, divisionScale)
+}
+
+// Amount is a monetary value that serializes at full two-place precision. A bare
+// decimal renders 19.20 as 19.2, which is not acceptable in an export a customer
+// reconciles against an invoice.
+type Amount struct {
+	decimal.Decimal
+}
+
+// NewAmount wraps a decimal for serialization. It does not round: round with
+// Round2 first where the value is computed.
+func NewAmount(d decimal.Decimal) Amount {
+	return Amount{Decimal: d}
+}
+
+// MarshalJSON renders the amount as a JSON number with exactly two decimal places.
+func (a Amount) MarshalJSON() ([]byte, error) {
+	return []byte(a.StringFixed(moneyPlaces)), nil
+}

--- a/internal/core/money/money_test.go
+++ b/internal/core/money/money_test.go
@@ -1,0 +1,136 @@
+package money_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/shopspring/decimal"
+)
+
+// dec builds a decimal from its string form, which is the only construction the
+// money rules allow.
+func dec(t *testing.T, s string) decimal.Decimal {
+	t.Helper()
+
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", s, err)
+	}
+	return d
+}
+
+func TestRound2IsHalfUp(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "2.025", want: "2.03"},
+		{in: "-2.025", want: "-2.03"},
+		{in: "2.024", want: "2.02"},
+		{in: "-2.024", want: "-2.02"},
+		{in: "2.035", want: "2.04"},
+		{in: "19.2", want: "19.2"},
+		{in: "0", want: "0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got := money.Round2(dec(t, tc.in))
+			if !got.Equal(dec(t, tc.want)) {
+				t.Errorf("Round2(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMinutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int64
+		want    string
+	}{
+		{name: "zero", seconds: 0, want: "0"},
+		{name: "exact minute", seconds: 60, want: "1"},
+		{name: "minute and a half", seconds: 90, want: "1.5"},
+		{name: "repeating decimal", seconds: 59, want: "0.9833"},
+		{name: "an hour", seconds: 3600, want: "60"},
+		{name: "negative", seconds: -90, want: "-1.5"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := money.Minutes(tc.seconds)
+			if !got.Equal(dec(t, tc.want)) {
+				t.Errorf("Minutes(%d) = %s, want %s", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDivPrecision(t *testing.T) {
+	// One third at the working precision: 28 digits after the point, and the
+	// last one rounded up rather than truncated.
+	got := money.Div(dec(t, "1"), dec(t, "3"))
+	want := dec(t, "0.3333333333333333333333333333")
+
+	if !got.Equal(want) {
+		t.Errorf("Div(1, 3) = %s, want %s", got, want)
+	}
+	if got.Exponent() != -28 {
+		t.Errorf("Div(1, 3) exponent = %d, want -28", got.Exponent())
+	}
+}
+
+func TestDivByZeroPanics(t *testing.T) {
+	// No billing input is legitimately a zero divisor, so this is a caller bug
+	// that must surface loudly rather than produce a silent zero.
+	defer func() {
+		if recover() == nil {
+			t.Error("Div(1, 0) returned normally, want a panic")
+		}
+	}()
+
+	money.Div(dec(t, "1"), decimal.Zero)
+}
+
+func TestAmountMarshalsWithTwoDecimals(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "2.03", want: "2.03"},
+		{in: "19.2", want: "19.20"},
+		{in: "0", want: "0.00"},
+		{in: "124.8", want: "124.80"},
+		{in: "-3.5", want: "-3.50"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := json.Marshal(money.NewAmount(dec(t, tc.in)))
+			if err != nil {
+				t.Fatalf("Marshal() = %v, want nil", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAmountMarshalsInsideAStruct(t *testing.T) {
+	// The exported shape is what a customer reconciles against an invoice, so
+	// the two places must survive being nested in a response body.
+	body := struct {
+		Total money.Amount `json:"total"`
+	}{Total: money.NewAmount(dec(t, "19.2"))}
+
+	got, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal() = %v, want nil", err)
+	}
+	if want := `{"total":19.20}`; string(got) != want {
+		t.Errorf("Marshal() = %s, want %s", got, want)
+	}
+}

--- a/internal/core/testkit/testkit.go
+++ b/internal/core/testkit/testkit.go
@@ -1,0 +1,160 @@
+// Package testkit holds the assertions every provider collector is tested
+// against, so that a new provider proves it produces events the core accepts
+// without reimplementing the rules.
+//
+// The normative specification is roadmap/00-conventions.md section 9.
+package testkit
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+// reporter is the part of *testing.T the assertions use. It exists so the
+// assertions can themselves be tested for the failures they are meant to report,
+// which a *testing.T cannot be made to do.
+type reporter interface {
+	Helper()
+	Errorf(format string, args ...any)
+}
+
+// AssertValidEvent fails the test unless raw decodes into an Event that passes
+// every validation rule.
+func AssertValidEvent(t *testing.T, raw []byte) {
+	t.Helper()
+	assertValidEvent(t, raw)
+}
+
+func assertValidEvent(t reporter, raw []byte) {
+	t.Helper()
+
+	var e event.Event
+	if err := json.Unmarshal(raw, &e); err != nil {
+		t.Errorf("decoding event: %v", err)
+		return
+	}
+	if err := e.Validate(); err != nil {
+		t.Errorf("validating event: %v", err)
+	}
+}
+
+// AssertDeterministicIDs fails the test unless fn returns the same id twice.
+func AssertDeterministicIDs(t *testing.T, fn func() string) {
+	t.Helper()
+	assertDeterministicIDs(t, fn)
+}
+
+func assertDeterministicIDs(t reporter, fn func() string) {
+	t.Helper()
+
+	first, second := fn(), fn()
+	if first != second {
+		t.Errorf("id function is not deterministic: got %q then %q", first, second)
+	}
+}
+
+// EventBuilder produces valid events for tests. Every method returns a copy, so
+// a builder can be shared as a base and specialized per case.
+type EventBuilder struct {
+	e event.Event
+}
+
+// NewEventBuilder returns a builder for a valid OpenStack instance create event.
+func NewEventBuilder() EventBuilder {
+	state := "active"
+	return EventBuilder{e: event.Event{
+		EventID:      "test-event-1",
+		Timestamp:    time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC),
+		EventType:    "compute.instance.create.end",
+		Platform:     "openstack",
+		Cloud:        "os-dev",
+		ResourceType: "instance",
+		ResourceID:   "resource-1",
+		ProjectID:    "project-1",
+		Source:       event.SourceCollector,
+		Payload: event.PayloadEnvelope{
+			State: &state,
+			Size:  map[string]any{"vcpus": 2, "ram_mb": 4096},
+		},
+	}}
+}
+
+// WithEventID sets the event id.
+func (b EventBuilder) WithEventID(id string) EventBuilder {
+	b.e.EventID = id
+	return b
+}
+
+// WithTimestamp sets the event timestamp.
+func (b EventBuilder) WithTimestamp(ts time.Time) EventBuilder {
+	b.e.Timestamp = ts
+	return b
+}
+
+// WithEventType sets the event type, which also decides the event's category.
+func (b EventBuilder) WithEventType(eventType string) EventBuilder {
+	b.e.EventType = eventType
+	return b
+}
+
+// WithResourceID sets the resource id.
+func (b EventBuilder) WithResourceID(id string) EventBuilder {
+	b.e.ResourceID = id
+	return b
+}
+
+// WithProjectID sets the owning project at or after this event.
+func (b EventBuilder) WithProjectID(id string) EventBuilder {
+	b.e.ProjectID = id
+	return b
+}
+
+// WithState sets the payload state.
+func (b EventBuilder) WithState(state string) EventBuilder {
+	b.e.Payload.State = &state
+	return b
+}
+
+// WithoutState clears the payload state, which is how an event says the state
+// did not change.
+func (b EventBuilder) WithoutState() EventBuilder {
+	b.e.Payload.State = nil
+	return b
+}
+
+// WithSize sets the payload size object.
+func (b EventBuilder) WithSize(size map[string]any) EventBuilder {
+	b.e.Payload.Size = size
+	return b
+}
+
+// WithoutSize clears the payload size, which is how an event says the size did
+// not change.
+func (b EventBuilder) WithoutSize() EventBuilder {
+	b.e.Payload.Size = nil
+	return b
+}
+
+// Build returns the event.
+func (b EventBuilder) Build() event.Event {
+	return b.e
+}
+
+// BuildStored returns the event paired with a server-side receipt timestamp.
+func (b EventBuilder) BuildStored(receivedAt time.Time) event.Stored {
+	return event.Stored{Event: b.e, ReceivedAt: receivedAt}
+}
+
+// BuildJSON returns the event encoded as it travels the wire.
+func (b EventBuilder) BuildJSON(t *testing.T) []byte {
+	t.Helper()
+
+	raw, err := json.Marshal(b.e)
+	if err != nil {
+		t.Fatalf("encoding fixture event: %v", err)
+	}
+	return raw
+}

--- a/internal/core/testkit/testkit_test.go
+++ b/internal/core/testkit/testkit_test.go
@@ -1,0 +1,96 @@
+package testkit
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// recorder stands in for *testing.T so the assertions can be checked for the
+// failures they are supposed to report.
+type recorder struct {
+	failures []string
+}
+
+func (r *recorder) Helper() {}
+
+func (r *recorder) Errorf(format string, args ...any) {
+	r.failures = append(r.failures, fmt.Sprintf(format, args...))
+}
+
+func TestAssertValidEventAcceptsBuilderOutput(t *testing.T) {
+	var rec recorder
+	assertValidEvent(&rec, NewEventBuilder().BuildJSON(t))
+
+	if len(rec.failures) != 0 {
+		t.Errorf("builder output was rejected: %v", rec.failures)
+	}
+}
+
+func TestAssertValidEventRejectsEnvelopeViolation(t *testing.T) {
+	// A create event without a size breaks the envelope rule, which is exactly
+	// what a provider collector must not be allowed to ship.
+	raw := NewEventBuilder().WithoutSize().BuildJSON(t)
+
+	var rec recorder
+	assertValidEvent(&rec, raw)
+
+	if len(rec.failures) == 0 {
+		t.Fatal("a create event without a size was accepted")
+	}
+}
+
+func TestAssertValidEventRejectsMalformedJSON(t *testing.T) {
+	var rec recorder
+	assertValidEvent(&rec, []byte(`{`))
+
+	if len(rec.failures) == 0 {
+		t.Fatal("malformed JSON was accepted")
+	}
+}
+
+func TestAssertDeterministicIDsAcceptsStableFunction(t *testing.T) {
+	var rec recorder
+	assertDeterministicIDs(&rec, func() string { return "stable" })
+
+	if len(rec.failures) != 0 {
+		t.Errorf("a stable function was rejected: %v", rec.failures)
+	}
+}
+
+func TestAssertDeterministicIDsRejectsUnstableFunction(t *testing.T) {
+	calls := 0
+	var rec recorder
+	assertDeterministicIDs(&rec, func() string {
+		calls++
+		return fmt.Sprintf("id-%d", calls)
+	})
+
+	if calls != 2 {
+		t.Errorf("the function was called %d times, want 2", calls)
+	}
+	if len(rec.failures) == 0 {
+		t.Fatal("an unstable function was accepted")
+	}
+}
+
+func TestEventBuilderCopiesOnEveryChange(t *testing.T) {
+	base := NewEventBuilder()
+	derived := base.WithEventID("other")
+
+	if base.Build().EventID == derived.Build().EventID {
+		t.Error("With* mutated the base builder instead of returning a copy")
+	}
+}
+
+func TestEventBuilderStored(t *testing.T) {
+	receivedAt := time.Date(2026, time.March, 1, 0, 0, 1, 0, time.UTC)
+
+	stored := NewEventBuilder().BuildStored(receivedAt)
+	if !stored.ReceivedAt.Equal(receivedAt) {
+		t.Errorf("ReceivedAt = %v, want %v", stored.ReceivedAt, receivedAt)
+	}
+	if stored.EventID != NewEventBuilder().Build().EventID {
+		t.Error("BuildStored changed the event")
+	}
+}

--- a/internal/core/timeline/timeline.go
+++ b/internal/core/timeline/timeline.go
@@ -1,0 +1,139 @@
+// Package timeline folds a resource's event history into the billable intervals
+// it implies. It is the one implementation shared by projection replay, the
+// lifecycle endpoint, and the metering engine, so that every consumer folds the
+// same history into the same intervals.
+//
+// The normative specification is roadmap/00-conventions.md section 5.
+package timeline
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+// WarningHistoryStartsWithoutCreate marks a timeline whose first event is not a
+// create, which means the create was missed and the resource's real start is
+// unknown.
+const WarningHistoryStartsWithoutCreate = "history_starts_without_create"
+
+// Interval is a half-open span [Start, End) over which a resource's billable
+// configuration did not change. An open interval (End nil) means the resource is
+// still in this configuration.
+type Interval struct {
+	Start     time.Time
+	End       *time.Time
+	State     string
+	Size      map[string]any
+	ProjectID string
+}
+
+// Timeline is a resource's folded history.
+type Timeline struct {
+	Intervals []Interval
+	// CreatedAt is the timestamp of the first create event, nil when the history
+	// starts mid-life.
+	CreatedAt *time.Time
+	// DeletedAt is the timestamp of the delete event, nil while the resource lives.
+	DeletedAt *time.Time
+	Warnings  []string
+}
+
+// Build folds an event history into intervals. The input may arrive in any
+// order; Build sorts it by (timestamp, received_at, event_id), which is a total
+// order even when several events share an instant.
+//
+// An empty or nil history yields the zero Timeline.
+func Build(events []event.Stored) Timeline {
+	if len(events) == 0 {
+		return Timeline{}
+	}
+
+	ordered := slices.Clone(events)
+	slices.SortStableFunc(ordered, compare)
+
+	var (
+		tl     Timeline
+		open   Interval
+		isOpen bool
+	)
+
+	for i, e := range ordered {
+		category := event.Categorize(e.EventType)
+
+		if i == 0 && category != event.CategoryCreate {
+			tl.Warnings = append(tl.Warnings, WarningHistoryStartsWithoutCreate)
+		}
+		if category == event.CategoryCreate && tl.CreatedAt == nil {
+			ts := e.Timestamp
+			tl.CreatedAt = &ts
+		}
+
+		// A delete closes the running interval and opens nothing: a deleted
+		// resource accrues no usage, so it produces no interval of its own.
+		if category == event.CategoryDelete {
+			if isOpen {
+				tl.Intervals = appendClosed(tl.Intervals, open, e.Timestamp)
+				isOpen = false
+			}
+			ts := e.Timestamp
+			tl.DeletedAt = &ts
+			continue
+		}
+
+		// An absent state or size means "unchanged", so the running values carry
+		// forward. The top-level project id is always authoritative.
+		next := Interval{
+			Start:     e.Timestamp,
+			State:     open.State,
+			Size:      open.Size,
+			ProjectID: e.ProjectID,
+		}
+		if e.Payload.State != nil {
+			next.State = *e.Payload.State
+		}
+		if e.Payload.Size != nil {
+			next.Size = e.Payload.Size
+		}
+
+		if !isOpen {
+			open, isOpen = next, true
+			continue
+		}
+		if next.State == open.State && next.ProjectID == open.ProjectID && reflect.DeepEqual(next.Size, open.Size) {
+			continue
+		}
+
+		tl.Intervals = appendClosed(tl.Intervals, open, e.Timestamp)
+		open = next
+	}
+
+	if isOpen {
+		tl.Intervals = append(tl.Intervals, open)
+	}
+	return tl
+}
+
+// appendClosed closes an interval at end and keeps it, unless it would carry no
+// duration. Two billable changes at the same instant produce such an interval,
+// and it bills nothing, so it never reaches the result.
+func appendClosed(intervals []Interval, open Interval, end time.Time) []Interval {
+	if !end.After(open.Start) {
+		return intervals
+	}
+	open.End = &end
+	return append(intervals, open)
+}
+
+func compare(a, b event.Stored) int {
+	if c := a.Timestamp.Compare(b.Timestamp); c != 0 {
+		return c
+	}
+	if c := a.ReceivedAt.Compare(b.ReceivedAt); c != 0 {
+		return c
+	}
+	return strings.Compare(a.EventID, b.EventID)
+}

--- a/internal/core/timeline/timeline_test.go
+++ b/internal/core/timeline/timeline_test.go
@@ -1,0 +1,302 @@
+package timeline_test
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/timeline"
+)
+
+var (
+	t0 = time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	t1 = time.Date(2026, time.March, 2, 0, 0, 0, 0, time.UTC)
+	t2 = time.Date(2026, time.March, 3, 0, 0, 0, 0, time.UTC)
+)
+
+type option func(*event.Stored)
+
+func withState(state string) option {
+	return func(s *event.Stored) { s.Payload.State = &state }
+}
+
+func withSize(size map[string]any) option {
+	return func(s *event.Stored) { s.Payload.Size = size }
+}
+
+func withProject(id string) option {
+	return func(s *event.Stored) { s.ProjectID = id }
+}
+
+func withReceivedAt(ts time.Time) option {
+	return func(s *event.Stored) { s.ReceivedAt = ts }
+}
+
+// ev builds a stored event. Defaults keep each test to the one dimension it
+// exercises: same project, receipt at the event time.
+func ev(id, eventType string, ts time.Time, opts ...option) event.Stored {
+	s := event.Stored{
+		Event: event.Event{
+			EventID:      id,
+			Timestamp:    ts,
+			EventType:    eventType,
+			Platform:     "openstack",
+			Cloud:        "os-prod-eu1",
+			ResourceType: "instance",
+			ResourceID:   "i-1",
+			ProjectID:    "p-1",
+			Source:       event.SourceCollector,
+		},
+		ReceivedAt: ts,
+	}
+	for _, opt := range opts {
+		opt(&s)
+	}
+	return s
+}
+
+func TestBuildEmptyHistory(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []event.Stored
+	}{
+		{name: "nil", events: nil},
+		{name: "empty slice", events: []event.Stored{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := timeline.Build(tc.events)
+
+			if len(got.Intervals) != 0 {
+				t.Errorf("Intervals = %v, want none", got.Intervals)
+			}
+			if got.CreatedAt != nil {
+				t.Errorf("CreatedAt = %v, want nil", got.CreatedAt)
+			}
+			if got.DeletedAt != nil {
+				t.Errorf("DeletedAt = %v, want nil", got.DeletedAt)
+			}
+			if len(got.Warnings) != 0 {
+				t.Errorf("Warnings = %v, want none", got.Warnings)
+			}
+		})
+	}
+}
+
+func TestBuildSingleCreateStaysOpen(t *testing.T) {
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 4})),
+	})
+
+	if len(got.Intervals) != 1 {
+		t.Fatalf("got %d intervals, want 1: %+v", len(got.Intervals), got.Intervals)
+	}
+	if got.Intervals[0].End != nil {
+		t.Errorf("End = %v, want nil for a live resource", got.Intervals[0].End)
+	}
+	if !got.Intervals[0].Start.Equal(t0) {
+		t.Errorf("Start = %v, want %v", got.Intervals[0].Start, t0)
+	}
+	if got.CreatedAt == nil || !got.CreatedAt.Equal(t0) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, t0)
+	}
+}
+
+func TestBuildCreateThenDelete(t *testing.T) {
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 4})),
+		ev("e2", "compute.instance.delete.end", t1),
+	})
+
+	if len(got.Intervals) != 1 {
+		t.Fatalf("got %d intervals, want 1: %+v", len(got.Intervals), got.Intervals)
+	}
+	if got.Intervals[0].End == nil || !got.Intervals[0].End.Equal(t1) {
+		t.Errorf("End = %v, want %v", got.Intervals[0].End, t1)
+	}
+	if got.DeletedAt == nil || !got.DeletedAt.Equal(t1) {
+		t.Errorf("DeletedAt = %v, want %v", got.DeletedAt, t1)
+	}
+	// A deleted resource accrues nothing, so the delete opens no interval.
+	for _, interval := range got.Intervals {
+		if interval.State == "deleted" {
+			t.Errorf("found an interval in state deleted: %+v", interval)
+		}
+	}
+}
+
+func TestBuildCreateResizeDelete(t *testing.T) {
+	small := map[string]any{"vcpus": 2}
+	large := map[string]any{"vcpus": 4}
+
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(small)),
+		ev("e2", "compute.instance.resize.end", t1, withState("active"), withSize(large)),
+		ev("e3", "compute.instance.delete.end", t2),
+	})
+
+	if len(got.Intervals) != 2 {
+		t.Fatalf("got %d intervals, want 2: %+v", len(got.Intervals), got.Intervals)
+	}
+	if got.Intervals[0].End == nil || !got.Intervals[0].End.Equal(t1) {
+		t.Errorf("first interval End = %v, want the resize timestamp %v", got.Intervals[0].End, t1)
+	}
+	if !got.Intervals[1].Start.Equal(t1) {
+		t.Errorf("second interval Start = %v, want the resize timestamp %v", got.Intervals[1].Start, t1)
+	}
+	if !reflect.DeepEqual(got.Intervals[0].Size, small) {
+		t.Errorf("first interval Size = %v, want %v", got.Intervals[0].Size, small)
+	}
+	if !reflect.DeepEqual(got.Intervals[1].Size, large) {
+		t.Errorf("second interval Size = %v, want %v", got.Intervals[1].Size, large)
+	}
+}
+
+func TestBuildResizeToAnEqualSizeIsNotBillable(t *testing.T) {
+	// Deep equality, not identity: a second map with the same contents is the
+	// same size and must not split the interval.
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 2})),
+		ev("e2", "compute.instance.resize.end", t1, withState("active"), withSize(map[string]any{"vcpus": 2})),
+	})
+
+	if len(got.Intervals) != 1 {
+		t.Fatalf("got %d intervals, want 1: %+v", len(got.Intervals), got.Intervals)
+	}
+}
+
+func TestBuildOrdersEqualTimestampsByReceivedAt(t *testing.T) {
+	early := t1.Add(-time.Hour)
+	late := t1.Add(time.Hour)
+
+	// Both changes carry the same event timestamp; the receipt order decides
+	// which state the resource ends in.
+	got := timeline.Build([]event.Stored{
+		ev("e3", "compute.instance.power_on.end", t1, withState("second"), withReceivedAt(late)),
+		ev("e2", "compute.instance.power_off.end", t1, withState("first"), withReceivedAt(early)),
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 2})),
+	})
+
+	last := got.Intervals[len(got.Intervals)-1]
+	if last.State != "second" {
+		t.Errorf("final state = %q, want %q (received_at breaks the tie)", last.State, "second")
+	}
+}
+
+func TestBuildOrdersEqualTimestampsAndReceiptsByEventID(t *testing.T) {
+	// Same timestamp and same receipt: only the event id is left to order by.
+	got := timeline.Build([]event.Stored{
+		ev("e-b", "compute.instance.power_on.end", t1, withState("second")),
+		ev("e-a", "compute.instance.power_off.end", t1, withState("first")),
+		ev("e-0", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 2})),
+	})
+
+	last := got.Intervals[len(got.Intervals)-1]
+	if last.State != "second" {
+		t.Errorf("final state = %q, want %q (event_id breaks the tie)", last.State, "second")
+	}
+}
+
+func TestBuildIgnoresNonBillableEvent(t *testing.T) {
+	size := map[string]any{"vcpus": 2}
+
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(size)),
+		// Same state, same size, same project: nothing billable changed.
+		ev("e2", "compute.instance.metadata.update.end", t1, withState("active"), withSize(size)),
+	})
+
+	if len(got.Intervals) != 1 {
+		t.Fatalf("got %d intervals, want 1: %+v", len(got.Intervals), got.Intervals)
+	}
+	if got.Intervals[0].End != nil {
+		t.Errorf("End = %v, want nil: a no-op event must not close the interval", got.Intervals[0].End)
+	}
+}
+
+func TestBuildDropsZeroLengthIntervals(t *testing.T) {
+	// Two billable changes at one instant leave an interval of no duration
+	// between them, which bills nothing and must not appear.
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 2})),
+		ev("e2", "compute.instance.power_off.end", t1, withState("shutoff"), withReceivedAt(t1)),
+		ev("e3", "compute.instance.power_on.end", t1, withState("active"), withReceivedAt(t1.Add(time.Second))),
+	})
+
+	for _, interval := range got.Intervals {
+		if interval.End != nil && !interval.End.After(interval.Start) {
+			t.Errorf("zero-length interval survived: %+v", interval)
+		}
+	}
+	if len(got.Intervals) != 2 {
+		t.Fatalf("got %d intervals, want 2: %+v", len(got.Intervals), got.Intervals)
+	}
+}
+
+func TestBuildProjectTransferSplitsInterval(t *testing.T) {
+	size := map[string]any{"vcpus": 2}
+
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(size)),
+		ev("e2", "volume.transfer.accept.end", t1, withState("active"), withSize(size), withProject("p-2")),
+	})
+
+	if len(got.Intervals) != 2 {
+		t.Fatalf("got %d intervals, want 2: %+v", len(got.Intervals), got.Intervals)
+	}
+	if got.Intervals[0].ProjectID != "p-1" || got.Intervals[1].ProjectID != "p-2" {
+		t.Errorf("project ids = %q then %q, want p-1 then p-2",
+			got.Intervals[0].ProjectID, got.Intervals[1].ProjectID)
+	}
+}
+
+func TestBuildHistoryStartingWithoutCreate(t *testing.T) {
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.power_off.end", t0, withState("shutoff"), withSize(map[string]any{"vcpus": 2})),
+	})
+
+	if len(got.Intervals) != 1 {
+		t.Fatalf("got %d intervals, want 1: %+v", len(got.Intervals), got.Intervals)
+	}
+	if !got.Intervals[0].Start.Equal(t0) {
+		t.Errorf("Start = %v, want the first event %v", got.Intervals[0].Start, t0)
+	}
+	if got.CreatedAt != nil {
+		t.Errorf("CreatedAt = %v, want nil: the create was never seen", got.CreatedAt)
+	}
+	if !slices.Contains(got.Warnings, timeline.WarningHistoryStartsWithoutCreate) {
+		t.Errorf("Warnings = %v, want %q", got.Warnings, timeline.WarningHistoryStartsWithoutCreate)
+	}
+}
+
+func TestBuildLoneDelete(t *testing.T) {
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.delete.end", t1),
+	})
+
+	if len(got.Intervals) != 0 {
+		t.Errorf("Intervals = %+v, want none", got.Intervals)
+	}
+	if got.DeletedAt == nil || !got.DeletedAt.Equal(t1) {
+		t.Errorf("DeletedAt = %v, want %v", got.DeletedAt, t1)
+	}
+	if !slices.Contains(got.Warnings, timeline.WarningHistoryStartsWithoutCreate) {
+		t.Errorf("Warnings = %v, want %q", got.Warnings, timeline.WarningHistoryStartsWithoutCreate)
+	}
+}
+
+func TestBuildDoesNotMutateInput(t *testing.T) {
+	events := []event.Stored{
+		ev("e2", "compute.instance.delete.end", t1),
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(map[string]any{"vcpus": 2})),
+	}
+
+	timeline.Build(events)
+
+	if events[0].EventID != "e2" {
+		t.Errorf("Build sorted the caller's slice in place: %q is first", events[0].EventID)
+	}
+}

--- a/roadmap/00-conventions.md
+++ b/roadmap/00-conventions.md
@@ -105,7 +105,7 @@ tally/
 ├── pricing/                       # versioned pricing model YAML files (Phase 3)
 ├── deploy/
 │   ├── kind/
-│   │   └── kind.yaml              # kind cluster config: pinned node image; ports 80/443/5432 → Gateway
+│   │   └── kind.yaml              # kind cluster config: pinned node image; host ports 8081/8443/5432 → Gateway
 │   └── kubernetes/
 │       ├── base/                  # kustomize base — one directory per component
 │       │   ├── kustomization.yaml

--- a/roadmap/01-phase-1-core-platform-openstack.md
+++ b/roadmap/01-phase-1-core-platform-openstack.md
@@ -69,15 +69,21 @@ WP1.1 scaffolding ─▶ WP1.2 core library ─▶ WP1.3 API skeleton+DB ─▶ 
   for local trust), `test`, `lint` (golangci-lint), `fmt` (gofumpt), `migrate` (goose up,
   both chains), `generate` (oapi-codegen, sqlc); add-on versions are pinned in the Makefile
 - `deploy/kind/kind.yaml` — cluster name `tally`, pinned `kindest/node` image, and exactly
-  three `extraPortMappings`: `80`, `443`, `5432`, wired to the Envoy proxy Service (fixed
-  NodePorts, pinned via an `EnvoyProxy` config in the dev overlay). **All** traffic enters
-  through the Gateway — no per-service host ports.
+  three `extraPortMappings`, wired to the Envoy proxy Service (fixed NodePorts, pinned via
+  an `EnvoyProxy` config in the dev overlay). **All** traffic enters through the Gateway —
+  no per-service host ports. The host side binds `8081` (http), `8443` (https), and `5432`
+  (postgres): Docker Desktop needs the `com.docker.vmnetd` helper to publish a privileged
+  port and does not have it on every Mac, and rootless Docker and Podman cannot publish one
+  at all. Only the host binding moves — node ports, Envoy Service ports, and Gateway
+  listeners keep the standard numbers, so prod is unaffected.
 - `deploy/kubernetes/base/gateway/` — `GatewayClass` `tally` (Envoy Gateway controller) and
   one `Gateway` `tally` with listeners `http` (:80, `RequestRedirect` → https), `https`
   (:443, wildcard certificate from a cert-manager `Certificate`), `postgres` (:5432, TCP;
   Gateway API experimental channel for `TCPRoute`). Dev hostname scheme
   `*.tally.127-0-0-1.nip.io` — nip.io resolves it to `127.0.0.1`, so dev has real URLs
-  without `/etc/hosts` edits.
+  without `/etc/hosts` edits, carrying the `:8443` suffix the host binding implies. The
+  redirect filter takes no port in the base (prod redirects to 443); the dev overlay patches
+  `port: 8443` into it so the `Location` header points at a port that is actually open.
 - `deploy/kubernetes/base/` (kustomize base) with components:
   - `timescaledb/` — StatefulSet, image `timescale/timescaledb:latest-pg16`, DB
     `tally_reporting`, PVC, readiness probe `pg_isready`, Service, `TCPRoute` on the
@@ -99,9 +105,9 @@ WP1.1 scaffolding ─▶ WP1.2 core library ─▶ WP1.3 API skeleton+DB ─▶ 
     readiness; Service, `HTTPRoute` → dev: `api.tally.127-0-0-1.nip.io`
 - `deploy/kubernetes/overlays/dev/` — namespace `tally`, nip.io hostname patches on all
   routes, self-signed CA `ClusterIssuer` (cert-manager), `EnvoyProxy` config pinning the
-  proxy Service NodePorts to match `kind.yaml`, dev-only Secret values, `replicas: 1`
-  everywhere; the prod overlay later swaps hostnames and issuer — Gateway and routes stay
-  identical
+  proxy Service NodePorts to match `kind.yaml`, the `port: 8443` patch on the redirect
+  route, dev-only Secret values, `replicas: 1` everywhere; the prod overlay later swaps
+  hostnames and issuer — Gateway and routes stay identical
 - `Tiltfile` — `docker_build` per service image (root `Dockerfile`, `ARG CMD`),
   `k8s_yaml(kustomize('deploy/kubernetes/overlays/dev'))`, resource grouping with the
   nip.io URLs attached as resource links (no port-forwards needed — the Gateway serves
@@ -115,8 +121,9 @@ WP1.1 scaffolding ─▶ WP1.2 core library ─▶ WP1.3 API skeleton+DB ─▶ 
 - `make up` creates the kind cluster, installs Envoy Gateway + cert-manager, and deploys
   the dev overlay; `kubectl get pods -n tally` shows all pods `Ready` (TimescaleDB,
   VictoriaMetrics, OTel Collector, Reporting API); the `Gateway` reports `Programmed`.
-- `https://vm.tally.127-0-0-1.nip.io` serves the VictoriaMetrics UI (`curl --cacert
-  <(make -s ca)` verifies cleanly; plain `http://` redirects to `https://`).
+- `https://vm.tally.127-0-0-1.nip.io:8443` serves the VictoriaMetrics UI (`curl --cacert
+  <(make -s ca)` verifies cleanly; `http://vm.tally.127-0-0-1.nip.io:8081` redirects to
+  the `:8443` URL).
 - `psql "host=db.tally.127-0-0-1.nip.io port=5432 ..."` reaches TimescaleDB through the
   Gateway's TCP listener (prerequisite for `make migrate`).
 - `tilt up` turns green for every resource; changing Go code rebuilds and redeploys the
@@ -372,7 +379,7 @@ setup, request-ID middleware.
 
 **Acceptance criteria**: `make migrate` creates the schema on the dev cluster (reaching
 TimescaleDB through the Gateway's `postgres` listener at `db.tally.127-0-0-1.nip.io:5432`);
-`GET https://api.tally.127-0-0-1.nip.io/healthz` returns 200 through the Gateway; hypertable +
+`GET https://api.tally.127-0-0-1.nip.io:8443/healthz` returns 200 through the Gateway; hypertable +
 compression policy verified in an integration test (`SELECT * FROM timescaledb_information.hypertables`).
 
 ---
@@ -953,8 +960,8 @@ scrape_configs:
    decision in `docs/openstack-metrics.md`.
 
 **Acceptance criteria**: on the dev cluster, a metric pushed to
-`https://otlp.tally.127-0-0-1.nip.io` (OTLP/HTTP through the Gateway) appears in
-VictoriaMetrics (`https://vm.tally.127-0-0-1.nip.io/api/v1/query`); scrape configs load
+`https://otlp.tally.127-0-0-1.nip.io:8443` (OTLP/HTTP through the Gateway) appears in
+VictoriaMetrics (`https://vm.tally.127-0-0-1.nip.io:8443/api/v1/query`); scrape configs load
 without error; evaluation doc committed.
 
 ---

--- a/roadmap/02-phase-2-reporting-dashboards.md
+++ b/roadmap/02-phase-2-reporting-dashboards.md
@@ -82,11 +82,13 @@ Add a `grafana` component to the kustomize base: Deployment (image `grafana/graf
 provisioning tree and dashboard JSON mounted from ConfigMaps (`configMapGenerator` — editing
 a dashboard file re-rolls the pod), admin password from a Secret, Service, and an
 `HTTPRoute` on the existing Gateway — dev hostname `grafana.tally.127-0-0-1.nip.io`,
-`GF_SERVER_ROOT_URL` derived from the route hostname. The dev overlay enables anonymous
+`GF_SERVER_ROOT_URL` derived from the route hostname. In dev that root URL has to carry the
+`:8443` host port (`https://grafana.tally.127-0-0-1.nip.io:8443`), or every absolute link and
+redirect Grafana emits points at a closed port. The dev overlay enables anonymous
 viewer access. No new host ports and no cluster changes — the route is live as soon as it
 is applied. The same base deploys unchanged to a real cluster via the prod overlay.
 
-**Acceptance criteria**: `make up` → `https://grafana.tally.127-0-0-1.nip.io` shows all
+**Acceptance criteria**: `make up` → `https://grafana.tally.127-0-0-1.nip.io:8443` shows all
 four dashboards with data from the dev cluster.
 
 ---


### PR DESCRIPTION
Turns an empty repository into a buildable Go monorepo with a Kubernetes dev environment and the shared domain library every later Phase 1 package imports. Covers WP 1.1 and WP 1.2 of `roadmap/01-phase-1-core-platform-openstack.md`.

Closes #2

## The commits, in order

**`Add the Go module, lint configuration, and CI workflow`** — the single module `github.com/b42labs/tally` with the toolchain pinned, `.golangci.yml` in v2 format carrying the conventions-section-6 float ban as two `forbidigo` patterns, gofumpt wired as the golangci-lint formatter, and a GitHub Actions job running lint, vet, and test.

**`Add the shared core library internal/core`** — `event` (wire types, a payload envelope that preserves unknown fields across a round-trip, `Validate`, `Categorize`), `ids` (deterministic and synthetic event-id hashing), `timeline` (the folding algorithm shared by projection replay, the lifecycle endpoint, and the Phase 3 engine), `money` (the only rounding and division entry points), and `testkit` (the provider conformance assertions). 44 unit tests, no I/O.

**`Add the placeholder Reporting API binary and the service Dockerfile`** — a stdlib-only binary answering the liveness and readiness probes, so the dev cluster reports every pod Ready and the Gateway, route, and certificate chain is proven against a real application pod. #3 replaces the file wholesale. The Dockerfile builds any `cmd/` package into a static binary on distroless.

**`Add the kind dev cluster, Makefile, and Tilt loop`** — the kustomize base (Gateway, TimescaleDB, VictoriaMetrics, OTel Collector, Reporting API), the dev overlay with nip.io hostnames and a self-signed CA, and the make targets.

## Decisions worth a reviewer's attention

**The kind node image is held one Kubernetes minor behind kind's default.** Envoy Gateway v1.8 supports Kubernetes v1.32 to v1.35; kind v0.32.0 defaults to v1.36.1, outside that range. Pinned to `kindest/node:v1.35.5` by digest.

**No separate Gateway API install.** Envoy Gateway v1.8.3's `install.yaml` already bundles the experimental-channel CRDs at bundle-version v1.5.1, `TCPRoute` included, so `make up` verifies the CRD is present and fails loudly rather than layering a second Gateway API version on top.

**`make migrate` runs goose from the module cache at a pinned version rather than from a `go.mod` tool directive.** The tool directive was tried and reverted: goose's CLI pulls in drivers for ClickHouse, MSSQL, YDB, Vertica, and libsql, adding 60 indirect dependencies and 240 lines of `go.sum` for a target that cannot run until the first migration lands in #3.

**Every `kubectl` call in the Makefile pins `--context kind-tally`.** Creating a kind cluster switches the current context, but reusing an existing one does not, so an unqualified `kubectl` in `make up` would deploy Tally into whatever cluster happened to be selected.

**`make fmt` drives gofumpt through `golangci-lint fmt`** instead of a standalone `gofumpt -w .`, so the formatter that writes and the linter that checks can never disagree on a version.

## Verification

Green locally: `go build ./...`, `go vet ./...`, `go test ./...` (44 tests, 5 packages), `make lint`, `make fmt`, `make migrate` and `make generate` on their empty-input paths, `make down` including the no-cluster path. The `forbidigo` guardrail was exercised by adding a file calling `decimal.NewFromFloat` and watching lint fail with the conventions-section-6 message, then pass again once removed. The config and the lint run were re-checked under the exact version CI pins, v2.12.2.

Every manifest in the dev overlay validates against a real API server with the real CRDs, through `kubectl apply --dry-run=server -k`: the Gateway, GatewayClass, all four HTTP routes, the GRPCRoute, the TCPRoute, the `EnvoyProxy` node-port patch, both cert-manager Certificates, and every workload.

**Not verified on the machine this was written on**, for reasons that are host limitations rather than defects in the change:

- Pod readiness, TLS through the Gateway, the HTTP-to-HTTPS redirect, the OTLP endpoint, and `psql` over the TCP listener. Docker Desktop on that host cannot bind privileged ports 80 and 443 (the `com.docker.vmnetd` helper is absent), and its 7.75 GiB VM was already saturated by three other kind clusters, so a fourth cluster's `kube-scheduler` and `kube-controller-manager` crash-looped. `make up` got as far as installing cert-manager and Envoy Gateway and confirming the `TCPRoute` CRD before the starved control plane stopped creating ReplicaSets.
- `tilt up`. Tilt is not installed there.

Both need one `make up` on a machine with room for the cluster.
