### PR TITLE
Expose query endpoints for events, resources, lifecycles, and dead-lettered events

### DIFF
--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -17,9 +17,9 @@ info:
   version: 0.1.0
   description: >-
     Event ingestion, resource inventory, and usage reporting for Tally.
-    This document covers the health probes, event ingestion, the resource-type
-    registry, and the projection rebuild; the query and reporting endpoints
-    arrive with their work packages.
+    This document covers the health probes, event ingestion, the queries over
+    events, resources, and lifecycles, the resource-type registry, dead-letter
+    review, and the projection rebuild.
 
 paths:
   /healthz:
@@ -154,14 +154,7 @@ paths:
             minimum: 1
             maximum: 1000
             default: 100
-        - name: cursor
-          in: query
-          description: >-
-            The `next_cursor` of the page before this one. It is opaque: a
-            client passes it back as it received it and reads nothing out of
-            it.
-          schema:
-            type: string
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
           description: One page of stored events.
@@ -298,14 +291,7 @@ paths:
             minimum: 1
             maximum: 1000
             default: 100
-        - name: cursor
-          in: query
-          description: >-
-            The `next_cursor` of the page before this one. It is opaque: a
-            client passes it back as it received it and reads nothing out of
-            it.
-          schema:
-            type: string
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
           description: One page of current resources.
@@ -551,6 +537,74 @@ paths:
         "500":
           $ref: "#/components/responses/Problem"
 
+  /api/v1/rejected-events:
+    get:
+      operationId: listRejectedEvents
+      summary: List the dead-lettered events
+      description: >-
+        Returns every ingest item this API refused server-side, with the reason
+        it was refused and the raw body as it was submitted. The order is
+        `(received_at, id)` ascending. `from` and `to` select the half-open
+        window `[from, to)` on `received_at`, which is when the item was refused
+        rather than when its event claims to have happened: an item received at
+        exactly `from` is served, one received at exactly `to` is not.
+
+        One call answers one page. `items` carries the items, and `next_cursor`
+        is what the next call passes as `cursor`; a null `next_cursor` is the
+        end of the walk. The cursor holds a position and nothing else, so
+        presenting it together with other filters is well defined: the filters
+        of that call apply from that position onwards.
+
+        The operation is admin-only: callers below the admin role are answered
+        403. No project scope applies, because the raw JSON of a refused item
+        carries no reliable project attribution.
+      security:
+        - apiToken: []
+      parameters:
+        - name: from
+          in: query
+          description: >-
+            Serve only the items refused at or after this instant, the inclusive
+            bound of the window.
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: >-
+            Serve only the items refused before this instant, the exclusive
+            bound of the window.
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          description: How many items one page carries at most.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: One page of dead-lettered events.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeadLetterList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
   # This route is not part of the public API: the other Tally components call it
   # with the shared internal token. It is described here because the request
   # validator refuses a path the contract does not carry, so leaving it out
@@ -612,6 +666,20 @@ components:
         sends and generates one otherwise; it appears on every log line of the
         request, so quoting it in a support request is what ties the two
         together.
+      schema:
+        type: string
+
+  parameters:
+    # The three paginated lists declare this parameter verbatim, so it lives
+    # here once: the wording a caller reads about the cursor's opacity is the
+    # same on every list, and it stays that way.
+    Cursor:
+      name: cursor
+      in: query
+      description: >-
+        The `next_cursor` of the page before this one. It is opaque: a
+        client passes it back as it received it and reads nothing out of
+        it.
       schema:
         type: string
 
@@ -1008,7 +1076,8 @@ components:
           description: >-
             Where the next page starts. It is always null today: the registry
             holds one row per resource type, so every registration fits into one
-            answer. Cursor pagination arrives with the query endpoints.
+            answer. The registry list stays a single page, while the query lists
+            page with cursors.
 
     RegisterResourceType:
       type: object
@@ -1021,6 +1090,54 @@ components:
             A JSON Schema draft 2020-12 document. It is compiled before it is
             stored, so the document a registration accepts is exactly the one
             ingestion can apply later.
+
+    # The name avoids RejectedEvent above, which is the ingest response's item
+    # and a different shape: that one names the position in the submitted batch,
+    # this one the dead-letter row ingestion kept.
+    DeadLetteredEvent:
+      type: object
+      description: >-
+        One ingest item this API refused, as the dead-letter table holds it.
+      required: [id, received_at, reason, raw]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: >-
+            The dead-letter row. A refused item has no event id this API can
+            trust, so the row's own id is what names it.
+        received_at:
+          type: string
+          format: date-time
+          description: When this API refused the item.
+        reason:
+          type: string
+          description: >-
+            Why ingestion refused the item, a schema violation for example,
+            prefixed the way the ingest response reports it.
+        raw:
+          description: >-
+            The item as it was submitted, with NUL characters scrubbed at
+            ingest. Nothing is constrained here: what a collector sent need not
+            be a JSON object, and this member carries whatever it was.
+
+    DeadLetterList:
+      type: object
+      description: One page of dead-lettered events.
+      required: [items, next_cursor]
+      properties:
+        items:
+          type: array
+          description: >-
+            The refused items of this page, ordered by received_at and id.
+          items:
+            $ref: "#/components/schemas/DeadLetteredEvent"
+        next_cursor:
+          type: string
+          nullable: true
+          description: >-
+            Where the next page starts, passed back as `cursor`. It is null on
+            the last page.
 
     RebuildRequest:
       type: object

--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -71,6 +71,115 @@ paths:
           $ref: "#/components/responses/Problem"
 
   /api/v1/events:
+    get:
+      operationId: listEvents
+      summary: List stored events
+      description: >-
+        Returns every stored event, narrowed by whichever filters the request
+        carries. The order is `(timestamp, event_id)` ascending. `from` and `to`
+        select the half-open window `[from, to)` on the event timestamp: an
+        event at exactly `from` is served, one at exactly `to` is not.
+
+        One call answers one page. `items` carries the events, and
+        `next_cursor` is what the next call passes as `cursor`; a null
+        `next_cursor` is the end of the walk. The cursor holds a position and
+        nothing else, so presenting it together with other filters is well
+        defined: the filters of that call apply from that position onwards.
+
+        This list is event-scoped rather than resource-scoped. A project token
+        reads every event whose `project_id` names one of its projects,
+        including the events a resource carried before it was transferred
+        away. The per-resource reads decide on the project the projection row
+        names today, so they stop serving the resource to the old project once
+        the transfer is stored.
+      security:
+        - apiToken: []
+      parameters:
+        - name: cloud
+          in: query
+          description: Serve only the events of this cloud.
+          schema:
+            type: string
+        - name: platform
+          in: query
+          description: Serve only the events of this platform.
+          schema:
+            type: string
+        - name: project_id
+          in: query
+          description: >-
+            Serve only the events of this project, named the way its cloud
+            names it. A token asking for a project outside its scope is
+            answered 403.
+          schema:
+            type: string
+        - name: resource_type
+          in: query
+          description: Serve only the events about resources of this type.
+          schema:
+            type: string
+        - name: event_type
+          in: query
+          description: >-
+            Serve only the events of this type, volume.create for example.
+          schema:
+            type: string
+        - name: source
+          in: query
+          description: Serve only the events the named pipeline produced.
+          schema:
+            type: string
+            enum: [collector, reconciliation]
+        - name: from
+          in: query
+          description: >-
+            Serve only the events at or after this instant, the inclusive bound
+            of the window.
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: >-
+            Serve only the events before this instant, the exclusive bound of
+            the window.
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          description: How many events one page carries at most.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - name: cursor
+          in: query
+          description: >-
+            The `next_cursor` of the page before this one. It is opaque: a
+            client passes it back as it received it and reads nothing out of
+            it.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: One page of stored events.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
     post:
       operationId: ingestEvents
       summary: Ingest events
@@ -400,6 +509,76 @@ components:
           description: >-
             Why the item was refused, for example
             "size_schema: 'vcpus' is a required property".
+
+    StoredEvent:
+      type: object
+      description: >-
+        One event as the events table holds it: what was submitted, plus the
+        instant this API stored it.
+      required: [event_id, timestamp, event_type, platform, cloud, resource_type,
+                 resource_id, project_id, source, payload, received_at]
+      properties:
+        event_id:
+          type: string
+          description: The idempotency key the event was submitted under.
+        timestamp:
+          type: string
+          format: date-time
+          description: When the event happened.
+        event_type:
+          type: string
+          description: >-
+            What happened, written resource.action with an optional phase, for
+            example compute.instance.create.end.
+        platform:
+          type: string
+          description: The platform the resource lives on.
+        cloud:
+          type: string
+          description: The installation the resource lives in.
+        resource_type:
+          type: string
+          description: The kind of resource the event is about.
+        resource_id:
+          type: string
+          description: The resource the event is about.
+        project_id:
+          type: string
+          description: The project owning the resource at or after this event.
+        source:
+          type: string
+          description: >-
+            Which pipeline produced the event, collector or reconciliation. It
+            is what the server recorded rather than what the submitter claimed.
+        payload:
+          type: object
+          nullable: true
+          description: >-
+            The normalized payload envelope, member for member as it was
+            stored. It is null for an event stored without one, which a delete
+            event may be. The members are not constrained here: an envelope
+            keeps the fields a provider sent beyond the ones this API names.
+        received_at:
+          type: string
+          format: date-time
+          description: When this API stored the event.
+
+    EventList:
+      type: object
+      description: One page of stored events.
+      required: [items, next_cursor]
+      properties:
+        items:
+          type: array
+          description: The events of this page, ordered by timestamp and event id.
+          items:
+            $ref: "#/components/schemas/StoredEvent"
+        next_cursor:
+          type: string
+          nullable: true
+          description: >-
+            Where the next page starts, passed back as `cursor`. It is null on
+            the last page.
 
     ResourceType:
       type: object

--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -89,9 +89,9 @@ paths:
         This list is event-scoped rather than resource-scoped. A project token
         reads every event whose `project_id` names one of its projects,
         including the events a resource carried before it was transferred
-        away. The per-resource reads decide on the project the projection row
-        names today, so they stop serving the resource to the old project once
-        the transfer is stored.
+        away. The per-resource reads scope every event the same way, so a
+        transfer moves the resource to its new project without handing that
+        project the history the resource carried under the old one.
       security:
         - apiToken: []
       parameters:
@@ -219,6 +219,238 @@ paths:
         "401":
           $ref: "#/components/responses/Problem"
         "413":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/resources:
+    get:
+      operationId: listResources
+      summary: List the current resources
+      description: >-
+        Returns the projection rows, one per resource, narrowed by whichever
+        filters the request carries. The order is
+        `(cloud, resource_type, resource_id)` ascending.
+
+        One call answers one page. `items` carries the rows, and `next_cursor`
+        is what the next call passes as `cursor`; a null `next_cursor` is the
+        end of the walk. The cursor holds a position and nothing else, so
+        presenting it together with other filters is well defined: the filters
+        of that call apply from that position onwards.
+
+        A deleted resource keeps its row, with `state` deleted and `deleted_at`
+        set. Rows are never removed, so a resource that is gone stays readable
+        here and through its history.
+
+        A project token reads the rows whose (cloud, project_id) pair one of
+        its projects names. The pair is what decides, so a project id another
+        cloud uses for something else stays out of the answer.
+      security:
+        - apiToken: []
+      parameters:
+        - name: cloud
+          in: query
+          description: Serve only the resources of this cloud.
+          schema:
+            type: string
+        - name: platform
+          in: query
+          description: Serve only the resources of this platform.
+          schema:
+            type: string
+        - name: project_id
+          in: query
+          description: >-
+            Serve only the resources of this project, named the way its cloud
+            names it. A token asking for a project outside its scope is
+            answered 403.
+          schema:
+            type: string
+        - name: resource_type
+          in: query
+          description: Serve only the resources of this type.
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: >-
+            Serve only the resources whose current state is exactly this,
+            shutoff for example.
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: >-
+            Which part of the fleet to serve. `active` serves the rows whose
+            state is not deleted, `deleted` serves those alone, and `all`
+            serves both. `state` and `status` are independent filters, so a
+            contradictory pair such as `state=active&status=deleted` yields the
+            empty page.
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+        - name: limit
+          in: query
+          description: How many resources one page carries at most.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - name: cursor
+          in: query
+          description: >-
+            The `next_cursor` of the page before this one. It is opaque: a
+            client passes it back as it received it and reads nothing out of
+            it.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: One page of current resources.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/resources/{cloud}/{resource_type}/{resource_id}/events:
+    parameters:
+      - name: cloud
+        in: path
+        required: true
+        description: The installation the resource lives in, os-prod-eu1 for example.
+        schema:
+          type: string
+      - name: resource_type
+        in: path
+        required: true
+        description: The kind of resource, instance or volume for example.
+        schema:
+          type: string
+      - name: resource_id
+        in: path
+        required: true
+        description: The resource itself, as its cloud names it.
+        schema:
+          type: string
+    get:
+      operationId: listResourceEvents
+      summary: Read the event history of one resource
+      description: >-
+        Returns the history of one resource, ordered by
+        `(timestamp, received_at, event_id)`. The answer is never paginated:
+        one call carries every event the request may see, and `next_cursor` is
+        always null. A resource with more than 10000 stored events is answered
+        422 (`urn:tally:error:history_too_long`) rather than a truncated
+        history; `GET /api/v1/events` pages such a history.
+
+        The read is gated on the project the resource's projection row names
+        today. A project token whose scope does not hold that
+        (cloud, project_id) pair is answered the 404 an unknown resource gets,
+        so a resource outside the scope cannot be told from one that does not
+        exist. Every served event is scoped the same way, so a project reads
+        the part of the history its own projects carried and no more: after a
+        transfer the old project stops reading the resource here, and the new
+        one reads the events stored since the transfer rather than the whole
+        history. `GET /api/v1/events` is where the old project keeps reading
+        the events it carried.
+      security:
+        - apiToken: []
+      responses:
+        "200":
+          description: >-
+            The ordered history of the resource, with `next_cursor` null.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventList"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle:
+    parameters:
+      - name: cloud
+        in: path
+        required: true
+        description: The installation the resource lives in, os-prod-eu1 for example.
+        schema:
+          type: string
+      - name: resource_type
+        in: path
+        required: true
+        description: The kind of resource, instance or volume for example.
+        schema:
+          type: string
+      - name: resource_id
+        in: path
+        required: true
+        description: The resource itself, as its cloud names it.
+        schema:
+          type: string
+    get:
+      operationId: getResourceLifecycle
+      summary: Read the folded lifecycle of one resource
+      description: >-
+        Returns the resource's history folded into the half-open billable
+        intervals of roadmap/00-conventions.md section 5, next to the
+        projection row and the events the fold ran on. It is the fold the
+        projection replay runs, so the intervals here are the ones every
+        derived row comes from.
+
+        `warnings` names what the fold could not trust, a history that starts
+        without a create for example.
+
+        The read is gated and scoped the way the per-resource history is: a
+        resource this API holds no projection row for and a resource outside
+        the token's scope are answered the same 404, the events a project token
+        folds are its own projects' events, and a resource with more than 10000
+        stored events is answered 422
+        (`urn:tally:error:history_too_long`). Folding a scoped history is what
+        keeps the intervals a project reads the spans it is billed for: a
+        transferred resource is folded from the transfer onwards, which
+        `warnings` reports as a history that starts without a create.
+
+        The embedded `resource` is the projection row and is not scoped, so its
+        `created_at` can predate the reader's ownership while the intervals
+        start at the transfer. Bill from `intervals`.
+      security:
+        - apiToken: []
+      responses:
+        "200":
+          description: The resource, its history, and the intervals it folds into.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Lifecycle"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "422":
           $ref: "#/components/responses/Problem"
         "500":
           $ref: "#/components/responses/Problem"
@@ -579,6 +811,162 @@ components:
           description: >-
             Where the next page starts, passed back as `cursor`. It is null on
             the last page.
+
+    Resource:
+      type: object
+      description: >-
+        One resource as the projection holds it: what its event history says it
+        is right now.
+      required: [cloud, platform, resource_type, resource_id, project_id, state,
+                 size, created_at, deleted_at, last_event_type, last_event_at,
+                 last_payload]
+      properties:
+        cloud:
+          type: string
+          description: The installation the resource lives in.
+        platform:
+          type: string
+          description: The platform the resource lives on.
+        resource_type:
+          type: string
+          description: The kind of resource.
+        resource_id:
+          type: string
+          description: The resource itself, as its cloud names it.
+        project_id:
+          type: string
+          description: The project owning the resource now.
+        state:
+          type: string
+          description: >-
+            The state the resource is in now. A deleted resource carries
+            deleted, which the server sets itself rather than reading it off the
+            delete event.
+        size:
+          type: object
+          description: >-
+            The size the resource has now, member for member as its events
+            reported it. It is the empty object for a history that reported no
+            size.
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the resource was created, as the projection folded it from the
+            resource's whole history. It is null for a history that never showed
+            a create. The projection is not scoped to the reading token, so on a
+            resource that changed projects this is the create of the project it
+            came from and predates the reader's ownership: what a project is
+            billed for is the lifecycle's `intervals`, never `created_at` paired
+            with `deleted_at`.
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the resource was deleted, null while it lives.
+        last_event_type:
+          type: string
+          description: The type of the newest event folded into this row.
+        last_event_at:
+          type: string
+          format: date-time
+          description: When that event happened.
+        last_payload:
+          type: object
+          nullable: true
+          description: >-
+            The payload envelope of that event, member for member as it was
+            stored, and null for a row that holds none.
+
+    ResourceList:
+      type: object
+      description: One page of current resources.
+      required: [items, next_cursor]
+      properties:
+        items:
+          type: array
+          description: >-
+            The resources of this page, ordered by cloud, resource type, and
+            resource id.
+          items:
+            $ref: "#/components/schemas/Resource"
+        next_cursor:
+          type: string
+          nullable: true
+          description: >-
+            Where the next page starts, passed back as `cursor`. It is null on
+            the last page.
+
+    LifecycleInterval:
+      type: object
+      description: >-
+        One half-open span `[from, to)` over which nothing billable about a
+        resource changed.
+      required: [from, to, state, size, project_id]
+      properties:
+        from:
+          type: string
+          format: date-time
+          description: When the interval starts, the inclusive bound.
+        to:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the interval ends, the exclusive bound. It is null while the
+            interval is open, which the last interval of a living resource is.
+        state:
+          type: string
+          description: The state the resource was in over the interval.
+        size:
+          type: object
+          description: The size the resource had over the interval.
+        project_id:
+          type: string
+          description: The project owning the resource over the interval.
+
+    Lifecycle:
+      type: object
+      description: >-
+        One resource, its event history, and the billable intervals that
+        history folds into. `resource` is always there: a resource this API
+        holds no projection row for is answered 404 rather than with an empty
+        lifecycle.
+
+
+        The two halves are derived from two different event sets. `events` and
+        `intervals` carry the history this token may read, while `resource` is
+        the projection row, folded from every event the resource has under no
+        scope. On a resource that changed projects the row therefore reports a
+        `created_at` from before the reader owned it, and the first interval
+        starts at the transfer.
+      required: [resource, events, intervals, warnings]
+      properties:
+        resource:
+          $ref: "#/components/schemas/Resource"
+        events:
+          type: array
+          description: >-
+            The full history the fold ran on, ordered by
+            `(timestamp, received_at, event_id)`.
+          items:
+            $ref: "#/components/schemas/StoredEvent"
+        intervals:
+          type: array
+          description: >-
+            The billable intervals the history implies, oldest first. Two
+            billable changes at the same instant leave no interval between them,
+            so a resource created and deleted at one instant has none at all.
+          items:
+            $ref: "#/components/schemas/LifecycleInterval"
+        warnings:
+          type: array
+          description: >-
+            What the fold could not trust, one entry each. A history whose first
+            event is not a create carries history_starts_without_create.
+          items:
+            type: string
 
     ResourceType:
       type: object

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -32,6 +32,7 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodGet + " /healthz": nil,
 		http.MethodGet + " /readyz":  nil,
 
+		http.MethodGet + " /api/v1/events":  auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodPost + " /api/v1/events": auth.Ingest(opts.Queries, opts.AuthMode, Logger),
 
 		http.MethodGet + " /api/v1/resource-types": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -44,6 +44,11 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodGet + " " + resourceRoute + "/events":    auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodGet + " " + resourceRoute + "/lifecycle": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 
+		// The dead-letter list is the second admin-only route, next to the
+		// registration below: a refused item carries whatever a collector sent,
+		// which no project scope narrows.
+		http.MethodGet + " /api/v1/rejected-events": auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+
 		http.MethodGet + " /api/v1/resource-types": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodGet + " " + resourceTypeRoute:   auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodPut + " " + resourceTypeRoute:   auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -14,6 +14,11 @@ import (
 // be the pattern the generated wiring registers, letter for letter.
 const resourceTypeRoute = "/api/v1/resource-types/{platform}/{resource_type}"
 
+// resourceRoute is the chi pattern the per-resource reads are mounted under. The
+// two operations append their own segment to it, and it has to be the pattern
+// the generated wiring registers, letter for letter.
+const resourceRoute = "/api/v1/resources/{cloud}/{resource_type}/{resource_id}"
+
 // newAuthDispatch builds the middleware that puts each route behind the guard
 // its class needs.
 //
@@ -34,6 +39,10 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 
 		http.MethodGet + " /api/v1/events":  auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodPost + " /api/v1/events": auth.Ingest(opts.Queries, opts.AuthMode, Logger),
+
+		http.MethodGet + " /api/v1/resources":               auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
+		http.MethodGet + " " + resourceRoute + "/events":    auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
+		http.MethodGet + " " + resourceRoute + "/lifecycle": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 
 		http.MethodGet + " /api/v1/resource-types": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodGet + " " + resourceTypeRoute:   auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -62,6 +62,35 @@ func TestAuthDispatch(t *testing.T) {
 			t.Error("the list handler ran for a request carrying no credential")
 		}
 	})
+
+	t.Run("puts the resource reads behind a credential", func(t *testing.T) {
+		// The two per-resource routes are keyed on the pattern rather than on a
+		// path, so what says the table names them is a request whose path
+		// parameters carry values no rule could match.
+		for _, tc := range []struct{ pattern, path string }{
+			{pattern: "/api/v1/resources", path: "/api/v1/resources"},
+			{
+				pattern: resourceRoute + "/events",
+				path:    "/api/v1/resources/os-prod-eu1/instance/i-1/events",
+			},
+			{
+				pattern: resourceRoute + "/lifecycle",
+				path:    "/api/v1/resources/os-prod-eu1/instance/i-1/lifecycle",
+			},
+		} {
+			t.Run(tc.pattern, func(t *testing.T) {
+				ran := false
+				handler := dispatchOn(t, http.MethodGet, tc.pattern, &ran)
+
+				rec := serve(handler, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+				assertChallenged(t, rec)
+				if ran {
+					t.Error("the handler ran for a request carrying no credential")
+				}
+			})
+		}
+	})
 }
 
 // dispatchOn mounts the dispatch middleware on one chi route the way the

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -63,6 +63,22 @@ func TestAuthDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("puts the dead-letter list behind a credential", func(t *testing.T) {
+		// The route is the admin-only one of the query class. What the table is
+		// keyed with is the pattern, so a request carrying no credential meets the
+		// guard rather than being refused as a route no rule covers; which role it
+		// demands is the integration test's business.
+		ran := false
+		handler := dispatchOn(t, http.MethodGet, "/api/v1/rejected-events", &ran)
+
+		rec := serve(handler, httptest.NewRequest(http.MethodGet, "/api/v1/rejected-events", nil))
+
+		assertChallenged(t, rec)
+		if ran {
+			t.Error("the dead-letter handler ran for a request carrying no credential")
+		}
+	})
+
 	t.Run("puts the resource reads behind a credential", func(t *testing.T) {
 		// The two per-resource routes are keyed on the pattern rather than on a
 		// path, so what says the table names them is a request whose path

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -47,6 +47,21 @@ func TestAuthDispatch(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("puts the events list behind a credential of its own", func(t *testing.T) {
+		// The list shares its pattern with the ingest endpoint, so what says the
+		// table keyed the two methods apart is a GET meeting a guard rather than
+		// being refused as a route no rule covers.
+		ran := false
+		handler := dispatchOn(t, http.MethodGet, "/api/v1/events", &ran)
+
+		rec := serve(handler, httptest.NewRequest(http.MethodGet, "/api/v1/events", nil))
+
+		assertChallenged(t, rec)
+		if ran {
+			t.Error("the list handler ran for a request carrying no credential")
+		}
+	})
 }
 
 // dispatchOn mounts the dispatch middleware on one chi route the way the

--- a/internal/reporting/httpapi/cursor.go
+++ b/internal/reporting/httpapi/cursor.go
@@ -1,0 +1,56 @@
+package httpapi
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// encodeCursor packs the sort key of the last item on a page into the cursor a
+// client sends back to ask for the one after it (roadmap/00-conventions.md
+// section 7).
+//
+// A cursor carries position and nothing else: the parts of the sort key, in the
+// order the list is ordered by, as a JSON array of strings, base64url-encoded
+// without padding so it travels in a query string as it is. The encoding is what
+// makes it opaque, not a secret, so a client has no reason to read it and no
+// promise that the next release spells it the same way.
+func encodeCursor(keys []string) string {
+	// Marshalling a slice of strings cannot fail, so there is no error to carry
+	// out of here and no caller that would have to handle one.
+	payload, _ := json.Marshal(keys)
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// decodeCursor reads a cursor encodeCursor wrote and returns the want key parts
+// the query resumes from.
+//
+// The cursor arrives from a client, so every step back through it is checked:
+// only a base64url payload holding a JSON array of exactly want non-empty
+// strings gets through, and anything else is refused instead of being handed to
+// a query. The element count is part of that because a cursor from a list with
+// another sort key would otherwise resume a query with the wrong number of
+// bounds.
+//
+// Callers answer every refusal with the same 400, so the errors here are for the
+// log and say which part of the cursor was wrong.
+func decodeCursor(cursor string, want int) ([]string, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return nil, fmt.Errorf("the cursor is not base64url: %w", err)
+	}
+
+	var keys []string
+	if err := json.Unmarshal(payload, &keys); err != nil {
+		return nil, fmt.Errorf("the cursor does not hold an array of strings: %w", err)
+	}
+	if len(keys) != want {
+		return nil, fmt.Errorf("the cursor holds %d keys, want %d", len(keys), want)
+	}
+	for i, key := range keys {
+		if key == "" {
+			return nil, fmt.Errorf("key %d of the cursor is empty", i)
+		}
+	}
+	return keys, nil
+}

--- a/internal/reporting/httpapi/cursor_test.go
+++ b/internal/reporting/httpapi/cursor_test.go
@@ -1,0 +1,82 @@
+package httpapi
+
+import (
+	"encoding/base64"
+	"slices"
+	"testing"
+)
+
+// TestCursorRoundTrip pins the property the paginated lists stand on: the cursor
+// handed out for the last row of a page comes back as exactly the key parts the
+// next query resumes from, whatever the sort key is made of.
+func TestCursorRoundTrip(t *testing.T) {
+	tests := map[string][]string{
+		"one key": {"2026-03-01T00:00:00Z"},
+		"two keys": {
+			"2026-03-01T00:00:00Z",
+			"9a0e6b2c-4d1f-4f7a-8b3e-2c5d6e7f8a90",
+		},
+		"three keys": {
+			"openstack",
+			"instance",
+			"9a0e6b2c-4d1f-4f7a-8b3e-2c5d6e7f8a90",
+		},
+	}
+
+	for name, keys := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := decodeCursor(encodeCursor(keys), len(keys))
+			if err != nil {
+				t.Fatalf("decodeCursor() error = %v, want nil", err)
+			}
+			if !slices.Equal(got, keys) {
+				t.Errorf("keys = %q, want %q", got, keys)
+			}
+		})
+	}
+}
+
+// TestCursorRefusesAMalformedCursor walks the ways a cursor can arrive broken. A
+// client types this value, so each of them ends in an error rather than in a key
+// set a query would be run with.
+func TestCursorRefusesAMalformedCursor(t *testing.T) {
+	tests := map[string]struct {
+		cursor string
+		want   int
+	}{
+		"not base64url at all": {
+			cursor: "not base64!",
+			want:   1,
+		},
+		"base64url over bytes that are not JSON": {
+			cursor: base64.RawURLEncoding.EncodeToString([]byte("{oops")),
+			want:   1,
+		},
+		"a JSON object rather than an array": {
+			cursor: base64.RawURLEncoding.EncodeToString([]byte(`{"after":"2026-03-01T00:00:00Z"}`)),
+			want:   1,
+		},
+		"a JSON array of numbers": {
+			cursor: base64.RawURLEncoding.EncodeToString([]byte(`[1,2]`)),
+			want:   2,
+		},
+		"more keys than the list orders by": {
+			cursor: encodeCursor([]string{"2026-03-01T00:00:00Z", "9a0e6b2c-4d1f-4f7a-8b3e-2c5d6e7f8a90"}),
+			want:   1,
+		},
+		"an empty key": {
+			cursor: encodeCursor([]string{"2026-03-01T00:00:00Z", ""}),
+			want:   2,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := decodeCursor(tc.cursor, tc.want)
+			if err == nil {
+				t.Fatalf("decodeCursor(%q, %d) error = nil, want an error (keys %q)",
+					tc.cursor, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/reporting/httpapi/eventsquery.go
+++ b/internal/reporting/httpapi/eventsquery.go
@@ -1,0 +1,239 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// defaultPageSize is how long a page is when the request names no limit. The
+// contract declares the same number, and bounds the parameter, so a limit that
+// reaches this handler is either absent or between 1 and 1000.
+const defaultPageSize = 100
+
+// eventCursorKeys is how many parts the sort key of this list has: the timestamp
+// and the event id, in the order ORDER BY names them.
+const eventCursorKeys = 2
+
+// badCursorDetail answers every cursor this API cannot use. Which part of it was
+// wrong goes to the log rather than to the client: a cursor is opaque, so a
+// caller has nothing to fix inside one and can only walk the list again.
+const badCursorDetail = "the cursor is not one this API issued"
+
+// errNoPrincipal is what a query route reports when the request context carries
+// no principal. Every route the dispatch table puts behind the query guard has
+// one, in enforced mode from the token and in disabled mode synthetically, so
+// finding none is this service disagreeing with itself.
+var errNoPrincipal = errors.New("the request context carries no query principal")
+
+// ListEvents answers one page of the stored events, narrowed by the filters the
+// request carries.
+//
+// The page is read one row longer than it is served, and that extra row is what
+// decides whether a cursor is sent: it tells "the page is full" from "there is
+// more" without a second query counting the rest.
+//
+// The list is event-scoped. A project token reads every event whose project_id
+// names one of its projects, which includes the events a resource carried before
+// it was transferred away, and the pair filter is what keeps a project id
+// another cloud uses for something else out of the answer.
+func (s *server) ListEvents(w http.ResponseWriter, r *http.Request, params ListEventsParams) {
+	ctx := r.Context()
+
+	principal, ok := auth.QueryFromContext(ctx)
+	if !ok {
+		writeInternal(ctx, w, "serving a query route without a principal", errNoPrincipal,
+			"the request could not be served")
+		return
+	}
+
+	scope, err := auth.ResolveProjectScope(ctx, s.queries, principal)
+	if err != nil {
+		writeInternal(ctx, w, "resolving the project scope", err,
+			"the request could not be served")
+		return
+	}
+	// A filtered scope holding no project reaches no event at all, so the empty
+	// page is answered here rather than asked of the database.
+	if !scope.Unfiltered && len(scope.Refs) == 0 {
+		writeJSON(w, EventList{Items: []StoredEvent{}})
+		return
+	}
+	// A project the token does not hold is refused rather than answered with an
+	// empty page, so that asking outside the scope is distinguishable from a
+	// project that has no events yet.
+	if params.ProjectId != nil && !scope.Unfiltered && !reachesProject(scope, *params.ProjectId) {
+		problem.Write(w, http.StatusForbidden, problem.TypeForbidden,
+			"Forbidden", "this token does not reach the project this query names")
+		return
+	}
+
+	var cursorAt pgtype.Timestamptz
+	var cursorEventID pgtype.Text
+	if params.Cursor != nil {
+		if cursorAt, cursorEventID, err = eventCursor(*params.Cursor); err != nil {
+			Logger(ctx).Warn("refusing a cursor", "error", err)
+			problem.Write(w, http.StatusBadRequest, problem.TypeValidation,
+				"Validation failed", badCursorDetail)
+			return
+		}
+	}
+
+	limit := defaultPageSize
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	clouds, projects := scopeFilter(scope)
+
+	// A from later than to yields nothing, which is what the half-open window
+	// means and needs no case of its own: each bound is a valid instant on its
+	// own, and the contract cannot express a rule spanning two parameters.
+	rows, err := s.queries.ListEvents(ctx, sqlcgen.ListEventsParams{
+		Cloud:         filterText(params.Cloud),
+		Platform:      filterText(params.Platform),
+		ProjectID:     filterText(params.ProjectId),
+		ResourceType:  filterText(params.ResourceType),
+		EventType:     filterText(params.EventType),
+		Source:        filterText((*string)(params.Source)),
+		FromTs:        filterInstant(params.From),
+		ToTs:          filterInstant(params.To),
+		ScopeClouds:   clouds,
+		ScopeProjects: projects,
+		CursorTs:      cursorAt,
+		CursorEventID: cursorEventID,
+		PageSize:      int32(limit) + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing events", err, "the events could not be read")
+		return
+	}
+
+	more := len(rows) > limit
+	if more {
+		rows = rows[:limit]
+	}
+	items := make([]StoredEvent, len(rows))
+	for i, row := range rows {
+		if items[i], err = storedEventOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored payload", err,
+				"the events could not be read")
+			return
+		}
+	}
+
+	list := EventList{Items: items}
+	if more {
+		// The cursor names the last item served, so the next page starts at the
+		// row after it. RFC3339Nano carries the microseconds a TIMESTAMPTZ holds,
+		// which is what makes the round trip exact.
+		last := items[len(items)-1]
+		cursor := encodeCursor([]string{last.Timestamp.Format(time.RFC3339Nano), last.EventId})
+		list.NextCursor = &cursor
+	}
+	writeJSON(w, list)
+}
+
+// eventCursor reads the position a cursor resumes from into the two bounds the
+// query compares its sort key against.
+//
+// The timestamp is parsed rather than passed through, so a cursor whose first
+// key is not an instant is refused here instead of reaching the database as a
+// cast that fails there.
+func eventCursor(cursor string) (pgtype.Timestamptz, pgtype.Text, error) {
+	keys, err := decodeCursor(cursor, eventCursorKeys)
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.Text{}, err
+	}
+	at, err := time.Parse(time.RFC3339Nano, keys[0])
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.Text{},
+			fmt.Errorf("the timestamp of the cursor is not RFC 3339: %w", err)
+	}
+	return pgtype.Timestamptz{Time: at, Valid: true}, pgtype.Text{String: keys[1], Valid: true}, nil
+}
+
+// scopeFilter zips the projects a filtered principal reads into the two parallel
+// arrays the query pairs positionally, so that clouds[i] belongs to
+// projects[i]. Pairing them is what keeps a project id one cloud uses from
+// matching the rows another cloud stores under the same id.
+//
+// An unfiltered principal yields two nil slices, which pgx sends as NULL and the
+// query reads as no scope filter at all.
+func scopeFilter(scope auth.Scope) (clouds, projects []string) {
+	if scope.Unfiltered {
+		return nil, nil
+	}
+	clouds = make([]string, len(scope.Refs))
+	projects = make([]string, len(scope.Refs))
+	for i, ref := range scope.Refs {
+		clouds[i] = ref.Cloud
+		projects[i] = ref.ExternalID
+	}
+	return clouds, projects
+}
+
+// reachesProject reports whether a filtered scope holds the project a request
+// asked for by name. The cloud is left out of the comparison: the pair filter of
+// the query narrows the answer to the cloud the token holds the project in
+// anyway, so a matching external id is enough to let the request through.
+func reachesProject(scope auth.Scope, externalID string) bool {
+	return slices.ContainsFunc(scope.Refs, func(ref auth.ProjectRef) bool {
+		return ref.ExternalID == externalID
+	})
+}
+
+// filterText maps one optional string filter onto its query parameter. A filter
+// the request left out becomes NULL, which the query reads as every value.
+func filterText(value *string) pgtype.Text {
+	if value == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *value, Valid: true}
+}
+
+// filterInstant maps one bound of the time window onto its query parameter.
+func filterInstant(value *time.Time) pgtype.Timestamptz {
+	if value == nil {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: *value, Valid: true}
+}
+
+// storedEventOf renders one events row as the answer the contract promises. The
+// timestamps come out in UTC, which is the zone the API states them in, and the
+// payload is decoded rather than passed through, because the contract types it
+// as an object and a row written past this API could hold anything.
+//
+// A row whose payload column is NULL renders as a null member: no envelope was
+// stored, and an empty object would claim one was.
+func storedEventOf(row sqlcgen.Event) (StoredEvent, error) {
+	item := StoredEvent{
+		EventId:      row.EventID,
+		Timestamp:    row.Timestamp.Time.UTC(),
+		EventType:    row.EventType,
+		Platform:     row.Platform,
+		Cloud:        row.Cloud,
+		ResourceType: row.ResourceType,
+		ResourceId:   row.ResourceID,
+		ProjectId:    row.ProjectID,
+		Source:       row.Source,
+		ReceivedAt:   row.ReceivedAt.Time.UTC(),
+	}
+	if len(row.Payload) > 0 {
+		var payload map[string]any
+		if err := json.Unmarshal(row.Payload, &payload); err != nil {
+			return StoredEvent{}, fmt.Errorf("decoding the payload of event %s: %w", row.EventID, err)
+		}
+		item.Payload = &payload
+	}
+	return item, nil
+}

--- a/internal/reporting/httpapi/eventsquery.go
+++ b/internal/reporting/httpapi/eventsquery.go
@@ -2,45 +2,27 @@ package httpapi
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/b42labs/tally/internal/reporting/auth"
 	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
 	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
 )
-
-// defaultPageSize is how long a page is when the request names no limit. The
-// contract declares the same number, and bounds the parameter, so a limit that
-// reaches this handler is either absent or between 1 and 1000.
-const defaultPageSize = 100
 
 // eventCursorKeys is how many parts the sort key of this list has: the timestamp
 // and the event id, in the order ORDER BY names them.
 const eventCursorKeys = 2
 
-// badCursorDetail answers every cursor this API cannot use. Which part of it was
-// wrong goes to the log rather than to the client: a cursor is opaque, so a
-// caller has nothing to fix inside one and can only walk the list again.
-const badCursorDetail = "the cursor is not one this API issued"
-
-// errNoPrincipal is what a query route reports when the request context carries
-// no principal. Every route the dispatch table puts behind the query guard has
-// one, in enforced mode from the token and in disabled mode synthetically, so
-// finding none is this service disagreeing with itself.
-var errNoPrincipal = errors.New("the request context carries no query principal")
+// eventsDetail answers every failure of this route a caller can do nothing
+// about.
+const eventsDetail = "the events could not be read"
 
 // ListEvents answers one page of the stored events, narrowed by the filters the
-// request carries.
-//
-// The page is read one row longer than it is served, and that extra row is what
-// decides whether a cursor is sent: it tells "the page is full" from "there is
-// more" without a second query counting the rest.
+// request carries. The page is read one row longer than it is served, which is
+// what trimPage turns into the cursor decision.
 //
 // The list is event-scoped. A project token reads every event whose project_id
 // names one of its projects, which includes the events a resource carried before
@@ -49,17 +31,8 @@ var errNoPrincipal = errors.New("the request context carries no query principal"
 func (s *server) ListEvents(w http.ResponseWriter, r *http.Request, params ListEventsParams) {
 	ctx := r.Context()
 
-	principal, ok := auth.QueryFromContext(ctx)
+	scope, ok := s.queryScope(w, r)
 	if !ok {
-		writeInternal(ctx, w, "serving a query route without a principal", errNoPrincipal,
-			"the request could not be served")
-		return
-	}
-
-	scope, err := auth.ResolveProjectScope(ctx, s.queries, principal)
-	if err != nil {
-		writeInternal(ctx, w, "resolving the project scope", err,
-			"the request could not be served")
 		return
 	}
 	// A filtered scope holding no project reaches no event at all, so the empty
@@ -80,18 +53,14 @@ func (s *server) ListEvents(w http.ResponseWriter, r *http.Request, params ListE
 	var cursorAt pgtype.Timestamptz
 	var cursorEventID pgtype.Text
 	if params.Cursor != nil {
+		var err error
 		if cursorAt, cursorEventID, err = eventCursor(*params.Cursor); err != nil {
-			Logger(ctx).Warn("refusing a cursor", "error", err)
-			problem.Write(w, http.StatusBadRequest, problem.TypeValidation,
-				"Validation failed", badCursorDetail)
+			refuseCursor(ctx, w, err)
 			return
 		}
 	}
 
-	limit := defaultPageSize
-	if params.Limit != nil {
-		limit = *params.Limit
-	}
+	limit := pageLimit(params.Limit)
 	clouds, projects := scopeFilter(scope)
 
 	// A from later than to yields nothing, which is what the half-open window
@@ -113,19 +82,15 @@ func (s *server) ListEvents(w http.ResponseWriter, r *http.Request, params ListE
 		PageSize:      int32(limit) + 1,
 	})
 	if err != nil {
-		writeInternal(ctx, w, "listing events", err, "the events could not be read")
+		writeInternal(ctx, w, "listing events", err, eventsDetail)
 		return
 	}
 
-	more := len(rows) > limit
-	if more {
-		rows = rows[:limit]
-	}
+	rows, more := trimPage(rows, limit)
 	items := make([]StoredEvent, len(rows))
 	for i, row := range rows {
 		if items[i], err = storedEventOf(row); err != nil {
-			writeInternal(ctx, w, "decoding a stored payload", err,
-				"the events could not be read")
+			writeInternal(ctx, w, "decoding a stored payload", err, eventsDetail)
 			return
 		}
 	}
@@ -159,53 +124,6 @@ func eventCursor(cursor string) (pgtype.Timestamptz, pgtype.Text, error) {
 			fmt.Errorf("the timestamp of the cursor is not RFC 3339: %w", err)
 	}
 	return pgtype.Timestamptz{Time: at, Valid: true}, pgtype.Text{String: keys[1], Valid: true}, nil
-}
-
-// scopeFilter zips the projects a filtered principal reads into the two parallel
-// arrays the query pairs positionally, so that clouds[i] belongs to
-// projects[i]. Pairing them is what keeps a project id one cloud uses from
-// matching the rows another cloud stores under the same id.
-//
-// An unfiltered principal yields two nil slices, which pgx sends as NULL and the
-// query reads as no scope filter at all.
-func scopeFilter(scope auth.Scope) (clouds, projects []string) {
-	if scope.Unfiltered {
-		return nil, nil
-	}
-	clouds = make([]string, len(scope.Refs))
-	projects = make([]string, len(scope.Refs))
-	for i, ref := range scope.Refs {
-		clouds[i] = ref.Cloud
-		projects[i] = ref.ExternalID
-	}
-	return clouds, projects
-}
-
-// reachesProject reports whether a filtered scope holds the project a request
-// asked for by name. The cloud is left out of the comparison: the pair filter of
-// the query narrows the answer to the cloud the token holds the project in
-// anyway, so a matching external id is enough to let the request through.
-func reachesProject(scope auth.Scope, externalID string) bool {
-	return slices.ContainsFunc(scope.Refs, func(ref auth.ProjectRef) bool {
-		return ref.ExternalID == externalID
-	})
-}
-
-// filterText maps one optional string filter onto its query parameter. A filter
-// the request left out becomes NULL, which the query reads as every value.
-func filterText(value *string) pgtype.Text {
-	if value == nil {
-		return pgtype.Text{}
-	}
-	return pgtype.Text{String: *value, Valid: true}
-}
-
-// filterInstant maps one bound of the time window onto its query parameter.
-func filterInstant(value *time.Time) pgtype.Timestamptz {
-	if value == nil {
-		return pgtype.Timestamptz{}
-	}
-	return pgtype.Timestamptz{Time: *value, Valid: true}
 }
 
 // storedEventOf renders one events row as the answer the contract promises. The

--- a/internal/reporting/httpapi/eventsquery_integration_test.go
+++ b/internal/reporting/httpapi/eventsquery_integration_test.go
@@ -1,0 +1,830 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// eventsRoute is the route the list tests call, spelled once because every one
+// of them addresses it.
+const eventsRoute = "/api/v1/events"
+
+// The clouds the base set of the list tests lives in, and the platform of the
+// third. Every subtest that stores more events works on a cloud of its own, so
+// the base set stays what the unfiltered subtests describe.
+const (
+	listCloudA    = "os-list-a"
+	listCloudB    = "os-list-b"
+	listCloudC    = "tally-list-c"
+	listPlatformC = "tallytest"
+)
+
+// The projects the base set names. The second one shares a cloud with the first,
+// which is what makes the project filter more than another spelling of the cloud
+// filter.
+const (
+	listProjectA = "list-project-a"
+	listProjectB = "list-project-b"
+)
+
+// listBase is the instant the base set starts at. The events sit one minute
+// apart on whole seconds, so what Postgres stores compares equal to what the
+// test passed in, and the order they are declared in is the order the list
+// serves them.
+var listBase = time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+
+// listAt is the instant of the nth base event.
+func listAt(n int) time.Time {
+	return listBase.Add(time.Duration(n) * time.Minute)
+}
+
+// TestListEventsOverHTTP drives GET /api/v1/events through the whole stack: the
+// contract validator, the query guard, the project scope, and the rows behind
+// them.
+//
+// The subtests share one database and run in order: the ones describing the
+// whole table come first, and the ones storing events of their own afterwards
+// work on clouds those assertions do not name.
+func TestListEventsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+	_, ingestToken := seedIngestCredential(t, a.queries, fixturePlatform, listCloudA)
+
+	base := seedBaseEvents(t, a)
+
+	t.Run("serves every stored event in timestamp and event id order", func(t *testing.T) {
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, adminToken, nil))
+
+		if list.NextCursor != nil {
+			t.Errorf("next_cursor = %q, want null on a page that holds everything", *list.NextCursor)
+		}
+		if got, want := ids(list.Items), base.ids(); !slices.Equal(got, want) {
+			t.Fatalf("served events = %v, want %v", got, want)
+		}
+		// Every member the contract requires, checked against the event that was
+		// submitted, so a mapper dropping or transposing a column is caught.
+		for i, item := range list.Items {
+			assertServedEvent(t, item, base[i], storedPayload(t, a, item.EventId))
+		}
+	})
+
+	t.Run("serves a payload with every member the submitted one held", func(t *testing.T) {
+		// The create event carries a provider block next to the state and the
+		// size, so this compares three members rather than one.
+		submitted := base.byID(t, "list-vol-create")
+		query := "?cloud=" + listCloudA + "&event_type=" + url.QueryEscape(submitted.EventType)
+
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+query, adminToken, nil))
+
+		if got, want := ids(list.Items), []string{submitted.EventID}; !slices.Equal(got, want) {
+			t.Fatalf("served events = %v, want %v", got, want)
+		}
+		if list.Items[0].Payload == nil {
+			t.Fatal("payload = null, want the stored envelope")
+		}
+		if got, want := *list.Items[0].Payload, asDocument(t, submitted.Payload); !reflect.DeepEqual(got, want) {
+			t.Errorf("payload = %v, want the submitted %v", got, want)
+		}
+	})
+
+	t.Run("serves an event stored without a payload as a null member", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, eventsRoute+"?event_type=volume.delete", adminToken, nil)
+
+		list := eventListOf(t, rec)
+		if got, want := ids(list.Items), []string{"list-vol-delete"}; !slices.Equal(got, want) {
+			t.Fatalf("served events = %v, want %v", got, want)
+		}
+		if list.Items[0].Payload != nil {
+			t.Errorf("payload = %v, want it served as null", *list.Items[0].Payload)
+		}
+		// A pointer that decoded to nil would also come from a member left out, so
+		// the raw body is what says the member is there and null.
+		if body := rec.Body.String(); !strings.Contains(body, `"payload":null`) {
+			t.Errorf("body = %s, want it to carry \"payload\":null", body)
+		}
+	})
+
+	t.Run("narrows the answer to what a filter names", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  []string
+		}{
+			{
+				name:  "cloud",
+				query: "cloud=" + listCloudA,
+				want: []string{
+					"list-vol-create", "list-vol-resize", "list-inst-create",
+					"list-vol-recon", "list-vol-delete",
+				},
+			},
+			{
+				name:  "platform",
+				query: "platform=" + listPlatformC,
+				want:  []string{"list-widget-create"},
+			},
+			{
+				name:  "project_id",
+				query: "project_id=" + listProjectB,
+				want:  []string{"list-inst-create"},
+			},
+			{
+				name:  "resource_type",
+				query: "resource_type=instance",
+				want:  []string{"list-inst-create"},
+			},
+			{
+				name:  "event_type",
+				query: "event_type=volume.resize",
+				want:  []string{"list-vol-resize"},
+			},
+			{
+				name:  "source",
+				query: "source=reconciliation",
+				want:  []string{"list-vol-recon"},
+			},
+			{
+				name: "cloud, event type, and a window at once",
+				query: "cloud=" + listCloudA + "&event_type=volume.create" +
+					"&from=" + instant(listAt(0)) + "&to=" + instant(listAt(1)),
+				want: []string{"list-vol-create"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?"+tc.query, adminToken, nil))
+
+				if got := ids(list.Items); !slices.Equal(got, tc.want) {
+					t.Errorf("served events = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("takes from as inclusive and to as exclusive", func(t *testing.T) {
+		// The window starts on the second base event and ends on the fourth, so
+		// what the two ends say is read off the bounds themselves.
+		query := "from=" + instant(listAt(1)) + "&to=" + instant(listAt(3))
+
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?"+query, adminToken, nil))
+
+		want := []string{"list-vol-resize", "list-inst-create"}
+		if got := ids(list.Items); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("answers an empty page rather than null items", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a filter nothing matches", query: "cloud=os-list-nothing"},
+			// Each bound is a valid instant on its own, and the window between
+			// them is empty, which is an answer rather than a refusal.
+			{name: "a from later than the to", query: "from=" + instant(listAt(6)) + "&to=" + instant(listAt(0))},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, eventsRoute+"?"+tc.query, adminToken, nil)
+
+				if got := rec.Code; got != http.StatusOK {
+					t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+				}
+				// The raw body rather than the decoded one: a client iterates items
+				// without a nil check, which null would break and [] does not.
+				want := `{"items":[],"next_cursor":null}`
+				if got := strings.TrimSpace(rec.Body.String()); got != want {
+					t.Errorf("body = %s, want %s", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("walks a list in pages and ends the walk with a null cursor", func(t *testing.T) {
+		const cloud = "os-list-pages"
+		_, token := seedIngestCredential(t, a.queries, fixturePlatform, cloud)
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-pages"}
+
+		items := make([]json.RawMessage, 7)
+		for i := range items {
+			items[i] = item(t, res.event(pageEventID(i), "volume.update",
+				pageAt(i), payloadOf("available", volumeSize(float64(10+i)))))
+		}
+		if got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, batch(t, items...))); got.Accepted != len(items) {
+			t.Fatalf("result = %+v, want the %d events of the walk stored", got, len(items))
+		}
+
+		whole := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?cloud="+cloud, adminToken, nil))
+		if len(whole.Items) != len(items) {
+			t.Fatalf("the unpaginated answer holds %d events, want %d", len(whole.Items), len(items))
+		}
+
+		for _, tc := range []struct {
+			name  string
+			limit int
+			sizes []int
+		}{
+			// The third, fourth, and fifth event share an instant, so the first
+			// page of this walk ends inside that group and the event id of the
+			// cursor is what says where the second one resumes.
+			{name: "a last page shorter than the limit", limit: 3, sizes: []int{3, 3, 1}},
+			// The whole list in one page: the last page is exactly full, which is
+			// what tells "the page is full" from "there is more".
+			{name: "a last page exactly as long as the limit", limit: len(items), sizes: []int{len(items)}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				page := fmt.Sprintf("%s?cloud=%s&limit=%d", eventsRoute, cloud, tc.limit)
+
+				var walked []StoredEvent
+				var sizes []int
+				for count := 1; ; count++ {
+					if count > len(items) {
+						t.Fatalf("the walk had not ended after %d pages, want it over after %d",
+							count, len(tc.sizes))
+					}
+					list := eventListOf(t, a.call(t, http.MethodGet, page, adminToken, nil))
+
+					sizes = append(sizes, len(list.Items))
+					walked = append(walked, list.Items...)
+					if list.NextCursor == nil {
+						break
+					}
+					page = fmt.Sprintf("%s?cloud=%s&limit=%d&cursor=%s",
+						eventsRoute, cloud, tc.limit, url.QueryEscape(*list.NextCursor))
+				}
+
+				if !slices.Equal(sizes, tc.sizes) {
+					t.Errorf("page sizes = %v, want %v", sizes, tc.sizes)
+				}
+				if !reflect.DeepEqual(walked, whole.Items) {
+					t.Errorf("the walk served %v, want the unpaginated %v", ids(walked), ids(whole.Items))
+				}
+			})
+		}
+	})
+
+	t.Run("serves the contract's default limit when the request names none", func(t *testing.T) {
+		// The number is spelled out rather than read off defaultPageSize: what is
+		// asserted is the `default: 100` of api/reporting/openapi.yaml, which the
+		// generated binding does not apply, so a handler drifting from the
+		// contract is what this catches.
+		const contractDefault = 100
+		// One event more than that, in a cloud of its own: what the page holds is
+		// the default rather than the whole cloud, and the cursor says the rest is
+		// behind it.
+		const cloud = "os-list-default-limit"
+		_, token := seedIngestCredential(t, a.queries, fixturePlatform, cloud)
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-default-limit"}
+
+		items := make([]json.RawMessage, contractDefault+1)
+		for i := range items {
+			items[i] = item(t, res.event(fmt.Sprintf("list-default-%03d", i), "volume.update",
+				listAt(30+i), payloadOf("available", volumeSize(float64(10+i)))))
+		}
+		if got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, batch(t, items...))); got.Accepted != len(items) {
+			t.Fatalf("result = %+v, want the %d events stored", got, len(items))
+		}
+
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?cloud="+cloud, adminToken, nil))
+
+		if got := len(list.Items); got != contractDefault {
+			t.Errorf("served events = %d, want the contract's default of %d", got, contractDefault)
+		}
+		if list.NextCursor == nil {
+			t.Error("next_cursor = null, want a cursor on a page the cloud has more events than")
+		}
+	})
+
+	t.Run("reports a row it cannot decode", func(t *testing.T) {
+		// The payload column is typed as an object by the contract, and the write
+		// path stores nothing else. A row written past this API could hold any
+		// JSON, so the mapper's refusal is only readable on a row that does.
+		const cloud = "os-list-undecodable"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-undecodable"}
+		e := res.event("list-undecodable", "volume.create", listAt(40), event.PayloadEnvelope{})
+		insertEventRow(t, a, e, []byte(`[1,2]`))
+		// The row stays out of the way of the subtests after this one, which read
+		// the whole table and would meet the same refusal.
+		t.Cleanup(func() {
+			if _, err := a.store.Pool().Exec(context.Background(),
+				`DELETE FROM events WHERE event_id = $1`, e.EventID); err != nil {
+				t.Fatalf("removing the undecodable row: %v", err)
+			}
+		})
+
+		rec := a.call(t, http.MethodGet, eventsRoute+"?cloud="+cloud, adminToken, nil)
+
+		assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+		if got, want := problemDetail(t, rec), "the events could not be read"; got != want {
+			t.Errorf("detail = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("refuses a cursor it did not issue", func(t *testing.T) {
+		const at = "2026-06-01T08:00:00Z"
+
+		for _, tc := range []struct {
+			name   string
+			cursor string
+		}{
+			{name: "not base64url", cursor: "not base64!"},
+			{name: "base64url that is not an array of strings", cursor: rawCursor(`{"at":"now"}`)},
+			{name: "one key where the sort key has two", cursor: encodeCursor([]string{at})},
+			{name: "three keys where the sort key has two", cursor: encodeCursor([]string{at, "a", "b"})},
+			{name: "an empty key", cursor: encodeCursor([]string{at, ""})},
+			{name: "a timestamp that is not an instant", cursor: encodeCursor([]string{"yesterday", "list-vol-create"})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					eventsRoute+"?cursor="+url.QueryEscape(tc.cursor), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec), "the cursor is not one this API issued"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a parameter the contract does not allow", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a limit below the minimum", query: "limit=0"},
+			{name: "a limit above the maximum", query: "limit=1001"},
+			{name: "a from that is not an instant", query: "from=not-a-date"},
+			{name: "a source outside the two pipelines", query: "source=banana"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, eventsRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			})
+		}
+	})
+
+	t.Run("confines a project token to the projects it holds", func(t *testing.T) {
+		// The same external id in two clouds, and two external ids in one cloud:
+		// only the pair the token holds may come back.
+		const (
+			cloudA = "os-list-scope-a"
+			cloudB = "os-list-scope-b"
+		)
+		held := seedProject(t, a, cloudA, "p-1")
+		seedProject(t, a, cloudA, "p-2")
+		seedProject(t, a, cloudB, "p-1")
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{held})
+
+		mine := seedScopedEvent(t, a, cloudA, "p-1", "list-scope-mine")
+		seedScopedEvent(t, a, cloudA, "p-2", "list-scope-sibling")
+		seedScopedEvent(t, a, cloudB, "p-1", "list-scope-other-cloud")
+
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, token, nil))
+
+		if got, want := ids(list.Items), []string{mine}; !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+
+		t.Run("refuses a project outside its scope", func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, eventsRoute+"?project_id=p-2", token, nil)
+
+			assertProblem(t, rec, http.StatusForbidden, problem.TypeForbidden)
+		})
+
+		t.Run("serves the project it holds", func(t *testing.T) {
+			// The other cloud spells the id of a project of its own the same way,
+			// so this also says the filter runs on the pair.
+			list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?project_id=p-1", token, nil))
+
+			if got, want := ids(list.Items), []string{mine}; !slices.Equal(got, want) {
+				t.Errorf("served events = %v, want %v", got, want)
+			}
+		})
+	})
+
+	t.Run("serves a token whose projects are gone an empty page", func(t *testing.T) {
+		const cloud = "os-list-gone"
+		project := seedProject(t, a, cloud, "p-gone")
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{project})
+		stored := seedScopedEvent(t, a, cloud, "p-gone", "list-gone")
+
+		before := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, token, nil))
+		if got, want := ids(before.Items), []string{stored}; !slices.Equal(got, want) {
+			t.Fatalf("served events = %v, want %v", got, want)
+		}
+
+		if _, err := a.store.Pool().Exec(t.Context(), `DELETE FROM projects WHERE id = $1`, project); err != nil {
+			t.Fatalf("deleting the project %s: %v", project, err)
+		}
+
+		// The scope narrows to nothing rather than widening to everything, so the
+		// token reads no event at all instead of every event there is.
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, token, nil))
+
+		if got := ids(list.Items); len(got) != 0 {
+			t.Errorf("served events = %v, want none for a token whose projects are gone", got)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		unknown, err := auth.GenerateAPIToken()
+		if err != nil {
+			t.Fatalf("generating the api token: %v", err)
+		}
+		revokedID, revoked := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+		if err := a.queries.RevokeAPIToken(t.Context(), revokedID); err != nil {
+			t.Fatalf("RevokeAPIToken() error = %v, want nil", err)
+		}
+
+		for _, tc := range []struct {
+			name  string
+			token string
+		}{
+			{name: "no token", token: ""},
+			{name: "an unknown token", token: unknown},
+			{name: "a revoked token", token: revoked},
+			// The ingest credentials are a store of their own, so a token issued
+			// for reporting events reads none of them back.
+			{name: "an ingest credential", token: ingestToken},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, eventsRoute, tc.token, nil)
+
+				assertChallenged(t, rec)
+			})
+		}
+	})
+
+	t.Run("serves a read_all token the whole list", func(t *testing.T) {
+		admin := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?limit=1000", adminToken, nil))
+
+		list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?limit=1000", readAllToken, nil))
+
+		if got, want := ids(list.Items), ids(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want the %v an admin token reads", got, want)
+		}
+	})
+
+	t.Run("serves the route without a token while authentication is disabled", func(t *testing.T) {
+		// A second router over the same database, which is the development setup:
+		// the guard injects an admin principal instead of reading a credential.
+		open := newAPIInMode(t, db.Store, auth.ModeDisabled)
+		admin := eventListOf(t, a.call(t, http.MethodGet, eventsRoute+"?limit=1000", adminToken, nil))
+
+		list := eventListOf(t, open.call(t, http.MethodGet, eventsRoute+"?limit=1000", "", nil))
+
+		if got, want := ids(list.Items), ids(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want the %v an admin token reads", got, want)
+		}
+	})
+}
+
+// TestListEventsReportsAFailedQuery drives the handler's own failure path. With
+// authentication disabled nothing reads the database before the list does, so a
+// database that is gone stops the request inside the query rather than at the
+// credential lookup in front of it.
+func TestListEventsReportsAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	rec := a.call(t, http.MethodGet, eventsRoute, "", nil)
+
+	assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+	// The detail is what tells the internal problems of this route apart: the
+	// query failed, rather than a scope that could not be resolved.
+	if got, want := problemDetail(t, rec), "the events could not be read"; got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+
+	// The outage was that request's alone: the database comes back and the route
+	// serves again. The container returns on a different host port, so everything
+	// bound to the old one is rebuilt from the endpoint it has now.
+	if err := db.Container.Start(t.Context()); err != nil {
+		t.Fatalf("starting the database container again: %v", err)
+	}
+	back := newAPIInMode(t, reopen(t, db), auth.ModeDisabled)
+	waitForReady(t, back.handler, time.Minute)
+
+	list := eventListOf(t, back.call(t, http.MethodGet, eventsRoute, "", nil))
+	if got := ids(list.Items); len(got) != 0 {
+		t.Errorf("served events = %v, want none in a database nothing was stored in", got)
+	}
+}
+
+// baseSet is the events the list tests describe: the whole table as the
+// unfiltered subtests expect it, in the order the list orders by.
+type baseSet []event.Event
+
+// ids is the event ids of the set, in order.
+func (b baseSet) ids() []string {
+	found := make([]string, len(b))
+	for i, e := range b {
+		found[i] = e.EventID
+	}
+	return found
+}
+
+// byID is the submitted event of one id, which is what a served event is
+// compared against member by member.
+func (b baseSet) byID(t *testing.T, eventID string) event.Event {
+	t.Helper()
+
+	for _, e := range b {
+		if e.EventID == eventID {
+			return e
+		}
+	}
+	t.Fatalf("the base set holds no event %q", eventID)
+	return event.Event{}
+}
+
+// seedBaseEvents stores the events every unfiltered subtest describes and
+// returns them in the order the list serves them.
+//
+// They go in through POST /api/v1/events, so the reads are checked against what
+// the write path stores rather than against rows a test wrote itself. Two of them
+// cannot come from that path: the pipeline records the source it ran under
+// whatever a collector claims, and it marshals an envelope for every item, so
+// the reconciliation row and the row without a payload are inserted through the
+// pool.
+func seedBaseEvents(t *testing.T, a api) baseSet {
+	t.Helper()
+
+	volume := fixture{cloud: listCloudA, resourceType: "volume", id: "vol-list"}
+	instance := fixture{cloud: listCloudA, resourceType: "instance", id: "inst-list"}
+	sibling := fixture{cloud: listCloudB, resourceType: "volume", id: "vol-list-b"}
+	widget := fixture{cloud: listCloudC, resourceType: "widget", id: "widget-list"}
+
+	// A payload with three members, so the fidelity check compares more than a
+	// state every mapper would keep.
+	state := "available"
+	created := volume.event("list-vol-create", "volume.create", listAt(0), event.PayloadEnvelope{
+		State:    &state,
+		Size:     volumeSize(10),
+		Provider: map[string]any{"az": "nova-1", "volume_type_id": "8f0e"},
+	})
+	created.ProjectID = listProjectA
+
+	resized := volume.event("list-vol-resize", "volume.resize", listAt(1),
+		payloadOf("available", volumeSize(20)))
+	resized.ProjectID = listProjectA
+
+	// The one event of a project of its own, in the cloud the others live in too.
+	launched := instance.event("list-inst-create", "instance.create", listAt(2),
+		payloadOf("active", map[string]any{"vcpus": 2, "ram_gb": 4, "disk_gb": 20, "flavor": "m1.small"}))
+	launched.ProjectID = listProjectB
+
+	elsewhere := sibling.event("list-vol-b-create", "volume.create", listAt(3),
+		payloadOf("available", volumeSize(30)))
+	elsewhere.ProjectID = listProjectA
+
+	// The one event of a platform of its own.
+	built := widget.event("list-widget-create", "widget.create", listAt(4),
+		payloadOf("ready", map[string]any{"units": 1}))
+	built.Platform = listPlatformC
+	built.ProjectID = listProjectA
+
+	for _, submitted := range []struct {
+		platform string
+		cloud    string
+		events   []event.Event
+	}{
+		{platform: fixturePlatform, cloud: listCloudA, events: []event.Event{created, resized, launched}},
+		{platform: fixturePlatform, cloud: listCloudB, events: []event.Event{elsewhere}},
+		{platform: listPlatformC, cloud: listCloudC, events: []event.Event{built}},
+	} {
+		_, token := seedIngestCredential(t, a.queries, submitted.platform, submitted.cloud)
+		items := make([]json.RawMessage, len(submitted.events))
+		for i, e := range submitted.events {
+			items[i] = item(t, e)
+		}
+		got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, batch(t, items...)))
+		if got.Accepted != len(submitted.events) {
+			t.Fatalf("result = %+v, want the %d events of %s stored",
+				got, len(submitted.events), submitted.cloud)
+		}
+	}
+
+	// A synthetic event of the reconciliation pipeline, which no request can
+	// store: the ingest path records the pipeline it ran under itself.
+	reconciled := volume.event("list-vol-recon", "volume.update", listAt(5),
+		payloadOf("available", nil))
+	reconciled.ProjectID = listProjectA
+	reconciled.Source = event.SourceReconciliation
+	payload, err := json.Marshal(reconciled.Payload)
+	if err != nil {
+		t.Fatalf("marshaling the payload of %s: %v", reconciled.EventID, err)
+	}
+	insertEventRow(t, a, reconciled, payload)
+
+	// A delete event whose payload column is NULL, which the ingest path stores
+	// for no item either: it marshals at least the empty envelope.
+	deleted := volume.event("list-vol-delete", "volume.delete", listAt(6), event.PayloadEnvelope{})
+	deleted.ProjectID = listProjectA
+	insertEventRow(t, a, deleted, nil)
+
+	return baseSet{created, resized, launched, elsewhere, built, reconciled, deleted}
+}
+
+// seedScopedEvent stores one event of a (cloud, project) pair through the ingest
+// path and returns its event id. The scope tests care about which pair an event
+// belongs to and about nothing else in it.
+func seedScopedEvent(t *testing.T, a api, cloud, projectID, eventID string) string {
+	t.Helper()
+
+	_, token := seedIngestCredential(t, a.queries, fixturePlatform, cloud)
+	res := fixture{cloud: cloud, resourceType: "volume", id: "vol-" + eventID}
+	e := res.event(eventID, "volume.create", listAt(20), payloadOf("available", volumeSize(10)))
+	e.ProjectID = projectID
+
+	if got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, item(t, e))); got.Accepted != 1 {
+		t.Fatalf("result = %+v, want the event of (%s, %s) stored", got, cloud, projectID)
+	}
+	return eventID
+}
+
+// insertEventRow writes one events row through the pool, with the source the
+// event names and the payload as it is given, NULL included. It exists for the
+// two states the ingest path cannot produce and is used for nothing else.
+func insertEventRow(t *testing.T, a api, e event.Event, payload []byte) {
+	t.Helper()
+
+	if _, err := a.store.Pool().Exec(t.Context(),
+		`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+		                     resource_type, resource_id, project_id, source, payload)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		e.EventID, e.Timestamp, e.EventType, e.Platform, e.Cloud,
+		e.ResourceType, e.ResourceID, e.ProjectID, string(e.Source), payload); err != nil {
+		t.Fatalf("inserting the event %s: %v", e.EventID, err)
+	}
+}
+
+// seedProject registers one project and returns its registry id, which is what a
+// project token is scoped by.
+func seedProject(t *testing.T, a api, cloud, externalID string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`INSERT INTO projects (platform, cloud, external_id) VALUES ('openstack', $1, $2) RETURNING id`,
+		cloud, externalID).Scan(&id); err != nil {
+		t.Fatalf("inserting the project (%s, %s): %v", cloud, externalID, err)
+	}
+	return id
+}
+
+// eventListOf decodes the answer of a list call, which the contract promises is
+// a 200 carrying one page.
+func eventListOf(t *testing.T, rec *httptest.ResponseRecorder) EventList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var list EventList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if list.Items == nil {
+		t.Errorf("body %q carries items as null, want an array", rec.Body)
+	}
+	return list
+}
+
+// assertServedEvent checks one served event against the event that was
+// submitted, member by member, plus the payload document its row holds.
+func assertServedEvent(t *testing.T, got StoredEvent, want event.Event, wantPayload map[string]any) {
+	t.Helper()
+
+	if got.EventId != want.EventID {
+		t.Errorf("event_id = %q, want %q", got.EventId, want.EventID)
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Errorf("timestamp of %s = %v, want %v", want.EventID, got.Timestamp, want.Timestamp)
+	}
+	if got.EventType != want.EventType {
+		t.Errorf("event_type of %s = %q, want %q", want.EventID, got.EventType, want.EventType)
+	}
+	if got.Platform != want.Platform {
+		t.Errorf("platform of %s = %q, want %q", want.EventID, got.Platform, want.Platform)
+	}
+	if got.Cloud != want.Cloud {
+		t.Errorf("cloud of %s = %q, want %q", want.EventID, got.Cloud, want.Cloud)
+	}
+	if got.ResourceType != want.ResourceType {
+		t.Errorf("resource_type of %s = %q, want %q", want.EventID, got.ResourceType, want.ResourceType)
+	}
+	if got.ResourceId != want.ResourceID {
+		t.Errorf("resource_id of %s = %q, want %q", want.EventID, got.ResourceId, want.ResourceID)
+	}
+	if got.ProjectId != want.ProjectID {
+		t.Errorf("project_id of %s = %q, want %q", want.EventID, got.ProjectId, want.ProjectID)
+	}
+	if got.Source != string(want.Source) {
+		t.Errorf("source of %s = %q, want %q", want.EventID, got.Source, want.Source)
+	}
+	// received_at is the server's own, so what is asserted is that it is there.
+	if got.ReceivedAt.IsZero() {
+		t.Errorf("received_at of %s is unset, want the instant the row was stored", want.EventID)
+	}
+
+	switch {
+	case wantPayload == nil:
+		if got.Payload != nil {
+			t.Errorf("payload of %s = %v, want null", want.EventID, *got.Payload)
+		}
+	case got.Payload == nil:
+		t.Errorf("payload of %s = null, want %v", want.EventID, wantPayload)
+	case !reflect.DeepEqual(*got.Payload, wantPayload):
+		t.Errorf("payload of %s = %v, want the stored %v", want.EventID, *got.Payload, wantPayload)
+	}
+}
+
+// storedPayload is the payload column of one event as the database holds it, and
+// nil for a row holding none.
+func storedPayload(t *testing.T, a api, eventID string) map[string]any {
+	t.Helper()
+
+	var payload map[string]any
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`SELECT payload FROM events WHERE event_id = $1`, eventID).Scan(&payload); err != nil {
+		t.Fatalf("reading the payload of event %s: %v", eventID, err)
+	}
+	return payload
+}
+
+// ids is the event ids of a served page, in order. The order assertions compare
+// these rather than whole events, so a failure names what came back.
+func ids(items []StoredEvent) []string {
+	found := make([]string, len(items))
+	for i, item := range items {
+		found[i] = item.EventId
+	}
+	return found
+}
+
+// pageEventID is the id of the nth event of the paginated walk. The ids sort the
+// way the timestamps do, so a page boundary is readable in a failure message.
+func pageEventID(n int) string {
+	return "list-page-" + string(rune('a'+n))
+}
+
+// pageAt is the instant of the nth event of the paginated walk.
+//
+// The third, fourth, and fifth share one instant, which is the shape a collector
+// batch has: every item of one resource change carries the same timestamp. With
+// a limit of three that group straddles a page boundary, so the walk only stays
+// whole if the event id decides where the next page resumes.
+//
+// That instant also carries a fraction of a second, which received_at and a
+// reconciliation run both produce. It is what the cursor's RFC3339Nano round
+// trip is readable on: a cursor cut to whole seconds would resume before the
+// event it was issued for and serve it twice.
+func pageAt(n int) time.Time {
+	if n >= 2 && n <= 4 {
+		return listAt(12).Add(500 * time.Microsecond)
+	}
+	return listAt(10 + n)
+}
+
+// instant renders one bound of the time window the way the contract asks for it,
+// escaped for the query string it travels in.
+func instant(at time.Time) string {
+	return url.QueryEscape(at.Format(time.RFC3339))
+}
+
+// rawCursor is a cursor carrying bytes of the test's own choosing: base64url, so
+// that it gets past the decoder, and whatever the test wants inside.
+func rawCursor(payload string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(payload))
+}

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -8,6 +8,7 @@ import (
 	"compress/flate"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -19,6 +20,24 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/oapi-codegen/runtime"
 )
+
+// Defines values for ListEventsParamsSource.
+const (
+	Collector      ListEventsParamsSource = "collector"
+	Reconciliation ListEventsParamsSource = "reconciliation"
+)
+
+// Valid indicates whether the value is a known member of the ListEventsParamsSource enum.
+func (e ListEventsParamsSource) Valid() bool {
+	switch e {
+	case Collector:
+		return true
+	case Reconciliation:
+		return true
+	default:
+		return false
+	}
+}
 
 // EventInput One canonical event. The members below are described rather than constrained; the normative schema is roadmap/00-conventions.md section 4.
 type EventInput struct {
@@ -52,6 +71,15 @@ type EventInput struct {
 	// Timestamp When the event happened, ISO 8601 with a timezone.
 	Timestamp            interface{}            `json:"timestamp,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// EventList One page of stored events.
+type EventList struct {
+	// Items The events of this page, ordered by timestamp and event id.
+	Items []StoredEvent `json:"items"`
+
+	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
+	NextCursor *string `json:"next_cursor"`
 }
 
 // IngestResult What one ingest call did with the batch it was given.
@@ -152,6 +180,78 @@ type ResourceTypeList struct {
 	// NextCursor Where the next page starts. It is always null today: the registry holds one row per resource type, so every registration fits into one answer. Cursor pagination arrives with the query endpoints.
 	NextCursor *string `json:"next_cursor"`
 }
+
+// StoredEvent One event as the events table holds it: what was submitted, plus the instant this API stored it.
+type StoredEvent struct {
+	// Cloud The installation the resource lives in.
+	Cloud string `json:"cloud"`
+
+	// EventId The idempotency key the event was submitted under.
+	EventId string `json:"event_id"`
+
+	// EventType What happened, written resource.action with an optional phase, for example compute.instance.create.end.
+	EventType string `json:"event_type"`
+
+	// Payload The normalized payload envelope, member for member as it was stored. It is null for an event stored without one, which a delete event may be. The members are not constrained here: an envelope keeps the fields a provider sent beyond the ones this API names.
+	Payload *map[string]interface{} `json:"payload"`
+
+	// Platform The platform the resource lives on.
+	Platform string `json:"platform"`
+
+	// ProjectId The project owning the resource at or after this event.
+	ProjectId string `json:"project_id"`
+
+	// ReceivedAt When this API stored the event.
+	ReceivedAt time.Time `json:"received_at"`
+
+	// ResourceId The resource the event is about.
+	ResourceId string `json:"resource_id"`
+
+	// ResourceType The kind of resource the event is about.
+	ResourceType string `json:"resource_type"`
+
+	// Source Which pipeline produced the event, collector or reconciliation. It is what the server recorded rather than what the submitter claimed.
+	Source string `json:"source"`
+
+	// Timestamp When the event happened.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ListEventsParams defines parameters for ListEvents.
+type ListEventsParams struct {
+	// Cloud Serve only the events of this cloud.
+	Cloud *string `form:"cloud,omitempty" json:"cloud,omitempty"`
+
+	// Platform Serve only the events of this platform.
+	Platform *string `form:"platform,omitempty" json:"platform,omitempty"`
+
+	// ProjectId Serve only the events of this project, named the way its cloud names it. A token asking for a project outside its scope is answered 403.
+	ProjectId *string `form:"project_id,omitempty" json:"project_id,omitempty"`
+
+	// ResourceType Serve only the events about resources of this type.
+	ResourceType *string `form:"resource_type,omitempty" json:"resource_type,omitempty"`
+
+	// EventType Serve only the events of this type, volume.create for example.
+	EventType *string `form:"event_type,omitempty" json:"event_type,omitempty"`
+
+	// Source Serve only the events the named pipeline produced.
+	Source *ListEventsParamsSource `form:"source,omitempty" json:"source,omitempty"`
+
+	// From Serve only the events at or after this instant, the inclusive bound of the window.
+	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
+
+	// To Serve only the events before this instant, the exclusive bound of the window.
+	To *time.Time `form:"to,omitempty" json:"to,omitempty"`
+
+	// Limit How many events one page carries at most.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListEventsParamsSource defines parameters for ListEvents.
+type ListEventsParamsSource string
 
 // IngestEventsJSONBody defines parameters for IngestEvents.
 type IngestEventsJSONBody struct {
@@ -417,6 +517,9 @@ func (t *IngestEventsJSONBody) UnmarshalJSON(b []byte) error {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// ListEvents List stored events
+	// (GET /api/v1/events)
+	ListEvents(w http.ResponseWriter, r *http.Request, params ListEventsParams)
 	// IngestEvents Ingest events
 	// (POST /api/v1/events)
 	IngestEvents(w http.ResponseWriter, r *http.Request)
@@ -443,6 +546,12 @@ type ServerInterface interface {
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
 
 type Unimplemented struct{}
+
+// ListEvents List stored events
+// (GET /api/v1/events)
+func (_ Unimplemented) ListEvents(w http.ResponseWriter, r *http.Request, params ListEventsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
 
 // IngestEvents Ingest events
 // (POST /api/v1/events)
@@ -494,6 +603,156 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListEvents operation middleware
+func (siw *ServerInterfaceWrapper) ListEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListEventsParams
+
+	// ------------- Optional query parameter "cloud" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cloud", r.URL.Query(), &params.Cloud, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cloud"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "platform" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "platform", r.URL.Query(), &params.Platform, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "platform"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "platform", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "project_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "project_id", r.URL.Query(), &params.ProjectId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "project_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "project_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "resource_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "resource_type", r.URL.Query(), &params.ResourceType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "resource_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "event_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "event_type", r.URL.Query(), &params.EventType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "event_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "event_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "source" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "source", r.URL.Query(), &params.Source, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "source"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "source", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "from" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "from", r.URL.Query(), &params.From, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "from"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "from", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "to" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "to", r.URL.Query(), &params.To, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "to"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "to", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListEvents(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // IngestEvents operation middleware
 func (siw *ServerInterfaceWrapper) IngestEvents(w http.ResponseWriter, r *http.Request) {
@@ -755,6 +1014,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/readyz", wrapper.Readyz)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/events", wrapper.ListEvents)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/events", wrapper.IngestEvents)
 	})
 	r.Group(func(r chi.Router) {
@@ -778,65 +1040,82 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"1Fptc9vGEf4rO2hn0kwpivJL2tKfnNRN1MnUGll9mbE91hFYEBcBd/DdgTTt0X/v7O4BBEiQkjyJk3yT",
-	"zcPdvjy7++zefUpSW9XWoAk+mX9KClQZOv7zEt836MP53+kfGfrU6Tpoa5J58p11DktF/wKdgc0hFNqD",
-	"ky+mcFUgeHQrdKAyWwcPoUCwBkFBqsoSHXg0mQdlMliiQacCel5gQ4FurT0+Ax1A1TUqR78ArtBtoLRL",
-	"KDWty3nPeOQEvIX3jQ3aLOk7bUCBb+rautCuAe1hXagAQaMIFNYWgl0iHTlNJolPC6wUqRs2NSbzxAen",
-	"zTK5vb2dJA59bY1Hts2Fs4sSK/oztSagCfSnqutSp2yW01pW/PknTxb71Nv7jw7zZJ784XRr+VP51Z+2",
-	"+/KJQ5tfbbWFXOkSM7HzwmYb8GrjobBr0qLnwv+dRCeeiBfHjo7LT7fuvuXTo0j02YsVmnBu6ka0zDJN",
-	"MqnywtkaHZkzmQfX4K7ILw1Cqow1OlUlOdBEbFRYLdB5WGBp16Acgny4wAycIndAKJSB1BofnNIGs2fs",
-	"MWNdpYJeIYh45FNnVVap+nQ2O0mtoUO0NX5aZeAxZYg+IbPUPWE/JWlpm2wf2CScNj6oMqJbMOZt41KE",
-	"Uq/QgzYTsP6kdjY7weYMcusAP6iqLnGa3E4S1vOdHtn9+9IuVFluoDH6fYOgM6xqG9CkG7jBDWH6DIKF",
-	"R0+/gbRQTqUBnZ/CcyPGo1hz6JtFpUPADNY6FCyhVxVC0BX6oKoaUtuY4EF5UJA1gsm+bILuXen+S7FR",
-	"UMQZzCawdnSI6bSfKjEmH6oM2FpAAHWhPE76ZgCCVxNwyqY0KU5ThyQCmozFqNWmtOqA/dnHpf6IGcR1",
-	"gGaFpa1xLtoGFRBUAOtA5YHBgmKhCf+ZN2UJDutSpViR3bz+iLAu0FBuSAtllqQhJZ9OC6fWUDu70hk6",
-	"yFRQImipQm5dNS5p++sYSiyhpEYyQHqzh5Ha2Z8wHUcJ7yy/g10bymiD/YeKax8DK5EcxWsO7tttsv2Q",
-	"QkgtbLOzwzhGaI8bbTjlt0sn0LqZ5FrZsqlwT2FZOgY6dLj1H6SE5NzZKhaRYB1m8TdVrinNOaSsLhm8",
-	"1jVyOQgEXm2W6CkwtBQEBaktS0yDdZSHjA1QKXcDOkTdOUYcptakutQS8bYJdTPIU1CpDSwQSswD/fwM",
-	"FKxU2SD9w+sM4bo755pRdT3c8xoc5o2PVUcHrNgmXcCOmsX0rLKNyvNXL+Gv38zOYhhy0H+0hoxMO0rZ",
-	"sgsCDx1xzha5RN+U4UDEU9EVw3Fphkz3EstChbSgoFkrD0u9QrOfSlWaYh1wBHE/2DVUymxaY9OOfIa4",
-	"lbaKEmsTcImORO4Slj+yIdlQ9qNQXSiPoEqHKttAgeWBnR2SWfBQ2u+2ZBHFY9mE7YMmuA2gSgvamVfe",
-	"Vckv42FcO5Otb5RzapMIoXjfaEfivN7acKB/T+S3I87tkZChOpf/+A7+9uTpXyCSEMgwKF1O4QVzKHTO",
-	"Omj5DHElzgbPL84hglR78IWqcSIsLuNScoDc7ANCThvxXlMpc0JeUosSAT/UpTISdL7GVOc6perHx9s0",
-	"bZxDqh1bX7Z0bJKwCiMAuUB3kmsss6iyJw2CpP4geZUNQjmPYlhncj4RqsbhwLtDpUqb7h/3o01j0hA2",
-	"avMcTUYZm/PDBHC6nDJDm/ZS86hGlV8eCFCirc6a5TYqJfkQk6XfyyjEyLY7KCMd5KQxOA0BOkmozDZ+",
-	"PFh+uLq6AFkAqc2w1wIIqkiYmP+T+ZPZbCwegw7lSEl4VRBpL4Zg8U1VKbdpDd36kTYdHJX8Z+hUDqk9",
-	"Y48Xt39fnlPYI8OOyJkJOt+09ffwkY0zc2KMmznDcr7F1Z0e4V9bS3QmH/POJS4aXWaRpY9BRadFV5M9",
-	"BRIzoM0Unrd1rC1gkOuSmCUYGwptllIsDWBVhw3ImeDkQB8brx5zwC6fs2tujF37ezPsSxYKrCk3A1rj",
-	"Owjxh6Mxcgc5uXvr1nf7Tjls7ztKZzRTNLYUtaEhZEU4Us22gq6JDfW32o2aHfy0e48jZql9QHcZd786",
-	"yOiYHseGinEjHzKJUz3PR+sN1aOP32272+Huz+Gfr17+C17J3plTeYBHs0ezk7NHkNm0qbglPOckR0WU",
-	"AhYWmFuH3Mb7SBUYoVzu40csF4npJNalgHr6Aj+oNEQIbMkNLUqV4TK2gVIFafl3rLZj3r5u4ybuF/k9",
-	"7V8yPphHML1gbijIVN6allfFJfumPdxJXnXUUGcdqYRUOacxaw3KkcohLUAXfxpZy6UjfgDGGpzAmlMI",
-	"T0nEetpk+KEbm8SEqAc0diRK+avDHOsrD7X1WmZHUpW3HS3zzYk0sJhxIwAf0dlDhE7F6cpucG62RulZ",
-	"eNikvum7dw5frdK68V8JNWhBANEhmzfJ3eVVFO8NADoJx7FzLCwFOhKHmA1jsIPRIG7jv9v+iKxnHc/Q",
-	"HLZUh5jcUlG7tg+2z2l1WZoFltYsqeJ8TtK+2tuPaA4DQ4Xu2NGdj2Ye2bcz4D3SUDLipKZmq71T4UiP",
-	"Fj1AQCuVD+3khDbMeV6VzBPa5oSatTtR1Plh13RDhQey3YWvH/UYZdgx0cALIwW9I8Z3ONBPwLqMt1xs",
-	"tsAh0O6Vknu2Ur1IGSGqBj+Ed2njvHXHBgy0DGq15AGSC75Nk3GsYJqyhGAztZlHkHN52UBhiQVxrbdr",
-	"qNEN1eDS1HKkXkXKNZUjE6zMvY1fo5vCdywmiaFj60MpeEWlv2X37xtu0kxWW20CO4JkI67VjlnvyENs",
-	"1KFd3o6VOo9p43TYcFzEZr7WV/YGR5Lqc8MdYqBfoVbeS1t4/bwJhXX6I2szh29ROXTwppnNHqe8mP/E",
-	"6ym8UGkBhChR3KgqlhJnSy73BjHzz0DFQ2Q6LDRA7IcZPJk97kb1pM6Cz9tGVRFCLVWIqv5hXdqRh0Mu",
-	"a6qcgPa+oZSPDv7UwnYidPRrhu9naX0eeH4kWbllzpSaJcEp7UCVPMG5l1YBnVHlAb2YzBWK7OQxdRiE",
-	"BPFA/Yonz9vwkjGHlHnZFJxtQkTi5LOV1dxWtMYMFupmUeo03vv4e6h5y4rmdl+/F0J5WkI32Uai5sG/",
-	"dRsZ6zae4lxs3jIfNsAUrqgR6GhkalfUCJEZClRlKLjPoxyGu2f1K98JV6o2RUy6ihzntgTv2Bg868W0",
-	"pMBWpi7CYwroMoB2sLbuBmqV3qilpOLYKyfixctuk+cX58kkIR3EQrPp2XRGSLE1GlXrZJ48ns6mjymb",
-	"q1BwjJ+qWp+uzk4Fi1z77Vh9eEXUm9iQTAFtvnuZ43s3UES8NQONB2ZsPKGbnKfpaxWgsj7A2Ww2i418",
-	"NX1jaAsJb9rk0WzG4xrKqP0bPtDBY5lzlVURjwRPNqkMCSbMU7sPtcn0SmeNKuNsL9PZvMd/48irHc1q",
-	"DzdYh3hvecJz3S4njxL2nj+J4Bu4bsd119R0b2fPFP9kGulrMmdr3nRdUN4T4zLTpYqxaPKcjRhb7TiM",
-	"DI0zXnBWNT5wiDmk8kRkVU7tKHmXY8+zZB5nwC/E2VIp0IdvbbY5cn25f21pDb7Mk/nr47W6d1V4O/l0",
-	"v/o++Ganur+9HVY3qn+7l7GPZrMHaXJMlsHA/MAtrHiMgFA7myKlyd2r2HX/Lo2SoA4/19XsJHki+o59",
-	"0dlle5NM688etv7s8YPWP32QPD3ewWgaFOrXb2/fTpI47OuwG7MNf9smr0EmZosuMYzNhDhyBgSNeUSv",
-	"wg9o9tdSkttnAb071l6z1b9AcghpgenNsLcahiDx7z6LlTj8hSC8R/wPPiY4Qv1/LqSefUEkbbnrLozI",
-	"DD1SP6LzEWydfmqhcnv6aYCV2x7shg7/Hgf+/lLufqirfz1PP5k9+U0g4xJVFue44yaS5wpOVRjYSq8/",
-	"ezpy8D0Asd1kzvyMujbF1HgwBuhXv2PPlCafN13p3eDfLdjuUOL+0r2dJPEJ0W6OFtP7vTxrc/bN8Vw9",
-	"Ab7N5Ncevj+QaW+Ee66VkZhU664HuM/sWW3nbCpAZlG6nPgdP0PqkcJ4rxKfmvj9gnDR7OeHz6Nlx1PD",
-	"yA3AFyZU90tPg+mmj+Y3dt3z3e+IP80e/4b51rFcGO991G4KpNoo7fHHI0xLnuWsC4wP+LDlx+AL25QZ",
-	"3CDW4BpjtFnyrCBXuvRyYbd9yEUNmE4RCuVhgWigMXL2hsOX0mn7PpAbJGtyvWwoukPh0Be2bK+LVAAF",
-	"wSnjNcV591TENkHGAzIIbMN1P0x/iDrfGR8BP4TTulR6JzK2l8T2ZmTyOxoNrf48mtSrn7FIP30g8J8+",
-	"CMi3Q8a1QkOu53GKIKidM51upySncUpyeAghl7q+/xhKU17micLI1bRcbYNH6r3jAHZnMkMZWgYOXvps",
-	"STeZNdi/OuugoEpYNsopE5DqeaHjsCdDp1fEF+zaz7ezBzWYAtm1DJBlftTKrrl0oJe+P1WGvskakYXb",
-	"iH0wxhvpi27zX6xqDF4afPF60b93P1gw5NI910b74ndVG75wbz0YF+8nfDHjMD4kWJk6PSzbt4mL4MxT",
-	"NMq9ea7TXq5fF0SXBg/3tIfGOFRp0Q7xdFpAUDeRzdU240crNgdng+oeIdP/xRQur/7HQoaV+LXSt9DP",
-	"YHes8XvM52RJPUjot7f/DwAA//8=",
+	"3Ft7j9tIcv8qBSXA3iIajcZrXxL5L9/GuZ1gkTXGzgNYG1aLLIl9Q3bT3c2RZWO+e1BV3XxIlOaxtvc2",
+	"/3kssrve9asHP08yW9XWoAl+svg8KVDl6PifV/ihQR8u/43+yNFnTtdBWzNZTH60zmGp6C/QOdg1hEJ7",
+	"cPLGDN4UCB7dDTpQua2Dh1AgWIOgIFNliQ48mtyDMjls0KBTAT0/YEOBbqs9PgcdQNU1Kke/AN6g20Fp",
+	"N1Bqem7NZ8Yrp+AtfGhs0GZD72kDCnxT19aF9AxoD9tCBQgahaCwtRDsBunK2WQ68VmBlSJ2w67GyWLi",
+	"g9NmM7m9vZ1OHPraGo8sm1fOrkqs6J+ZNQFNoH+qui51xmI5r+WJf/qbJ4l97p39jw7Xk8XkH847yZ/L",
+	"r/48ncs3DmX+puMW1kqXmIucVzbfgVc7D4XdEhc9Ff7vWVTimWhx7Or4+Hmn7lu+PZJEr728QRMuTd0I",
+	"l3muiSZVvnK2RkfinCyCa3Cf5F8MQqaMNTpTJSnQRNuosFqh87DC0m5BOQR5cYU5OEXqgFAoA5k1Pjil",
+	"DebPWWPGukoFfYMg5JFOnVV5perz+fwss4Yu0db4WZWDx4xN9CmJpe4R+3mSlbbJDw2biNPGB1VG6xYb",
+	"87ZxGUKpb9CDNlOw/qx2Nj/D5gLW1gF+VFVd4mxyO50wn+/1yOl/Le1KleUOGqM/NAg6x6q2AU22g2vc",
+	"kU1fQLDw5NmfISuUU1lA52fwwojwyNcc+mZV6RAwh60OBVPoVYUQdIU+qKqGzDYmeFAeFOSN2GSfNrHu",
+	"fer+h3yjII8zmE9h6+gS03I/UyJMvlQZsLUYAdSF8jjtiwHIvJqAMxalyXCWOSQS0ORMRq12pVVH5M86",
+	"LvUnzCE+B2husLQ1LoTboAKCCmAdqHVgY0GR0JT/uW7KEhzWpcqwIrl5/QlhW6Ch2JAVymyIQwo+LRdO",
+	"baF29kbn6CBXQQmhpQpr66pxStOvY1ZiyUpqJAFk1wc2Ujv7N8zGrYRPlt/Bbg1FtMH5Q8a1j441kRjF",
+	"zxw9tz2ke5FcSK1ss3fCuI3QGdfacMhPj04hqZnourFlU+EBw/LomNGhw05/kJElr52tYhIJ1mEef1Pl",
+	"lsKcQ4rqEsFrXSOng0DGq80GPTmGloSgILNliVmwjuKQsQEq5a5Bh8g7+4jDzJpMl1o83jahbgZxCiq1",
+	"gxVCietAPz8HBTeqbJD+8DpHWLb3LNmqlsMzl+Bw3fiYdXTAimXSOuyoWExPKp1XXr7+Bf7lz/OL6Ibs",
+	"9J+sISHTiZK27IqMh67gyP2z9uHwCgrOtdpwJu2L2R8GS6LYjxtDFGNCAHTgFKzLkc5b7XpBieSSohhd",
+	"0R56Kh++ZsKYi0nHn3JO7ehvgx/D+6xx3rpTpkWPCa8+KBf8FGrlPRFIvqk8LOWM5Qwu2R8MBZAY/Uvl",
+	"5WUimn5QqxJTvtvHCeRAHxrtMJ8sfo0sDsl8N6KlS7bbK/RNGY7EZYJGYt4MoCDXvfC/UiErKLRtlYeN",
+	"vkFzqEOVZVgHHIkLP9ktVMrski7pRL5DrIKOihRrE3CDjkhu04o/cSDzz+dRQF0pj6BKhyrfQYHlkZMd",
+	"kljwWHJuj2QSxa/yKcsHTXA7QJUV97avq3jZEQvb02crwwH/PZLHlNuDikN2rv79R/jXp8/+GSJUhByD",
+	"0uUMXjLSReesg4Q6CdGyh714dQkxlGgPvlA1TgVr55zwj0DQQ4OQ20a011TKnJGWyNABP9alMhIafY2Z",
+	"XuuMMApfb7OscQ4pw08OnGE6YRZGDOQVurO1xjKPLHviIEiCDpL9WCCUmSjS6lzuJ9jbOBxod8hUabPD",
+	"6362WQztUjPY9RpNTnmVo/gUcLaZMY6e9RLoKEeV3xxxUCounDWbzislRVC9Qb+XkYiRY/esjHiQm8bM",
+	"aT8EEhhqjgTnn968eQXyAGQ2x16hJlZFxMQsPVk8nc/H/DHoUI4k7tcFlVbF0Fh8U1XK7ZKgkx7p0MFV",
+	"k/8eKpVd6kDY4xDkv64uye2RzY4gtAl6vUso6fiVjTMLwvW7BZvlorOrOzXCvyZJtCIf084Vrhpd5rGW",
+	"GjMVnRUtcvLkSIxTdzN4kdBGghmw1iXhfzA2FNpsBNIYwKoOO5A7wcmFPpbHPXzX5ubAqrk2duvvXQdd",
+	"MVFgTbkbgM8u0/OLoz5yB4S8++iku0OlHJf3HakziikKW5LaUBDyRDiRzTpCtwQs+kfte82e/aSzxy1m",
+	"o31AdxVPf3MUd3MRE8tetht5kaG26mk+Sm/IHr38vutBDE9/Af/x+pf/hNdydu7UOsCT+ZP52cUTyG3W",
+	"VFy4CzSiJEoOCytcW4fcbPERKrCFcrqPLzFdRKYTX5cE6ukN/KiyEE2gAzf0UKYMp7EdlCpIY2ZPanvi",
+	"7fM2LuJ+kh8FwhFHMLxgpCqWqbw1CVfFRw5Fe7zebwEyFe4J+kOmnNOYJ4Gyp7JLi6GLPo08y6kjvgDG",
+	"GpzClkMI97JEetrk+LFtbsWAqAfFxoiX8lvHMdZ3HmrrtXT4JCt3fQfGm1NpM2DO5Rp8QmePAToVe2D7",
+	"zrnrhNKT8LCV8Lav3gV8d5PVjf9OoEEyAogK2b2d3J1ehfFem6alcNx2TrmlmI74IeZDH2zNaOC38e9U",
+	"xZL0rONOp8MEdQjJbRQV1YfG9piGBFOzwtKaDWWcxwTtNwfnEcxhw1ChvXb05JORR85tBXiPMDQZUVJT",
+	"s9Teq3Ciko4aIEPjki72t+jANXcVJ4sJHXNGJeudVtTqYV90Q4YHtN1lX+N1+p6IBlp4WK0+fHVQpreG",
+	"Q0Z7kEruWUr1POXL1eopTMbmD1fmweZqt4hGzullB4UlFMS53m6hRjdkg1NTwki9jLTWlI5MsDKdMH6L",
+	"bgY/MplEho6lD4XgG0r9Cd1/aLhIM3ltdWyafJ3mQL8FMhqAYnPMH2I+kYkOC0kNZPptEJ9CXTYxR3D7",
+	"LnT1ZWwH6fCF++bjReLJ9LnfIu96YgNuoDH5ACrsn//7trxHyHpsC3yaygS6PP5T+QRSYsum38aKcEKE",
+	"FjVLDFGF0QMUCnIsMSTpSstzOK2hFGVs6E9lgPx2wedH+uAasRa74hKf8nTbV/d09Ap3NqZGa1Ijg8zO",
+	"qApPOVLnE7+lLT+uja/Qjx/Nshnqm9OZauiDrb3fN089bAiABzOAx2GD/ZnAfY8+PhYgm2y7+7WzeZP1",
+	"xTHttfa5Tdbvtyf7l2lvN4ump1y+N2PsHorBxEFWKl3huN8+vGn/SITRw6fdnYNwNu2jEAnMh2ikbw0D",
+	"O2+F38WioYG+G6u7PGaN02HHIC12lmv9xl7jCMJ/YdiUA/2aWu7Kw/JFEwrr9CdW1gL+gsqhg7fNfP5D",
+	"xg/zP3E5g5cqK4Dyj2QVjhDifbbk2tMg5v45qHiJDJSlJpVkjjk8nf/QTveJnRXf1ymgCKGWkohK0OO8",
+	"pP67Q66xVDkF7X1DQRod/CkpYyq9ke8ZSz2K60uJv1IipJROcVzQttIOVMlDn3txFdAZVR7hizsLhSI5",
+	"ecwcii/wFga84WF1h/Wk5y6QQQ4FZ5sQYdH00cxq7nElYQYLdbMqdRZXRfw92LxlRtf2kL+XEoRSd2Ha",
+	"hSjNuwLW7WQS3HgCnSLzVIazACgJat/1NDJ7Q9mQxFCgKkPBTUcC1Lh/Vz9PnHHZlPDqtC0Po0uSeccu",
+	"1fMewBQ8nmhq4WbEoy0c1Q621l1DrbJrtZEsGhu3E9HiVXvIi1eXk+mEeBAJzWcXszlZiq3RqFpPFpMf",
+	"ZvPZDxwYQsE+fq5qfX5zcS62SP+zwTDW2wuNM6kZ2Z8qTsEo5+xWyg2GHPRQ2+Ps7fLEfocX8MFFClnI",
+	"8k9tGIySfq/z75egfCbd/Bks185WcQIb7BI8UoYQTalyfUYMwlab3G5h+Ss9PIVgv1+mUZ/or71m0eEm",
+	"FdqGVbxE+zh1kdlT/wG6Wkx69tbIDkxZxnAkJQqPE2HJJcAy8dvD72Idy15psBzkMy6S+FR2Od+fYVIw",
+	"ZOB38Dqfb/LUnd+q8lpkLM/EckF1jR8iIjafAUsvRVTtkGBcXLRK61NiiRI2kk6JYixLyHFNWHERQaH8",
+	"yESoyIW0+7iPJCEuUWDNVrncz94a9sFSyxoXS+nMZ7beS+ats8lvM3jRQjdJEA5V2yyPdURhPcKyy4zL",
+	"mGasbJlRgRh/9FPQJiubPGHAtETQBZXUq+u6owTLg1PGr9GRO6it2onYa3Rn7YtCWI6ZzjHZY0v6Xpiw",
+	"25QJqRBOXVd2uJqt8gCjBunL2jLvoKyJMC0R1/VxKXq0SfcynywmP2sfXorvU1RwqsLAO2a/HsyFyCm6",
+	"7v7efkA7NdD0LIc4wvuKQ3uCMMfX8KYPu63flxq7sAefvtydIt4payiPjrZjK2L+ouZ0INsUm1T+uu37",
+	"duqJqyX0IhvzGKQZZWoA8X4rWwzdT8xoxig4aIh9KdlKI0c2jGJ9PVw0GqdnAJl/MzEcf1m3B+XJMQJa",
+	"oN1djqapCOW3VYyA714R08PfD1bafkUaOzzTiN2ysvGEHla26aUDzovHWKDYPGDgfhXN/eiNwfKQVPz4",
+	"CFKD/QKE7i/FpKzdJmsVoLLSoR8jotSVDgM6clwrHlJezOfTSaU+6opM4GLOf2oT/xwbJo5h9mF2TwN3",
+	"orAvTSoSIsK2tfrQ4AIUZKWmxBehgw7tGpQmT5cCkEcSjD0pLSUQwD2jdWwMjoZw6WOecrN3e6vUT+bz",
+	"E2vUD1uf7tbdRhaoTy68fYml6enkqfAy9kbLc7fjTc9fPPD5Hx70/LMH0dMr7zmxd4X9r+9IbXG7I8KB",
+	"oQy5iWbH5hfcvyaMJFtqdr2/Eu57e+yE7TTDOdt2tqV/yXMEejs6HpDjRLuvGB+m9j0d8mQ+53UirjH6",
+	"tYUOHss1gzIVS1TCZNHS1arkhqgK7Yva5PpG540q4+5ZrvNFbz4b23VpwVN7uMY6xI7TGafwdmYwOlDu",
+	"lXjkdgaWaZ1sSRCha3NVioOmE/fOna0lGBa2TCuAjKAJMaya9ZqFGDFeXJbj6kyKi6rxgatuh4HqTEi3",
+	"tiPjIQKUHcUWA0Z5/sXmuwd5rzX4y5qt604/lg8OKPrda/40eGdv+vTudthdC67B268YhwYLnUe+5RCN",
+	"kSHUzmbo/eEHHdv+eIIwvATeP0isuviWsWrQu9sPV6KONlLdTtt+xqA5c9++Rm8a22v6DVDv99KlG1bH",
+	"+8sA/TV0h5AVmF0PZ/+HRVh/yip++JVM+GAwffSTpBOj6S9lqRd/P1kvnOL5hG2df06mcnv+eWArtz2z",
+	"Gyr8rzjQ97dS90NV/ftp+un86d+FZVyhyuOe4biIZOJ7om1y7+2do18VRUBeq1CMdjiG2e9BhfD9tn96",
+	"3wHdTdjhmOq+1L2bTuKHiPsxWkTvD+KsXbNuTsfqqYwR+Zsx318YSl8s9FQrK1uSrduxwH12I1W3B6YC",
+	"5BZ9HKjze/wxYw8UpqpLPljzhwnhVXMYHx4Hy06HhpEN1W8MqO4Xngbbdz6K39htT3f/f2u9b4u3TsXC",
+	"uJes9kMg5UaZmH06gbTk475tgbGrjwkfgy9sU+a8YAKuMYZnPpfyNbSXplL3OSi3wTOEQnlYIRpojNy9",
+	"Y/elcJqGBlwgWbPWm0ZWLhz6wpZpnVkFUNIk57ZJ+ymTbYJMDGVRLbnroZv+FHm+0z8Cfgzndan0nmd0",
+	"HzHY65Hm1ag3JP55dU7ffMEk/eyBhv/sQYZ8O0RcN2hI9TxhFQtKo+fzbiJyHgenvCA72oSQjw58fztD",
+	"U1zmjsLIpxMypYoDxLgguDeFoQjdzfSyFO3zXsuNRy7JFFQJm0Y5ZQJSPi90nP/m6Ljh5uzWL7reg9qf",
+	"+PB0TtqiiXbNqQO91P2ZMqkTzd07KiMOjTF+MfGqPfyrZY3BlzDfPF/0vws5mjDko5C1NtoXf6jc8I1r",
+	"68EGyWHAFzEO/UOclaHTw6J9ClxkztxFo9i7XuusF+u3BcGlwYel2kNjHKqsSE08nRUQ1HVEc7XNU/va",
+	"2aDavc443qIQLiPtMZdhJn6v8C3wM9g9afwR4zlJUg8C+u3t/wUAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -39,6 +39,27 @@ func (e ListEventsParamsSource) Valid() bool {
 	}
 }
 
+// Defines values for ListResourcesParamsStatus.
+const (
+	Active  ListResourcesParamsStatus = "active"
+	All     ListResourcesParamsStatus = "all"
+	Deleted ListResourcesParamsStatus = "deleted"
+)
+
+// Valid indicates whether the value is a known member of the ListResourcesParamsStatus enum.
+func (e ListResourcesParamsStatus) Valid() bool {
+	switch e {
+	case Active:
+		return true
+	case All:
+		return true
+	case Deleted:
+		return true
+	default:
+		return false
+	}
+}
+
 // EventInput One canonical event. The members below are described rather than constrained; the normative schema is roadmap/00-conventions.md section 4.
 type EventInput struct {
 	// Cloud The installation the resource lives in, os-prod-eu1 for example.
@@ -92,6 +113,41 @@ type IngestResult struct {
 
 	// Rejected The items the call refused, one entry each.
 	Rejected []RejectedEvent `json:"rejected"`
+}
+
+// Lifecycle One resource, its event history, and the billable intervals that history folds into. `resource` is always there: a resource this API holds no projection row for is answered 404 rather than with an empty lifecycle.
+//
+// The two halves are derived from two different event sets. `events` and `intervals` carry the history this token may read, while `resource` is the projection row, folded from every event the resource has under no scope. On a resource that changed projects the row therefore reports a `created_at` from before the reader owned it, and the first interval starts at the transfer.
+type Lifecycle struct {
+	// Events The full history the fold ran on, ordered by `(timestamp, received_at, event_id)`.
+	Events []StoredEvent `json:"events"`
+
+	// Intervals The billable intervals the history implies, oldest first. Two billable changes at the same instant leave no interval between them, so a resource created and deleted at one instant has none at all.
+	Intervals []LifecycleInterval `json:"intervals"`
+
+	// Resource One resource as the projection holds it: what its event history says it is right now.
+	Resource Resource `json:"resource"`
+
+	// Warnings What the fold could not trust, one entry each. A history whose first event is not a create carries history_starts_without_create.
+	Warnings []string `json:"warnings"`
+}
+
+// LifecycleInterval One half-open span `[from, to)` over which nothing billable about a resource changed.
+type LifecycleInterval struct {
+	// From When the interval starts, the inclusive bound.
+	From time.Time `json:"from"`
+
+	// ProjectId The project owning the resource over the interval.
+	ProjectId string `json:"project_id"`
+
+	// Size The size the resource had over the interval.
+	Size map[string]interface{} `json:"size"`
+
+	// State The state the resource was in over the interval.
+	State string `json:"state"`
+
+	// To When the interval ends, the exclusive bound. It is null while the interval is open, which the last interval of a living resource is.
+	To *time.Time `json:"to"`
 }
 
 // Problem RFC 9457 problem detail. Every error response in this API uses this shape, served as application/problem+json.
@@ -155,6 +211,54 @@ type RejectedEvent struct {
 
 	// Reason Why the item was refused, for example "size_schema: 'vcpus' is a required property".
 	Reason string `json:"reason"`
+}
+
+// Resource One resource as the projection holds it: what its event history says it is right now.
+type Resource struct {
+	// Cloud The installation the resource lives in.
+	Cloud string `json:"cloud"`
+
+	// CreatedAt When the resource was created, as the projection folded it from the resource's whole history. It is null for a history that never showed a create. The projection is not scoped to the reading token, so on a resource that changed projects this is the create of the project it came from and predates the reader's ownership: what a project is billed for is the lifecycle's `intervals`, never `created_at` paired with `deleted_at`.
+	CreatedAt *time.Time `json:"created_at"`
+
+	// DeletedAt When the resource was deleted, null while it lives.
+	DeletedAt *time.Time `json:"deleted_at"`
+
+	// LastEventAt When that event happened.
+	LastEventAt time.Time `json:"last_event_at"`
+
+	// LastEventType The type of the newest event folded into this row.
+	LastEventType string `json:"last_event_type"`
+
+	// LastPayload The payload envelope of that event, member for member as it was stored, and null for a row that holds none.
+	LastPayload *map[string]interface{} `json:"last_payload"`
+
+	// Platform The platform the resource lives on.
+	Platform string `json:"platform"`
+
+	// ProjectId The project owning the resource now.
+	ProjectId string `json:"project_id"`
+
+	// ResourceId The resource itself, as its cloud names it.
+	ResourceId string `json:"resource_id"`
+
+	// ResourceType The kind of resource.
+	ResourceType string `json:"resource_type"`
+
+	// Size The size the resource has now, member for member as its events reported it. It is the empty object for a history that reported no size.
+	Size map[string]interface{} `json:"size"`
+
+	// State The state the resource is in now. A deleted resource carries deleted, which the server sets itself rather than reading it off the delete event.
+	State string `json:"state"`
+}
+
+// ResourceList One page of current resources.
+type ResourceList struct {
+	// Items The resources of this page, ordered by cloud, resource type, and resource id.
+	Items []Resource `json:"items"`
+
+	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
+	NextCursor *string `json:"next_cursor"`
 }
 
 // ResourceType One registered resource type and the size schema the sizes reported for it are validated against.
@@ -260,6 +364,36 @@ type IngestEventsJSONBody struct {
 
 // IngestEventsJSONBody1 defines parameters for IngestEvents.
 type IngestEventsJSONBody1 = []EventInput
+
+// ListResourcesParams defines parameters for ListResources.
+type ListResourcesParams struct {
+	// Cloud Serve only the resources of this cloud.
+	Cloud *string `form:"cloud,omitempty" json:"cloud,omitempty"`
+
+	// Platform Serve only the resources of this platform.
+	Platform *string `form:"platform,omitempty" json:"platform,omitempty"`
+
+	// ProjectId Serve only the resources of this project, named the way its cloud names it. A token asking for a project outside its scope is answered 403.
+	ProjectId *string `form:"project_id,omitempty" json:"project_id,omitempty"`
+
+	// ResourceType Serve only the resources of this type.
+	ResourceType *string `form:"resource_type,omitempty" json:"resource_type,omitempty"`
+
+	// State Serve only the resources whose current state is exactly this, shutoff for example.
+	State *string `form:"state,omitempty" json:"state,omitempty"`
+
+	// Status Which part of the fleet to serve. `active` serves the rows whose state is not deleted, `deleted` serves those alone, and `all` serves both. `state` and `status` are independent filters, so a contradictory pair such as `state=active&status=deleted` yields the empty page.
+	Status *ListResourcesParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// Limit How many resources one page carries at most.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListResourcesParamsStatus defines parameters for ListResources.
+type ListResourcesParamsStatus string
 
 // IngestEventsJSONRequestBody defines body for IngestEvents for application/json ContentType.
 type IngestEventsJSONRequestBody IngestEventsJSONBody
@@ -532,6 +666,15 @@ type ServerInterface interface {
 	// PutResourceType Register a resource type
 	// (PUT /api/v1/resource-types/{platform}/{resource_type})
 	PutResourceType(w http.ResponseWriter, r *http.Request, platform string, resourceType string)
+	// ListResources List the current resources
+	// (GET /api/v1/resources)
+	ListResources(w http.ResponseWriter, r *http.Request, params ListResourcesParams)
+	// ListResourceEvents Read the event history of one resource
+	// (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/events)
+	ListResourceEvents(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string)
+	// GetResourceLifecycle Read the folded lifecycle of one resource
+	// (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle)
+	GetResourceLifecycle(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string)
 	// Healthz Liveness probe
 	// (GET /healthz)
 	Healthz(w http.ResponseWriter, r *http.Request)
@@ -574,6 +717,24 @@ func (_ Unimplemented) GetResourceType(w http.ResponseWriter, r *http.Request, p
 // PutResourceType Register a resource type
 // (PUT /api/v1/resource-types/{platform}/{resource_type})
 func (_ Unimplemented) PutResourceType(w http.ResponseWriter, r *http.Request, platform string, resourceType string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListResources List the current resources
+// (GET /api/v1/resources)
+func (_ Unimplemented) ListResources(w http.ResponseWriter, r *http.Request, params ListResourcesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListResourceEvents Read the event history of one resource
+// (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/events)
+func (_ Unimplemented) ListResourceEvents(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// GetResourceLifecycle Read the folded lifecycle of one resource
+// (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle)
+func (_ Unimplemented) GetResourceLifecycle(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -852,6 +1013,218 @@ func (siw *ServerInterfaceWrapper) PutResourceType(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// ListResources operation middleware
+func (siw *ServerInterfaceWrapper) ListResources(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListResourcesParams
+
+	// ------------- Optional query parameter "cloud" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cloud", r.URL.Query(), &params.Cloud, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cloud"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "platform" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "platform", r.URL.Query(), &params.Platform, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "platform"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "platform", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "project_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "project_id", r.URL.Query(), &params.ProjectId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "project_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "project_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "resource_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "resource_type", r.URL.Query(), &params.ResourceType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "resource_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "state" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "state", r.URL.Query(), &params.State, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "state"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "state", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "status", r.URL.Query(), &params.Status, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "status"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListResources(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListResourceEvents operation middleware
+func (siw *ServerInterfaceWrapper) ListResourceEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "cloud" -------------
+	var cloud string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "cloud", chi.URLParam(r, "cloud"), &cloud, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "resource_type" -------------
+	var resourceType string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "resource_type", chi.URLParam(r, "resource_type"), &resourceType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_type", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "resource_id" -------------
+	var resourceId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "resource_id", chi.URLParam(r, "resource_id"), &resourceId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListResourceEvents(w, r, cloud, resourceType, resourceId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetResourceLifecycle operation middleware
+func (siw *ServerInterfaceWrapper) GetResourceLifecycle(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "cloud" -------------
+	var cloud string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "cloud", chi.URLParam(r, "cloud"), &cloud, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "resource_type" -------------
+	var resourceType string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "resource_type", chi.URLParam(r, "resource_type"), &resourceType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_type", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "resource_id" -------------
+	var resourceId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "resource_id", chi.URLParam(r, "resource_id"), &resourceId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "resource_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetResourceLifecycle(w, r, cloud, resourceType, resourceId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // Healthz operation middleware
 func (siw *ServerInterfaceWrapper) Healthz(w http.ResponseWriter, r *http.Request) {
 
@@ -1020,6 +1393,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/api/v1/events", wrapper.IngestEvents)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/resources", wrapper.ListResources)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/resources/{cloud}/{resource_type}/{resource_id}/events", wrapper.ListResourceEvents)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle", wrapper.GetResourceLifecycle)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/resource-types", wrapper.ListResourceTypes)
 	})
 	r.Group(func(r chi.Router) {
@@ -1040,82 +1422,117 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"3Ft7j9tIcv8qBSXA3iIajcZrXxL5L9/GuZ1gkTXGzgNYG1aLLIl9Q3bT3c2RZWO+e1BV3XxIlOaxtvc2",
-	"/3kssrve9asHP08yW9XWoAl+svg8KVDl6PifV/ihQR8u/43+yNFnTtdBWzNZTH60zmGp6C/QOdg1hEJ7",
-	"cPLGDN4UCB7dDTpQua2Dh1AgWIOgIFNliQ48mtyDMjls0KBTAT0/YEOBbqs9PgcdQNU1Kke/AN6g20Fp",
-	"N1Bqem7NZ8Yrp+AtfGhs0GZD72kDCnxT19aF9AxoD9tCBQgahaCwtRDsBunK2WQ68VmBlSJ2w67GyWLi",
-	"g9NmM7m9vZ1OHPraGo8sm1fOrkqs6J+ZNQFNoH+qui51xmI5r+WJf/qbJ4l97p39jw7Xk8XkH847yZ/L",
-	"r/48ncs3DmX+puMW1kqXmIucVzbfgVc7D4XdEhc9Ff7vWVTimWhx7Or4+Hmn7lu+PZJEr728QRMuTd0I",
-	"l3muiSZVvnK2RkfinCyCa3Cf5F8MQqaMNTpTJSnQRNuosFqh87DC0m5BOQR5cYU5OEXqgFAoA5k1Pjil",
-	"DebPWWPGukoFfYMg5JFOnVV5perz+fwss4Yu0db4WZWDx4xN9CmJpe4R+3mSlbbJDw2biNPGB1VG6xYb",
-	"87ZxGUKpb9CDNlOw/qx2Nj/D5gLW1gF+VFVd4mxyO50wn+/1yOl/Le1KleUOGqM/NAg6x6q2AU22g2vc",
-	"kU1fQLDw5NmfISuUU1lA52fwwojwyNcc+mZV6RAwh60OBVPoVYUQdIU+qKqGzDYmeFAeFOSN2GSfNrHu",
-	"fer+h3yjII8zmE9h6+gS03I/UyJMvlQZsLUYAdSF8jjtiwHIvJqAMxalyXCWOSQS0ORMRq12pVVH5M86",
-	"LvUnzCE+B2husLQ1LoTboAKCCmAdqHVgY0GR0JT/uW7KEhzWpcqwIrl5/QlhW6Ch2JAVymyIQwo+LRdO",
-	"baF29kbn6CBXQQmhpQpr66pxStOvY1ZiyUpqJAFk1wc2Ujv7N8zGrYRPlt/Bbg1FtMH5Q8a1j441kRjF",
-	"zxw9tz2ke5FcSK1ss3fCuI3QGdfacMhPj04hqZnourFlU+EBw/LomNGhw05/kJElr52tYhIJ1mEef1Pl",
-	"lsKcQ4rqEsFrXSOng0DGq80GPTmGloSgILNliVmwjuKQsQEq5a5Bh8g7+4jDzJpMl1o83jahbgZxCiq1",
-	"gxVCietAPz8HBTeqbJD+8DpHWLb3LNmqlsMzl+Bw3fiYdXTAimXSOuyoWExPKp1XXr7+Bf7lz/OL6Ibs",
-	"9J+sISHTiZK27IqMh67gyP2z9uHwCgrOtdpwJu2L2R8GS6LYjxtDFGNCAHTgFKzLkc5b7XpBieSSohhd",
-	"0R56Kh++ZsKYi0nHn3JO7ehvgx/D+6xx3rpTpkWPCa8+KBf8FGrlPRFIvqk8LOWM5Qwu2R8MBZAY/Uvl",
-	"5WUimn5QqxJTvtvHCeRAHxrtMJ8sfo0sDsl8N6KlS7bbK/RNGY7EZYJGYt4MoCDXvfC/UiErKLRtlYeN",
-	"vkFzqEOVZVgHHIkLP9ktVMrski7pRL5DrIKOihRrE3CDjkhu04o/cSDzz+dRQF0pj6BKhyrfQYHlkZMd",
-	"kljwWHJuj2QSxa/yKcsHTXA7QJUV97avq3jZEQvb02crwwH/PZLHlNuDikN2rv79R/jXp8/+GSJUhByD",
-	"0uUMXjLSReesg4Q6CdGyh714dQkxlGgPvlA1TgVr55zwj0DQQ4OQ20a011TKnJGWyNABP9alMhIafY2Z",
-	"XuuMMApfb7OscQ4pw08OnGE6YRZGDOQVurO1xjKPLHviIEiCDpL9WCCUmSjS6lzuJ9jbOBxod8hUabPD",
-	"6362WQztUjPY9RpNTnmVo/gUcLaZMY6e9RLoKEeV3xxxUCounDWbzislRVC9Qb+XkYiRY/esjHiQm8bM",
-	"aT8EEhhqjgTnn968eQXyAGQ2x16hJlZFxMQsPVk8nc/H/DHoUI4k7tcFlVbF0Fh8U1XK7ZKgkx7p0MFV",
-	"k/8eKpVd6kDY4xDkv64uye2RzY4gtAl6vUso6fiVjTMLwvW7BZvlorOrOzXCvyZJtCIf084Vrhpd5rGW",
-	"GjMVnRUtcvLkSIxTdzN4kdBGghmw1iXhfzA2FNpsBNIYwKoOO5A7wcmFPpbHPXzX5ubAqrk2duvvXQdd",
-	"MVFgTbkbgM8u0/OLoz5yB4S8++iku0OlHJf3HakziikKW5LaUBDyRDiRzTpCtwQs+kfte82e/aSzxy1m",
-	"o31AdxVPf3MUd3MRE8tetht5kaG26mk+Sm/IHr38vutBDE9/Af/x+pf/hNdydu7UOsCT+ZP52cUTyG3W",
-	"VFy4CzSiJEoOCytcW4fcbPERKrCFcrqPLzFdRKYTX5cE6ukN/KiyEE2gAzf0UKYMp7EdlCpIY2ZPanvi",
-	"7fM2LuJ+kh8FwhFHMLxgpCqWqbw1CVfFRw5Fe7zebwEyFe4J+kOmnNOYJ4Gyp7JLi6GLPo08y6kjvgDG",
-	"GpzClkMI97JEetrk+LFtbsWAqAfFxoiX8lvHMdZ3HmrrtXT4JCt3fQfGm1NpM2DO5Rp8QmePAToVe2D7",
-	"zrnrhNKT8LCV8Lav3gV8d5PVjf9OoEEyAogK2b2d3J1ehfFem6alcNx2TrmlmI74IeZDH2zNaOC38e9U",
-	"xZL0rONOp8MEdQjJbRQV1YfG9piGBFOzwtKaDWWcxwTtNwfnEcxhw1ChvXb05JORR85tBXiPMDQZUVJT",
-	"s9Teq3Ciko4aIEPjki72t+jANXcVJ4sJHXNGJeudVtTqYV90Q4YHtN1lX+N1+p6IBlp4WK0+fHVQpreG",
-	"Q0Z7kEruWUr1POXL1eopTMbmD1fmweZqt4hGzullB4UlFMS53m6hRjdkg1NTwki9jLTWlI5MsDKdMH6L",
-	"bgY/MplEho6lD4XgG0r9Cd1/aLhIM3ltdWyafJ3mQL8FMhqAYnPMH2I+kYkOC0kNZPptEJ9CXTYxR3D7",
-	"LnT1ZWwH6fCF++bjReLJ9LnfIu96YgNuoDH5ACrsn//7trxHyHpsC3yaygS6PP5T+QRSYsum38aKcEKE",
-	"FjVLDFGF0QMUCnIsMSTpSstzOK2hFGVs6E9lgPx2wedH+uAasRa74hKf8nTbV/d09Ap3NqZGa1Ijg8zO",
-	"qApPOVLnE7+lLT+uja/Qjx/Nshnqm9OZauiDrb3fN089bAiABzOAx2GD/ZnAfY8+PhYgm2y7+7WzeZP1",
-	"xTHttfa5Tdbvtyf7l2lvN4ump1y+N2PsHorBxEFWKl3huN8+vGn/SITRw6fdnYNwNu2jEAnMh2ikbw0D",
-	"O2+F38WioYG+G6u7PGaN02HHIC12lmv9xl7jCMJ/YdiUA/2aWu7Kw/JFEwrr9CdW1gL+gsqhg7fNfP5D",
-	"xg/zP3E5g5cqK4Dyj2QVjhDifbbk2tMg5v45qHiJDJSlJpVkjjk8nf/QTveJnRXf1ymgCKGWkohK0OO8",
-	"pP67Q66xVDkF7X1DQRod/CkpYyq9ke8ZSz2K60uJv1IipJROcVzQttIOVMlDn3txFdAZVR7hizsLhSI5",
-	"ecwcii/wFga84WF1h/Wk5y6QQQ4FZ5sQYdH00cxq7nElYQYLdbMqdRZXRfw92LxlRtf2kL+XEoRSd2Ha",
-	"hSjNuwLW7WQS3HgCnSLzVIazACgJat/1NDJ7Q9mQxFCgKkPBTUcC1Lh/Vz9PnHHZlPDqtC0Po0uSeccu",
-	"1fMewBQ8nmhq4WbEoy0c1Q621l1DrbJrtZEsGhu3E9HiVXvIi1eXk+mEeBAJzWcXszlZiq3RqFpPFpMf",
-	"ZvPZDxwYQsE+fq5qfX5zcS62SP+zwTDW2wuNM6kZ2Z8qTsEo5+xWyg2GHPRQ2+Ps7fLEfocX8MFFClnI",
-	"8k9tGIySfq/z75egfCbd/Bks185WcQIb7BI8UoYQTalyfUYMwlab3G5h+Ss9PIVgv1+mUZ/or71m0eEm",
-	"FdqGVbxE+zh1kdlT/wG6Wkx69tbIDkxZxnAkJQqPE2HJJcAy8dvD72Idy15psBzkMy6S+FR2Od+fYVIw",
-	"ZOB38Dqfb/LUnd+q8lpkLM/EckF1jR8iIjafAUsvRVTtkGBcXLRK61NiiRI2kk6JYixLyHFNWHERQaH8",
-	"yESoyIW0+7iPJCEuUWDNVrncz94a9sFSyxoXS+nMZ7beS+ats8lvM3jRQjdJEA5V2yyPdURhPcKyy4zL",
-	"mGasbJlRgRh/9FPQJiubPGHAtETQBZXUq+u6owTLg1PGr9GRO6it2onYa3Rn7YtCWI6ZzjHZY0v6Xpiw",
-	"25QJqRBOXVd2uJqt8gCjBunL2jLvoKyJMC0R1/VxKXq0SfcynywmP2sfXorvU1RwqsLAO2a/HsyFyCm6",
-	"7v7efkA7NdD0LIc4wvuKQ3uCMMfX8KYPu63flxq7sAefvtydIt4payiPjrZjK2L+ouZ0INsUm1T+uu37",
-	"duqJqyX0IhvzGKQZZWoA8X4rWwzdT8xoxig4aIh9KdlKI0c2jGJ9PVw0GqdnAJl/MzEcf1m3B+XJMQJa",
-	"oN1djqapCOW3VYyA714R08PfD1bafkUaOzzTiN2ysvGEHla26aUDzovHWKDYPGDgfhXN/eiNwfKQVPz4",
-	"CFKD/QKE7i/FpKzdJmsVoLLSoR8jotSVDgM6clwrHlJezOfTSaU+6opM4GLOf2oT/xwbJo5h9mF2TwN3",
-	"orAvTSoSIsK2tfrQ4AIUZKWmxBehgw7tGpQmT5cCkEcSjD0pLSUQwD2jdWwMjoZw6WOecrN3e6vUT+bz",
-	"E2vUD1uf7tbdRhaoTy68fYml6enkqfAy9kbLc7fjTc9fPPD5Hx70/LMH0dMr7zmxd4X9r+9IbXG7I8KB",
-	"oQy5iWbH5hfcvyaMJFtqdr2/Eu57e+yE7TTDOdt2tqV/yXMEejs6HpDjRLuvGB+m9j0d8mQ+53UirjH6",
-	"tYUOHss1gzIVS1TCZNHS1arkhqgK7Yva5PpG540q4+5ZrvNFbz4b23VpwVN7uMY6xI7TGafwdmYwOlDu",
-	"lXjkdgaWaZ1sSRCha3NVioOmE/fOna0lGBa2TCuAjKAJMaya9ZqFGDFeXJbj6kyKi6rxgatuh4HqTEi3",
-	"tiPjIQKUHcUWA0Z5/sXmuwd5rzX4y5qt604/lg8OKPrda/40eGdv+vTudthdC67B268YhwYLnUe+5RCN",
-	"kSHUzmbo/eEHHdv+eIIwvATeP0isuviWsWrQu9sPV6KONlLdTtt+xqA5c9++Rm8a22v6DVDv99KlG1bH",
-	"+8sA/TV0h5AVmF0PZ/+HRVh/yip++JVM+GAwffSTpBOj6S9lqRd/P1kvnOL5hG2df06mcnv+eWArtz2z",
-	"Gyr8rzjQ97dS90NV/ftp+un86d+FZVyhyuOe4biIZOJ7om1y7+2do18VRUBeq1CMdjiG2e9BhfD9tn96",
-	"3wHdTdjhmOq+1L2bTuKHiPsxWkTvD+KsXbNuTsfqqYwR+Zsx318YSl8s9FQrK1uSrduxwH12I1W3B6YC",
-	"5BZ9HKjze/wxYw8UpqpLPljzhwnhVXMYHx4Hy06HhpEN1W8MqO4Xngbbdz6K39htT3f/f2u9b4u3TsXC",
-	"uJes9kMg5UaZmH06gbTk475tgbGrjwkfgy9sU+a8YAKuMYZnPpfyNbSXplL3OSi3wTOEQnlYIRpojNy9",
-	"Y/elcJqGBlwgWbPWm0ZWLhz6wpZpnVkFUNIk57ZJ+ymTbYJMDGVRLbnroZv+FHm+0z8Cfgzndan0nmd0",
-	"HzHY65Hm1ag3JP55dU7ffMEk/eyBhv/sQYZ8O0RcN2hI9TxhFQtKo+fzbiJyHgenvCA72oSQjw58fztD",
-	"U1zmjsLIpxMypYoDxLgguDeFoQjdzfSyFO3zXsuNRy7JFFQJm0Y5ZQJSPi90nP/m6Ljh5uzWL7reg9qf",
-	"+PB0TtqiiXbNqQO91P2ZMqkTzd07KiMOjTF+MfGqPfyrZY3BlzDfPF/0vws5mjDko5C1NtoXf6jc8I1r",
-	"68EGyWHAFzEO/UOclaHTw6J9ClxkztxFo9i7XuusF+u3BcGlwYel2kNjHKqsSE08nRUQ1HVEc7XNU/va",
-	"2aDavc443qIQLiPtMZdhJn6v8C3wM9g9afwR4zlJUg8C+u3t/wUAAP//",
+	"7F17jxs3kv8qhO4Ab3A9Gtlx9u4m2D+8e9ldH4KL4fgeQGxYVHdJzZ0W2SHZIyvGfPdDVZFsdqul0dhj",
+	"54H8J426+SgWq371nPez0mxbo0F7N7t6P6tBVmDp40v4sQPnn/8HfqnAlVa1Xhk9u5r9xVgLjcRvQlXC",
+	"rIWvlROW35iLVzUIB/YGrJCVab0TvgZhNAgpStk0YIUDXTkhdSU2oMFKD44eML4Gu1MOvhbKC9m2IC3+",
+	"IuAG7F40ZiMahc+tacwwZSGcET92xiu9wfeUFlK4rm2N9fEZoZzY1dILr4AX5HdGeLMBnHI+K2aurGEr",
+	"cbt+38Lsaua8VXozu729LWYWXGu0A6LNC2tWDWzxY2m0B+3xo2zbRpVElsuWn/iXfzik2Pts7H+2sJ5d",
+	"zf7psqf8Jf/qLuO4NOOQ5q/63Yq1VA1UTOeVqfbCyb0TtdnhLrIj/L+LcIgXfIpTU4fHL/vjvqXZw5Lw",
+	"tW9uQPvnuu14l1WlcE2yeWFNCxbJObvytoPxkr/TIEqpjValbPAAdeCNLWxXYJ1YQWN2QloQ/OIKKmEl",
+	"HofwtdSiNNp5K5WG6ms6MW3sVnp1A4KXh2dqjay2sr1cLC5Ko3ESZbSbbyvhoCQWfYpkabPFvp+Vjemq",
+	"Q8bGxSntvGwCdzOPOdPZEkSjbsAJpQth3EVrTXUB3WOxNlbAO7ltG5jPbosZ7fOtmhj9b41ZyabZi06r",
+	"HzsQqoJtazzoci+uYY88/Vh4I5589UdR1tLK0oN1c/FMM/Hwrllw3WqrvIdK7JSvaYVObkF4tQXn5bYV",
+	"pem0d0I6IUXVMU/ma2PuHq/uf/Fu1HjjNFSF2FmcRKfdzyUTkyaVWpiWmUC0tXRQ5GQQyF6dhzmRUpcw",
+	"Ly3gEkBXtIxW7hsjj9CfzrhRP0ElwnMC9A00poUr3q2XHoT0wlgh156YBZhCBX1cd00jLLSNLGGLdHPq",
+	"JxC7GjTKhrKWeoM7ROGTdmHlTrTW3KgKrKikl7zQRvq1sdvplcZfp7jEIJe0gAQorw94pLXmH1BOcwmN",
+	"zL8Ls9Mo0QbjDzeuXLhYM5ZR9MzRcdMg/Yt4heTKdKMRpnkEx7hWmkR+fLQQ8ZhxXTem6bZwsGF+dIrp",
+	"wEJ/fqJETl5bsw1KxBsLVfhNNjsUcxZQqrMEb1ULpA48Mq/SG3B4MRQrBClK0zRQemNRDmnjxVbaa6F8",
+	"2DvdEQul0aVqFN940/m2G8gpsZV7sQLRwNrjz18LKW5k0wF+caoCsUzzLImrlsMxl8LCunNB6ygPW6JJ",
+	"urCTZNEZVfpb+fz778S//XHxOFxDuvQ/GY1ExhFZbZkVMg9OQZL7W+X84RQonFu5IU2ak9kdCktcsZtm",
+	"hkDGiABwwEIYWwGOt9pnQgnpEqUYTpEGPaUPv6eF0S5m/f6ktXKP3zW882/LzjpjT7EWPsZ7dV5a7wrR",
+	"SudwgXg3pRNLHmM5F8/pPmgUIEH6N9Lxy7ho/EGuGoj6bowT8AL92CkL1ezqh7DF4TLfTJzSc+Lbl+C6",
+	"xh+RywiNmL0JQIlKZeJ/JX1Zo2jbSSc26gb04RnKsoTWw4Rc+LvZia3U+3iWOCLNwVyBQ4UVK+1hAxaX",
+	"nNSKOzEg7Z/GQ4G6kg6EbCzIai9qaI6MbAHJAseUcxqSlsj3qiqIPqC93QuQZX02f70Mkx3hsNF5JhoO",
+	"9p8teepwv1VrKPdlA9NXMJOiUSqJWiHp96yh6IAVs51AOtkb2TgWeOFBsTZNhcDEmznKHh5xSZKdZSZC",
+	"KrgScqQAnr14Lmp6V5uoc1AGWrMjCY4DaLejy/x08XSAzSIOgG3r96KJu5y/1q/1qwCua9mgLmSAZ9UN",
+	"VCTb6bdKrddgcbu8aQfezcWSmTCI0bTdpSiltXsiRtw07cCba9AkoJGvCrGrVQMjGvheoYbNFUSxuBq2",
+	"LHgVA01bSyc6jYBAG+FK08JcfKeHVJQJUMQ5eEIkIVF9bSwknSXFkqFQ9Vb6JU+/4kd4ZsTiqPWDEosM",
+	"sFYWDZhAjiDGEAmQGWOldms2YYaXnok5fZMIJPW0BCKJsIjs9ECEL/+QhHiByhLwHN9KX4iIdL9YPpRA",
+	"Twc+vebJe9BzhNq2jQJXCDxcNJOQanPxamf6N/mwEu0IOTN+8aIBeYP4syf0CvwOWBVvA6RIZx8Oks6o",
+	"ggboc5TUPCAykCazF9FLczaVksx4HhYyRau4kLtlXHjutpjtpEVA6Y5omcQGpemaSiBg8rZD83okX8Wz",
+	"RPRdbVxk0AQo8U0ZKERXF03u8MZb5t63KEBM598G2yCnzUit3iGWEyGKyPA5I2WbPimeE6knxXQtm/UF",
+	"4nnhWqnF8ge8uoXw5oulMDdgUfCUNe67RsCe2I2Q9YBrWFgc3lUc8AQQHN39IvyxbDqH5vDKdJoGXZOF",
+	"PLuaVdLDBd7cWXFIz4+xP2i7+ZLmUzOgyTU9NhljIzlbnRy1Py0y/Y4MS1bhYFyEQ0qfuWBvzqE+6CrQ",
+	"Ht4NaZ9DR9ZCgxeVI3OwCIySkGV6wKyFRNsR6Z12oNzRM70fFCXuok1GIoYjGvDC1AXJXF1D4rz861/E",
+	"vz/96l9FcHWJCrxUzVx8w/rUWmNF9JrhOSTIEUwh5YSrZQsF+worclgccaEd3heebQJ9dlupL1CT0gWE",
+	"d20jNZt2roVSrVUpvOHpTVl21oIuYZIlaAsTsvIF2Iu1gqYKW3a4A88OhgA2iCAIn9BSVBXPv5aq6exQ",
+	"1A031ZjycLpvTRlMU/Z5mvUadIV8QlZoIWC+mZMfcJ45ACZ3tHWbI6JfObGzRm96q4JNXNIK0osmLGJi",
+	"2BGr4R54pil2GmsxZMbuiLr/+6tXLwQ/IEpTQeZoZq7CxQQvw+zq6WIxZU945aew9/e1sV7UQ2Zx3XYr",
+	"7T4SOp4jDjqYavY/w0Mlk+CI0hpP/N8vn6PZAsR2QlWgvVrvo5Q9PmVn9ZWXTbO/Ira86vnqzhOhXyMl",
+	"EsmnTuclrDrVVMEXPMUqKLwilyH8Zj/bHhFB8JZEN4lYq8aDdVEpMn6KBgPPKSxP6AIIz4B18i14Oppr",
+	"bXbubD/uS1qUMLrZD1RC76mgFyfvyB0usLuHjmd3eCjH6X2H6R/IFIg9BR/4CX/CGu8XigbdYKjxrTkA",
+	"WDz2NMdslPNgI8p8ddRvSHo/uO2Jb/hFMjRzkypQb7g9fPltH0MZjv5M/Of33/2X+J7Hrqxce/Fk8WRx",
+	"8fiJqEzZbSnwwPoZATJe2Gh2KforuzqIQ8ldEV6ideEyLd91dgA4fAPeydIHFuidM/hQKTWpsb1opGer",
+	"bES1EXnzvU2TOHdSHPEikB+E3CPJaLQgndHRLxQeOWIkHkWCKfAQXZcBzifAQzeVrjQzOp+n5mfZPuYX",
+	"yBKK+IdicfsAkSp4l4JzQSCqgbN04pbSW8d9RI+caI1THKFkrdzHTchfVnCYJDoBfgJrjjmkZIjhjS/n",
+	"vidKRuFhKOR1frxX4tFN2XbuEUODyAQiHMj+9exu9cobz8JMaYXTvHPM8547nxB5jbwk7BZS/iocy9g5",
+	"xSFHvj1WbWovNIcfHzDONnnwvf/kBF4fmADhjWJil8ENpHzwS2WvPkKGNE3yLgwAPsus3nsivdCowYSr",
+	"zQ6RbJiUwwjZhME2JmdSxTiU3T4EAMw1WgjOCHOWl0m5eAGDpd3jFlKuKounkFRoLVQUae+dTY8cuZus",
+	"q1Ubzlr2AziyZPGOsDeQzJZoMT9yuYeuCBQYOLhaSfxNmHIZnCT4w4daNcWsH+Tc4w9vFLlppjwz2Yev",
+	"A423t3wHTyxF+lEE53wTPZvgeCwOf4mnrmEHyQcTGVtHU8fy7Zye5mQ8dhyE5fnizooI+5BDwkfpotKJ",
+	"ehWZL7s47ByVPjmf9anoSi/NPiYcO39oP4g+QtHzg7DKO2jWBdMrQFKh5RaFn/8QbDoVnn0A7wye0O7o",
+	"QadYKju5SZwegoOA9ycEZ3pNG5r9ARw/ivw+eEDiWfLN9i644I9MgqF3yYSkJQfehdMZxDyioFYejXCG",
+	"ijRIjMHfpbxZHWaMPD7SIfsMGPTAcZNpwoFcPJQdY3E1uvangMPdwWN2ofjevrhXAPnQfDqIIRPRiqGF",
+	"wCKlP/DqHiG/3h3+G40nn7bFGPix8ZVfC9Il0XYYGGvhe3bDCQ54CuwFPwSCno1ETHd4/B8itmk1K2iM",
+	"3jjhzYdKw+F4iENU0Mtx2qPy8ai5yeMmAp5he05JtK6t7sax4QRQlRLfhKSsc1HEiH9OSJ18w4O13cVf",
+	"0/JhRKLBKXyYfOBXB3IhMc5AFET/wb2EAd2UhxMI8d6H6Dtdf28qub8KTE4+hX2AP+TgMTvRgh0LOWeS",
+	"YyxzQ6xR6RK0o9giRejn4i+0TFyGCv5u1HMIfpJL98eOPPO6ao0KmT6fRgLlYd5JARQyutyho29keBKK",
+	"jJZ7IdqmC46BEGJNQYWQw6T85zBCT/tMxnmdfSLXYDecW3Bi/J83T3MKLn9g3uY5RsKhfR2zXsPJhnix",
+	"yLxIcgC/Qp7eMMUYVRRa3FkqsQjJMLo3aa4BWhcyLQD5T/bJoA6HXsHeBNVodIxeIdsRXP/1GS/Hkkgn",
+	"tWxK+TiqqYZ3MPH7+dbufTJX4SBx9WEspXOHPp7LijyZUlJba6quzMlRZPmoFBvNk0Qj/+9iIkawRfAp",
+	"W40S4/uHgjCxomyk2sL0vb1/pukHIozMKdnPORBnA9snmkP3sYFiqkeURUMGfTPlbHdQdlb5PYG0kA7Z",
+	"qlfmGibcus80sTInlgVcj5D+WedrY9VPdFhX4s8gLVjxulssvizpYfoIy7n4Rpa1QP3DWoUNes4JY9eT",
+	"Bqjc10KGSbgKgl2pWbrdl6kkBbezovn6A6i9b9kPvgHnj+8lJo1aIMe6bAqhnOtQSIMVf4iHUbCV9QW7",
+	"CT9k1899SMOjmpug0lGOM9qWygrZBEfPGbvyYLVsjuyLzP5aIp0clBb4LlDpkHhFFRY91uNE0ZSLQbn+",
+	"pvMBFhUfvNngyQ3E9Ea03apRZahvcmds85Y2up7IO/mGhVAMKWW2r6ICl5Qc2jkEnUzzGHshAqASVK4P",
+	"ZJXmBrUhZcuBbHxNkWYE1DCeK9cTF2Q2Rbza5yPm6ZQcmvw6A5iMx+OaEtwMeDTBUWXFzthr0cryWm5Y",
+	"i4Zo/YxP8WUa5NmL57NihntgCi3mj+cL5BTTgpatml3Nvpwv5l+SYPA13fFL2arLm8eXfRbkBvxUQNd3",
+	"VscIdJ4KXwgtrSWH/mrPkINc3DGwnRWgRacSgw8yUpBDBrmTfbqkkK7kFI65WK6t2YZ8V2+WwgFqCD6p",
+	"lHS2U7oyu1HaWS630zRXPW6SPkUpwyTKhVQbTujLH8CpmaXnrzUXbjVNEEdsopDPQizJBFgmJ1qP35k7",
+	"lplpsBzoMzKSaFS6ci53lKAwJOB38DqNr6vo5N7J5pppzM8Ec0H20T5yNYc0PGgcG1GtBYRxwXcXa/6Y",
+	"E1lsxDPFFUPTiArWiBWvAijkH6Pnm2lDMd4QN0IRF1dg9E7ays1fa7qDjeLaQ6LSRYj8DL2K4bLxb3Px",
+	"LEE3VhAWZMqQCHYEJV0ue824DGrGcGkkGogxUFRwmmAVMWCsfBk7RPOQOMLymFaM10Hu5D7EssBepBd5",
+	"YbTsgyxqyqzdyX1Im42jia25SQGoiLsMLVjDLm08gv1a6rBwpHCkyiALHA43wknbpBOaSgSlkzTy82p2",
+	"NftWOf9NzBZtpZVb8FQ1+cNBphDemD7fY1TxkvJIFD5L8g+NAUlyP+Kb44Wlxf1my51WUxNm2Orh5mSq",
+	"F8RhVbiF+6mIhXgWGFa665QJ0JshoVgKX2SWmcA7k5sa4L+P3RZn5B7P2plawYG37KFoy14erpkLxvew",
+	"dG56PQM8/dGLIeFMZ3tguxxbQELh/eSguy2FOKKJw8g8s3AycH7vQxubq8H9M5kGnXQFKc1jWwgZsf0G",
+	"zjN3zltvqukYL3WUNXzeUjlr9yMXOi7ziio9aXLpxdaw+35qEY3aKj9YRwVrSWlrjxeLYraV79QWWeDx",
+	"gr4qHb5OpZdNAfqh6o+pDLjCnJoozAP8Nq38saOqprJRqHYCrlA+BWKUTxUrFK8gYCqrlJNIeYqkL4+K",
+	"cHZynrpmb0bNAZ4sFicaA9yvIUBfwDnREuBkCedDtAEoZk95L1NvpD33XQvw+cf3fP7Lez3/1b3Wk9n+",
+	"pNh7q/+HN3hsId83wIEhDcnDZqaCG+TcRgDFdZdmPW5y4LLODAj8FGE9k9ze7NykIAOl/fPFE3hxAt9v",
+	"51xEx+oRB3myWFCCOcRihtTVgsPUiNhksF9DUVJMay4Ig0NfBVGpG1V1sgnVlJWqrrKMveDLiyXLyolr",
+	"aH1wR12QCk8BhckUw8z+oxQUsYwFkkuECL0PbCv3WY1cZU3LwpDSrpi4BK8RMay69ZqIGPx0ofyTTDe2",
+	"PLad82SSW/BohIo4a0oiHCJArrpNGDDQ88+m2t/r9hoN362Ju+68x9xCA6XfWcGpwTuj0NSb26HrzdsO",
+	"bj+hHBqUKB/pTsInhozQWlOCc4ctSnZ57IJx/69IVj3+nLJq4Ngbiys+jiSpbovk7Bh4bs51emSh2swj",
+	"OEC9X7ALb2g6jzMF8sYKFkRZQ3k9TAw4NMLyECzfw0/EwgdR66NNdk7ErR+KUx//crSeP7XnE7x1+T6y",
+	"yu3l+wGv3GZsNzzwv8HgvD/Xcd/3qH++k366ePqL4IyXIKtQeTJNIg4Hn3CbnJ3ac7RPTgDkrfT1pIdj",
+	"qP3uZQiflxqUdba5e2GHMaxzV/emmIXWWmMZzaR3B3LWrOlsTsvqgmOM1AXJ5dlEsQdHdrScz8XaOsUM",
+	"zqmWkX2SmPSiMuBCtJ3eo+KADBRGqysU4R8qhBfdoXz4MFh2WjRM1Cx9ZkB1nngapObFcgttdtnZ/XZt",
+	"vc+Lt07JwlCpJscicEI33g25DtuROA7H5PlfDxF6GuXNvmVnYxZbHwSi7h314YX/HvMZxXwmEs45uwjB",
+	"MfWe4WoYSuZe9p1DkI5ZhYxw4OfipdmFFCbgXJCtuUmSd1gfpJzY4IE5z03SQkkz5Shy2NaablPTMmJJ",
+	"E652KtQUjzfEmSIn9Y74YA1MRJtCQhTHivCZyA4VlKoCF9aeKoxw53waHEwgnwOqI2e20J9o2FZw1/nk",
+	"GjltU9w3tnOiTPjThHcmst8/R4RnYtrfSJDn54rrZMXVdGViUQQXpwzqhRXegbrzZr0+J9aTij7OX1tI",
+	"RJM2XZZ1A4BXnL14c7GUpVc3sOTvBxc+rRqxXCqTieIpe8tQSzfKyCQBJpsm/boyvp4nOUc/c+eBJUk0",
+	"pStoQVdUrcayNjVt1N7KSpUU4CUh4rqyJt1Bo/2JV/+6Wyye/JHH/FNa254TOPvKo1hrcYy4nZuOasx4",
+	"llmRQlvpD2GyWTGTTXNWWGuiCv/3AMyvIQAzqIO6IwYzWQn1exzmgzxSB7ScRtuX70k9HXigsu+quj03",
+	"BSxPLAk2dg/I79sSTwwDOIzgQnUGgkwT4Xa8/4d9CBnfb+VeOIAjWDurMUHd3Jc+I8rc8rWVmoJLi2GE",
+	"a6ianzwRf1iOm8zElm3emLeN0ZvlF4PMJSm87XRJ1V/h0a/F8m/fvBLD3LslXREXxHgGP1+FOnRCrzSM",
+	"0YMS9lFF/qhHZUitNRU3oBlC2aDKCIQkxwSaDoyXj4LanCo4/dPFUyG16PS1Nrs+W0tswLsxEo/wh70t",
+	"OHPoO7wC4XFqMh1MbFiclgXvlPOxc1bohpUy0WOzgMOkqrjhHrXnSj+1RfRU499D9JgmxWYTMclVSK7I",
+	"ErVi+lScxHnTur5XwaBEGCz0yaEaduHqxFUFfgvc51QM4qW5cqbqQ4Cp88IkS5FhESuw8oWyuZUvNPJ7",
+	"6kVy2mzIYoI/R1g/mfH9rer/3UGURmxEDoQBiYBfjef66ZMnvxxPd1YAMS3+z3J3f9R/Dph0KvcFEh/l",
+	"6r5/y/YHdnEXH9cH4dRa1P3o8+YjUESTt3K+E0hkaivv09x35cgTvCc62+J53fmvLb4q2McWBhzpxyiR",
+	"s0S/rMtv3qRhzXpxlNlPnc5sp13qjNUvjx1LUfzqhF9io2ecvzR4htTO/7Vexj6sMVd5d7rl7KhNROh5",
+	"HBODU3fZnG2nAAXSINOgO845GeYxJ03p7t8jG8c/ggAIhzyKjhBpYQgsSJk/XTwthmnZQxTDrb3JYB6p",
+	"8UeDvHv5yZHfXPzVNKRSZSRoTzc+zL6MsueTKZTiWqljNKNvMHSVoY9BvFG5Qb/uAXIIjtdYEZoxWeq5",
+	"7c5kpcA+sF1BhZPd1UWc6D5o6ETXBM9p0ASplDp2XjrSeGmiYazjVR70+BZ/Vk3DdMiaLx3imSzS3neg",
+	"/4SIpp/kjmBWkXuge9DY71v5vJ/973jmQ/FMuDJJaf0OaX7LkIar+n46gUxYGu5qCKYWxDQ94WrSvSi9",
+	"Udtrqkt7zv9mzLGPu/8/S2idqtAWagWAhjHPvSdyo67ILbnS6LXadKzzLDhUpQFNUKs5EmzkPEz/I8R0",
+	"nqsag5wOrsJDGff3sOc7xZqHd/6ybaQaCbS+u665nsihn5Rjcf/kelE3D5gr9NU9fXxf3ctndzt0s92A",
+	"xqOnKlB2rcXy2Mtey12G4k5q4jOZC83dcN20ATXR05c9/aHI0fVIONOshGZSBLqMSSdV5ngmyBlZQTZi",
+	"00krtQcQK6hV0CgZEHVXfQq0HGtxAnfFyGOSQdegv6kghnzYG8ldQYbMGFr5vkiDf7LklUGL5s+etpI3",
+	"LD6q6rlb8Vpp5epfVYrKZ07xHVS5H2pyJuPwfvBlpQyu+0n7KLiQncnFiLJ3vVZlJut7HJqksXKi0xZk",
+	"WcdaAmqWJ69D2LA1VQziWONl6j0TquxQhHMKxtSVoU38XOKbs+BiUDRR49coz1+SszMX6Le3/x8AAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // Defines values for ListEventsParamsSource.
@@ -58,6 +59,30 @@ func (e ListResourcesParamsStatus) Valid() bool {
 	default:
 		return false
 	}
+}
+
+// DeadLetterList One page of dead-lettered events.
+type DeadLetterList struct {
+	// Items The refused items of this page, ordered by received_at and id.
+	Items []DeadLetteredEvent `json:"items"`
+
+	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
+	NextCursor *string `json:"next_cursor"`
+}
+
+// DeadLetteredEvent One ingest item this API refused, as the dead-letter table holds it.
+type DeadLetteredEvent struct {
+	// Id The dead-letter row. A refused item has no event id this API can trust, so the row's own id is what names it.
+	Id openapi_types.UUID `json:"id"`
+
+	// Raw The item as it was submitted, with NUL characters scrubbed at ingest. Nothing is constrained here: what a collector sent need not be a JSON object, and this member carries whatever it was.
+	Raw interface{} `json:"raw"`
+
+	// Reason Why ingestion refused the item, a schema violation for example, prefixed the way the ingest response reports it.
+	Reason string `json:"reason"`
+
+	// ReceivedAt When this API refused the item.
+	ReceivedAt time.Time `json:"received_at"`
 }
 
 // EventInput One canonical event. The members below are described rather than constrained; the normative schema is roadmap/00-conventions.md section 4.
@@ -281,7 +306,7 @@ type ResourceTypeList struct {
 	// Items The resource types, ordered by platform and resource type.
 	Items []ResourceType `json:"items"`
 
-	// NextCursor Where the next page starts. It is always null today: the registry holds one row per resource type, so every registration fits into one answer. Cursor pagination arrives with the query endpoints.
+	// NextCursor Where the next page starts. It is always null today: the registry holds one row per resource type, so every registration fits into one answer. The registry list stays a single page, while the query lists page with cursors.
 	NextCursor *string `json:"next_cursor"`
 }
 
@@ -321,6 +346,9 @@ type StoredEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// Cursor defines model for Cursor.
+type Cursor = string
+
 // ListEventsParams defines parameters for ListEvents.
 type ListEventsParams struct {
 	// Cloud Serve only the events of this cloud.
@@ -351,7 +379,7 @@ type ListEventsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
 	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
 // ListEventsParamsSource defines parameters for ListEvents.
@@ -364,6 +392,21 @@ type IngestEventsJSONBody struct {
 
 // IngestEventsJSONBody1 defines parameters for IngestEvents.
 type IngestEventsJSONBody1 = []EventInput
+
+// ListRejectedEventsParams defines parameters for ListRejectedEvents.
+type ListRejectedEventsParams struct {
+	// From Serve only the items refused at or after this instant, the inclusive bound of the window.
+	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
+
+	// To Serve only the items refused before this instant, the exclusive bound of the window.
+	To *time.Time `form:"to,omitempty" json:"to,omitempty"`
+
+	// Limit How many items one page carries at most.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
 
 // ListResourcesParams defines parameters for ListResources.
 type ListResourcesParams struct {
@@ -389,7 +432,7 @@ type ListResourcesParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
 	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
 // ListResourcesParamsStatus defines parameters for ListResources.
@@ -657,6 +700,9 @@ type ServerInterface interface {
 	// IngestEvents Ingest events
 	// (POST /api/v1/events)
 	IngestEvents(w http.ResponseWriter, r *http.Request)
+	// ListRejectedEvents List the dead-lettered events
+	// (GET /api/v1/rejected-events)
+	ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams)
 	// ListResourceTypes List the registered resource types
 	// (GET /api/v1/resource-types)
 	ListResourceTypes(w http.ResponseWriter, r *http.Request)
@@ -699,6 +745,12 @@ func (_ Unimplemented) ListEvents(w http.ResponseWriter, r *http.Request, params
 // IngestEvents Ingest events
 // (POST /api/v1/events)
 func (_ Unimplemented) IngestEvents(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListRejectedEvents List the dead-lettered events
+// (GET /api/v1/rejected-events)
+func (_ Unimplemented) ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -920,6 +972,78 @@ func (siw *ServerInterfaceWrapper) IngestEvents(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.IngestEvents(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListRejectedEvents operation middleware
+func (siw *ServerInterfaceWrapper) ListRejectedEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListRejectedEventsParams
+
+	// ------------- Optional query parameter "from" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "from", r.URL.Query(), &params.From, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "from"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "from", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "to" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "to", r.URL.Query(), &params.To, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "to"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "to", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListRejectedEvents(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1411,6 +1535,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/api/v1/resource-types/{platform}/{resource_type}", wrapper.PutResourceType)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/rejected-events", wrapper.ListRejectedEvents)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/internal/projection/rebuild", wrapper.RebuildProjection)
 	})
 
@@ -1422,117 +1549,125 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7F17jxs3kv8qhO4Ab3A9Gtlx9u4m2D+8e9ldH4KL4fgeQGxYVHdJzZ0W2SHZIyvGfPdDVZFsdqul0dhj",
-	"54H8J426+SgWq371nPez0mxbo0F7N7t6P6tBVmDp40v4sQPnn/8HfqnAlVa1Xhk9u5r9xVgLjcRvQlXC",
-	"rIWvlROW35iLVzUIB/YGrJCVab0TvgZhNAgpStk0YIUDXTkhdSU2oMFKD44eML4Gu1MOvhbKC9m2IC3+",
-	"IuAG7F40ZiMahc+tacwwZSGcET92xiu9wfeUFlK4rm2N9fEZoZzY1dILr4AX5HdGeLMBnHI+K2aurGEr",
-	"cbt+38Lsaua8VXozu729LWYWXGu0A6LNC2tWDWzxY2m0B+3xo2zbRpVElsuWn/iXfzik2Pts7H+2sJ5d",
-	"zf7psqf8Jf/qLuO4NOOQ5q/63Yq1VA1UTOeVqfbCyb0TtdnhLrIj/L+LcIgXfIpTU4fHL/vjvqXZw5Lw",
-	"tW9uQPvnuu14l1WlcE2yeWFNCxbJObvytoPxkr/TIEqpjValbPAAdeCNLWxXYJ1YQWN2QloQ/OIKKmEl",
-	"HofwtdSiNNp5K5WG6ms6MW3sVnp1A4KXh2dqjay2sr1cLC5Ko3ESZbSbbyvhoCQWfYpkabPFvp+Vjemq",
-	"Q8bGxSntvGwCdzOPOdPZEkSjbsAJpQth3EVrTXUB3WOxNlbAO7ltG5jPbosZ7fOtmhj9b41ZyabZi06r",
-	"HzsQqoJtazzoci+uYY88/Vh4I5589UdR1tLK0oN1c/FMM/Hwrllw3WqrvIdK7JSvaYVObkF4tQXn5bYV",
-	"pem0d0I6IUXVMU/ma2PuHq/uf/Fu1HjjNFSF2FmcRKfdzyUTkyaVWpiWmUC0tXRQ5GQQyF6dhzmRUpcw",
-	"Ly3gEkBXtIxW7hsjj9CfzrhRP0ElwnMC9A00poUr3q2XHoT0wlgh156YBZhCBX1cd00jLLSNLGGLdHPq",
-	"JxC7GjTKhrKWeoM7ROGTdmHlTrTW3KgKrKikl7zQRvq1sdvplcZfp7jEIJe0gAQorw94pLXmH1BOcwmN",
-	"zL8Ls9Mo0QbjDzeuXLhYM5ZR9MzRcdMg/Yt4heTKdKMRpnkEx7hWmkR+fLQQ8ZhxXTem6bZwsGF+dIrp",
-	"wEJ/fqJETl5bsw1KxBsLVfhNNjsUcxZQqrMEb1ULpA48Mq/SG3B4MRQrBClK0zRQemNRDmnjxVbaa6F8",
-	"2DvdEQul0aVqFN940/m2G8gpsZV7sQLRwNrjz18LKW5k0wF+caoCsUzzLImrlsMxl8LCunNB6ygPW6JJ",
-	"urCTZNEZVfpb+fz778S//XHxOFxDuvQ/GY1ExhFZbZkVMg9OQZL7W+X84RQonFu5IU2ak9kdCktcsZtm",
-	"hkDGiABwwEIYWwGOt9pnQgnpEqUYTpEGPaUPv6eF0S5m/f6ktXKP3zW882/LzjpjT7EWPsZ7dV5a7wrR",
-	"SudwgXg3pRNLHmM5F8/pPmgUIEH6N9Lxy7ho/EGuGoj6bowT8AL92CkL1ezqh7DF4TLfTJzSc+Lbl+C6",
-	"xh+RywiNmL0JQIlKZeJ/JX1Zo2jbSSc26gb04RnKsoTWw4Rc+LvZia3U+3iWOCLNwVyBQ4UVK+1hAxaX",
-	"nNSKOzEg7Z/GQ4G6kg6EbCzIai9qaI6MbAHJAseUcxqSlsj3qiqIPqC93QuQZX02f70Mkx3hsNF5JhoO",
-	"9p8teepwv1VrKPdlA9NXMJOiUSqJWiHp96yh6IAVs51AOtkb2TgWeOFBsTZNhcDEmznKHh5xSZKdZSZC",
-	"KrgScqQAnr14Lmp6V5uoc1AGWrMjCY4DaLejy/x08XSAzSIOgG3r96KJu5y/1q/1qwCua9mgLmSAZ9UN",
-	"VCTb6bdKrddgcbu8aQfezcWSmTCI0bTdpSiltXsiRtw07cCba9AkoJGvCrGrVQMjGvheoYbNFUSxuBq2",
-	"LHgVA01bSyc6jYBAG+FK08JcfKeHVJQJUMQ5eEIkIVF9bSwknSXFkqFQ9Vb6JU+/4kd4ZsTiqPWDEosM",
-	"sFYWDZhAjiDGEAmQGWOldms2YYaXnok5fZMIJPW0BCKJsIjs9ECEL/+QhHiByhLwHN9KX4iIdL9YPpRA",
-	"Twc+vebJe9BzhNq2jQJXCDxcNJOQanPxamf6N/mwEu0IOTN+8aIBeYP4syf0CvwOWBVvA6RIZx8Oks6o",
-	"ggboc5TUPCAykCazF9FLczaVksx4HhYyRau4kLtlXHjutpjtpEVA6Y5omcQGpemaSiBg8rZD83okX8Wz",
-	"RPRdbVxk0AQo8U0ZKERXF03u8MZb5t63KEBM598G2yCnzUit3iGWEyGKyPA5I2WbPimeE6knxXQtm/UF",
-	"4nnhWqnF8ge8uoXw5oulMDdgUfCUNe67RsCe2I2Q9YBrWFgc3lUc8AQQHN39IvyxbDqH5vDKdJoGXZOF",
-	"PLuaVdLDBd7cWXFIz4+xP2i7+ZLmUzOgyTU9NhljIzlbnRy1Py0y/Y4MS1bhYFyEQ0qfuWBvzqE+6CrQ",
-	"Ht4NaZ9DR9ZCgxeVI3OwCIySkGV6wKyFRNsR6Z12oNzRM70fFCXuok1GIoYjGvDC1AXJXF1D4rz861/E",
-	"vz/96l9FcHWJCrxUzVx8w/rUWmNF9JrhOSTIEUwh5YSrZQsF+worclgccaEd3heebQJ9dlupL1CT0gWE",
-	"d20jNZt2roVSrVUpvOHpTVl21oIuYZIlaAsTsvIF2Iu1gqYKW3a4A88OhgA2iCAIn9BSVBXPv5aq6exQ",
-	"1A031ZjycLpvTRlMU/Z5mvUadIV8QlZoIWC+mZMfcJ45ACZ3tHWbI6JfObGzRm96q4JNXNIK0osmLGJi",
-	"2BGr4R54pil2GmsxZMbuiLr/+6tXLwQ/IEpTQeZoZq7CxQQvw+zq6WIxZU945aew9/e1sV7UQ2Zx3XYr",
-	"7T4SOp4jDjqYavY/w0Mlk+CI0hpP/N8vn6PZAsR2QlWgvVrvo5Q9PmVn9ZWXTbO/Ira86vnqzhOhXyMl",
-	"EsmnTuclrDrVVMEXPMUqKLwilyH8Zj/bHhFB8JZEN4lYq8aDdVEpMn6KBgPPKSxP6AIIz4B18i14Oppr",
-	"bXbubD/uS1qUMLrZD1RC76mgFyfvyB0usLuHjmd3eCjH6X2H6R/IFIg9BR/4CX/CGu8XigbdYKjxrTkA",
-	"WDz2NMdslPNgI8p8ddRvSHo/uO2Jb/hFMjRzkypQb7g9fPltH0MZjv5M/Of33/2X+J7Hrqxce/Fk8WRx",
-	"8fiJqEzZbSnwwPoZATJe2Gh2KforuzqIQ8ldEV6ideEyLd91dgA4fAPeydIHFuidM/hQKTWpsb1opGer",
-	"bES1EXnzvU2TOHdSHPEikB+E3CPJaLQgndHRLxQeOWIkHkWCKfAQXZcBzifAQzeVrjQzOp+n5mfZPuYX",
-	"yBKK+IdicfsAkSp4l4JzQSCqgbN04pbSW8d9RI+caI1THKFkrdzHTchfVnCYJDoBfgJrjjmkZIjhjS/n",
-	"vidKRuFhKOR1frxX4tFN2XbuEUODyAQiHMj+9exu9cobz8JMaYXTvHPM8547nxB5jbwk7BZS/iocy9g5",
-	"xSFHvj1WbWovNIcfHzDONnnwvf/kBF4fmADhjWJil8ENpHzwS2WvPkKGNE3yLgwAPsus3nsivdCowYSr",
-	"zQ6RbJiUwwjZhME2JmdSxTiU3T4EAMw1WgjOCHOWl0m5eAGDpd3jFlKuKounkFRoLVQUae+dTY8cuZus",
-	"q1Ubzlr2AziyZPGOsDeQzJZoMT9yuYeuCBQYOLhaSfxNmHIZnCT4w4daNcWsH+Tc4w9vFLlppjwz2Yev",
-	"A423t3wHTyxF+lEE53wTPZvgeCwOf4mnrmEHyQcTGVtHU8fy7Zye5mQ8dhyE5fnizooI+5BDwkfpotKJ",
-	"ehWZL7s47ByVPjmf9anoSi/NPiYcO39oP4g+QtHzg7DKO2jWBdMrQFKh5RaFn/8QbDoVnn0A7wye0O7o",
-	"QadYKju5SZwegoOA9ycEZ3pNG5r9ARw/ivw+eEDiWfLN9i644I9MgqF3yYSkJQfehdMZxDyioFYejXCG",
-	"ijRIjMHfpbxZHWaMPD7SIfsMGPTAcZNpwoFcPJQdY3E1uvangMPdwWN2ofjevrhXAPnQfDqIIRPRiqGF",
-	"wCKlP/DqHiG/3h3+G40nn7bFGPix8ZVfC9Il0XYYGGvhe3bDCQ54CuwFPwSCno1ETHd4/B8itmk1K2iM",
-	"3jjhzYdKw+F4iENU0Mtx2qPy8ai5yeMmAp5he05JtK6t7sax4QRQlRLfhKSsc1HEiH9OSJ18w4O13cVf",
-	"0/JhRKLBKXyYfOBXB3IhMc5AFET/wb2EAd2UhxMI8d6H6Dtdf28qub8KTE4+hX2AP+TgMTvRgh0LOWeS",
-	"YyxzQ6xR6RK0o9giRejn4i+0TFyGCv5u1HMIfpJL98eOPPO6ao0KmT6fRgLlYd5JARQyutyho29keBKK",
-	"jJZ7IdqmC46BEGJNQYWQw6T85zBCT/tMxnmdfSLXYDecW3Bi/J83T3MKLn9g3uY5RsKhfR2zXsPJhnix",
-	"yLxIcgC/Qp7eMMUYVRRa3FkqsQjJMLo3aa4BWhcyLQD5T/bJoA6HXsHeBNVodIxeIdsRXP/1GS/Hkkgn",
-	"tWxK+TiqqYZ3MPH7+dbufTJX4SBx9WEspXOHPp7LijyZUlJba6quzMlRZPmoFBvNk0Qj/+9iIkawRfAp",
-	"W40S4/uHgjCxomyk2sL0vb1/pukHIozMKdnPORBnA9snmkP3sYFiqkeURUMGfTPlbHdQdlb5PYG0kA7Z",
-	"qlfmGibcus80sTInlgVcj5D+WedrY9VPdFhX4s8gLVjxulssvizpYfoIy7n4Rpa1QP3DWoUNes4JY9eT",
-	"Bqjc10KGSbgKgl2pWbrdl6kkBbezovn6A6i9b9kPvgHnj+8lJo1aIMe6bAqhnOtQSIMVf4iHUbCV9QW7",
-	"CT9k1899SMOjmpug0lGOM9qWygrZBEfPGbvyYLVsjuyLzP5aIp0clBb4LlDpkHhFFRY91uNE0ZSLQbn+",
-	"pvMBFhUfvNngyQ3E9Ea03apRZahvcmds85Y2up7IO/mGhVAMKWW2r6ICl5Qc2jkEnUzzGHshAqASVK4P",
-	"ZJXmBrUhZcuBbHxNkWYE1DCeK9cTF2Q2Rbza5yPm6ZQcmvw6A5iMx+OaEtwMeDTBUWXFzthr0cryWm5Y",
-	"i4Zo/YxP8WUa5NmL57NihntgCi3mj+cL5BTTgpatml3Nvpwv5l+SYPA13fFL2arLm8eXfRbkBvxUQNd3",
-	"VscIdJ4KXwgtrSWH/mrPkINc3DGwnRWgRacSgw8yUpBDBrmTfbqkkK7kFI65WK6t2YZ8V2+WwgFqCD6p",
-	"lHS2U7oyu1HaWS630zRXPW6SPkUpwyTKhVQbTujLH8CpmaXnrzUXbjVNEEdsopDPQizJBFgmJ1qP35k7",
-	"lplpsBzoMzKSaFS6ci53lKAwJOB38DqNr6vo5N7J5pppzM8Ec0H20T5yNYc0PGgcG1GtBYRxwXcXa/6Y",
-	"E1lsxDPFFUPTiArWiBWvAijkH6Pnm2lDMd4QN0IRF1dg9E7ays1fa7qDjeLaQ6LSRYj8DL2K4bLxb3Px",
-	"LEE3VhAWZMqQCHYEJV0ue824DGrGcGkkGogxUFRwmmAVMWCsfBk7RPOQOMLymFaM10Hu5D7EssBepBd5",
-	"YbTsgyxqyqzdyX1Im42jia25SQGoiLsMLVjDLm08gv1a6rBwpHCkyiALHA43wknbpBOaSgSlkzTy82p2",
-	"NftWOf9NzBZtpZVb8FQ1+cNBphDemD7fY1TxkvJIFD5L8g+NAUlyP+Kb44Wlxf1my51WUxNm2Orh5mSq",
-	"F8RhVbiF+6mIhXgWGFa665QJ0JshoVgKX2SWmcA7k5sa4L+P3RZn5B7P2plawYG37KFoy14erpkLxvew",
-	"dG56PQM8/dGLIeFMZ3tguxxbQELh/eSguy2FOKKJw8g8s3AycH7vQxubq8H9M5kGnXQFKc1jWwgZsf0G",
-	"zjN3zltvqukYL3WUNXzeUjlr9yMXOi7ziio9aXLpxdaw+35qEY3aKj9YRwVrSWlrjxeLYraV79QWWeDx",
-	"gr4qHb5OpZdNAfqh6o+pDLjCnJoozAP8Nq38saOqprJRqHYCrlA+BWKUTxUrFK8gYCqrlJNIeYqkL4+K",
-	"cHZynrpmb0bNAZ4sFicaA9yvIUBfwDnREuBkCedDtAEoZk95L1NvpD33XQvw+cf3fP7Lez3/1b3Wk9n+",
-	"pNh7q/+HN3hsId83wIEhDcnDZqaCG+TcRgDFdZdmPW5y4LLODAj8FGE9k9ze7NykIAOl/fPFE3hxAt9v",
-	"51xEx+oRB3myWFCCOcRihtTVgsPUiNhksF9DUVJMay4Ig0NfBVGpG1V1sgnVlJWqrrKMveDLiyXLyolr",
-	"aH1wR12QCk8BhckUw8z+oxQUsYwFkkuECL0PbCv3WY1cZU3LwpDSrpi4BK8RMay69ZqIGPx0ofyTTDe2",
-	"PLad82SSW/BohIo4a0oiHCJArrpNGDDQ88+m2t/r9hoN362Ju+68x9xCA6XfWcGpwTuj0NSb26HrzdsO",
-	"bj+hHBqUKB/pTsInhozQWlOCc4ctSnZ57IJx/69IVj3+nLJq4Ngbiys+jiSpbovk7Bh4bs51emSh2swj",
-	"OEC9X7ALb2g6jzMF8sYKFkRZQ3k9TAw4NMLyECzfw0/EwgdR66NNdk7ErR+KUx//crSeP7XnE7x1+T6y",
-	"yu3l+wGv3GZsNzzwv8HgvD/Xcd/3qH++k366ePqL4IyXIKtQeTJNIg4Hn3CbnJ3ac7RPTgDkrfT1pIdj",
-	"qP3uZQiflxqUdba5e2GHMaxzV/emmIXWWmMZzaR3B3LWrOlsTsvqgmOM1AXJ5dlEsQdHdrScz8XaOsUM",
-	"zqmWkX2SmPSiMuBCtJ3eo+KADBRGqysU4R8qhBfdoXz4MFh2WjRM1Cx9ZkB1nngapObFcgttdtnZ/XZt",
-	"vc+Lt07JwlCpJscicEI33g25DtuROA7H5PlfDxF6GuXNvmVnYxZbHwSi7h314YX/HvMZxXwmEs45uwjB",
-	"MfWe4WoYSuZe9p1DkI5ZhYxw4OfipdmFFCbgXJCtuUmSd1gfpJzY4IE5z03SQkkz5Shy2NaablPTMmJJ",
-	"E652KtQUjzfEmSIn9Y74YA1MRJtCQhTHivCZyA4VlKoCF9aeKoxw53waHEwgnwOqI2e20J9o2FZw1/nk",
-	"GjltU9w3tnOiTPjThHcmst8/R4RnYtrfSJDn54rrZMXVdGViUQQXpwzqhRXegbrzZr0+J9aTij7OX1tI",
-	"RJM2XZZ1A4BXnL14c7GUpVc3sOTvBxc+rRqxXCqTieIpe8tQSzfKyCQBJpsm/boyvp4nOUc/c+eBJUk0",
-	"pStoQVdUrcayNjVt1N7KSpUU4CUh4rqyJt1Bo/2JV/+6Wyye/JHH/FNa254TOPvKo1hrcYy4nZuOasx4",
-	"llmRQlvpD2GyWTGTTXNWWGuiCv/3AMyvIQAzqIO6IwYzWQn1exzmgzxSB7ScRtuX70k9HXigsu+quj03",
-	"BSxPLAk2dg/I79sSTwwDOIzgQnUGgkwT4Xa8/4d9CBnfb+VeOIAjWDurMUHd3Jc+I8rc8rWVmoJLi2GE",
-	"a6ianzwRf1iOm8zElm3emLeN0ZvlF4PMJSm87XRJ1V/h0a/F8m/fvBLD3LslXREXxHgGP1+FOnRCrzSM",
-	"0YMS9lFF/qhHZUitNRU3oBlC2aDKCIQkxwSaDoyXj4LanCo4/dPFUyG16PS1Nrs+W0tswLsxEo/wh70t",
-	"OHPoO7wC4XFqMh1MbFiclgXvlPOxc1bohpUy0WOzgMOkqrjhHrXnSj+1RfRU499D9JgmxWYTMclVSK7I",
-	"ErVi+lScxHnTur5XwaBEGCz0yaEaduHqxFUFfgvc51QM4qW5cqbqQ4Cp88IkS5FhESuw8oWyuZUvNPJ7",
-	"6kVy2mzIYoI/R1g/mfH9rer/3UGURmxEDoQBiYBfjef66ZMnvxxPd1YAMS3+z3J3f9R/Dph0KvcFEh/l",
-	"6r5/y/YHdnEXH9cH4dRa1P3o8+YjUESTt3K+E0hkaivv09x35cgTvCc62+J53fmvLb4q2McWBhzpxyiR",
-	"s0S/rMtv3qRhzXpxlNlPnc5sp13qjNUvjx1LUfzqhF9io2ecvzR4htTO/7Vexj6sMVd5d7rl7KhNROh5",
-	"HBODU3fZnG2nAAXSINOgO845GeYxJ03p7t8jG8c/ggAIhzyKjhBpYQgsSJk/XTwthmnZQxTDrb3JYB6p",
-	"8UeDvHv5yZHfXPzVNKRSZSRoTzc+zL6MsueTKZTiWqljNKNvMHSVoY9BvFG5Qb/uAXIIjtdYEZoxWeq5",
-	"7c5kpcA+sF1BhZPd1UWc6D5o6ETXBM9p0ASplDp2XjrSeGmiYazjVR70+BZ/Vk3DdMiaLx3imSzS3neg",
-	"/4SIpp/kjmBWkXuge9DY71v5vJ/973jmQ/FMuDJJaf0OaX7LkIar+n46gUxYGu5qCKYWxDQ94WrSvSi9",
-	"Udtrqkt7zv9mzLGPu/8/S2idqtAWagWAhjHPvSdyo67ILbnS6LXadKzzLDhUpQFNUKs5EmzkPEz/I8R0",
-	"nqsag5wOrsJDGff3sOc7xZqHd/6ybaQaCbS+u665nsihn5Rjcf/kelE3D5gr9NU9fXxf3ctndzt0s92A",
-	"xqOnKlB2rcXy2Mtey12G4k5q4jOZC83dcN20ATXR05c9/aHI0fVIONOshGZSBLqMSSdV5ngmyBlZQTZi",
-	"00krtQcQK6hV0CgZEHVXfQq0HGtxAnfFyGOSQdegv6kghnzYG8ldQYbMGFr5vkiDf7LklUGL5s+etpI3",
-	"LD6q6rlb8Vpp5epfVYrKZ07xHVS5H2pyJuPwfvBlpQyu+0n7KLiQncnFiLJ3vVZlJut7HJqksXKi0xZk",
-	"WcdaAmqWJ69D2LA1VQziWONl6j0TquxQhHMKxtSVoU38XOKbs+BiUDRR49coz1+SszMX6Le3/x8AAP//",
+	"7H19jxs3kvdXIfQ8gDd4ejRjx9nnboL9w7ub3fUhSAzHe3dAHFhUd0niTovskOyRlWC++6GqSDb7RRrJ",
+	"Hjsv5/88VjdfqopVv3ph9c+z0mwbo0F7N7v+ebYBWYGlf76EH1tw/vlf8Y8KXGlV45XRs+vZX4y1UEv8",
+	"S6hKmJXwG+WE5Tfm4tUGhAN7C1bIyjTeCb8BYTQIKUpZ12CFA105IXUl1qDBSg+OHjB+A3anHHwplBey",
+	"aUBa/EXALdi9qM1a1AqfW9GYYcpCOCN+bI1Xeo3vKS2kcG3TGOvjM0I5sdtIL7wCXpDfGeHNGnDK+ayY",
+	"uXIDW4nb9fsGZtcz563S69nd3V0xa6SVW/CBOH9prTN2TBnc+ULDW/+mpCcWcaGNXINYwspYYGIZDXPx",
+	"nFZlGvljC9dInFqB9qKRzoHDjSxleSMk/dNCCeoWKqKLroQFWTmhjd/gpk3rcSrlcSMKl/JjC3Y/K2Za",
+	"bnEvvJ77dmnBNUY7oE2+sGZZwxb/WRrtQXv8p2yaWpXE/MuGn/h//3K4+5+zsf+vhdXsevZ/Ljv5uuRf",
+	"3WUcl2Yc0y/yayVVDRVL09JUe+Hk3omN2eEWM0H974sgqhcsq1NTh8cvO6G+o9nDkvC1v4KsvgbvwX6t",
+	"nB+z9lsduGhWogJZXdT0MFQomto7XFVjTQMWBQzfVx62blpGLKxaR7yErUsHCIcvhLEVDbvcJ56/kcxz",
+	"VRF747jHiNxtB6qvcIGzuyJyXFor9/h3Jqnjdf7XBkhYQeBjvHfnpfWuYAmtkngugrRHidZtXeOhxZdr",
+	"6fhlXDr+IJc1zK69baEYiSBK4I+tslDNrr8PG+0v84f0kln+C0ra1nivk9xTek16wMOW6f3sxfPIiQK3",
+	"gcvNWCs8LlVsTF25cLIGDK6muZuPYc1uLp71GC42Eg8uyw0q0LSYUmrhbRsUGik4s3vkhNmRoo0aDI90",
+	"XNHK2K30s+tZ26pqNqJoMbNyN71KWgrrlp10wrXLrfIeSbFTfiO++efXotxIK0tUesKVtl0uoRLSB0LO",
+	"xTdB+SgnSqOdt1JpqATKzTWvVIrS1DWU3pDK90IDVKi0xBKNwX989+03gvlYkIATJbawXYIVpbQWVTUO",
+	"hNo/LHROmwIZVM5QZvdhdWibItF92G2BVoHOh7hVJhiwlbEC3sptU0MhGgsr9Ta8spN7fpXlJupGYQHt",
+	"SmTAmODdoZ08VHokfGmBPYZW0sOFV1uY3XtOkPH5tIlAzP6pM0Pn5LluWlbqVaVwhbJ+kUk4n9HxQSql",
+	"NlqVsmYRZhXNXHNiCbXZCWnxGOCLKDNWoo0VfiN1LilfsnahDatbiLxBKGFktZXN5dXVRWk0TqKMdvNt",
+	"JRyUxLan4+NY1qY9cCKVdl7WgeMMHJxpbQmiVrd4lnQhjLtorKkuoH2cCwXJG+3zzdR5/3ttlrKu96LV",
+	"6scWhKpg2xgPutyLG9ijbn8svBFPvvhjdpzm4pnuzr+FdPj47OEKndyCQPY7L7eNKE2rvcPzKkXVsgnO",
+	"18YMHoub9GKDMErTwbY4iU67n0smJk0qtTANC4FoNtJBkZNBoI1pPcyJlLqEeWkBlwC6omU0cl8beYD+",
+	"xONa/QSVCM8J0LdQmwauebdeekDdYqyQK1K+G2AKFfTPFZoUC00tS9gi3Zz6CcQOj5PySFm9Ji2uq24X",
+	"Vu5EY82tqsCKSnrJC62lx0M2vdL465SUGJSSBpAA5c1IRhpr8HC9OWQVwu+ozFFp9sbvb1y5cLBYnfAz",
+	"B8dNg3Qv4hGSS9MORpiWERzjRmnC8fHRQkQ247puTd1uYbRhfvQYcODFlCjJK2u2wTPwJqEmIesdorqo",
+	"UgkqqwYI4/tNsjVkOcko5hallBpNyVbaG6F82DudEQul0aWqFZ940/qm7ekpsZV7tEE1rDz+/KWQ4lbW",
+	"LeAfTlUgFmmeBUnVoj/mIihvlylvRFjxwB5U/ZEq3al8/t234t/+ePU4HEM69D+hf0CKflpz349RczKf",
+	"B04DGQ+i0k4pIV2iFjsZmX5HC/u9Y9LnJLcvwbW1P6CXTYdJ0SsWlcrU/1L6chOx2Vrdgh7zUJYlNB4m",
+	"9MI/zE5spd5HXuKINAdLRYZblPawBotLTmbFHRmQPRZCytLLpXQgZI2+6F5soD4wsgUkC1SHgWi2xITI",
+	"kT6gvd0LkOXmZPl6GSY7IGEDfiYa9vafLXmKuV+rFZT7sobpI5hp0aiVxEYh6fcR5oJYKhY7gXSyt7J2",
+	"rPDCg2LFbof2Zo66h0dckGZnnekZZ8uBAUBcyS6LNtHmEBg2O9LgOIB2OzrMT6+e9rBZxAGwbfxe1HGX",
+	"89f6tX4VIiYbWaMtZIBnKSKBup1+q9RqBRa3y5t24N1cLFgIgxpN210QwmeIHTdNO/DmBjQpaJSrQuw2",
+	"qoYBDXxnUMPmCqJYXA2Hi3gVPUuLvlerERBoI1xpGpiLb3WfijIBijiHi84YU53CONFmSbFgKITQe8HT",
+	"p0gP0B7AotUPRiwKwEpZ9EYDOYIaQyRAsSkrtVtxXKp/6JmY0yeJQFJHSyCSCIvITvdU+OIPSYkXeZSh",
+	"EBHpfrZ4KIWeGD695slz0EmE2ja1AlcIZK7zTLW5eLUz3ZvMrEQ7Qs6MX7yoQd4i/uwIvQS/AzbF2wAp",
+	"Eu8DI4lHFdTg2eFlTc0DsvOuCbPJuj6ZSklnPA8LmaJVXMj9Oi48d1fMdtIioHQHrEwSg9K0NfveIcQw",
+	"0K/iWSL6bmNcFNAEKPFNGSiUnPPwxhuW3jeoQEzr3wTfIKfNyE8+qpYTIYoo8LkgZZs+qp4TqSfV9EbW",
+	"qwvE88I1UovF93h0C+HNZwthbsGi4ik3KcSaxI2QdU9qWFmMzyoOeAQIDs5+Ef6zrFuH7vDStLo6NSTw",
+	"fv4HbTdf0mRkA12u6bHJGRvo2eroqB23yPU7MCx5hb1xEQ4pfeKCvTmF+qCrQHt426d9Dh3ZCvVepNg9",
+	"6CIISkKW6QGzEhJ9R6R32oFyB3l6HhQl6aJNRiIGFvVkYeqAZJH9PnFe/u0v4t+ffvH/RYjsiwq8VPVc",
+	"fMX21Fpju0CYykJZwRVSTriNbKDgBFBFAYsDGYPxeeHZJtBnu5X6Ai0pHUB429RSs2vnGijVSpXCm5BY",
+	"KcvWWtAlTIoEbWFCV74Ae7FSUFdhyw534DnAEMAGEQThE3qKqgrhQ6nq1vZVXX9TtSnH031tyuCacn7I",
+	"rFagK5QT8kILAfP1nNIe8ywAMLmjrVsfUP3KiZ01et15FeziklWQXtRhEfN7I4y4B55pSpyGVgyFsT1g",
+	"7v/x6tULwQ+I0lSQZQ9ZqnAxIcowu356dTXlT3jlp7D3dxtjvdj0hcW12620+5SIC3zEQXtTzf6zz1SY",
+	"jKZPh1D++ZJiuUBiJ1QF2qvVPmrZw1O2Vl97Wdf7axLL606u7uUI/RopkUg+xZ2XsGxVXYXU15SooPKK",
+	"Uobwm+Nse0QEIVoSwyRipWpKBwSjyPgpOgw8p7A8oQsgPAPWKbbAmZUbbXbu5DjuS1qUMLre90xCF6mg",
+	"Fw/E5I+GwO4fOvJuzJTD9L7H9Q9kCsSegg/8hD/ijXcLRYeuN9Tw1IwAFo89LTFr5TzYiDJfHYwbkt0P",
+	"YXuSG36RHM3cpQrU628PX37TpYz7oz/j5NB3PHZl5cqLJ1dPri4ePxGVKdstJR7YPiNAxgMb3S5F/8uh",
+	"jpRJiy/RunCZls86BwAcvgFvZemDCHTBGXyolJrM2F7U0rNXNqDagLz53qZJnAcpDkQRspRhdBo5rxPj",
+	"QuGRA07iQSSYJR5DGpDhfAI8dFLpSLOgMz91TJ2if8wvkCcU8Q+lJ2PKrIK3KV8ZFKLqBUsnTim9dThG",
+	"9MiJxjjFZSdslbu8CcXLCk6TxCDAT2DNoYDU4fxhIkpG4X4q5HXO3mvx6LZsWveIoUEUAhEYsn89u9+8",
+	"8sazNFNa4bTsHIq858GnmNDOoiQxkx2Ss6PgFFdY8Omxar3xQnO1xQPm2SYZ38VPjuD1ngsQ3igmdhnC",
+	"QMqHuFT26iMUSFOn6EIP4LPO6qIn0gtNeWe3MTtEsmFSTiNkEwbfmIJJFeNQDvsQADA36CE4I8xJUSbl",
+	"4gEMnnaHW8i4qiyfQlqhsVBR+VQXbOKKAbBuo5qUiE8DOPJk8YxwNJDclugxP3J5hK4IFOgFuBpJ8k2Y",
+	"chGCJPjDu3o1xawb5FT2hzeK3DVTnoXs3deBztsbPoNHliL9IINzuoueTXA4F4e/RK5r2EGKwUTB1tHV",
+	"sXw6p6c5mo8dJmF5vrizIsI+lJDwz6xQJNhVFL7s4HBwVPoUfNbHsiudNnufdOz8oeMg+gBFT0/CKu+g",
+	"XhVMrwBJewU752LTqfTsA0RnkEO7g4xOuVQOcpM6HYODgPcnFGd6TRua/QECP4riPprLqWJstgvBhXhk",
+	"UgxdSCZUojqgkh3kTi/nERW18uiEhxowHCTm4O8z3mwOM0EesrQvPj0BHQVuMkvY04tj3TFUV4Njfww4",
+	"3J885hCK7/yLM6sbh+7TKIdMRCv6HkIR6lojw6szUn5dOPx3mk8+7osx8GPnKz8WZEui79Bz1sLf2Qkn",
+	"OOApsRfiEAh61hIx3Zj976K2aTVLqI1eO+HNu2rD/niIQ1Swy3Hag/rxoLvJ4yYCnuB7Tmm0tqnux7GB",
+	"A2hKSW5CUdY71v4d0Tr5hntru0++pvXDgEQ9LrybfuBXe3ohCU5PFcT4wVnKgE7KwymEeO5D9p2OvzeV",
+	"3F8HIaeYwj7AHwrwmJ1owA6VnDMpMJaFIVZodAnaUW6RMvTsaaSRa+U8LmaPfqZTel1DUKxdboKq/ulJ",
+	"VroM03m37sNppzwFPKmcQrWXGwcBB07poBS5qdsQNAjp15RwCPVNU3XZD++gHo+nDGs+uyKv3m647uDI",
+	"+L9sDecUlH7Hms5THIix7x0rYgNnQy5ZZBEm2YNmoYavX36M5gu98XFBOo4f3Z0bgMaFKgxA+ZNdoSjV",
+	"qS9hb4LZNDpmtlDsCMr/9hybQwWm71e/HjiV5P10T/icqlYYFbU+jBd16tCH61xRJlO5amNN1ZY5OYqs",
+	"VpXypnkBaZT/XSzSCH4KPmWrQdF891BQJlaUtVRbmD6351ehviP6yAKW3Zw9ddbzi6KrdI5/FMtAoi7q",
+	"C+gPU4F4B2Vrld8TgAulko16ZW5gIuT7TJMoc9FZwPwI95+1fmOs+omYdS3+DNKCFa/bq6vPS3qY/gmL",
+	"ufhKlhuB9oetCjv7XC/GYSkNULkvhQyT8A0JDrNmpXifpzuIuJ0lzdcxYON9wzHyNTh/eC+xoNQCBd1l",
+	"XQjlXItKGqz4Q2RGwR7YZxxCfJddP/ehRI8uWQaTjnqckbhUVsg6BIFO2JUHq2V9YF8UEthIpJOD0gKf",
+	"BborKl7R7YsOB3IRaarToHsApvXgyKAU77zZEOUNxPRGNO2yVmW40OpO2OYdbXQ1UZPyFSuhmG7K/GJF",
+	"l19S4WjrENMxzWNehgiARlC5LslVmlu0hlRJB7L2G8pCI9iG4VwRNiq0PKiBmJfdIhzPnWLEoVgm/nxB",
+	"blhEqUX/9hvcKth1NY95ySanP+cpiX09Y1a+TLt79uL5rJjhRphMV/PH8ysUF9OAlo2aXc8+n1/NPyft",
+	"4Dd00C9loy5vH192ZZJr8FMZX99aHVPUea18IbS0liL+yz3jDoqBx8x3du04Rp0YgZAXg2LSK67s6imF",
+	"dCXXeMzFYmXNNhTEerMQDtBMMLtSVdpO6crsBnVpufJO01x34En6lMYMkygXanG44i9/AKdmuZ6/1nyz",
+	"q66DTmIfhoIaYkF+wCJF2ToQz6ztX3nOjRp5UTRquNScRVJQIxL6G71O4+sqRsF3sr5hGvMzwWeQXTqQ",
+	"YtGhTg9qx15WYwGxXAjuxZveDJRZd0Se4oqhrkUFKwSM1wEZ8o8xNM60oSRwSCyhnosrMHonbeXmrzUd",
+	"RPLVIsy6CKmhftgxnB7+bS6eJfzGVoLvd+d1zFyVuejM4yLYGsMX4tGDjJmkgusIqwgE49WYYcQ0z5kj",
+	"No91x3gc5E7uQ7IL7EV6kRdGyx6VWVPp7U7uQ11tHE1szW3KUEXwZWjBGnZp4xHxb6QOC0cKR6r0ysRh",
+	"vBGu6ibDUFciWJ5klp9Xs+vZ18r5r2I5aX6j//tRKRGemK4gZHAlJhWaTN60DyDn8EX74rzZ8qjW1IQZ",
+	"wHq4OZnqBUlYdx12IqUhngWBle4mlQp0vki4TYUvsshMgJ7JTfVA4Ptui0t2D5f1TK1gFE57KNpyGIgv",
+	"1QUPvH+3bno9PVD93osh5Uy8HTkwhxaQoHg3Oeh2SzmQ6OcwPM/cnAyhn820oc8aYkCTddLJVpDRPLSF",
+	"UDLbbeA0n+e09ebtPXpLHZQVn7ZULut9z4UO74FFk54sufRia9zBriG12irfW0cFK0l1bY+vrorZVr5V",
+	"WxSBx1f0p9Lhz6n6s+mwbaeGL0NXlbsfBo1InlxdHWlCcl7zke725ET7kaP3Jx+i5Ugxe8p7mXoj7bnr",
+	"kILPPz7z+c/Pev6Ls9aTOddkNDu3+vsfkG2h2DaY2j4NKYRlpjILFD1GcMKXHs1q2GHAZV1gEFQpwlEm",
+	"xZU5ekgRfqq5Z6EWKJThsG3nfIONTQ8O8uTqiqq7Id4kSH2COEeMaEgGBzHcCIo1xUXXkyIUu6lbVbWy",
+	"DlcZK1VdZ+VyvWYPBDZvoPEh3nNB5jEVaE/W94XJYyZei0W8nbhA89sFmbbcsSJcUKusaVjRUM0TE5eg",
+	"K1rjZbtaERFDICzcvSS3iFH9tnWefF4L3u4JO/KsqYKvj674ymvCV4GefzbV/qzTazR8uyLpuvccc/8K",
+	"1CwnZYZ67wzyQj/c9WNb3rZw9wH1UO9+8IFOSMwxFITGmhKcG7dD2uXJAcbUvyFd9fhj6qpe5Gyorpgd",
+	"SVPdFSmQEIX+4qyIwrFeQ/nJL045+vSr3DHbJzr2jOIPvRudDxl7WGQjL3p1v/FS1aBwdhDFpm4dseqU",
+	"Ith032AjbyFJcac6U8uze4Mak0++T3SD/utTcGMiuAFZqBt9uWqr9AVC4esYCg0BbpyGfuU4uLTQd/zE",
+	"N+l+enANSZuCK8QSStk6SILPfaJWZIKyovjIMG2EhVpROjmOKL23atnG603jOECvAv/ceADb+XRGfyuO",
+	"Sn/Zv2Z/JTTG+1/vrgy6Et7jsxzqS/jJdTnbdRn0Asy8mB42yFIgp0KDrIYqS8f1ok2fcf6sr9WHJXx5",
+	"xyMLotxAedOv2JtSel1tFGP0DyS3o3Kyg80+jxSUPZTYPv51idXBPR+Rrcufo6jcXf7ck5W7TOz6DP87",
+	"9Pj9sdh9Lqt/OU4/vXr6q5CMlyCrAGOnSTS7uweenFxze7CBXTCojfSbycxC3zM+KwB9Ws1u1nLu/oWN",
+	"C0hOXd0PxSz0vBzqaCa9G+lZsyLeHNfVBRf4UHtCl5f5xuZYGWu50Joxf0rYn3KNVXbV29KLyoALpW70",
+	"Ht3ay7zG6DKE7jhjg/CiHeuHdwvZHFcNE5eJP3Kw5TT11KuZj/cgtdllvPv9gqmPG4s5pgvDFXI5VIET",
+	"tvF+yDXuE+Y4YpAXZj9EycfgQssbTvJlhW29IMzZ8Qhe+KdwxCAcMXETjEt7ERxTUzi+pkq3rBZdSy+k",
+	"Y3Z1VTjwc/HS7EL9MHAh5tbcJs3bv7irnFgjw7gaP/UaocsDHLGzpl1vaBnxrjGudqrEI7I31HdESeoS",
+	"4MEbmKjyCNXIXKOBz0RxqKBUFbiw9nT1F3fO3OAkPuUj0Bw5s4WOo2Fb4ZsCPqVNjvsU58ZQjvTv+DBl",
+	"FRPX0j5GZcXEtL+T4opfqp4i63pCRybeVuRbo71GHgrPwKb1ZrU6pcYi3cY8fW2hClzadFhWNQAecY5Q",
+	"z8VCll7dwoL/Hh34tGrEcun+alRP2VuGeq3SdQhSYLKu069L4zfzpOfoZ24JtCCNpnQFDeiKrpGzrk3d",
+	"lLW3slIlFVaREnFtuSHbQaP9iVf/ur26evJHHvNPaW17vj3RXQmOlyAPEbd10+G5Gc8yK1JJSfqPMNms",
+	"mMm6PqmcZKI9zqdIYu/y7z1xxMnrv5+CiO8U7RnRchrJXv5Mqn8U3cn+VtXdqWXNebFk8F87sHtuH1jR",
+	"L5xgdNTItdLSI4AzEcrGszVuvsvYeSv3wgEcwLHZxUr+Ykrs94EIbsuZCqmpqOOqX1nSN3tPnog/LIad",
+	"1WKfUm/Mm9ro9eKzXmZSCm9bXdKV5/Dol2Lx969eiX49+YKOiAsqMoN2r0LzFUKGNIzRvb4tgzY0g8bM",
+	"4c6IqbjrWh8mBjNBBj45/QjLGYseBIw5VXD6p1dPhdSi1Tfa7LoKZLEG74YoN0ILjmTgzKHZ/hKEx6kJ",
+	"lpvYpT8tC94q52O7yNACMl2xih1yxoXCccMdIs4NauoF7PlTOAn+xtJfdklISK5DHi4rPo4lwSnZ6E3j",
+	"ugY9vb4YYKG7raBhF45OXFWQtyB9TsXimTRXLlRd6U1qNzQpUpw/D9eO84WyK5MvNMp7asB1HJJntTi/",
+	"RDldcpG7U9V9uC1qI3bQesqAVMBvJir89MmTX08UObvZN63+Twolv9fnciYDtt3Nv/cKI5//nZIHDh8X",
+	"79f859ha1Hn0+eE9UESdf7/gXiCRma384wRdK6q8cGiinTvy697vOX1RcPwqDDiwj1EjZ8XrWWv7vDPR",
+	"iu3i4KoZtfe0rXapHWS3PA7aRPWrE36JXzfA+UuDPKRv2LzWi9h8PN6/2R3vsz7ojRQa/cfLLqmlei62",
+	"U4ACaZBZ0Ph1st7dnGQp3fkfhsDxDyAAwiGPYpChV8mTjPnTq6dF/6pRH8Xw9yzIGR2Y8Ue9u2TygyO/",
+	"ufibqcmkykjQjm7MzK4/QCcnUyjFNVLHTEHXVe86Qx+9XJ5yvY9U9JBDCGrGorpMyNKHJtyJohTEB7ZL",
+	"qHCy+z6dwd+WzLsY0jFBPvU6/5VSx3aDB7oNTnRJd7zK0YctxJ9VXTMdso6DYzyTZbG7z658QETTTXJP",
+	"oqjIo7sdaOz2rXz+EZdPeOZd8Uw4MslofYI0v2dIw9fVfzqCTFgb7jYQXC2I5fHCbcj2ovZGa6+p3vk5",
+	"f0rYcfy4+7ggeqcq9EJcAqBjzHPvidxoK3JPrjR6pdYt2zwLDk1pQBPUX5UUG32+OX0Yy7Ser+sHPR2y",
+	"ZmMd94+w53vVmoe3/rKppRootK6lvLmZqLOc1GNx/xR6UbcPWIfzxZkxvi/Oitnd9cNst6CR9dTegENr",
+	"se/DZWflLkO3AepcN3kHiVvAu2kHaqKRPUfRQ/G865BwZlkJzaTsbhkLOqrs098+L6eWtVi30krtAcQS",
+	"NipYlAyIuuvu6pEcWnECd8UgYpJB12C/6ZIndfpbSzVRHB36179Ig3+wwpDedwk+eklI3qX/oKnnFv0r",
+	"pZXb/KbKPz7y1Zpe+5axJWcy9s8HH1aqjjpP20fFheJMIUbUvauVKjNd3+HQpI2VE622IMtNvMNHHWLl",
+	"TUjJNaaKKW9rvExN1cLNcVThXN4wdWRoE7+U+uYKs5hwTNT4LerzlxTszBX63d3/BAAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/problem/problem.go
+++ b/internal/reporting/httpapi/problem/problem.go
@@ -30,6 +30,9 @@ const (
 	// TypePayloadTooLarge marks a request that carries more than the endpoint
 	// takes at once, such as an event batch above the item limit.
 	TypePayloadTooLarge = "urn:tally:error:payload_too_large"
+	// TypeHistoryTooLong marks a resource whose stored history is longer than
+	// the unpaginated per-resource reads answer at once.
+	TypeHistoryTooLong = "urn:tally:error:history_too_long"
 	// TypeInternal marks a failure the caller cannot do anything about.
 	TypeInternal = "urn:tally:error:internal"
 	// TypeUnavailable marks a dependency the service needs and cannot reach.

--- a/internal/reporting/httpapi/query.go
+++ b/internal/reporting/httpapi/query.go
@@ -1,0 +1,141 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+)
+
+// The plumbing the query routes share. Each of them lives in a file of its own,
+// and the pagination protocol, the scope resolution, and the filter mapping are
+// one contract across all of them, so they are stated here once rather than in
+// whichever endpoint file happened to need them first.
+
+// defaultPageSize is how long a page is when the request names no limit. The
+// contract declares the same number, and bounds the parameter, so a limit that
+// reaches a handler is either absent or between 1 and 1000.
+const defaultPageSize = 100
+
+// badCursorDetail answers every cursor this API cannot use. Which part of it was
+// wrong goes to the log rather than to the client: a cursor is opaque, so a
+// caller has nothing to fix inside one and can only walk the list again.
+const badCursorDetail = "the cursor is not one this API issued"
+
+// errNoPrincipal is what a query route reports when the request context carries
+// no principal. Every route the dispatch table puts behind the query guard has
+// one, in enforced mode from the token and in disabled mode synthetically, so
+// finding none is this service disagreeing with itself.
+var errNoPrincipal = errors.New("the request context carries no query principal")
+
+// queryScope resolves what the request's principal may read, and answers the
+// request itself when it cannot: a route the dispatch table puts behind the
+// query guard has no answer without a scope.
+func (s *server) queryScope(w http.ResponseWriter, r *http.Request) (auth.Scope, bool) {
+	ctx := r.Context()
+
+	principal, ok := auth.QueryFromContext(ctx)
+	if !ok {
+		writeInternal(ctx, w, "serving a query route without a principal", errNoPrincipal,
+			"the request could not be served")
+		return auth.Scope{}, false
+	}
+	scope, err := auth.ResolveProjectScope(ctx, s.queries, principal)
+	if err != nil {
+		writeInternal(ctx, w, "resolving the project scope", err,
+			"the request could not be served")
+		return auth.Scope{}, false
+	}
+	return scope, true
+}
+
+// pageLimit resolves how long a page is: the limit the request names, or the
+// default when it names none. The contract bounds the parameter, so a value that
+// reaches here is between 1 and 1000.
+func pageLimit(limit *int) int {
+	if limit == nil {
+		return defaultPageSize
+	}
+	return *limit
+}
+
+// refuseCursor answers a cursor this API cannot use, and logs which part of it
+// was wrong.
+func refuseCursor(ctx context.Context, w http.ResponseWriter, err error) {
+	Logger(ctx).Warn("refusing a cursor", "error", err)
+	problem.Write(w, http.StatusBadRequest, problem.TypeValidation,
+		"Validation failed", badCursorDetail)
+}
+
+// trimPage cuts a page read one row longer than it is served back to its length,
+// and reports whether that extra row was there. It is what tells "the page is
+// full" from "there is more" without a second query counting the rest, and so
+// what decides whether a cursor is sent.
+func trimPage[Row any](rows []Row, limit int) ([]Row, bool) {
+	if len(rows) > limit {
+		return rows[:limit], true
+	}
+	return rows, false
+}
+
+// scopeFilter zips the projects a filtered principal reads into the two parallel
+// arrays the queries pair positionally, so that clouds[i] belongs to
+// projects[i]. Pairing them is what keeps a project id one cloud uses from
+// matching the rows another cloud stores under the same id.
+//
+// An unfiltered principal yields two nil slices, which pgx sends as NULL and the
+// queries read as no scope filter at all.
+func scopeFilter(scope auth.Scope) (clouds, projects []string) {
+	if scope.Unfiltered {
+		return nil, nil
+	}
+	clouds = make([]string, len(scope.Refs))
+	projects = make([]string, len(scope.Refs))
+	for i, ref := range scope.Refs {
+		clouds[i] = ref.Cloud
+		projects[i] = ref.ExternalID
+	}
+	return clouds, projects
+}
+
+// reachesProject reports whether a filtered scope holds the project a request
+// asked for by name. The cloud is left out of the comparison: the pair filter of
+// the query narrows the answer to the cloud the token holds the project in
+// anyway, so a matching external id is enough to let the request through.
+func reachesProject(scope auth.Scope, externalID string) bool {
+	return slices.ContainsFunc(scope.Refs, func(ref auth.ProjectRef) bool {
+		return ref.ExternalID == externalID
+	})
+}
+
+// reachesPair reports whether a filtered scope holds the (cloud, project id)
+// pair a projection row names. Both halves are compared here, unlike the lists,
+// where the query's own pair filter has already narrowed the rows.
+func reachesPair(scope auth.Scope, cloud, projectID string) bool {
+	return slices.ContainsFunc(scope.Refs, func(ref auth.ProjectRef) bool {
+		return ref.Cloud == cloud && ref.ExternalID == projectID
+	})
+}
+
+// filterText maps one optional string filter onto its query parameter. A filter
+// the request left out becomes NULL, which the query reads as every value.
+func filterText(value *string) pgtype.Text {
+	if value == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *value, Valid: true}
+}
+
+// filterInstant maps one bound of a time window onto its query parameter.
+func filterInstant(value *time.Time) pgtype.Timestamptz {
+	if value == nil {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: *value, Valid: true}
+}

--- a/internal/reporting/httpapi/rejectedevents.go
+++ b/internal/reporting/httpapi/rejectedevents.go
@@ -1,0 +1,123 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// deadLetterCursorKeys is how many parts the sort key of this list has: the
+// instant the item was refused and the row's id, in the order ORDER BY names
+// them.
+const deadLetterCursorKeys = 2
+
+// deadLetterDetail answers every failure of this route a caller can do nothing
+// about.
+const deadLetterDetail = "the dead-lettered events could not be read"
+
+// ListRejectedEvents answers one page of the items ingestion refused, so that a
+// server-side rejection is something an operator can review after the collector
+// has dropped the batch from its buffer. The page is read one row longer than it
+// is served, which is what trimPage turns into the cursor decision.
+//
+// Nothing here reads a principal or resolves a scope. The dispatch table puts
+// the route behind the admin role, so every request that arrives may read the
+// whole table, and a refused item has no project to be scoped by: its raw JSON
+// is whatever a collector sent, which is what made the item refusable in the
+// first place.
+func (s *server) ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams) {
+	ctx := r.Context()
+
+	var cursorAt pgtype.Timestamptz
+	var cursorID pgtype.UUID
+	if params.Cursor != nil {
+		var err error
+		if cursorAt, cursorID, err = deadLetterCursor(*params.Cursor); err != nil {
+			refuseCursor(ctx, w, err)
+			return
+		}
+	}
+
+	limit := pageLimit(params.Limit)
+
+	// A from later than to yields nothing, which is what the half-open window
+	// means and needs no case of its own: each bound is a valid instant on its
+	// own, and the contract cannot express a rule spanning two parameters.
+	rows, err := s.queries.ListRejectedEvents(ctx, sqlcgen.ListRejectedEventsParams{
+		FromTs:   filterInstant(params.From),
+		ToTs:     filterInstant(params.To),
+		CursorTs: cursorAt,
+		CursorID: cursorID,
+		PageSize: int32(limit) + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing rejected events", err, deadLetterDetail)
+		return
+	}
+
+	rows, more := trimPage(rows, limit)
+	items := make([]DeadLetteredEvent, len(rows))
+	for i, row := range rows {
+		if items[i], err = deadLetteredEventOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a dead-lettered item", err, deadLetterDetail)
+			return
+		}
+	}
+
+	list := DeadLetterList{Items: items}
+	if more {
+		// The cursor names the last item served, so the next page starts at the
+		// row after it. RFC3339Nano carries the microseconds a TIMESTAMPTZ holds,
+		// which is what makes the round trip exact.
+		last := items[len(items)-1]
+		cursor := encodeCursor([]string{last.ReceivedAt.Format(time.RFC3339Nano), last.Id.String()})
+		list.NextCursor = &cursor
+	}
+	writeJSON(w, list)
+}
+
+// deadLetterCursor reads the position a cursor resumes from into the two bounds
+// the query compares its sort key against.
+//
+// Both keys are parsed rather than passed through, so a cursor whose instant is
+// not an instant and one whose id is not a UUID are refused here instead of
+// reaching the database as casts that fail there.
+func deadLetterCursor(cursor string) (pgtype.Timestamptz, pgtype.UUID, error) {
+	keys, err := decodeCursor(cursor, deadLetterCursorKeys)
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.UUID{}, err
+	}
+	at, err := time.Parse(time.RFC3339Nano, keys[0])
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.UUID{},
+			fmt.Errorf("the timestamp of the cursor is not RFC 3339: %w", err)
+	}
+	id, err := uuid.Parse(keys[1])
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.UUID{},
+			fmt.Errorf("the id of the cursor is not a UUID: %w", err)
+	}
+	return pgtype.Timestamptz{Time: at, Valid: true}, pgtype.UUID{Bytes: id, Valid: true}, nil
+}
+
+// deadLetteredEventOf renders one rejected_events row as the answer the contract
+// promises. The instant comes out in UTC, the zone this API states them in, and
+// the raw item is decoded rather than passed through, because the contract
+// constrains it to nothing and a collector may have submitted anything.
+func deadLetteredEventOf(row sqlcgen.RejectedEvent) (DeadLetteredEvent, error) {
+	item := DeadLetteredEvent{
+		Id:         row.ID,
+		ReceivedAt: row.ReceivedAt.Time.UTC(),
+		Reason:     row.Reason,
+	}
+	if err := json.Unmarshal(row.Raw, &item.Raw); err != nil {
+		return DeadLetteredEvent{}, fmt.Errorf("decoding the raw item of %s: %w", row.ID, err)
+	}
+	return item, nil
+}

--- a/internal/reporting/httpapi/rejectedevents_integration_test.go
+++ b/internal/reporting/httpapi/rejectedevents_integration_test.go
@@ -1,0 +1,406 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// rejectedEventsRoute is the route the dead-letter tests call, spelled once
+// because every one of them addresses it.
+const rejectedEventsRoute = "/api/v1/rejected-events"
+
+// refusedEventType is what makes the pipeline refuse an item these tests submit:
+// a hyphen where the pattern (*event.Event).Validate() holds every event to
+// demands a dot.
+const refusedEventType = "volume-create"
+
+// beforeAnyRefusal is a bound earlier than anything this test dead-letters, so a
+// window ending there matches no row at all.
+var beforeAnyRefusal = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// TestListRejectedEventsOverHTTP drives GET /api/v1/rejected-events through the
+// whole stack: the contract validator, the admin guard, and the rows ingestion
+// dead-lettered behind them.
+//
+// The subtests share one database and run in order. The first describes the
+// whole table while nothing has been refused yet, and the ones after it refuse
+// more items, so the counts they assert include what the earlier ones left.
+func TestListRejectedEventsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+
+	t.Run("keeps a refused item reviewable with the reason ingest reported", func(t *testing.T) {
+		const cloud = "os-dead-review"
+		_, ingestToken := seedIngestCredential(t, a.queries, fixturePlatform, cloud)
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-review"}
+		// One item the pipeline refuses between two it stores, which is the batch a
+		// collector drops from its buffer once the call returns: what the list
+		// answers afterwards is the only copy of the refused item left.
+		refused := res.event("dead-review-refused", refusedEventType, createTime,
+			payloadOf("available", volumeSize(10)))
+		body := batch(t,
+			item(t, res.event("dead-review-first", "volume.create", createTime,
+				payloadOf("available", volumeSize(10)))),
+			item(t, refused),
+			item(t, res.event("dead-review-last", "volume.resize", updateTime,
+				payloadOf("available", volumeSize(20)))),
+		)
+
+		ingested := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, ingestToken, body))
+		if ingested.Accepted != 2 || len(ingested.Rejected) != 1 {
+			t.Fatalf("result = %+v, want the two valid items stored and the third refused", ingested)
+		}
+		assertRejected(t, ingested.Rejected[0], 1, refused.EventID, "schema: ")
+
+		list := deadLetterListOf(t, a.call(t, http.MethodGet, rejectedEventsRoute, adminToken, nil))
+
+		if list.NextCursor != nil {
+			t.Errorf("next_cursor = %q, want null on a page that holds everything", *list.NextCursor)
+		}
+		if len(list.Items) != 1 {
+			t.Fatalf("served items = %v, want the one refused item", deadLetterEventIDs(t, list.Items))
+		}
+		kept := list.Items[0]
+		if kept.Id == uuid.Nil {
+			t.Error("id = the nil UUID, want the id of the dead-letter row")
+		}
+		if kept.ReceivedAt.IsZero() {
+			t.Error("received_at is unset, want the instant the item was refused")
+		}
+		// The two reasons are one string: the answer of the call that refused the
+		// item and the row it left behind name the same failure.
+		if got, want := kept.Reason, ingested.Rejected[0].Reason; got != want {
+			t.Errorf("reason = %q, want the %q ingest reported", got, want)
+		}
+		if want := asDocument(t, refused); !reflect.DeepEqual(kept.Raw, want) {
+			t.Errorf("raw = %v, want the submitted %v", kept.Raw, want)
+		}
+	})
+
+	t.Run("walks the list in pages and ends the walk with a null cursor", func(t *testing.T) {
+		// Two batches of three, which brings the table to the seven rows this walk
+		// needs: the six here and the one the subtest above refused. Each batch is
+		// one transaction, so its rows share the received_at now() assigned it and
+		// the id breaks the tie, which puts a page boundary inside a group of
+		// equal instants.
+		seedRefusedItems(t, a, "os-dead-walk-a", "dead-walk-a1", "dead-walk-a2", "dead-walk-a3")
+		seedRefusedItems(t, a, "os-dead-walk-b", "dead-walk-b1", "dead-walk-b2", "dead-walk-b3")
+
+		whole := deadLetterListOf(t, a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000", adminToken, nil))
+		if len(whole.Items) != 7 {
+			t.Fatalf("the unpaginated answer holds %d items, want the 7 refused so far", len(whole.Items))
+		}
+
+		for _, tc := range []struct {
+			name  string
+			limit int
+			sizes []int
+		}{
+			{name: "a last page shorter than the limit", limit: 3, sizes: []int{3, 3, 1}},
+			// The whole table in one page: the last page is exactly full, which is
+			// what tells "the page is full" from "there is more".
+			{name: "a last page exactly as long as the limit", limit: 7, sizes: []int{7}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				page := fmt.Sprintf("%s?limit=%d", rejectedEventsRoute, tc.limit)
+
+				var walked []DeadLetteredEvent
+				var sizes []int
+				for count := 1; ; count++ {
+					if count > len(whole.Items) {
+						t.Fatalf("the walk had not ended after %d pages, want it over after %d",
+							count, len(tc.sizes))
+					}
+					list := deadLetterListOf(t, a.call(t, http.MethodGet, page, adminToken, nil))
+
+					sizes = append(sizes, len(list.Items))
+					walked = append(walked, list.Items...)
+					if list.NextCursor == nil {
+						break
+					}
+					page = fmt.Sprintf("%s?limit=%d&cursor=%s",
+						rejectedEventsRoute, tc.limit, url.QueryEscape(*list.NextCursor))
+				}
+
+				if !slices.Equal(sizes, tc.sizes) {
+					t.Errorf("page sizes = %v, want %v", sizes, tc.sizes)
+				}
+				if !reflect.DeepEqual(walked, whole.Items) {
+					t.Errorf("the walk served %v, want the unpaginated %v",
+						deadLetterEventIDs(t, walked), deadLetterEventIDs(t, whole.Items))
+				}
+			})
+		}
+	})
+
+	t.Run("takes from as inclusive and to as exclusive on received_at", func(t *testing.T) {
+		whole := deadLetterListOf(t, a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000", adminToken, nil))
+		if len(whole.Items) < 3 {
+			t.Fatalf("the table holds %d items, want the rows the batches above refused", len(whole.Items))
+		}
+		// received_at is the database's own, so the bound is read off an answer
+		// rather than chosen by the test. The rows of one batch share the instant,
+		// which is why the expected halves are cut on the bound instead of on the
+		// position the bound was taken from.
+		middle := whole.Items[len(whole.Items)/2]
+		var wantFrom, wantTo []DeadLetteredEvent
+		for _, kept := range whole.Items {
+			if kept.ReceivedAt.Before(middle.ReceivedAt) {
+				wantTo = append(wantTo, kept)
+				continue
+			}
+			wantFrom = append(wantFrom, kept)
+		}
+
+		from := deadLetterListOf(t, a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000&from="+deadLetterBound(middle.ReceivedAt), adminToken, nil))
+		to := deadLetterListOf(t, a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000&to="+deadLetterBound(middle.ReceivedAt), adminToken, nil))
+
+		served, want := deadLetterEventIDs(t, from.Items), deadLetterEventIDs(t, wantFrom)
+		if !slices.Equal(served, want) {
+			t.Errorf("from served %v, want the items refused at or after the bound, %v", served, want)
+		}
+		// The row the bound came from is the one the two ends of the window differ
+		// in, which is what inclusive and exclusive mean here.
+		if refused := deadLetterEventID(t, middle); !slices.Contains(served, refused) {
+			t.Errorf("from served %v, want it to hold %s, whose received_at the bound is", served, refused)
+		}
+
+		served, want = deadLetterEventIDs(t, to.Items), deadLetterEventIDs(t, wantTo)
+		if !slices.Equal(served, want) {
+			t.Errorf("to served %v, want the items refused before the bound, %v", served, want)
+		}
+		if refused := deadLetterEventID(t, middle); slices.Contains(served, refused) {
+			t.Errorf("to served %v, want %s left out, whose received_at the bound is", served, refused)
+		}
+	})
+
+	t.Run("answers an empty page rather than null items", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?to="+deadLetterBound(beforeAnyRefusal), adminToken, nil)
+
+		if got := rec.Code; got != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+		}
+		// The raw body rather than the decoded one: a client iterates items without
+		// a nil check, which null would break and [] does not.
+		want := `{"items":[],"next_cursor":null}`
+		if got := strings.TrimSpace(rec.Body.String()); got != want {
+			t.Errorf("body = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("refuses a cursor it did not issue", func(t *testing.T) {
+		const (
+			at = "2026-06-01T08:00:00Z"
+			id = "9b1d2b7e-4c31-4d0a-8f6b-0f2a1c3e5d70"
+		)
+
+		for _, tc := range []struct {
+			name   string
+			cursor string
+		}{
+			{name: "not base64url", cursor: "not base64!"},
+			{name: "base64url that is not an array of strings", cursor: rawCursor(`{"at":"now"}`)},
+			{name: "one key where the sort key has two", cursor: encodeCursor([]string{at})},
+			{name: "three keys where the sort key has two", cursor: encodeCursor([]string{at, id, "b"})},
+			{name: "an empty key", cursor: encodeCursor([]string{at, ""})},
+			{name: "a timestamp that is not an instant", cursor: encodeCursor([]string{"yesterday", id})},
+			// The id of this list is a UUID rather than a column a client could have
+			// read off an item, so a cursor spelling it as anything else is refused
+			// here instead of reaching the database as a cast that fails there.
+			{name: "an id that is not a UUID", cursor: encodeCursor([]string{at, "dead-review-refused"})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					rejectedEventsRoute+"?cursor="+url.QueryEscape(tc.cursor), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec), "the cursor is not one this API issued"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a parameter the contract does not allow", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a limit below the minimum", query: "limit=0"},
+			{name: "a limit above the maximum", query: "limit=1001"},
+			{name: "a from that is not an instant", query: "from=not-a-date"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, rejectedEventsRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			})
+		}
+	})
+
+	t.Run("serves the admin role alone", func(t *testing.T) {
+		_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+		project := seedProject(t, a, "os-dead-scope", "p-dead")
+		_, projectToken := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{project})
+
+		// A refused item has no project to be scoped by, so a token below the admin
+		// role is refused rather than served a narrowed page.
+		for name, token := range map[string]string{
+			"a read_all token": readAllToken,
+			"a project token":  projectToken,
+		} {
+			t.Run(name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, rejectedEventsRoute, token, nil)
+
+				assertProblem(t, rec, http.StatusForbidden, problem.TypeForbidden)
+			})
+		}
+
+		t.Run("no token at all", func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, rejectedEventsRoute, "", nil)
+
+			assertChallenged(t, rec)
+		})
+	})
+
+	t.Run("serves the route without a token while authentication is disabled", func(t *testing.T) {
+		// A second router over the same database, which is the development setup:
+		// the guard injects an admin principal instead of reading a credential.
+		open := newAPIInMode(t, db.Store, auth.ModeDisabled)
+		admin := deadLetterListOf(t, a.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000", adminToken, nil))
+
+		list := deadLetterListOf(t, open.call(t, http.MethodGet,
+			rejectedEventsRoute+"?limit=1000", "", nil))
+
+		if got, want := deadLetterEventIDs(t, list.Items), deadLetterEventIDs(t, admin.Items); !slices.Equal(got, want) {
+			t.Errorf("served items = %v, want the %v an admin token reads", got, want)
+		}
+	})
+}
+
+// TestListRejectedEventsReportsAFailedQuery drives the handler's own failure
+// path. With authentication disabled nothing reads the database before the list
+// does, so a database that is gone stops the request inside the query rather
+// than at the credential lookup in front of it.
+func TestListRejectedEventsReportsAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	rec := a.call(t, http.MethodGet, rejectedEventsRoute, "", nil)
+
+	assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+	// The detail is what tells the internal problems of this route apart: the
+	// query failed, rather than anything in front of it.
+	if got, want := problemDetail(t, rec), "the dead-lettered events could not be read"; got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+// seedRefusedItems submits one batch under a credential for cloud in which every
+// item is refused, and fails the test unless each of them was. The items go in
+// through POST /api/v1/events, so the rows the list reads back are the ones the
+// pipeline really wrote.
+func seedRefusedItems(t *testing.T, a api, cloud string, eventIDs ...string) {
+	t.Helper()
+
+	_, token := seedIngestCredential(t, a.queries, fixturePlatform, cloud)
+	res := fixture{cloud: cloud, resourceType: "volume", id: "vol-" + cloud}
+	items := make([]json.RawMessage, len(eventIDs))
+	for i, eventID := range eventIDs {
+		items[i] = item(t, res.event(eventID, refusedEventType,
+			createTime.Add(time.Duration(i)*time.Minute), payloadOf("available", volumeSize(10))))
+	}
+
+	got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, batch(t, items...)))
+	if got.Accepted != 0 || len(got.Rejected) != len(eventIDs) {
+		t.Fatalf("result = %+v, want all %d items of %s refused", got, len(eventIDs), cloud)
+	}
+}
+
+// deadLetterListOf decodes the answer of a dead-letter list call, which the
+// contract promises is a 200 carrying one page.
+func deadLetterListOf(t *testing.T, rec *httptest.ResponseRecorder) DeadLetterList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var list DeadLetterList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if list.Items == nil {
+		t.Errorf("body %q carries items as null, want an array", rec.Body)
+	}
+	return list
+}
+
+// deadLetterEventIDs is the event ids of a served page, in order. The order
+// assertions compare these rather than whole items, so a failure names what came
+// back.
+func deadLetterEventIDs(t *testing.T, items []DeadLetteredEvent) []string {
+	t.Helper()
+
+	found := make([]string, len(items))
+	for i, kept := range items {
+		found[i] = deadLetterEventID(t, kept)
+	}
+	return found
+}
+
+// deadLetterEventID is the event id the raw document of one refused item
+// carries. The row's own id is a UUID the database chose, so the id the test
+// submitted is what a failure message is readable by.
+func deadLetterEventID(t *testing.T, kept DeadLetteredEvent) string {
+	t.Helper()
+
+	document, ok := kept.Raw.(map[string]any)
+	if !ok {
+		t.Fatalf("the raw item of %s decoded to %T, want the submitted JSON object", kept.Id, kept.Raw)
+	}
+	eventID, ok := document["event_id"].(string)
+	if !ok {
+		t.Fatalf("the raw item of %s carries no event_id, want the one it was submitted with", kept.Id)
+	}
+	return eventID
+}
+
+// deadLetterBound renders one bound of the window the way the contract asks for
+// it, escaped for the query string it travels in. It keeps the fractional
+// seconds instant() drops, because received_at is what the database assigned and
+// does not sit on a whole second.
+func deadLetterBound(at time.Time) string {
+	return url.QueryEscape(at.Format(time.RFC3339Nano))
+}

--- a/internal/reporting/httpapi/resources.go
+++ b/internal/reporting/httpapi/resources.go
@@ -1,0 +1,450 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/timeline"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/projection"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// resourceCursorKeys is how many parts the sort key of the resource list has:
+// the three columns of the projection's primary key, in the order ORDER BY
+// names them.
+const resourceCursorKeys = 3
+
+// unknownResourceDetail answers every read of a resource this token has no
+// answer for. A resource that does not exist and one the scope does not reach
+// are told apart nowhere in the response, so a caller cannot map the fleet of
+// another project by asking for its resources one by one.
+const unknownResourceDetail = "this resource is not known"
+
+// The details that answer a failure of one of these routes a caller can do
+// nothing about. Which route failed is what they tell apart, so each is spelled
+// once rather than at every writeInternal of that route.
+const (
+	resourcesDetail = "the resources could not be read"
+	historyDetail   = "the resource history could not be read"
+	lifecycleDetail = "the lifecycle could not be read"
+)
+
+// maxResourceHistory is how many events the two per-resource reads answer at
+// most. Neither is paginated, so without a bound the memory one request costs is
+// set by how many events a collector has written for that resource, which is a
+// number this service does not control: a caller could hold the whole history of
+// a long-lived resource resident, and concurrent requests for it multiply that.
+//
+// The bound counts rows, not bytes. What one event's payload may weigh is the
+// ingest path's to say, and it does not say it today, so this bounds how many
+// payloads a request holds rather than how much they add up to.
+//
+// A resource above the bound is refused rather than answered short, so a client
+// never mistakes a truncated history for a whole one. It is far above any real
+// history: a resource changing every five minutes reaches it in about a month.
+const maxResourceHistory = 10000
+
+// longHistoryDetail answers a resource whose stored history is longer than the
+// unpaginated reads serve at once. It names the bound, because a caller that
+// walks the event list instead needs to know what it ran into.
+const longHistoryDetail = "this resource has more stored events than the unpaginated per-resource reads serve; " +
+	"read them through GET /api/v1/events instead"
+
+// ListResources answers one page of the projection rows, narrowed by the filters
+// the request carries. The page is read one row longer than it is served, which
+// is what trimPage turns into the cursor decision.
+//
+// A project token reads the rows whose (cloud, project_id) pair one of its
+// projects names, which is the pair the projection row carries today rather than
+// the one an older event of the resource did.
+func (s *server) ListResources(w http.ResponseWriter, r *http.Request, params ListResourcesParams) {
+	ctx := r.Context()
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+	// A filtered scope holding no project reaches no resource at all, so the
+	// empty page is answered here rather than asked of the database.
+	if !scope.Unfiltered && len(scope.Refs) == 0 {
+		writeJSON(w, ResourceList{Items: []Resource{}})
+		return
+	}
+	// A project the token does not hold is refused rather than answered with an
+	// empty page, so that asking outside the scope is distinguishable from a
+	// project that has no resources yet.
+	if params.ProjectId != nil && !scope.Unfiltered && !reachesProject(scope, *params.ProjectId) {
+		problem.Write(w, http.StatusForbidden, problem.TypeForbidden,
+			"Forbidden", "this token does not reach the project this query names")
+		return
+	}
+
+	var cursorCloud, cursorType, cursorID pgtype.Text
+	if params.Cursor != nil {
+		keys, err := decodeCursor(*params.Cursor, resourceCursorKeys)
+		if err != nil {
+			refuseCursor(ctx, w, err)
+			return
+		}
+		cursorCloud = pgtype.Text{String: keys[0], Valid: true}
+		cursorType = pgtype.Text{String: keys[1], Valid: true}
+		cursorID = pgtype.Text{String: keys[2], Valid: true}
+	}
+
+	limit := pageLimit(params.Limit)
+	clouds, projects := scopeFilter(scope)
+
+	// state and status filter independently, so a request naming a live state
+	// together with status=deleted is served the empty page rather than refused:
+	// each parameter is valid on its own, and the contract cannot express a rule
+	// spanning two of them.
+	rows, err := s.queries.ListCurrentResources(ctx, sqlcgen.ListCurrentResourcesParams{
+		Cloud:              filterText(params.Cloud),
+		Platform:           filterText(params.Platform),
+		ProjectID:          filterText(params.ProjectId),
+		ResourceType:       filterText(params.ResourceType),
+		State:              filterText(params.State),
+		Deleted:            filterStatus(params.Status),
+		ScopeClouds:        clouds,
+		ScopeProjects:      projects,
+		CursorCloud:        cursorCloud,
+		CursorResourceType: cursorType,
+		CursorResourceID:   cursorID,
+		PageSize:           int32(limit) + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing resources", err, resourcesDetail)
+		return
+	}
+
+	rows, more := trimPage(rows, limit)
+	items := make([]Resource, len(rows))
+	for i, row := range rows {
+		if items[i], err = resourceOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored resource", err, resourcesDetail)
+			return
+		}
+	}
+
+	list := ResourceList{Items: items}
+	if more {
+		// The cursor names the last item served, so the next page starts at the
+		// row after it. The three keys are the columns themselves, so nothing
+		// has to be formatted for the round trip.
+		last := items[len(items)-1]
+		cursor := encodeCursor([]string{last.Cloud, last.ResourceType, last.ResourceId})
+		list.NextCursor = &cursor
+	}
+	writeJSON(w, list)
+}
+
+// ListResourceEvents answers with the history of one resource the request may
+// see, in the order the fold reads a history in.
+//
+// The answer is never paginated: the events of one resource are what a client
+// asks for here, and cutting them into pages would make the caller reassemble
+// the history before it can do anything with it. A history above
+// maxResourceHistory is refused instead, which is what keeps the answer bounded.
+func (s *server) ListResourceEvents(w http.ResponseWriter, r *http.Request, cloud, resourceType, resourceID string) {
+	ctx := r.Context()
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+	if _, ok = s.loadScopedResource(w, r, scope, cloud, resourceType, resourceID); !ok {
+		return
+	}
+
+	rows, ok := s.resourceHistory(w, r, scope, cloud, resourceType, resourceID, historyDetail)
+	if !ok {
+		return
+	}
+
+	var err error
+	items := make([]StoredEvent, len(rows))
+	for i, row := range rows {
+		if items[i], err = storedEventOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored payload", err, historyDetail)
+			return
+		}
+	}
+	// The cursor stays null: one answer carries the whole history, so there is
+	// never a page after this one.
+	writeJSON(w, EventList{Items: items})
+}
+
+// GetResourceLifecycle answers with one resource, the history the request may
+// see, and the billable intervals that history folds into.
+//
+// The fold is internal/core/timeline, the one the projection replay runs, so
+// what this endpoint reports about a resource and what the projection row holds
+// are derived from the same reading of the same events. The replay folds every
+// event; a project token folds its own, so the intervals it reads are the spans
+// it is billed for and not the ones another project was.
+func (s *server) GetResourceLifecycle(w http.ResponseWriter, r *http.Request, cloud, resourceType, resourceID string) {
+	ctx := r.Context()
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+	row, ok := s.loadScopedResource(w, r, scope, cloud, resourceType, resourceID)
+	if !ok {
+		return
+	}
+	resource, err := resourceOf(row)
+	if err != nil {
+		writeInternal(ctx, w, "decoding a stored resource", err, lifecycleDetail)
+		return
+	}
+
+	rows, ok := s.resourceHistory(w, r, scope, cloud, resourceType, resourceID, lifecycleDetail)
+	if !ok {
+		return
+	}
+
+	// Each row is read twice: once as the event the answer carries, and once as
+	// the value the fold works on, which decodes the payload into the envelope
+	// instead of into a free document.
+	events := make([]StoredEvent, len(rows))
+	history := make([]event.Stored, len(rows))
+	for i, row := range rows {
+		if events[i], err = storedEventOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored payload", err, lifecycleDetail)
+			return
+		}
+		if history[i], err = projection.Decode(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored payload", err, lifecycleDetail)
+			return
+		}
+	}
+
+	folded := timeline.Build(history)
+	// The three arrays are answered as arrays even when they are empty, which a
+	// history without a single billable interval leaves the middle one: a client
+	// iterates them without a nil check, and null would break that.
+	intervals := make([]LifecycleInterval, len(folded.Intervals))
+	for i, interval := range folded.Intervals {
+		intervals[i] = lifecycleIntervalOf(interval)
+	}
+	warnings := folded.Warnings
+	if warnings == nil {
+		warnings = []string{}
+	}
+	writeJSON(w, Lifecycle{
+		Resource:  resource,
+		Events:    events,
+		Intervals: intervals,
+		Warnings:  warnings,
+	})
+}
+
+// resourceHistory reads the events of one resource the request may see, and
+// answers the request itself when it has no history to serve.
+//
+// The scope runs per event rather than per resource: the gate in front of this
+// says whether the resource is the token's today, and this says which of its
+// events are. The two differ exactly once a resource has been transferred, and
+// then the events of the project the resource left are the old project's alone.
+// A principal reading unfiltered passes no scope and reads every event there is.
+//
+// The read is bounded, and a resource above the bound is refused rather than
+// answered short, because neither route paginates.
+//
+// The bound is decided by counting first. The row set of the read below is
+// materialized whole before the caller sees any of it, so a refusal taken off it
+// would have cost every payload the refusal exists to avoid holding. The count
+// runs under the same scope, so what decides the refusal is the history this
+// request would be served rather than the one the resource has, and it stops one
+// row past the bound, so a history far above it costs the same as one just above
+// it rather than growing with how far above it is.
+//
+// The read is still asked for one row past the bound, and the answer is refused
+// if it comes back: an event stored between the two queries would otherwise be
+// served as a history one event short of the whole one.
+func (s *server) resourceHistory(w http.ResponseWriter, r *http.Request, scope auth.Scope,
+	cloud, resourceType, resourceID, detail string,
+) ([]sqlcgen.Event, bool) {
+	ctx := r.Context()
+
+	clouds, projects := scopeFilter(scope)
+	// The count saturates at the row that decides the refusal, so what comes back
+	// answers whether the history is too long and not how long it is.
+	count, err := s.queries.CountEventsForResource(ctx, sqlcgen.CountEventsForResourceParams{
+		Cloud:         cloud,
+		ResourceType:  resourceType,
+		ResourceID:    resourceID,
+		ScopeClouds:   clouds,
+		ScopeProjects: projects,
+		ProbeLimit:    maxResourceHistory + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "counting the resource history", err, detail)
+		return nil, false
+	}
+	if count > maxResourceHistory {
+		refuseLongHistory(ctx, w, cloud, resourceType, resourceID)
+		return nil, false
+	}
+
+	rows, err := s.queries.ListEventsForResource(ctx, sqlcgen.ListEventsForResourceParams{
+		Cloud:         cloud,
+		ResourceType:  resourceType,
+		ResourceID:    resourceID,
+		ScopeClouds:   clouds,
+		ScopeProjects: projects,
+		PageSize:      pgtype.Int4{Int32: maxResourceHistory + 1, Valid: true},
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing the resource history", err, detail)
+		return nil, false
+	}
+	if len(rows) > maxResourceHistory {
+		refuseLongHistory(ctx, w, cloud, resourceType, resourceID)
+		return nil, false
+	}
+	return rows, true
+}
+
+// refuseLongHistory answers a request for a history the unpaginated reads do not
+// serve, and logs the resource it was about: the bound being hit at all is an
+// operational signal, and the response says nothing about which resource hit it.
+func refuseLongHistory(ctx context.Context, w http.ResponseWriter, cloud, resourceType, resourceID string) {
+	Logger(ctx).Warn("refusing a resource history above the bound",
+		"cloud", cloud, "resource_type", resourceType, "resource_id", resourceID,
+		"bound", maxResourceHistory)
+	problem.Write(w, http.StatusUnprocessableEntity, problem.TypeHistoryTooLong,
+		"History too long", longHistoryDetail)
+}
+
+// loadScopedResource reads the projection row a per-resource read is about and
+// reports whether the request may see it. A request it has no answer for is
+// answered here, and the caller returns.
+//
+// The row's own (cloud, project_id) pair is what the scope is checked against,
+// which is the pair the resource carries today: a transferred resource follows
+// its new project, and the old project stops reading it here. What the new
+// project then reads is not the whole history but its own part of it, which
+// resourceHistory is what decides.
+//
+// A resource without a row and a resource outside the scope leave through the
+// same problem.Write, so the two responses are identical byte for byte and a
+// caller learns nothing about the resources of a project it does not hold.
+func (s *server) loadScopedResource(w http.ResponseWriter, r *http.Request, scope auth.Scope,
+	cloud, resourceType, resourceID string,
+) (sqlcgen.CurrentResource, bool) {
+	ctx := r.Context()
+
+	row, err := s.queries.GetCurrentResource(ctx, sqlcgen.GetCurrentResourceParams{
+		Cloud:        cloud,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+	case err != nil:
+		writeInternal(ctx, w, "loading the resource", err, "the resource could not be read")
+		return sqlcgen.CurrentResource{}, false
+	case scope.Unfiltered || reachesPair(scope, row.Cloud, row.ProjectID):
+		return row, true
+	}
+
+	problem.Write(w, http.StatusNotFound, problem.TypeNotFound, "Not found", unknownResourceDetail)
+	return sqlcgen.CurrentResource{}, false
+}
+
+// filterStatus maps the status parameter onto the one boolean the query splits
+// the fleet with: false serves the rows that live, true the deleted ones, and
+// NULL both.
+//
+// A request naming no status is served the active rows. The contract's default
+// says so, and the generated binding does not apply it, so it is applied here.
+func filterStatus(status *ListResourcesParamsStatus) pgtype.Bool {
+	value := Active
+	if status != nil {
+		value = *status
+	}
+	if value == All {
+		return pgtype.Bool{}
+	}
+	return pgtype.Bool{Bool: value == Deleted, Valid: true}
+}
+
+// resourceOf renders one projection row as the answer the contract promises. The
+// instants come out in UTC, the zone this API states them in, and the two JSON
+// columns are decoded rather than passed through, because the contract types
+// them as objects and a row written past this API could hold anything.
+//
+// created_at stays null for a history that never showed a create and deleted_at
+// while the resource lives, so both members are set only when their column holds
+// an instant. A row whose last_payload column is NULL renders as a null member:
+// no envelope was stored, and an empty object would claim one was.
+func resourceOf(row sqlcgen.CurrentResource) (Resource, error) {
+	var size map[string]any
+	if err := json.Unmarshal(row.Size, &size); err != nil {
+		return Resource{}, fmt.Errorf("decoding the size of %s/%s/%s: %w",
+			row.Cloud, row.ResourceType, row.ResourceID, err)
+	}
+
+	item := Resource{
+		Cloud:         row.Cloud,
+		Platform:      row.Platform,
+		ResourceType:  row.ResourceType,
+		ResourceId:    row.ResourceID,
+		ProjectId:     row.ProjectID,
+		State:         row.State,
+		Size:          size,
+		LastEventType: row.LastEventType,
+		LastEventAt:   row.LastEventAt.Time.UTC(),
+	}
+	if row.CreatedAt.Valid {
+		at := row.CreatedAt.Time.UTC()
+		item.CreatedAt = &at
+	}
+	if row.DeletedAt.Valid {
+		at := row.DeletedAt.Time.UTC()
+		item.DeletedAt = &at
+	}
+	if len(row.LastPayload) > 0 {
+		var payload map[string]any
+		if err := json.Unmarshal(row.LastPayload, &payload); err != nil {
+			return Resource{}, fmt.Errorf("decoding the last payload of %s/%s/%s: %w",
+				row.Cloud, row.ResourceType, row.ResourceID, err)
+		}
+		item.LastPayload = &payload
+	}
+	return item, nil
+}
+
+// lifecycleIntervalOf renders one folded interval as the answer the contract
+// promises: the instants in UTC, and the open end as a null `to`.
+//
+// A size the history never reported leaves the interval's size nil, which the
+// contract types as an object, so the empty one stands for it the way the
+// projection's size column does.
+func lifecycleIntervalOf(interval timeline.Interval) LifecycleInterval {
+	item := LifecycleInterval{
+		From:      interval.Start.UTC(),
+		State:     interval.State,
+		Size:      interval.Size,
+		ProjectId: interval.ProjectID,
+	}
+	if item.Size == nil {
+		item.Size = map[string]any{}
+	}
+	if interval.End != nil {
+		end := interval.End.UTC()
+		item.To = &end
+	}
+	return item
+}

--- a/internal/reporting/httpapi/resources_integration_test.go
+++ b/internal/reporting/httpapi/resources_integration_test.go
@@ -1,0 +1,1335 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/timeline"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// resourcesRoute is the route the resource list tests call, spelled once because
+// every one of them addresses it.
+const resourcesRoute = "/api/v1/resources"
+
+// The clouds the base fleet lives in, and the platform of the third. Every
+// subtest that seeds resources of its own works on a cloud of its own, so the
+// base fleet stays what the subtests describing it expect.
+const (
+	fleetCloudA    = "os-fleet-a"
+	fleetCloudB    = "os-fleet-b"
+	fleetCloudC    = "tally-fleet-c"
+	fleetPlatformC = "tallytest"
+)
+
+// fleetProjectB is the project of the one base-fleet resource that does not
+// belong to the fixture's own project, in the cloud the others live in too. It
+// is what makes the project filter more than another spelling of the cloud
+// filter.
+const fleetProjectB = "fleet-project-b"
+
+// The instants the resource fixtures use: a create, a change, and a delete two
+// hours apart on whole seconds, so what Postgres stores compares equal to what
+// the test passed in.
+var (
+	fleetCreated = time.Date(2026, 7, 1, 6, 0, 0, 0, time.UTC)
+	fleetChanged = fleetCreated.Add(time.Hour)
+	fleetRemoved = fleetCreated.Add(2 * time.Hour)
+)
+
+// TestListResourcesOverHTTP drives GET /api/v1/resources through the whole
+// stack: the contract validator, the query guard, the project scope, and the
+// projection rows behind them.
+//
+// The subtests share one database and run in order: the ones describing the base
+// fleet come first, and the ones seeding resources of their own afterwards work
+// on clouds those assertions do not name.
+func TestListResourcesOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+
+	seedFleet(t, a)
+
+	t.Run("serves the rows of a cloud in cloud, type, and id order", func(t *testing.T) {
+		// status=all, because the fleet holds a deleted resource and the default
+		// leaves it out, which the status subtests below are about.
+		list := resourceListOf(t, a.call(t, http.MethodGet,
+			resourcesRoute+"?cloud="+fleetCloudA+"&status=all", adminToken, nil))
+
+		if list.NextCursor != nil {
+			t.Errorf("next_cursor = %q, want null on a page that holds everything", *list.NextCursor)
+		}
+		// The resource type sorts before the resource id, so the instance leads
+		// the volumes however their ids compare.
+		want := []string{"inst-off", "vol-alive", "vol-gone", "vol-orphan", "vol-project-b"}
+		if got := resourceIDs(list.Items); !slices.Equal(got, want) {
+			t.Errorf("served resources = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("narrows the answer to what a filter names", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  []string
+		}{
+			{
+				name:  "cloud",
+				query: "cloud=" + fleetCloudA + "&status=all",
+				want:  []string{"inst-off", "vol-alive", "vol-gone", "vol-orphan", "vol-project-b"},
+			},
+			{
+				name:  "platform",
+				query: "platform=" + fleetPlatformC,
+				want:  []string{"widget-c"},
+			},
+			{
+				name:  "project_id",
+				query: "project_id=" + fleetProjectB,
+				want:  []string{"vol-project-b"},
+			},
+			{
+				name:  "resource_type",
+				query: "resource_type=instance",
+				want:  []string{"inst-off"},
+			},
+			{
+				// The state is matched exactly: the instance was powered off, and
+				// nothing else in the fleet reports that state.
+				name:  "state",
+				query: "state=shutoff",
+				want:  []string{"inst-off"},
+			},
+			{
+				name:  "cloud and resource type at once",
+				query: "cloud=" + fleetCloudB + "&resource_type=volume",
+				want:  []string{"vol-elsewhere"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := resourceListOf(t, a.call(t, http.MethodGet,
+					resourcesRoute+"?"+tc.query, adminToken, nil))
+
+				if got := resourceIDs(list.Items); !slices.Equal(got, tc.want) {
+					t.Errorf("served resources = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("serves the part of the fleet the status names", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  []string
+		}{
+			{
+				// No status at all: the contract's default is active, and the
+				// deleted volume is what says it was applied.
+				name:  "no status",
+				query: "",
+				want:  []string{"inst-off", "vol-alive", "vol-orphan", "vol-project-b"},
+			},
+			{name: "status=active", query: "&status=active", want: []string{"inst-off", "vol-alive", "vol-orphan", "vol-project-b"}},
+			{name: "status=deleted", query: "&status=deleted", want: []string{"vol-gone"}},
+			{
+				name:  "status=all",
+				query: "&status=all",
+				want:  []string{"inst-off", "vol-alive", "vol-gone", "vol-orphan", "vol-project-b"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := resourceListOf(t, a.call(t, http.MethodGet,
+					resourcesRoute+"?cloud="+fleetCloudA+tc.query, adminToken, nil))
+
+				if got := resourceIDs(list.Items); !slices.Equal(got, tc.want) {
+					t.Errorf("served resources = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("answers an empty page rather than null items", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a filter nothing matches", query: "cloud=os-fleet-nothing"},
+			// The two filters are independent, and no row can be in a live state
+			// and deleted at once, so the contradiction is an answer rather than a
+			// refusal.
+			{name: "a live state together with status=deleted", query: "state=available&status=deleted"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, resourcesRoute+"?"+tc.query, adminToken, nil)
+
+				if got := rec.Code; got != http.StatusOK {
+					t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+				}
+				// The raw body rather than the decoded one: a client iterates items
+				// without a nil check, which null would break and [] does not.
+				want := `{"items":[],"next_cursor":null}`
+				if got := strings.TrimSpace(rec.Body.String()); got != want {
+					t.Errorf("body = %s, want %s", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("serves the instants a history implies", func(t *testing.T) {
+		list := resourceListOf(t, a.call(t, http.MethodGet,
+			resourcesRoute+"?cloud="+fleetCloudA+"&status=all", adminToken, nil))
+
+		t.Run("created_at is set and deleted_at null while the resource lives", func(t *testing.T) {
+			alive := byResourceID(t, list.Items, "vol-alive")
+
+			if alive.CreatedAt == nil {
+				t.Errorf("created_at = null, want %v", fleetCreated)
+			} else if !alive.CreatedAt.Equal(fleetCreated) {
+				t.Errorf("created_at = %v, want %v", alive.CreatedAt, fleetCreated)
+			}
+			if alive.DeletedAt != nil {
+				t.Errorf("deleted_at = %v, want null while the resource lives", *alive.DeletedAt)
+			}
+		})
+
+		t.Run("deleted_at and the deleted state are set once it is gone", func(t *testing.T) {
+			gone := byResourceID(t, list.Items, "vol-gone")
+
+			if gone.DeletedAt == nil {
+				t.Errorf("deleted_at = null, want %v", fleetRemoved)
+			} else if !gone.DeletedAt.Equal(fleetRemoved) {
+				t.Errorf("deleted_at = %v, want %v", gone.DeletedAt, fleetRemoved)
+			}
+			if got, want := gone.State, "deleted"; got != want {
+				t.Errorf("state = %q, want %q", got, want)
+			}
+		})
+
+		t.Run("created_at is null for a history that never showed a create", func(t *testing.T) {
+			orphan := byResourceID(t, list.Items, "vol-orphan")
+
+			if orphan.CreatedAt != nil {
+				t.Errorf("created_at = %v, want null for a history that starts with an update",
+					*orphan.CreatedAt)
+			}
+		})
+	})
+
+	t.Run("serves every member of a projection row", func(t *testing.T) {
+		const cloud = "os-fleet-members"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-members"}
+		created := res.event("vol-members-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(10)))
+		resized := res.event("vol-members-resize", "volume.resize", fleetChanged,
+			payloadOf("in-use", volumeSize(20)))
+		ingestEvents(t, a, fixturePlatform, cloud, created, resized)
+
+		list := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?cloud="+cloud, adminToken, nil))
+
+		if len(list.Items) != 1 {
+			t.Fatalf("served resources = %v, want the one of %s", resourceIDs(list.Items), cloud)
+		}
+		got := list.Items[0]
+		if got.Cloud != cloud {
+			t.Errorf("cloud = %q, want %q", got.Cloud, cloud)
+		}
+		if got.Platform != fixturePlatform {
+			t.Errorf("platform = %q, want %q", got.Platform, fixturePlatform)
+		}
+		if got.ResourceType != res.resourceType {
+			t.Errorf("resource_type = %q, want %q", got.ResourceType, res.resourceType)
+		}
+		if got.ResourceId != res.id {
+			t.Errorf("resource_id = %q, want %q", got.ResourceId, res.id)
+		}
+		if got.ProjectId != fixtureProject {
+			t.Errorf("project_id = %q, want %q", got.ProjectId, fixtureProject)
+		}
+		// The state and the size come from the newer of the two events, which is
+		// what says the row was folded rather than taken from the create.
+		if want := "in-use"; got.State != want {
+			t.Errorf("state = %q, want %q", got.State, want)
+		}
+		if want := asDocument(t, volumeSize(20)); !reflect.DeepEqual(got.Size, want) {
+			t.Errorf("size = %v, want %v", got.Size, want)
+		}
+		if got.CreatedAt == nil || !got.CreatedAt.Equal(fleetCreated) {
+			t.Errorf("created_at = %v, want %v", got.CreatedAt, fleetCreated)
+		}
+		if got.DeletedAt != nil {
+			t.Errorf("deleted_at = %v, want null", *got.DeletedAt)
+		}
+		if got.LastEventType != resized.EventType {
+			t.Errorf("last_event_type = %q, want %q", got.LastEventType, resized.EventType)
+		}
+		if !got.LastEventAt.Equal(fleetChanged) {
+			t.Errorf("last_event_at = %v, want %v", got.LastEventAt, fleetChanged)
+		}
+		if got.LastPayload == nil {
+			t.Fatalf("last_payload = null, want the envelope of %s", resized.EventID)
+		}
+		if want := asDocument(t, resized.Payload); !reflect.DeepEqual(*got.LastPayload, want) {
+			t.Errorf("last_payload = %v, want the stored %v", *got.LastPayload, want)
+		}
+	})
+
+	t.Run("serves a row whose last payload is NULL as a null member", func(t *testing.T) {
+		const cloud = "os-fleet-payloadless"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-payloadless"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-payloadless-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))))
+
+		// The column is nullable, and the write path never leaves it NULL: it
+		// marshals an envelope for every event it folds. What the mapper does with
+		// a NULL is only readable on a row that carries one, so the row is put
+		// into that state through the pool.
+		if _, err := a.store.Pool().Exec(t.Context(),
+			`UPDATE current_resources SET last_payload = NULL WHERE cloud = $1`, cloud); err != nil {
+			t.Fatalf("clearing the last payload of %s: %v", cloud, err)
+		}
+
+		rec := a.call(t, http.MethodGet, resourcesRoute+"?cloud="+cloud, adminToken, nil)
+
+		list := resourceListOf(t, rec)
+		if len(list.Items) != 1 {
+			t.Fatalf("served resources = %v, want the one of %s", resourceIDs(list.Items), cloud)
+		}
+		if list.Items[0].LastPayload != nil {
+			t.Errorf("last_payload = %v, want it served as null", *list.Items[0].LastPayload)
+		}
+		// A pointer that decoded to nil would also come from a member left out, so
+		// the raw body is what says the member is there and null.
+		if body := rec.Body.String(); !strings.Contains(body, `"last_payload":null`) {
+			t.Errorf("body = %s, want it to carry \"last_payload\":null", body)
+		}
+	})
+
+	t.Run("walks a list in pages and ends the walk with a null cursor", func(t *testing.T) {
+		const cloud = "os-fleet-pages"
+		events := make([]event.Event, 7)
+		for i := range events {
+			res := fixture{cloud: cloud, resourceType: "volume", id: fmt.Sprintf("vol-page-%d", i)}
+			events[i] = res.event(fmt.Sprintf("vol-page-%d-create", i), "volume.create",
+				fleetCreated, payloadOf("available", volumeSize(float64(10+i))))
+		}
+		ingestEvents(t, a, fixturePlatform, cloud, events...)
+
+		whole := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?cloud="+cloud, adminToken, nil))
+		if len(whole.Items) != len(events) {
+			t.Fatalf("the unpaginated answer holds %d resources, want %d", len(whole.Items), len(events))
+		}
+
+		for _, tc := range []struct {
+			name  string
+			limit int
+			sizes []int
+		}{
+			{name: "a last page shorter than the limit", limit: 3, sizes: []int{3, 3, 1}},
+			// The whole fleet in one page: the last page is exactly full, which is
+			// what tells "the page is full" from "there is more".
+			{name: "a last page exactly as long as the limit", limit: len(events), sizes: []int{len(events)}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				page := fmt.Sprintf("%s?cloud=%s&limit=%d", resourcesRoute, cloud, tc.limit)
+
+				var walked []Resource
+				var sizes []int
+				for count := 1; ; count++ {
+					if count > len(events) {
+						t.Fatalf("the walk had not ended after %d pages, want it over after %d",
+							count, len(tc.sizes))
+					}
+					list := resourceListOf(t, a.call(t, http.MethodGet, page, adminToken, nil))
+
+					sizes = append(sizes, len(list.Items))
+					walked = append(walked, list.Items...)
+					if list.NextCursor == nil {
+						break
+					}
+					page = fmt.Sprintf("%s?cloud=%s&limit=%d&cursor=%s",
+						resourcesRoute, cloud, tc.limit, url.QueryEscape(*list.NextCursor))
+				}
+
+				if !slices.Equal(sizes, tc.sizes) {
+					t.Errorf("page sizes = %v, want %v", sizes, tc.sizes)
+				}
+				if !reflect.DeepEqual(walked, whole.Items) {
+					t.Errorf("the walk served %v, want the unpaginated %v",
+						resourceIDs(walked), resourceIDs(whole.Items))
+				}
+			})
+		}
+	})
+
+	t.Run("reports a row it cannot decode", func(t *testing.T) {
+		// The size column is typed as an object by the contract, and the write
+		// path stores nothing else. A row written past this API could hold any
+		// JSON, so the mapper's refusal is only readable on a row that does.
+		const cloud = "os-fleet-undecodable"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-undecodable"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-undecodable-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))))
+		if _, err := a.store.Pool().Exec(t.Context(),
+			`UPDATE current_resources SET size = '"x"'::jsonb WHERE cloud = $1`, cloud); err != nil {
+			t.Fatalf("writing an undecodable size into %s: %v", cloud, err)
+		}
+		// The row stays out of the way of the subtests after this one, which read
+		// the whole projection and would meet the same refusal.
+		t.Cleanup(func() {
+			if _, err := a.store.Pool().Exec(context.Background(),
+				`DELETE FROM current_resources WHERE cloud = $1`, cloud); err != nil {
+				t.Fatalf("removing the undecodable row: %v", err)
+			}
+		})
+
+		rec := a.call(t, http.MethodGet, resourcesRoute+"?cloud="+cloud, adminToken, nil)
+
+		assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+		if got, want := problemDetail(t, rec), "the resources could not be read"; got != want {
+			t.Errorf("detail = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("refuses a cursor it did not issue", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			cursor string
+		}{
+			{name: "not base64url", cursor: "not base64!"},
+			// The sort key of this list has three parts, so a cursor of the events
+			// list resumes nothing here.
+			{name: "two keys where the sort key has three", cursor: encodeCursor([]string{fleetCloudA, "volume"})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					resourcesRoute+"?cursor="+url.QueryEscape(tc.cursor), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec), "the cursor is not one this API issued"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a parameter the contract does not allow", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a status outside the three", query: "status=banana"},
+			{name: "a limit above the maximum", query: "limit=1001"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, resourcesRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			})
+		}
+	})
+
+	t.Run("confines a project token to the projects it holds", func(t *testing.T) {
+		// The same external id in two clouds, and two external ids in one cloud:
+		// only the pair the token holds may come back.
+		const (
+			cloudA = "os-fleet-scope-a"
+			cloudB = "os-fleet-scope-b"
+		)
+		held := seedProject(t, a, cloudA, "p-1")
+		seedProject(t, a, cloudA, "p-2")
+		seedProject(t, a, cloudB, "p-1")
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{held})
+
+		mine := seedScopedResource(t, a, cloudA, "p-1", "vol-scope-mine")
+		seedScopedResource(t, a, cloudA, "p-2", "vol-scope-sibling")
+		seedScopedResource(t, a, cloudB, "p-1", "vol-scope-other-cloud")
+
+		list := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute, token, nil))
+
+		if got, want := resourceIDs(list.Items), []string{mine}; !slices.Equal(got, want) {
+			t.Errorf("served resources = %v, want %v", got, want)
+		}
+
+		t.Run("refuses a project outside its scope", func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, resourcesRoute+"?project_id=p-2", token, nil)
+
+			assertProblem(t, rec, http.StatusForbidden, problem.TypeForbidden)
+		})
+
+		t.Run("serves the project it holds", func(t *testing.T) {
+			// The other cloud spells the id of a project of its own the same way,
+			// so this also says the filter runs on the pair.
+			list := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?project_id=p-1", token, nil))
+
+			if got, want := resourceIDs(list.Items), []string{mine}; !slices.Equal(got, want) {
+				t.Errorf("served resources = %v, want %v", got, want)
+			}
+		})
+	})
+
+	t.Run("serves a token whose projects are gone an empty page", func(t *testing.T) {
+		const cloud = "os-fleet-orphaned-token"
+		project := seedProject(t, a, cloud, "p-orphaned")
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{project})
+		stored := seedScopedResource(t, a, cloud, "p-orphaned", "vol-orphaned-token")
+
+		before := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute, token, nil))
+		if got, want := resourceIDs(before.Items), []string{stored}; !slices.Equal(got, want) {
+			t.Fatalf("served resources = %v, want %v", got, want)
+		}
+
+		if _, err := a.store.Pool().Exec(t.Context(), `DELETE FROM projects WHERE id = $1`, project); err != nil {
+			t.Fatalf("deleting the project %s: %v", project, err)
+		}
+
+		// The scope narrows to nothing rather than widening to everything, so the
+		// token reads no resource at all instead of every resource there is.
+		list := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute, token, nil))
+
+		if got := resourceIDs(list.Items); len(got) != 0 {
+			t.Errorf("served resources = %v, want none for a token whose projects are gone", got)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, resourcesRoute, "", nil)
+
+		assertChallenged(t, rec)
+	})
+
+	t.Run("serves a read_all token the whole list", func(t *testing.T) {
+		admin := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?limit=1000&status=all", adminToken, nil))
+
+		list := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?limit=1000&status=all", readAllToken, nil))
+
+		if got, want := resourceIDs(list.Items), resourceIDs(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("served resources = %v, want the %v an admin token reads", got, want)
+		}
+	})
+
+	t.Run("serves the route without a token while authentication is disabled", func(t *testing.T) {
+		// A second router over the same database, which is the development setup:
+		// the guard injects an admin principal instead of reading a credential.
+		open := newAPIInMode(t, db.Store, auth.ModeDisabled)
+		admin := resourceListOf(t, a.call(t, http.MethodGet, resourcesRoute+"?limit=1000&status=all", adminToken, nil))
+
+		list := resourceListOf(t, open.call(t, http.MethodGet, resourcesRoute+"?limit=1000&status=all", "", nil))
+
+		if got, want := resourceIDs(list.Items), resourceIDs(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("served resources = %v, want the %v an admin token reads", got, want)
+		}
+	})
+}
+
+// TestReadResourceHistoryOverHTTP drives
+// GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/events: the whole
+// history of one resource, in the order the fold reads it in and never paged.
+func TestReadResourceHistoryOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+
+	const cloud = "os-history"
+	alive := fixture{cloud: cloud, resourceType: "volume", id: "vol-history"}
+	gone := fixture{cloud: cloud, resourceType: "volume", id: "vol-history-gone"}
+	// A second resource in the same cloud, so the answer being one resource's
+	// history rather than the cloud's is readable off it.
+	ingestEvents(t, a, fixturePlatform, cloud,
+		alive.event("vol-history-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(10))),
+		alive.event("vol-history-resize", "volume.resize", fleetChanged,
+			payloadOf("available", volumeSize(20))),
+		alive.event("vol-history-attach", "volume.update", fleetRemoved,
+			payloadOf("in-use", nil)),
+		gone.event("vol-history-gone-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(30))),
+		gone.event("vol-history-gone-delete", "volume.delete", fleetRemoved,
+			event.PayloadEnvelope{}))
+
+	t.Run("serves the full history in timestamp order with a null cursor", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			resourceEventsPath(cloud, alive.resourceType, alive.id), adminToken, nil)
+
+		list := eventListOf(t, rec)
+		if list.NextCursor != nil {
+			t.Errorf("next_cursor = %q, want null on an answer that is never paged", *list.NextCursor)
+		}
+		want := []string{"vol-history-create", "vol-history-resize", "vol-history-attach"}
+		if got := ids(list.Items); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("serves the history of a deleted resource", func(t *testing.T) {
+		// The projection keeps the row of a deleted resource forever, so its
+		// history stays readable after the delete.
+		list := eventListOf(t, a.call(t, http.MethodGet,
+			resourceEventsPath(cloud, gone.resourceType, gone.id), adminToken, nil))
+
+		want := []string{"vol-history-gone-create", "vol-history-gone-delete"}
+		if got := ids(list.Items); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("serves a read_all token the history", func(t *testing.T) {
+		list := eventListOf(t, a.call(t, http.MethodGet,
+			resourceEventsPath(cloud, alive.resourceType, alive.id), readAllToken, nil))
+
+		if got, want := len(list.Items), 3; got != want {
+			t.Errorf("served events = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("refuses a history longer than the unpaginated reads serve", func(t *testing.T) {
+		// One event past the bound, written through the pool rather than ingested:
+		// what is being pinned is the handler's refusal, and folding ten thousand
+		// events through the write path would say nothing more about it.
+		//
+		// The bulk carries a project of its own, so that the resource's history and
+		// the slice of it a project token reads differ in length. Only the create is
+		// the fixture project's, which is therefore the pair the projection row
+		// carries and the one a project token is let past the gate on.
+		const (
+			longCloud = "os-history-long"
+			longBulk  = "project-history-long-bulk"
+		)
+		long := fixture{cloud: longCloud, resourceType: "volume", id: "vol-history-long"}
+		ingestEvents(t, a, fixturePlatform, longCloud,
+			long.event("vol-history-long-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))))
+		if _, err := a.store.Pool().Exec(t.Context(),
+			`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+			                     resource_type, resource_id, project_id, source, payload)
+			 SELECT 'vol-history-long-' || n, $1::timestamptz + (n * INTERVAL '1 second'),
+			        'volume.update', $2, $3, $4, $5, $6, 'collector', '{"state": "available"}'::jsonb
+			 FROM generate_series(1, $7::int) AS n`,
+			fleetCreated, fixturePlatform, longCloud, long.resourceType, long.id, longBulk,
+			maxResourceHistory); err != nil {
+			t.Fatalf("writing a history past the bound: %v", err)
+		}
+
+		for name, path := range map[string]string{
+			"the history":   resourceEventsPath(longCloud, long.resourceType, long.id),
+			"the lifecycle": resourceLifecyclePath(longCloud, long.resourceType, long.id),
+		} {
+			t.Run(name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, path, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeHistoryTooLong)
+			})
+		}
+
+		t.Run("measures the bound against the history the token reads", func(t *testing.T) {
+			// The refusal is decided before the payloads are fetched, and what it is
+			// decided on has to be the scoped history rather than the resource's: a
+			// token that reads one event of this resource is served it, though the
+			// resource has one event more than the bound.
+			project := seedProject(t, a, longCloud, fixtureProject)
+			_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{project})
+
+			list := eventListOf(t, a.call(t, http.MethodGet,
+				resourceEventsPath(longCloud, long.resourceType, long.id), token, nil))
+
+			if got, want := ids(list.Items), []string{"vol-history-long-create"}; !slices.Equal(got, want) {
+				t.Errorf("served events = %v, want the %v this token's scope reaches", got, want)
+			}
+		})
+
+		t.Run("serves a history exactly as long as the bound", func(t *testing.T) {
+			// The row one past the bound is what the refusal is decided on, so the
+			// history that fills it exactly is the boundary the answer still holds.
+			if _, err := a.store.Pool().Exec(t.Context(),
+				`DELETE FROM events WHERE event_id = $1`,
+				fmt.Sprintf("vol-history-long-%d", maxResourceHistory)); err != nil {
+				t.Fatalf("cutting the history back to the bound: %v", err)
+			}
+
+			list := eventListOf(t, a.call(t, http.MethodGet,
+				resourceEventsPath(longCloud, long.resourceType, long.id), adminToken, nil))
+
+			if got := len(list.Items); got != maxResourceHistory {
+				t.Errorf("served events = %d, want the %d the bound allows", got, maxResourceHistory)
+			}
+		})
+	})
+
+	t.Run("reports a row it cannot decode", func(t *testing.T) {
+		const badCloud = "os-history-undecodable"
+		bad := fixture{cloud: badCloud, resourceType: "volume", id: "vol-history-undecodable"}
+		ingestEvents(t, a, fixturePlatform, badCloud,
+			bad.event("vol-history-undecodable-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))))
+		// The payload column is typed as an object by the contract, and the write
+		// path stores nothing else. A row written past this API could hold any
+		// JSON, so the mapper's refusal is only readable on a row that does.
+		insertEventRow(t, a, bad.event("vol-history-undecodable-update", "volume.update",
+			fleetChanged, event.PayloadEnvelope{}), []byte(`[1,2]`))
+
+		for name, tc := range map[string]struct {
+			path   string
+			detail string
+		}{
+			"the history": {
+				path:   resourceEventsPath(badCloud, bad.resourceType, bad.id),
+				detail: "the resource history could not be read",
+			},
+			"the lifecycle": {
+				path:   resourceLifecyclePath(badCloud, bad.resourceType, bad.id),
+				detail: "the lifecycle could not be read",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, tc.path, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+				if got := problemDetail(t, rec); got != tc.detail {
+					t.Errorf("detail = %q, want %q", got, tc.detail)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			resourceEventsPath(cloud, alive.resourceType, alive.id), "", nil)
+
+		assertChallenged(t, rec)
+	})
+
+	t.Run("serves the route without a token while authentication is disabled", func(t *testing.T) {
+		open := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+		list := eventListOf(t, open.call(t, http.MethodGet,
+			resourceEventsPath(cloud, alive.resourceType, alive.id), "", nil))
+
+		if got, want := len(list.Items), 3; got != want {
+			t.Errorf("served events = %d, want %d", got, want)
+		}
+	})
+}
+
+// TestResourceLifecycleOverHTTP drives
+// GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle: the
+// fold of one resource's history into the intervals it implies.
+func TestResourceLifecycleOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+
+	t.Run("folds the resize example into two intervals", func(t *testing.T) {
+		// The concept's Example 1, as roadmap/01-phase-1-core-platform-openstack.md
+		// states it: an instance created on the first of March and resized halfway
+		// through the month.
+		const cloud = "os-lifecycle-resize"
+		res := fixture{cloud: cloud, resourceType: "instance", id: "inst-resize"}
+		created := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+		resized := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+		small := map[string]any{"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "flavor": "m1.small"}
+		large := map[string]any{"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("inst-resize-create", "compute.instance.create.end", created,
+				payloadOf("active", small)),
+			res.event("inst-resize-resize", "compute.instance.resize.end", resized,
+				payloadOf("active", large)))
+
+		got := lifecycleOf(t, a.call(t, http.MethodGet,
+			resourceLifecyclePath(cloud, res.resourceType, res.id), adminToken, nil))
+
+		if len(got.Intervals) != 2 {
+			t.Fatalf("intervals = %+v, want the one before and the one after the resize", got.Intervals)
+		}
+		assertInterval(t, got.Intervals[0], created, &resized, "active", asDocument(t, small))
+		assertInterval(t, got.Intervals[1], resized, nil, "active", asDocument(t, large))
+		if len(got.Warnings) != 0 {
+			t.Errorf("warnings = %v, want none for a history that starts with a create", got.Warnings)
+		}
+
+		// The resource is the projection row, which carries the size the resize
+		// left behind rather than the one the instance started on.
+		if want := asDocument(t, large); !reflect.DeepEqual(got.Resource.Size, want) {
+			t.Errorf("the resource's size = %v, want %v", got.Resource.Size, want)
+		}
+		if got.Resource.CreatedAt == nil || !got.Resource.CreatedAt.Equal(created) {
+			t.Errorf("the resource's created_at = %v, want %v", got.Resource.CreatedAt, created)
+		}
+		want := []string{"inst-resize-create", "inst-resize-resize"}
+		if got := ids(got.Events); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("closes every interval of a history that ends in a delete", func(t *testing.T) {
+		const cloud = "os-lifecycle-deleted"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-deleted"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-deleted-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))),
+			res.event("vol-deleted-resize", "volume.resize", fleetChanged,
+				payloadOf("available", volumeSize(20))),
+			res.event("vol-deleted-delete", "volume.delete", fleetRemoved,
+				event.PayloadEnvelope{}))
+
+		got := lifecycleOf(t, a.call(t, http.MethodGet,
+			resourceLifecyclePath(cloud, res.resourceType, res.id), adminToken, nil))
+
+		if len(got.Intervals) != 2 {
+			t.Fatalf("intervals = %+v, want the one before and the one after the resize", got.Intervals)
+		}
+		for i, interval := range got.Intervals {
+			if interval.To == nil {
+				t.Errorf("interval %d is open, want every interval of a deleted resource closed", i)
+			}
+		}
+		// A delete opens no interval of its own: a deleted resource accrues no
+		// usage. The row is what reports the end of its life.
+		if got, want := got.Resource.State, "deleted"; got != want {
+			t.Errorf("the resource's state = %q, want %q", got, want)
+		}
+		if got.Resource.DeletedAt == nil || !got.Resource.DeletedAt.Equal(fleetRemoved) {
+			t.Errorf("the resource's deleted_at = %v, want %v", got.Resource.DeletedAt, fleetRemoved)
+		}
+	})
+
+	t.Run("serves an interval no event reported a size for as an empty object", func(t *testing.T) {
+		// A history whose only event reports a state and no size. Ingestion holds
+		// every create to a size, so the case arises on a history that starts
+		// mid-life: the fold carries no size forward and leaves the interval's
+		// nil. The contract types size as an object rather than as a nullable
+		// one, so the empty object stands for it the way the projection's size
+		// column does.
+		const cloud = "os-lifecycle-sizeless"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-sizeless"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-sizeless-update", "volume.update", fleetCreated,
+				payloadOf("available", nil)))
+
+		rec := a.call(t, http.MethodGet, resourceLifecyclePath(cloud, res.resourceType, res.id), adminToken, nil)
+
+		got := lifecycleOf(t, rec)
+		if len(got.Intervals) != 1 {
+			t.Fatalf("intervals = %+v, want the one the create opened", got.Intervals)
+		}
+		if want := map[string]any{}; !reflect.DeepEqual(got.Intervals[0].Size, want) {
+			t.Errorf("size = %v, want %v", got.Intervals[0].Size, want)
+		}
+		// The raw body rather than the decoded one: a decoded empty map and a
+		// null both read as len 0 in Go, and only one of them is the contract.
+		if body := strings.TrimSpace(rec.Body.String()); !strings.Contains(body, `"size":{}`) {
+			t.Errorf("body = %s, want it to carry \"size\":{}", body)
+		}
+	})
+
+	t.Run("warns about a history that starts without a create", func(t *testing.T) {
+		const cloud = "os-lifecycle-orphan"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-lifecycle-orphan"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-lifecycle-orphan-update", "volume.update", fleetChanged,
+				payloadOf("available", volumeSize(10))))
+
+		got := lifecycleOf(t, a.call(t, http.MethodGet,
+			resourceLifecyclePath(cloud, res.resourceType, res.id), adminToken, nil))
+
+		want := []string{timeline.WarningHistoryStartsWithoutCreate}
+		if !slices.Equal(got.Warnings, want) {
+			t.Errorf("warnings = %v, want %v", got.Warnings, want)
+		}
+		if got.Resource.CreatedAt != nil {
+			t.Errorf("the resource's created_at = %v, want null when the create was missed",
+				*got.Resource.CreatedAt)
+		}
+	})
+
+	t.Run("drops the interval of a resource created and deleted at one instant", func(t *testing.T) {
+		const cloud = "os-lifecycle-instant"
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-instant"}
+		// Both events share the instant and the transaction, so what orders them
+		// is the event id, and the create sorts first.
+		ingestEvents(t, a, fixturePlatform, cloud,
+			res.event("vol-instant-a-create", "volume.create", fleetCreated,
+				payloadOf("available", volumeSize(10))),
+			res.event("vol-instant-b-delete", "volume.delete", fleetCreated,
+				event.PayloadEnvelope{}))
+
+		rec := a.call(t, http.MethodGet, resourceLifecyclePath(cloud, res.resourceType, res.id), adminToken, nil)
+
+		got := lifecycleOf(t, rec)
+		// The interval carries no duration, so it bills nothing and is dropped.
+		// The events it was folded from are answered all the same.
+		if len(got.Intervals) != 0 {
+			t.Errorf("intervals = %+v, want none for two changes at one instant", got.Intervals)
+		}
+		want := []string{"vol-instant-a-create", "vol-instant-b-delete"}
+		if got := ids(got.Events); !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+		// The raw body rather than the decoded one: a client iterates the three
+		// arrays without a nil check, which null would break and [] does not.
+		body := strings.TrimSpace(rec.Body.String())
+		if !strings.Contains(body, `"intervals":[]`) || !strings.Contains(body, `"warnings":[]`) {
+			t.Errorf("body = %s, want it to carry \"intervals\":[] and \"warnings\":[]", body)
+		}
+		if strings.Contains(body, `"events":null`) {
+			t.Errorf("body = %s, want the events as an array", body)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, resourceLifecyclePath("os-lifecycle-resize", "instance", "inst-resize"), "", nil)
+
+		assertChallenged(t, rec)
+	})
+
+	t.Run("serves the route without a token while authentication is disabled", func(t *testing.T) {
+		open := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+		got := lifecycleOf(t, open.call(t, http.MethodGet,
+			resourceLifecyclePath("os-lifecycle-resize", "instance", "inst-resize"), "", nil))
+
+		if len(got.Intervals) != 2 {
+			t.Errorf("intervals = %+v, want the two of the resize example", got.Intervals)
+		}
+	})
+}
+
+// TestResourceReadsHideWhatIsNotVisible pins the answer both per-resource reads
+// give a resource the caller may not see: the 404 of a resource that does not
+// exist, byte for byte. A caller that could tell the two apart would be able to
+// map another project's fleet by asking for its resources one at a time.
+func TestResourceReadsHideWhatIsNotVisible(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	const cloud = "os-hidden"
+	held := seedProject(t, a, cloud, "p-held")
+	seedProject(t, a, cloud, "p-foreign")
+	_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{held})
+
+	seedScopedResource(t, a, cloud, "p-held", "vol-held")
+	foreign := seedScopedResource(t, a, cloud, "p-foreign", "vol-foreign")
+
+	// The token reads its own resource, so what the subtests below assert is a
+	// refusal rather than a route that answers nothing at all.
+	if list := eventListOf(t, a.call(t, http.MethodGet,
+		resourceEventsPath(cloud, "volume", "vol-held"), token, nil)); len(list.Items) == 0 {
+		t.Fatalf("the history of the token's own resource is empty, want the seeded event")
+	}
+
+	for _, tc := range []struct {
+		name string
+		path func(cloud, resourceType, resourceID string) string
+	}{
+		{name: "events", path: resourceEventsPath},
+		{name: "lifecycle", path: resourceLifecyclePath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unknown := a.call(t, http.MethodGet, tc.path(cloud, "volume", "vol-nothing"), token, nil)
+			outside := a.call(t, http.MethodGet, tc.path(cloud, "volume", foreign), token, nil)
+
+			for name, rec := range map[string]*httptest.ResponseRecorder{
+				"an unknown resource":                  unknown,
+				"a resource outside the token's scope": outside,
+			} {
+				assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+				if got, want := problemDetail(t, rec), "this resource is not known"; got != want {
+					t.Errorf("detail of %s = %q, want %q", name, got, want)
+				}
+			}
+			if got, want := outside.Body.String(), unknown.Body.String(); got != want {
+				t.Errorf("the body of a resource outside the scope = %s, want the %s of an unknown one",
+					got, want)
+			}
+		})
+	}
+}
+
+// TestResourceReadsFollowAnOwnershipTransfer pins where the two scoping rules of
+// this API meet: a transfer moves a resource from one project to another, and
+// what each project reads afterwards is what keeps the transfer from handing
+// either of them the other's billing history.
+//
+// The event list is event-scoped, so the project that gave the resource away
+// keeps reading the events it carried. The per-resource reads are gated on the
+// projection row, so the same project stops reading the resource there — and the
+// project that accepted it reads the events stored since the transfer rather
+// than the whole history.
+func TestResourceReadsFollowAnOwnershipTransfer(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	const (
+		cloud    = "os-transfer"
+		fromID   = "p-transfer-from"
+		toID     = "p-transfer-to"
+		acquired = "vol-transferred-accept"
+		created  = "vol-transferred-create"
+	)
+	from := seedProject(t, a, cloud, fromID)
+	to := seedProject(t, a, cloud, toID)
+	_, fromToken := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{from})
+	_, toToken := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{to})
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+
+	// The volume lives in one project and is accepted by the other, which is the
+	// event roadmap/01-phase-1-core-platform-openstack.md maps
+	// volume.transfer.accept.end onto: the same resource under a new project id.
+	res := fixture{cloud: cloud, resourceType: "volume", id: "vol-transferred"}
+	birth := res.event(created, "volume.create", fleetCreated, payloadOf("available", volumeSize(10)))
+	birth.ProjectID = fromID
+	accept := res.event(acquired, "volume.transfer.accept.end", fleetChanged,
+		payloadOf("available", volumeSize(10)))
+	accept.ProjectID = toID
+	ingestEvents(t, a, fixturePlatform, cloud, birth, accept)
+
+	path := resourceEventsPath(cloud, res.resourceType, res.id)
+
+	t.Run("keeps the whole history readable for an unfiltered token", func(t *testing.T) {
+		list := eventListOf(t, a.call(t, http.MethodGet, path, adminToken, nil))
+
+		if got, want := ids(list.Items), []string{created, acquired}; !slices.Equal(got, want) {
+			t.Errorf("served events = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("the project that gave the resource away", func(t *testing.T) {
+		t.Run("keeps reading its events through the event list", func(t *testing.T) {
+			list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, fromToken, nil))
+
+			if got, want := ids(list.Items), []string{created}; !slices.Equal(got, want) {
+				t.Errorf("served events = %v, want the event it carried, %v", got, want)
+			}
+		})
+
+		t.Run("stops reading the resource itself", func(t *testing.T) {
+			for name, target := range map[string]string{
+				"events":    path,
+				"lifecycle": resourceLifecyclePath(cloud, res.resourceType, res.id),
+			} {
+				t.Run(name, func(t *testing.T) {
+					rec := a.call(t, http.MethodGet, target, fromToken, nil)
+
+					assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+				})
+			}
+		})
+	})
+
+	t.Run("the project that accepted the resource", func(t *testing.T) {
+		t.Run("reads no event of the project it came from", func(t *testing.T) {
+			list := eventListOf(t, a.call(t, http.MethodGet, eventsRoute, toToken, nil))
+
+			if got, want := ids(list.Items), []string{acquired}; !slices.Equal(got, want) {
+				t.Errorf("served events = %v, want %v", got, want)
+			}
+		})
+
+		t.Run("reads the resource history from the transfer onwards", func(t *testing.T) {
+			list := eventListOf(t, a.call(t, http.MethodGet, path, toToken, nil))
+
+			if got, want := ids(list.Items), []string{acquired}; !slices.Equal(got, want) {
+				t.Errorf("served events = %v, want the history since the transfer, %v", got, want)
+			}
+		})
+
+		t.Run("folds no interval the other project was billed for", func(t *testing.T) {
+			got := lifecycleOf(t, a.call(t, http.MethodGet,
+				resourceLifecyclePath(cloud, res.resourceType, res.id), toToken, nil))
+
+			if want := []string{acquired}; !slices.Equal(ids(got.Events), want) {
+				t.Errorf("served events = %v, want %v", ids(got.Events), want)
+			}
+			if len(got.Intervals) != 1 {
+				t.Fatalf("intervals = %+v, want the one open since the transfer", got.Intervals)
+			}
+			if !got.Intervals[0].From.Equal(fleetChanged) {
+				t.Errorf("the interval starts at %v, want the transfer at %v",
+					got.Intervals[0].From, fleetChanged)
+			}
+			if got, want := got.Intervals[0].ProjectId, toID; got != want {
+				t.Errorf("project_id = %q, want %q", got, want)
+			}
+			// The create belongs to the project the resource left, so the history
+			// this token folds legitimately starts mid-life and says so.
+			if want := []string{timeline.WarningHistoryStartsWithoutCreate}; !slices.Equal(got.Warnings, want) {
+				t.Errorf("warnings = %v, want %v", got.Warnings, want)
+			}
+			// The embedded resource is the projection row, which is folded from
+			// every event under no scope, so its created_at is the create of the
+			// project the resource came from. The contract says so, and pins it
+			// here: a consumer that bills a span from created_at rather than from
+			// the intervals bills this project for the other one's ownership.
+			if got.Resource.CreatedAt == nil || !got.Resource.CreatedAt.Equal(fleetCreated) {
+				t.Errorf("the resource's created_at = %v, want the unscoped create at %v",
+					got.Resource.CreatedAt, fleetCreated)
+			}
+		})
+	})
+}
+
+// TestResourceReadsReportAFailedQuery drives the failure paths of the three
+// reads. With authentication disabled nothing reads the database before the
+// handler does, so a database that is gone stops the request inside the query
+// rather than at the credential lookup in front of it.
+func TestResourceReadsReportAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		target string
+		detail string
+	}{
+		{
+			name:   "the list",
+			target: resourcesRoute,
+			detail: "the resources could not be read",
+		},
+		{
+			// The gate in front of the two per-resource reads: a row that cannot
+			// be loaded is not a row that is not there, so the answer is a 500
+			// rather than the 404 of an unknown resource.
+			name:   "the gate of a per-resource read",
+			target: resourceLifecyclePath("os-outage", "volume", "vol-outage"),
+			detail: "the resource could not be read",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, tc.target, "", nil)
+
+			assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+			if got := problemDetail(t, rec); got != tc.detail {
+				t.Errorf("detail = %q, want %q", got, tc.detail)
+			}
+		})
+	}
+}
+
+// seedFleet stores the resources every subtest describing the base fleet works
+// on. They go in through POST /api/v1/events, so what the reads answer is
+// checked against the rows the write path really folded.
+func seedFleet(t *testing.T, a api) {
+	t.Helper()
+
+	off := fixture{cloud: fleetCloudA, resourceType: "instance", id: "inst-off"}
+	alive := fixture{cloud: fleetCloudA, resourceType: "volume", id: "vol-alive"}
+	gone := fixture{cloud: fleetCloudA, resourceType: "volume", id: "vol-gone"}
+	orphan := fixture{cloud: fleetCloudA, resourceType: "volume", id: "vol-orphan"}
+	sibling := fixture{cloud: fleetCloudA, resourceType: "volume", id: "vol-project-b"}
+	elsewhere := fixture{cloud: fleetCloudB, resourceType: "volume", id: "vol-elsewhere"}
+	widget := fixture{cloud: fleetCloudC, resourceType: "widget", id: "widget-c"}
+
+	// The one resource of a project of its own, in the cloud the others live in
+	// too.
+	inSibling := sibling.event("vol-project-b-create", "volume.create", fleetCreated,
+		payloadOf("available", volumeSize(50)))
+	inSibling.ProjectID = fleetProjectB
+
+	ingestEvents(t, a, fixturePlatform, fleetCloudA,
+		// An instance that was powered off, which is the one resource of the fleet
+		// whose state is neither a volume state nor deleted.
+		off.event("inst-off-create", "instance.create", fleetCreated,
+			payloadOf("active", map[string]any{
+				"vcpus": 2, "ram_gb": 4, "disk_gb": 20, "flavor": "m1.small",
+			})),
+		off.event("inst-off-power-off", "instance.power_off", fleetChanged,
+			payloadOf("shutoff", nil)),
+		alive.event("vol-alive-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(10))),
+		alive.event("vol-alive-resize", "volume.resize", fleetChanged,
+			payloadOf("available", volumeSize(20))),
+		gone.event("vol-gone-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(30))),
+		gone.event("vol-gone-delete", "volume.delete", fleetRemoved, event.PayloadEnvelope{}),
+		// A history that starts with an update, which is what a missed create
+		// leaves behind.
+		orphan.event("vol-orphan-update", "volume.update", fleetChanged,
+			payloadOf("available", volumeSize(40))),
+		inSibling)
+
+	ingestEvents(t, a, fixturePlatform, fleetCloudB,
+		elsewhere.event("vol-elsewhere-create", "volume.create", fleetCreated,
+			payloadOf("available", volumeSize(60))))
+
+	// The one resource of a platform of its own.
+	built := widget.event("widget-c-create", "widget.create", fleetCreated,
+		payloadOf("ready", map[string]any{"units": 1}))
+	built.Platform = fleetPlatformC
+	ingestEvents(t, a, fleetPlatformC, fleetCloudC, built)
+}
+
+// seedScopedResource stores one resource of a (cloud, project) pair through the
+// ingest path and returns its resource id. The scope tests care about which pair
+// a resource belongs to and about nothing else in it.
+func seedScopedResource(t *testing.T, a api, cloud, projectID, resourceID string) string {
+	t.Helper()
+
+	res := fixture{cloud: cloud, resourceType: "volume", id: resourceID}
+	e := res.event(resourceID+"-create", "volume.create", fleetCreated,
+		payloadOf("available", volumeSize(10)))
+	e.ProjectID = projectID
+	ingestEvents(t, a, fixturePlatform, cloud, e)
+
+	return resourceID
+}
+
+// ingestEvents submits one batch through POST /api/v1/events under a credential
+// for the (platform, cloud) pair it names, and fails the test unless every item
+// was stored.
+func ingestEvents(t *testing.T, a api, platform, cloud string, events ...event.Event) {
+	t.Helper()
+
+	_, token := seedIngestCredential(t, a.queries, platform, cloud)
+	items := make([]json.RawMessage, len(events))
+	for i, e := range events {
+		items[i] = item(t, e)
+	}
+
+	got := ingestResultOf(t, a.call(t, http.MethodPost, eventsRoute, token, batch(t, items...)))
+	if got.Accepted != len(events) {
+		t.Fatalf("result = %+v, want the %d events of %s stored", got, len(events), cloud)
+	}
+}
+
+// resourceEventsPath is the per-resource history route of one resource.
+func resourceEventsPath(cloud, resourceType, resourceID string) string {
+	return resourcePath(cloud, resourceType, resourceID) + "/events"
+}
+
+// resourceLifecyclePath is the lifecycle route of one resource.
+func resourceLifecyclePath(cloud, resourceType, resourceID string) string {
+	return resourcePath(cloud, resourceType, resourceID) + "/lifecycle"
+}
+
+// resourcePath is the prefix the two per-resource routes share, with every
+// segment escaped the way a client sends it.
+func resourcePath(cloud, resourceType, resourceID string) string {
+	return resourcesRoute + "/" + url.PathEscape(cloud) +
+		"/" + url.PathEscape(resourceType) + "/" + url.PathEscape(resourceID)
+}
+
+// resourceListOf decodes the answer of a resource list call, which the contract
+// promises is a 200 carrying one page.
+func resourceListOf(t *testing.T, rec *httptest.ResponseRecorder) ResourceList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var list ResourceList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if list.Items == nil {
+		t.Errorf("body %q carries items as null, want an array", rec.Body)
+	}
+	return list
+}
+
+// lifecycleOf decodes the answer of a lifecycle call, which the contract
+// promises is a 200 carrying the resource, its history, and its intervals. None
+// of the three arrays may be null, so a client iterates them without a nil
+// check.
+func lifecycleOf(t *testing.T, rec *httptest.ResponseRecorder) Lifecycle {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+
+	var got Lifecycle
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if got.Events == nil || got.Intervals == nil || got.Warnings == nil {
+		t.Errorf("body %q carries one of events, intervals, and warnings as null, want arrays", rec.Body)
+	}
+	return got
+}
+
+// assertInterval checks one served interval against the span the history
+// implies. A nil to is the open end of a resource that still lives, and the
+// project is the fixture's own: no history here transfers a resource.
+func assertInterval(t *testing.T, got LifecycleInterval, from time.Time, to *time.Time,
+	state string, size map[string]any,
+) {
+	t.Helper()
+
+	if !got.From.Equal(from) {
+		t.Errorf("from = %v, want %v", got.From, from)
+	}
+	switch {
+	case to == nil && got.To != nil:
+		t.Errorf("to = %v, want null on the open interval", *got.To)
+	case to != nil && got.To == nil:
+		t.Errorf("to = null, want %v", *to)
+	case to != nil && !got.To.Equal(*to):
+		t.Errorf("to = %v, want %v", *got.To, *to)
+	}
+	if got.State != state {
+		t.Errorf("state = %q, want %q", got.State, state)
+	}
+	if !reflect.DeepEqual(got.Size, size) {
+		t.Errorf("size = %v, want %v", got.Size, size)
+	}
+	if got.ProjectId != fixtureProject {
+		t.Errorf("project_id = %q, want %q", got.ProjectId, fixtureProject)
+	}
+}
+
+// resourceIDs is the resource ids of a served page, in order. The order
+// assertions compare these rather than whole rows, so a failure names what came
+// back.
+func resourceIDs(items []Resource) []string {
+	found := make([]string, len(items))
+	for i, item := range items {
+		found[i] = item.ResourceId
+	}
+	return found
+}
+
+// byResourceID is the served row of one resource, which is what a member
+// assertion works on.
+func byResourceID(t *testing.T, items []Resource, resourceID string) Resource {
+	t.Helper()
+
+	for _, item := range items {
+		if item.ResourceId == resourceID {
+			return item
+		}
+	}
+	t.Fatalf("the page holds no resource %q, only %v", resourceID, resourceIDs(items))
+	return Resource{}
+}

--- a/internal/reporting/projection/projection.go
+++ b/internal/reporting/projection/projection.go
@@ -129,6 +129,9 @@ func Replay(ctx context.Context, tx pgx.Tx, key Key) error {
 		return err
 	}
 
+	// No scope and no page size: the projection row is derived from every event
+	// stored for the key, whoever owned the resource when each of them arrived
+	// and however many there are.
 	rows, err := q.ListEventsForResource(ctx, sqlcgen.ListEventsForResourceParams{
 		Cloud:        key.Cloud,
 		ResourceType: key.ResourceType,
@@ -143,7 +146,7 @@ func Replay(ctx context.Context, tx pgx.Tx, key Key) error {
 
 	history := make([]event.Stored, len(rows))
 	for i, row := range rows {
-		stored, err := decode(row)
+		stored, err := Decode(row)
 		if err != nil {
 			return err
 		}
@@ -377,10 +380,13 @@ func upsert(ctx context.Context, q *sqlcgen.Queries, key Key, s snapshot) error 
 	return nil
 }
 
-// decode turns one events row into the stored event the fold works on. A row
+// Decode turns one events row into the stored event the fold works on. A row
 // whose payload column is NULL carries the empty envelope, which reports neither
 // a state nor a size.
-func decode(row sqlcgen.Event) (event.Stored, error) {
+//
+// It is exported so that every consumer folding a history reads the rows into
+// the fold's input the same way this package does.
+func Decode(row sqlcgen.Event) (event.Stored, error) {
 	stored := event.Stored{
 		Event: event.Event{
 			EventID:      row.EventID,

--- a/internal/reporting/store/migrate_test.go
+++ b/internal/reporting/store/migrate_test.go
@@ -25,6 +25,11 @@ var chainVersions = func() []int64 {
 	return versions
 }()
 
+// afterInit is every version the chain adds on top of the schema 0001 creates,
+// oldest first. It is derived rather than spelled out so that adding a migration
+// does not need the rollback tests below rewritten.
+var afterInit = chainVersions[1:]
+
 // wantTables is every table migration 0001 creates, sorted.
 var wantTables = []string{
 	"api_tokens",
@@ -176,7 +181,10 @@ func TestMigrate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MigrateDownTo(1) error = %v, want nil", err)
 		}
-		if want := []int64{2}; !slices.Equal(rolledBack, want) {
+		// Newest first, which is the order a rollback undoes the chain in.
+		want := slices.Clone(afterInit)
+		slices.Reverse(want)
+		if !slices.Equal(rolledBack, want) {
 			t.Errorf("MigrateDownTo(1) = %v, want %v", rolledBack, want)
 		}
 		var remaining int
@@ -222,8 +230,8 @@ func TestMigrate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Migrate() error = %v, want nil", err)
 		}
-		if want := []int64{2}; !slices.Equal(applied, want) {
-			t.Errorf("Migrate() = %v, want %v", applied, want)
+		if !slices.Equal(applied, afterInit) {
+			t.Errorf("Migrate() = %v, want %v", applied, afterInit)
 		}
 
 		var stored []byte

--- a/internal/reporting/store/migrate_test.go
+++ b/internal/reporting/store/migrate_test.go
@@ -176,6 +176,40 @@ func TestMigrate(t *testing.T) {
 		assertSeededResourceTypes(t, db.Store)
 	})
 
+	t.Run("a rollback repeats after one that dropped without recording", func(t *testing.T) {
+		// The index migrations run outside a transaction in both directions, so a
+		// rollback that dies after dropping the index and before goose deletes the
+		// version row leaves the index gone with the migration still recorded as
+		// applied: migrating up is then a no-op and the index never comes back.
+		// Running the rollback again is the operator's repair, and it only works
+		// if the drops tolerate the index they already dropped.
+		interrupted := db.NewSiblingDB(t, "migrate_interrupted")
+		if _, err := store.Migrate(t.Context(), interrupted); err != nil {
+			t.Fatalf("Migrate() error = %v, want nil", err)
+		}
+		s, err := store.New(t.Context(), interrupted, 1)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		defer s.Close()
+		for _, index := range []string{"idx_events_cloud_project", "idx_rejected_events_received"} {
+			if _, err := s.Pool().Exec(t.Context(), "DROP INDEX "+index); err != nil {
+				t.Fatalf("dropping %s the way an interrupted rollback leaves it: %v", index, err)
+			}
+		}
+
+		rolledBack, err := store.MigrateDownTo(t.Context(), interrupted, 0)
+		if err != nil {
+			t.Fatalf("MigrateDownTo(0) error = %v, want nil", err)
+		}
+		// Newest first, the order a rollback has to run in.
+		want := slices.Clone(chainVersions)
+		slices.Reverse(want)
+		if !slices.Equal(rolledBack, want) {
+			t.Errorf("MigrateDownTo(0) = %v, want %v", rolledBack, want)
+		}
+	})
+
 	t.Run("rolling back the seed empties the registry", func(t *testing.T) {
 		rolledBack, err := store.MigrateDownTo(t.Context(), db.URL, 1)
 		if err != nil {

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -101,12 +101,48 @@ SET platform = EXCLUDED.platform,
     last_event_at = EXCLUDED.last_event_at,
     last_payload = EXCLUDED.last_payload;
 
+-- The history of one resource. Two callers read it: the projection replay, which
+-- folds every event there is under no scope and no bound, and the two
+-- per-resource routes of the API, which pass both. A NULL page size is every
+-- row, which is what the replay folds.
 -- name: ListEventsForResource :many
 SELECT event_id, timestamp, received_at, event_type, platform, cloud,
        resource_type, resource_id, project_id, source, payload
 FROM events
 WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
-ORDER BY timestamp, received_at, event_id;
+  -- The same pair filter the event list runs, per event rather than per
+  -- resource: a transfer moves the resource to its new project, and the events
+  -- it carried before the transfer stay the old project's alone.
+  AND (sqlc.narg('scope_clouds')::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                         unnest(sqlc.narg('scope_projects')::text[])))
+ORDER BY timestamp, received_at, event_id
+LIMIT sqlc.narg('page_size');
+
+-- How long the history above is under the same scope, counted no further than
+-- probe_limit. The unpaginated per-resource routes ask this before they read
+-- anything, because the bound they enforce is a memory bound and the read above
+-- materializes every row it returns before the caller sees the first one:
+-- deciding the refusal off the rows themselves would cost exactly the payloads
+-- the refusal exists to avoid.
+--
+-- The answer saturates at probe_limit, and a caller reads it as "at least this
+-- many" rather than as the length of the history. A plain count(*) cannot stop
+-- early: it would answer the bounded question of whether the history is too long
+-- by walking every event the resource has, on exactly the request the bound
+-- exists to keep cheap, and this table has no ceiling on how many that is. The
+-- inner LIMIT is what stops the walk at the only rows the decision needs.
+-- name: CountEventsForResource :one
+SELECT count(*)
+FROM (
+    SELECT 1
+    FROM events
+    WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+      AND (sqlc.narg('scope_clouds')::text[] IS NULL
+           OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                             unnest(sqlc.narg('scope_projects')::text[])))
+    LIMIT sqlc.arg('probe_limit')
+) probe;
 
 -- name: ListResourceKeys :many
 SELECT DISTINCT cloud, resource_type, resource_id
@@ -141,3 +177,37 @@ WHERE (sqlc.narg('cloud')::text IS NULL OR cloud = sqlc.narg('cloud'))
                                    sqlc.narg('cursor_event_id')::text))
 ORDER BY timestamp, event_id
 LIMIT sqlc.arg('page_size');
+
+-- name: ListCurrentResources :many
+SELECT cloud, platform, resource_type, resource_id, project_id, state, size,
+       created_at, deleted_at, last_event_type, last_event_at, last_payload
+FROM current_resources
+WHERE (sqlc.narg('cloud')::text IS NULL OR cloud = sqlc.narg('cloud'))
+  AND (sqlc.narg('platform')::text IS NULL OR platform = sqlc.narg('platform'))
+  AND (sqlc.narg('project_id')::text IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('resource_type')::text IS NULL OR resource_type = sqlc.narg('resource_type'))
+  AND (sqlc.narg('state')::text IS NULL OR state = sqlc.narg('state'))
+  -- The status filter of the API, as the one boolean the two halves of the
+  -- fleet differ in: true serves the deleted rows, false the ones that live,
+  -- and NULL both.
+  AND (sqlc.narg('deleted')::boolean IS NULL OR (state = 'deleted') = sqlc.narg('deleted'))
+  AND (sqlc.narg('scope_clouds')::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                         unnest(sqlc.narg('scope_projects')::text[])))
+  -- Every bound is cast: inside a row comparison sqlc reads the type of the
+  -- later placeholders off the first one, which is why the events cursor above
+  -- casts both of its bounds too.
+  AND (sqlc.narg('cursor_cloud')::text IS NULL
+       OR (cloud, resource_type, resource_id) > (sqlc.narg('cursor_cloud')::text,
+                                                 sqlc.narg('cursor_resource_type')::text,
+                                                 sqlc.narg('cursor_resource_id')::text))
+ORDER BY cloud, resource_type, resource_id
+LIMIT sqlc.arg('page_size');
+
+-- The read path of one projection row. It is GetCurrentResourceForUpdate
+-- without the row lock: a read must not make a writer wait on it.
+-- name: GetCurrentResource :one
+SELECT cloud, platform, resource_type, resource_id, project_id, state, size,
+       created_at, deleted_at, last_event_type, last_event_at, last_payload
+FROM current_resources
+WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3;

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -117,3 +117,27 @@ ORDER BY cloud, resource_type, resource_id;
 
 -- name: LockResource :exec
 SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text || ':' || $3::text, 0));
+
+-- name: ListEvents :many
+SELECT event_id, timestamp, received_at, event_type, platform, cloud,
+       resource_type, resource_id, project_id, source, payload
+FROM events
+WHERE (sqlc.narg('cloud')::text IS NULL OR cloud = sqlc.narg('cloud'))
+  AND (sqlc.narg('platform')::text IS NULL OR platform = sqlc.narg('platform'))
+  AND (sqlc.narg('project_id')::text IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('resource_type')::text IS NULL OR resource_type = sqlc.narg('resource_type'))
+  AND (sqlc.narg('event_type')::text IS NULL OR event_type = sqlc.narg('event_type'))
+  AND (sqlc.narg('source')::text IS NULL OR source = sqlc.narg('source'))
+  AND (sqlc.narg('from_ts')::timestamptz IS NULL OR timestamp >= sqlc.narg('from_ts'))
+  AND (sqlc.narg('to_ts')::timestamptz IS NULL OR timestamp < sqlc.narg('to_ts'))
+  AND (sqlc.narg('scope_clouds')::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                         unnest(sqlc.narg('scope_projects')::text[])))
+  -- Both bounds are cast: inside a row comparison sqlc reads the type of the
+  -- second placeholder off the first one, which would make the event id a
+  -- timestamp in the generated parameters.
+  AND (sqlc.narg('cursor_ts')::timestamptz IS NULL
+       OR (timestamp, event_id) > (sqlc.narg('cursor_ts')::timestamptz,
+                                   sqlc.narg('cursor_event_id')::text))
+ORDER BY timestamp, event_id
+LIMIT sqlc.arg('page_size');

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -204,6 +204,17 @@ WHERE (sqlc.narg('cloud')::text IS NULL OR cloud = sqlc.narg('cloud'))
 ORDER BY cloud, resource_type, resource_id
 LIMIT sqlc.arg('page_size');
 
+-- name: ListRejectedEvents :many
+SELECT id, received_at, reason, raw
+FROM rejected_events
+WHERE (sqlc.narg('from_ts')::timestamptz IS NULL OR received_at >= sqlc.narg('from_ts'))
+  AND (sqlc.narg('to_ts')::timestamptz IS NULL OR received_at < sqlc.narg('to_ts'))
+  -- Both bounds are cast, for the reason the events cursor above names.
+  AND (sqlc.narg('cursor_ts')::timestamptz IS NULL
+       OR (received_at, id) > (sqlc.narg('cursor_ts')::timestamptz, sqlc.narg('cursor_id')::uuid))
+ORDER BY received_at, id
+LIMIT sqlc.arg('page_size');
+
 -- The read path of one projection row. It is GetCurrentResourceForUpdate
 -- without the row lock: a read must not make a writer wait on it.
 -- name: GetCurrentResource :one

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -12,6 +12,55 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countEventsForResource = `-- name: CountEventsForResource :one
+SELECT count(*)
+FROM (
+    SELECT 1
+    FROM events
+    WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+      AND ($4::text[] IS NULL
+           OR (cloud, project_id) IN (SELECT unnest($4::text[]),
+                                             unnest($5::text[])))
+    LIMIT $6
+) probe
+`
+
+type CountEventsForResourceParams struct {
+	Cloud         string
+	ResourceType  string
+	ResourceID    string
+	ScopeClouds   []string
+	ScopeProjects []string
+	ProbeLimit    int32
+}
+
+// How long the history above is under the same scope, counted no further than
+// probe_limit. The unpaginated per-resource routes ask this before they read
+// anything, because the bound they enforce is a memory bound and the read above
+// materializes every row it returns before the caller sees the first one:
+// deciding the refusal off the rows themselves would cost exactly the payloads
+// the refusal exists to avoid.
+//
+// The answer saturates at probe_limit, and a caller reads it as "at least this
+// many" rather than as the length of the history. A plain count(*) cannot stop
+// early: it would answer the bounded question of whether the history is too long
+// by walking every event the resource has, on exactly the request the bound
+// exists to keep cheap, and this table has no ceiling on how many that is. The
+// inner LIMIT is what stops the walk at the only rows the decision needs.
+func (q *Queries) CountEventsForResource(ctx context.Context, arg CountEventsForResourceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countEventsForResource,
+		arg.Cloud,
+		arg.ResourceType,
+		arg.ResourceID,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.ProbeLimit,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createAPIToken = `-- name: CreateAPIToken :one
 INSERT INTO api_tokens (token_hash, role, project_ids, description)
 VALUES ($1, $2, $3, $4)
@@ -101,6 +150,41 @@ func (q *Queries) GetAPITokenForUpdate(ctx context.Context, id uuid.UUID) (ApiTo
 		&i.Description,
 		&i.CreatedAt,
 		&i.RevokedAt,
+	)
+	return i, err
+}
+
+const getCurrentResource = `-- name: GetCurrentResource :one
+SELECT cloud, platform, resource_type, resource_id, project_id, state, size,
+       created_at, deleted_at, last_event_type, last_event_at, last_payload
+FROM current_resources
+WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+`
+
+type GetCurrentResourceParams struct {
+	Cloud        string
+	ResourceType string
+	ResourceID   string
+}
+
+// The read path of one projection row. It is GetCurrentResourceForUpdate
+// without the row lock: a read must not make a writer wait on it.
+func (q *Queries) GetCurrentResource(ctx context.Context, arg GetCurrentResourceParams) (CurrentResource, error) {
+	row := q.db.QueryRow(ctx, getCurrentResource, arg.Cloud, arg.ResourceType, arg.ResourceID)
+	var i CurrentResource
+	err := row.Scan(
+		&i.Cloud,
+		&i.Platform,
+		&i.ResourceType,
+		&i.ResourceID,
+		&i.ProjectID,
+		&i.State,
+		&i.Size,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.LastEventType,
+		&i.LastEventAt,
+		&i.LastPayload,
 	)
 	return i, err
 }
@@ -315,6 +399,94 @@ func (q *Queries) InsertRejectedEvent(ctx context.Context, arg InsertRejectedEve
 	return err
 }
 
+const listCurrentResources = `-- name: ListCurrentResources :many
+SELECT cloud, platform, resource_type, resource_id, project_id, state, size,
+       created_at, deleted_at, last_event_type, last_event_at, last_payload
+FROM current_resources
+WHERE ($1::text IS NULL OR cloud = $1)
+  AND ($2::text IS NULL OR platform = $2)
+  AND ($3::text IS NULL OR project_id = $3)
+  AND ($4::text IS NULL OR resource_type = $4)
+  AND ($5::text IS NULL OR state = $5)
+  -- The status filter of the API, as the one boolean the two halves of the
+  -- fleet differ in: true serves the deleted rows, false the ones that live,
+  -- and NULL both.
+  AND ($6::boolean IS NULL OR (state = 'deleted') = $6)
+  AND ($7::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest($7::text[]),
+                                         unnest($8::text[])))
+  -- Every bound is cast: inside a row comparison sqlc reads the type of the
+  -- later placeholders off the first one, which is why the events cursor above
+  -- casts both of its bounds too.
+  AND ($9::text IS NULL
+       OR (cloud, resource_type, resource_id) > ($9::text,
+                                                 $10::text,
+                                                 $11::text))
+ORDER BY cloud, resource_type, resource_id
+LIMIT $12
+`
+
+type ListCurrentResourcesParams struct {
+	Cloud              pgtype.Text
+	Platform           pgtype.Text
+	ProjectID          pgtype.Text
+	ResourceType       pgtype.Text
+	State              pgtype.Text
+	Deleted            pgtype.Bool
+	ScopeClouds        []string
+	ScopeProjects      []string
+	CursorCloud        pgtype.Text
+	CursorResourceType pgtype.Text
+	CursorResourceID   pgtype.Text
+	PageSize           int32
+}
+
+func (q *Queries) ListCurrentResources(ctx context.Context, arg ListCurrentResourcesParams) ([]CurrentResource, error) {
+	rows, err := q.db.Query(ctx, listCurrentResources,
+		arg.Cloud,
+		arg.Platform,
+		arg.ProjectID,
+		arg.ResourceType,
+		arg.State,
+		arg.Deleted,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.CursorCloud,
+		arg.CursorResourceType,
+		arg.CursorResourceID,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CurrentResource
+	for rows.Next() {
+		var i CurrentResource
+		if err := rows.Scan(
+			&i.Cloud,
+			&i.Platform,
+			&i.ResourceType,
+			&i.ResourceID,
+			&i.ProjectID,
+			&i.State,
+			&i.Size,
+			&i.CreatedAt,
+			&i.DeletedAt,
+			&i.LastEventType,
+			&i.LastEventAt,
+			&i.LastPayload,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEvents = `-- name: ListEvents :many
 SELECT event_id, timestamp, received_at, event_type, platform, cloud,
        resource_type, resource_id, project_id, source, payload
@@ -407,17 +579,38 @@ SELECT event_id, timestamp, received_at, event_type, platform, cloud,
        resource_type, resource_id, project_id, source, payload
 FROM events
 WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+  -- The same pair filter the event list runs, per event rather than per
+  -- resource: a transfer moves the resource to its new project, and the events
+  -- it carried before the transfer stay the old project's alone.
+  AND ($4::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest($4::text[]),
+                                         unnest($5::text[])))
 ORDER BY timestamp, received_at, event_id
+LIMIT $6
 `
 
 type ListEventsForResourceParams struct {
-	Cloud        string
-	ResourceType string
-	ResourceID   string
+	Cloud         string
+	ResourceType  string
+	ResourceID    string
+	ScopeClouds   []string
+	ScopeProjects []string
+	PageSize      pgtype.Int4
 }
 
+// The history of one resource. Two callers read it: the projection replay, which
+// folds every event there is under no scope and no bound, and the two
+// per-resource routes of the API, which pass both. A NULL page size is every
+// row, which is what the replay folds.
 func (q *Queries) ListEventsForResource(ctx context.Context, arg ListEventsForResourceParams) ([]Event, error) {
-	rows, err := q.db.Query(ctx, listEventsForResource, arg.Cloud, arg.ResourceType, arg.ResourceID)
+	rows, err := q.db.Query(ctx, listEventsForResource,
+		arg.Cloud,
+		arg.ResourceType,
+		arg.ResourceID,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.PageSize,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -641,6 +641,57 @@ func (q *Queries) ListEventsForResource(ctx context.Context, arg ListEventsForRe
 	return items, nil
 }
 
+const listRejectedEvents = `-- name: ListRejectedEvents :many
+SELECT id, received_at, reason, raw
+FROM rejected_events
+WHERE ($1::timestamptz IS NULL OR received_at >= $1)
+  AND ($2::timestamptz IS NULL OR received_at < $2)
+  -- Both bounds are cast, for the reason the events cursor above names.
+  AND ($3::timestamptz IS NULL
+       OR (received_at, id) > ($3::timestamptz, $4::uuid))
+ORDER BY received_at, id
+LIMIT $5
+`
+
+type ListRejectedEventsParams struct {
+	FromTs   pgtype.Timestamptz
+	ToTs     pgtype.Timestamptz
+	CursorTs pgtype.Timestamptz
+	CursorID pgtype.UUID
+	PageSize int32
+}
+
+func (q *Queries) ListRejectedEvents(ctx context.Context, arg ListRejectedEventsParams) ([]RejectedEvent, error) {
+	rows, err := q.db.Query(ctx, listRejectedEvents,
+		arg.FromTs,
+		arg.ToTs,
+		arg.CursorTs,
+		arg.CursorID,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []RejectedEvent
+	for rows.Next() {
+		var i RejectedEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.ReceivedAt,
+			&i.Reason,
+			&i.Raw,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listResourceKeys = `-- name: ListResourceKeys :many
 SELECT DISTINCT cloud, resource_type, resource_id
 FROM events

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -315,6 +315,93 @@ func (q *Queries) InsertRejectedEvent(ctx context.Context, arg InsertRejectedEve
 	return err
 }
 
+const listEvents = `-- name: ListEvents :many
+SELECT event_id, timestamp, received_at, event_type, platform, cloud,
+       resource_type, resource_id, project_id, source, payload
+FROM events
+WHERE ($1::text IS NULL OR cloud = $1)
+  AND ($2::text IS NULL OR platform = $2)
+  AND ($3::text IS NULL OR project_id = $3)
+  AND ($4::text IS NULL OR resource_type = $4)
+  AND ($5::text IS NULL OR event_type = $5)
+  AND ($6::text IS NULL OR source = $6)
+  AND ($7::timestamptz IS NULL OR timestamp >= $7)
+  AND ($8::timestamptz IS NULL OR timestamp < $8)
+  AND ($9::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest($9::text[]),
+                                         unnest($10::text[])))
+  -- Both bounds are cast: inside a row comparison sqlc reads the type of the
+  -- second placeholder off the first one, which would make the event id a
+  -- timestamp in the generated parameters.
+  AND ($11::timestamptz IS NULL
+       OR (timestamp, event_id) > ($11::timestamptz,
+                                   $12::text))
+ORDER BY timestamp, event_id
+LIMIT $13
+`
+
+type ListEventsParams struct {
+	Cloud         pgtype.Text
+	Platform      pgtype.Text
+	ProjectID     pgtype.Text
+	ResourceType  pgtype.Text
+	EventType     pgtype.Text
+	Source        pgtype.Text
+	FromTs        pgtype.Timestamptz
+	ToTs          pgtype.Timestamptz
+	ScopeClouds   []string
+	ScopeProjects []string
+	CursorTs      pgtype.Timestamptz
+	CursorEventID pgtype.Text
+	PageSize      int32
+}
+
+func (q *Queries) ListEvents(ctx context.Context, arg ListEventsParams) ([]Event, error) {
+	rows, err := q.db.Query(ctx, listEvents,
+		arg.Cloud,
+		arg.Platform,
+		arg.ProjectID,
+		arg.ResourceType,
+		arg.EventType,
+		arg.Source,
+		arg.FromTs,
+		arg.ToTs,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.CursorTs,
+		arg.CursorEventID,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Event
+	for rows.Next() {
+		var i Event
+		if err := rows.Scan(
+			&i.EventID,
+			&i.Timestamp,
+			&i.ReceivedAt,
+			&i.EventType,
+			&i.Platform,
+			&i.Cloud,
+			&i.ResourceType,
+			&i.ResourceID,
+			&i.ProjectID,
+			&i.Source,
+			&i.Payload,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEventsForResource = `-- name: ListEventsForResource :many
 SELECT event_id, timestamp, received_at, event_type, platform, cloud,
        resource_type, resource_id, project_id, source, payload

--- a/migrations/reporting/0003_events_scope_index.sql
+++ b/migrations/reporting/0003_events_scope_index.sql
@@ -1,0 +1,37 @@
+-- The index the scoped event reads seek through. Every request from a
+-- project-role token carries the (cloud, project_id) pair filter of WP 1.8, and
+-- 0001 indexes project_id alone, which cannot serve a filter on the pair: the
+-- planner is left with the time-dimension scan plus a per-row check, so the rows
+-- it walks to fill one page grow with the share of the table the token does not
+-- hold.
+--
+-- The normative specification is roadmap/01-phase-1-core-platform-openstack.md,
+-- WP 1.8.
+--
+-- The build runs per chunk and therefore outside a transaction. A plain CREATE
+-- INDEX on a hypertable takes a SHARE lock on every chunk and holds all of them
+-- until the last one is built, and SHARE conflicts with the ROW EXCLUSIVE an
+-- INSERT needs: ingestion would stop for the length of the whole build, which is
+-- longest on exactly the events table this index is worth having on. The
+-- per-chunk form releases each chunk's lock when that chunk is done, so writes to
+-- every other chunk keep flowing while it works.
+--
+-- A build that dies partway leaves the chunks it finished indexed and the
+-- migration unrecorded, so a rerun fails on the index that is already there
+-- rather than silently leaving the rest unindexed. Dropping the index and
+-- rerunning is what recovers from that.
+--
+-- The directive is read per file rather than per direction, so the rollback runs
+-- outside a transaction too: goose drops the index and records the rollback as
+-- two separable steps, and a rollback that dies between them leaves the index
+-- gone with the migration still recorded as applied. The drop says IF EXISTS so
+-- that rerunning it is what repairs that, rather than failing on the index it
+-- already dropped and leaving the version row to be edited by hand.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX idx_events_cloud_project ON events (cloud, project_id, timestamp)
+    WITH (timescaledb.transaction_per_chunk);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_cloud_project;

--- a/migrations/reporting/0004_rejected_events_received_index.sql
+++ b/migrations/reporting/0004_rejected_events_received_index.sql
@@ -1,0 +1,37 @@
+-- The index the dead-letter list seeks through. It orders by (received_at, id)
+-- and resumes a walk on that pair, and 0001 gives rejected_events its primary
+-- key alone, so without this every page is a full scan of a TOAST-heavy JSONB
+-- table plus a sort — page 100 costing what page 1 did. 0001 leaves the events
+-- table's received_at unindexed on purpose, because nothing read it; this table
+-- is written only when ingestion refuses an item, so the insert contention that
+-- argument is about does not arise here.
+--
+-- The normative specification is roadmap/01-phase-1-core-platform-openstack.md,
+-- WP 1.8.
+--
+-- The build runs concurrently and therefore outside a transaction. A plain CREATE
+-- INDEX takes a SHARE lock on the table for the length of the build, and SHARE
+-- conflicts with the ROW EXCLUSIVE an INSERT needs: this table is written from
+-- inside the ingest transaction, so blocking it blocks every batch carrying a
+-- refused item until the index is there.
+--
+-- A concurrent build that fails leaves an INVALID index behind, which the planner
+-- ignores. The statement does not say IF NOT EXISTS, so a rerun fails on that
+-- leftover rather than recording the migration over an index nothing uses;
+-- dropping it and rerunning is what recovers from that.
+--
+-- The directive is read per file rather than per direction, so the rollback runs
+-- outside a transaction too: goose drops the index and records the rollback as
+-- two separable steps, and a rollback that dies between them leaves the index
+-- gone with the migration still recorded as applied. The drop says IF EXISTS so
+-- that rerunning it is what repairs that, rather than failing on the index it
+-- already dropped and leaving the version row to be edited by hand. It is also
+-- the drop that clears the INVALID leftover above, which the same rerun path
+-- reaches.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX CONCURRENTLY idx_rejected_events_received ON rejected_events (received_at, id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_rejected_events_received;

--- a/migrations/reporting/embed.go
+++ b/migrations/reporting/embed.go
@@ -18,4 +18,4 @@ var FS embed.FS
 // schema its code is newer than.
 //
 // Adding a migration means raising this; a test fails otherwise.
-const Version int64 = 2
+const Version int64 = 3

--- a/migrations/reporting/embed.go
+++ b/migrations/reporting/embed.go
@@ -18,4 +18,4 @@ var FS embed.FS
 // schema its code is newer than.
 //
 // Adding a migration means raising this; a test fails otherwise.
-const Version int64 = 3
+const Version int64 = 4


### PR DESCRIPTION
Closes #5

Adds the read path of the Reporting API: five GET operations over the data the write path of #4 stores. Every one is declared in `api/reporting/openapi.yaml` first, served by the regenerated chi wiring, validated by kin-openapi at runtime, and backed by a static sqlc statement.

## The change set, in commit order

**`3d1c1b6` Add the cursor codec shared by the paginated lists**

`internal/reporting/httpapi/cursor.go`: `encodeCursor` is `base64.RawURLEncoding` over the JSON array of the last served row's sort key, `decodeCursor` checks the whole way back — base64, JSON string array, element count, empty elements — so a cursor a client made up or lifted from another list is refused rather than used to bound a query. It lives next to the handlers because all three paginated lists page this way and differ only in how many parts their sort key has. Unit tests cover the round-trip and one case per rejection.

**`b157d86` Declare listEvents in the contract and serve it**

`GET /api/v1/events`: every stored event, filterable by `cloud`, `platform`, `project_id`, `resource_type`, `event_type`, `source`, and a half-open `[from, to)` window on `timestamp`; ordered by `(timestamp, event_id)` and paged with the codec above. New schemas `StoredEvent` and `EventList`.

The handler resolves the token's project scope before it queries. The scope refs travel into the statement as two parallel arrays compared as a pair — `(cloud, project_id) IN (SELECT unnest(...), unnest(...))` — so a project id one cloud uses cannot match the rows another cloud stores under the same id. A scope that resolves to no project answers the empty page without touching the database; an explicit `project_id` outside the scope is answered 403. One row past the page is read to decide whether a cursor is sent, which avoids counting the remainder.

The list is event-scoped: the events a resource carried before it moved between projects stay visible to the project that owned it then.

Also here, not named in the issue: `migrations/reporting/0003_events_scope_index.sql` adds `idx_events_cloud_project` on `(cloud, project_id, timestamp)`. `0001` indexes `project_id` alone, which cannot serve a filter on the pair, so a project token's page cost would grow with the share of the table it does not hold. The build runs `WITH (timescaledb.transaction_per_chunk)` outside a transaction so it does not hold a SHARE lock on every chunk — and therefore block ingestion — for the length of the whole build. The migration header states the recovery path for a build that dies partway.

**`401ee36` Cover the events list with integration tests**

Read back through the same router the events went in through, against a real TimescaleDB: the base set is submitted with `POST /api/v1/events`, so the reads are checked against what the write path stores. Two rows go in through the pool because the ingest path cannot produce them (a reconciliation row, and a row whose `payload` column is NULL). Covered: order and every member of a served event, the null payload asserted on the raw JSON, each filter alone and three at once, the inclusive `from` and exclusive `to`, the empty page as `[]` rather than `null`, a 3/3/1 walk whose concatenation equals the unpaginated answer, five unusable cursors, the four parameters the contract refuses, a query against a stopped database, and the confinement of a project token (pair filter, 403 on a foreign project, empty page once its projects are deleted).

**`682b393` Declare the resource reads and serve them**

Three reads over the projection:

- `GET /api/v1/resources` pages the current rows in `(cloud, resource_type, resource_id)` order — the table's primary key, so the cursor is a position in a total order. `status` becomes one nullable boolean the query compares `state = 'deleted'` against; `state` filters independently, so a contradictory pair yields the empty page rather than a refusal.
- `GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/events` and `.../lifecycle` answer the full history of one resource and the intervals it folds into. Neither pages, so `next_cursor` stays null. The fold is `internal/core/timeline`, the same one the projection replay runs, so the intervals reported here and the projection row come from one reading of the same events.

Both per-resource reads pass through one gate that loads the projection row. An unknown resource and a resource whose `(cloud, project_id)` the token's scope does not hold leave through the same `problem.Write` call, so the two 404 bodies are byte-identical and a caller cannot map another project's fleet by asking for its resources one at a time. `GetCurrentResource` repeats the column list of `GetCurrentResourceForUpdate` without the row lock: a read path must not make a writer wait on it.

`internal/reporting/httpapi/query.go` appears here rather than in the events commit — the scope resolution, page-limit defaulting, filter mapping, and bad-cursor answer became shared plumbing the moment the second endpoint needed them.

**`e129e78` Cover the resource reads with integration tests**

The fleet goes in through `POST /api/v1/events`, so the reads are checked against rows the write path folded rather than rows a test wrote. One state that path cannot produce (`last_payload` NULL) is set through the pool. On the list: the order, each filter alone and two at once, the exact `state` match, all three `status` values including the default, the empty page as `[]`, all twelve members of a row against the events it was folded from, a 3/3/1 walk, two unusable cursors, the refused parameters, a stopped database, and the project-token confinement. On the per-resource reads: the full history of a living and of a deleted resource, the concept's resize example folded into two intervals, a history closed by a delete, the warning a missed create leaves, and a resource created and deleted at one instant whose `intervals` serialize as `[]` while its `events` do not. The unknown-resource 404 and the out-of-scope 404 are compared byte for byte on both routes.

**`0806992` Declare listRejectedEvents and serve the dead-letter list**

Ingestion refuses an item server-side and keeps it in `rejected_events` with the reason and the body as submitted. Nothing read that table, so a refusal was silent data loss from the collector's side: it drops the batch once the call returns and must not retry a refused item. `GET /api/v1/rejected-events` makes the table reviewable, ordered by `(received_at, id)` and paged with the same codec; `from`/`to` filter on `received_at`, when the item was refused, not on when its event claims to have happened.

The route is admin-only and no project scope narrows it: the raw JSON of a refused item is whatever a collector submitted, so it carries no project attribution this API can trust. For the same reason the answer names the dead-letter row's own id rather than an event id. The response schema is `DeadLetteredEvent`, not the existing `RejectedEvent` — that one is the ingest answer's item and names a position in the submitted batch; this one is the stored row, and its `raw` member constrains nothing because a refused item need not be a JSON object at all.

`migrations/reporting/0004_rejected_events_received_index.sql` adds `idx_rejected_events_received` on `(received_at, id)`, built `CONCURRENTLY`: without it every page is a full scan of a TOAST-heavy JSONB table plus a sort.

**`0cd6cdc` Cover the dead-letter list with integration tests**

The refused item goes in through `POST /api/v1/events`, so the list answers the row the pipeline wrote. The reviewability story is asserted end to end: a batch of two valid items and one whose `event_type` fails `(*event.Event).Validate()`, the reason the ingest answer reported, then the same reason and a byte-identical raw document coming back out of the list. `received_at` is the database's own, so the window assertions read the bound off a prior answer instead of choosing it — a batch is one transaction and `now()` is transaction-scoped, so one batch's rows share a `received_at` and the id becomes the tie-breaker; the 3/3/1 walk crosses a page boundary inside such a group. Also covered: the empty page, seven unusable cursors, the refused limits, the 403 a `read_all` and a project token meet, the challenge a request without a token gets, and the route serving in `ModeDisabled`.

Each test commit also extends `TestAuthDispatch`, so every new GET meeting a guard rather than being refused as uncovered is pinned next to the fail-closed case.

## Where the diff diverges from the issue

- **The two per-resource reads are bounded at 10 000 events** and answer 422 `urn:tally:error:history_too_long` above it. The issue specified them as the unpaginated full history with no ceiling. Neither route paginates and the row set is materialized whole before the caller sees any of it, so an unbounded read is an unbounded memory cost per request; refusing with a pointer to `GET /api/v1/events` was chosen over truncating. The decision is taken by `CountEventsForResource`, a probe that saturates one row past the bound, and the read then asks for one row past it too, so an event stored between the two queries cannot be served as a history one event short.
- **The per-resource history is scope-filtered per event**, not only gated on the projection row. The issue argued the opposite ("filtering the history per event would serve partial histories that the timeline fold misreads"). What ships: the gate decides whether the resource is the token's *today* off the row's current pair, and the per-event filter decides which of its events are. The two differ exactly once a resource has been transferred, and then the pre-transfer events stay the old project's alone — consistent with the events list, which is event-scoped for the same reason. An unfiltered principal passes no scope and reads every event.
- **Two migrations that the issue's file list does not mention** (`0003`, `0004`), for the reasons given above. Both carry `-- +goose NO TRANSACTION` and document their recovery paths, and `migrate_test.go` and `embed.go` grew with them.
- **`projection.decode` is exported as `projection.Decode`** instead of a private `storedOf` mapper living in `eventsquery.go`, so every consumer folding a history reads rows into the fold's input exactly the way the replay does.
- **`query.go` holds the shared query plumbing** the issue described as living in `eventsquery.go`.

## Review notes

- Everything database-touching runs against real TimescaleDB via `storetest.NewDB`; there are no mocked stores in the new tests.
- `openapi.gen.go` and `sqlcgen/queries.sql.go` are `make generate` output and carry no hand edits.
- Non-goals of the issue are unchanged here: no metrics (#8), no project registry endpoints (#6), no caching or ETags, no client library.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
