### PR TITLE
Add the project registry with temporally valid relations

### DIFF
--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -18,8 +18,8 @@ info:
   description: >-
     Event ingestion, resource inventory, and usage reporting for Tally.
     This document covers the health probes, event ingestion, the queries over
-    events, resources, and lifecycles, the resource-type registry, dead-letter
-    review, and the projection rebuild.
+    events, resources, and lifecycles, the resource-type registry, the project
+    registry, dead-letter review, and the projection rebuild.
 
 paths:
   /healthz:
@@ -537,6 +537,185 @@ paths:
         "500":
           $ref: "#/components/responses/Problem"
 
+  /api/v1/projects:
+    post:
+      operationId: createProject
+      summary: Register a project
+      description: >-
+        Registers one project. The registry is keyed by `(cloud, external_id)`:
+        a pair it already holds is answered 409 rather than replaced, so a
+        repeated registration never overwrites what an operator entered before.
+
+        The `id` the answer carries is how the other operations address the
+        project. An external id alone does not, because two clouds may name
+        different projects the same way.
+      security:
+        - apiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateProject"
+      responses:
+        "201":
+          description: The project as it is now registered.
+          headers:
+            Location:
+              description: The URL of the created project.
+              schema:
+                type: string
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+    get:
+      operationId: listProjects
+      summary: List the registered projects
+      description: >-
+        Returns the registered projects, narrowed by whichever filters the
+        request carries. The order is `(cloud, external_id)` ascending.
+
+        One call answers one page. `items` carries the projects, and
+        `next_cursor` is what the next call passes as `cursor`; a null
+        `next_cursor` is the end of the walk. The cursor holds a position and
+        nothing else, so presenting it together with other filters is well
+        defined: the filters of that call apply from that position onwards.
+      security:
+        - apiToken: []
+      parameters:
+        - name: platform
+          in: query
+          description: Serve only the projects of this platform.
+          schema:
+            type: string
+        - name: cloud
+          in: query
+          description: Serve only the projects of this cloud.
+          schema:
+            type: string
+        - name: external_id
+          in: query
+          description: >-
+            Serve only the projects their cloud names this way. It is not a key
+            on its own, so two clouds using the same external id are both
+            served unless `cloud` narrows the answer.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: How many projects one page carries at most.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: One page of registered projects.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/projects/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The project, as this API names it.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+    get:
+      operationId: getProject
+      summary: Read one registered project
+      security:
+        - apiToken: []
+      responses:
+        "200":
+          description: The registered project.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+    patch:
+      operationId: updateProject
+      summary: Update one registered project
+      description: >-
+        Changes the name or the metadata of one project. A member the request
+        leaves out stays as it is, and `metadata` is replaced wholesale rather
+        than merged, so a request carrying it carries every member the project
+        keeps.
+
+        Neither the platform nor the `(cloud, external_id)` key is writable
+        here. They are what the registry is keyed by, and a project that moves
+        to another cloud is a different project.
+      security:
+        - apiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateProject"
+      responses:
+        "200":
+          description: The project as it now stands.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
   /api/v1/rejected-events:
     get:
       operationId: listRejectedEvents
@@ -722,6 +901,18 @@ components:
               msg:
                 type: string
                 description: What is wrong with the value at that location.
+
+    # The shape every id in a path is constrained to. It lives here rather than
+    # at each parameter, so that the copies cannot drift apart; what an id names
+    # stays with the parameter, because that differs per route.
+    Uuid:
+      type: string
+      format: uuid
+      # The request validator checks a pattern and ignores an unregistered
+      # format, so the RFC 4122 shape is spelled out here as well. That is
+      # what answers a malformed id with the contract's 400 rather than
+      # letting the generated binding fail behind the validator.
+      pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 
     # This schema constrains nothing, and that is load-bearing rather than
     # sloppy. It is what the request validator applies to a whole batch, so a
@@ -1090,6 +1281,110 @@ components:
             A JSON Schema draft 2020-12 document. It is compiled before it is
             stored, so the document a registration accepts is exactly the one
             ingestion can apply later.
+
+    Project:
+      type: object
+      description: >-
+        One registered project. The registry is keyed by
+        `(cloud, external_id)`, and `id` is what the other operations address
+        the project by.
+      required: [id, platform, cloud, external_id, name, metadata, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The project, as this API names it.
+        platform:
+          type: string
+          description: The platform the project lives on, openstack for example.
+        cloud:
+          type: string
+          description: >-
+            The installation the project lives in, os-prod-eu1 for example.
+        external_id:
+          type: string
+          description: >-
+            The project as its cloud names it, which is the id an event carries.
+        name:
+          type: string
+          nullable: true
+          description: >-
+            What the project is called, null for a project registered without a
+            name.
+        metadata:
+          type: object
+          description: >-
+            Whatever else was stored about the project. It is the empty object
+            for a project registered without any.
+        created_at:
+          type: string
+          format: date-time
+          description: When the project was registered.
+
+    ProjectList:
+      type: object
+      description: One page of registered projects.
+      required: [items, next_cursor]
+      properties:
+        items:
+          type: array
+          description: The projects of this page, ordered by cloud and external id.
+          items:
+            $ref: "#/components/schemas/Project"
+        next_cursor:
+          type: string
+          nullable: true
+          description: >-
+            Where the next page starts, passed back as `cursor`. It is null on
+            the last page.
+
+    CreateProject:
+      type: object
+      description: >-
+        The project to register. Its `(cloud, external_id)` pair has to be one
+        the registry does not hold yet.
+      required: [platform, cloud, external_id]
+      properties:
+        platform:
+          type: string
+          minLength: 1
+          description: The platform the project lives on, openstack for example.
+        cloud:
+          type: string
+          minLength: 1
+          description: >-
+            The installation the project lives in, os-prod-eu1 for example.
+        external_id:
+          type: string
+          minLength: 1
+          description: The project as its cloud names it.
+        name:
+          type: string
+          minLength: 1
+          description: What the project is called.
+        metadata:
+          type: object
+          description: >-
+            Whatever else is worth keeping about the project. A registration
+            that leaves it out stores the empty object.
+
+    UpdateProject:
+      type: object
+      description: >-
+        What to change about a project. A member the request leaves out stays
+        as it is, so at least one of them has to be present.
+      minProperties: 1
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: What the project is called from now on.
+        metadata:
+          type: object
+          description: >-
+            The metadata the project carries from now on. It replaces the
+            stored object wholesale rather than being merged into it, so a
+            request carrying it carries every member the project keeps.
 
     # The name avoids RejectedEvent above, which is the ingest response's item
     # and a different shape: that one names the position in the submitted batch,

--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -716,6 +716,287 @@ paths:
         "500":
           $ref: "#/components/responses/Problem"
 
+  /api/v1/projects/{id}/relations:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The project the relations are addressed under.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+    post:
+      operationId: createProjectRelation
+      summary: Relate one project to another
+      description: >-
+        Creates one relation leaving the project the path names. A relation is
+        valid at `t` iff `valid_from <= t AND (valid_to IS NULL OR valid_to >
+        t)`, and `valid_from` defaults to the instant the relation is written.
+
+        One triple of source, target and `relation_type` carries a single open
+        relation at a time. A triple that is already active is answered 409;
+        the same triple after a close is created again.
+
+        A source project this registry does not hold is answered 404. A target
+        it does not hold, and a target that is the source itself, are answered
+        422.
+
+        A relation of one of the configured attributing types keeps
+        attribution a forest. Its creation walks the active attributing
+        relations out of `target_id` first, and a relation that reaches the
+        source again is answered 422
+        (`urn:tally:error:relation_cycle`) without being written. A type
+        outside that list is created without the walk.
+      security:
+        - apiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRelation"
+      responses:
+        "201":
+          description: The relation as it is now stored.
+          headers:
+            Location:
+              description: The URL of the created relation.
+              schema:
+                type: string
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Relation"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+    get:
+      operationId: listProjectRelations
+      summary: List the relations of one project
+      description: >-
+        Returns the relations of the project that are valid at `at`, ordered by
+        `(created_at, id)`. A relation is valid at `t` iff `valid_from <= t AND
+        (valid_to IS NULL OR valid_to > t)`, so the answer is the point-in-time
+        view of the neighborhood and history is read by passing a past `at`.
+
+        The answer is never paginated. A project this registry does not hold is
+        answered 404, which is what tells an empty neighborhood from an unknown
+        project.
+      security:
+        - apiToken: []
+      parameters:
+        - name: direction
+          in: query
+          description: >-
+            Which relations to serve: `outgoing` the ones leaving the project,
+            `incoming` the ones reaching it, `both` either.
+          schema:
+            type: string
+            enum: [outgoing, incoming, both]
+            default: both
+        - name: relation_type
+          in: query
+          description: Serve only the relations of this type.
+          schema:
+            type: string
+        - name: at
+          in: query
+          description: >-
+            The instant the answer describes. It defaults to now.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: The relations valid at that instant.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RelationList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/projects/{id}/relations/{relation_id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The project the relation leaves.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+      - name: relation_id
+        in: path
+        required: true
+        description: The relation itself, as this API names it.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+    patch:
+      operationId: updateProjectRelation
+      summary: Update one relation
+      description: >-
+        Changes the metadata or the end of one relation. A member the request
+        leaves out stays as it is, and `metadata` is replaced wholesale rather
+        than merged.
+
+        `valid_to` has to be after `valid_from`, which is 422 otherwise. It is
+        also where a closed relation gets its close instant corrected; the
+        member is not nullable, so reopening a closed relation is not
+        supported.
+
+        A relation the path does not name, and a relation that does not leave
+        the project of the path, are both answered 404.
+      security:
+        - apiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateRelation"
+      responses:
+        "200":
+          description: The relation as it now stands.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Relation"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+    delete:
+      operationId: deleteProjectRelation
+      summary: Close one relation
+      description: >-
+        Closes the relation by setting `valid_to` to now. The row is never
+        deleted, so a read at an earlier `at` still finds the relation.
+
+        A relation that is already closed is answered 204 as well, and the
+        stored `valid_to` does not move: the close instant a relation was given
+        is the one it keeps. A relation this API does not hold, and one that
+        does not leave the project of the path, are answered 404.
+      security:
+        - apiToken: []
+      responses:
+        "204":
+          description: The relation is closed.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/projects/{id}/related:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The project the traversal starts from.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+    get:
+      operationId: listRelatedProjects
+      summary: List the projects one project reaches
+      description: >-
+        Walks the outgoing relations that are valid at `at`, up to `depth`
+        relations out, and returns every project the walk reaches. A relation
+        is valid at `t` iff `valid_from <= t AND (valid_to IS NULL OR valid_to
+        > t)`, so the answer is the point-in-time view of the graph and history
+        is read by passing a past `at`.
+
+        The walk is breadth-first and visits a project once, which terminates a
+        cycle and keeps the project of the path out of the answer. The items
+        come in the order they were visited, and `path` names the relations the
+        walk took to reach each of them.
+
+        The answer is never paginated. A project this registry does not hold is
+        answered 404.
+      security:
+        - apiToken: []
+      parameters:
+        - name: depth
+          in: query
+          description: How many relations out the walk goes.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10
+            default: 1
+        - name: relation_type
+          in: query
+          description: Walk only the relations of this type.
+          schema:
+            type: string
+        - name: at
+          in: query
+          description: >-
+            The instant the answer describes. It defaults to now.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: The projects the walk reached.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RelatedProjectList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
   /api/v1/rejected-events:
     get:
       operationId: listRejectedEvents
@@ -1385,6 +1666,154 @@ components:
             The metadata the project carries from now on. It replaces the
             stored object wholesale rather than being merged into it, so a
             request carrying it carries every member the project keeps.
+
+    Relation:
+      type: object
+      description: >-
+        One relation between two projects. It is valid at `t` iff
+        `valid_from <= t AND (valid_to IS NULL OR valid_to > t)`, and it is
+        closed rather than deleted, so a read at an earlier instant still finds
+        it.
+      required:
+        [id, source_id, target_id, relation_type, metadata, valid_from,
+         valid_to, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The relation, as this API names it.
+        source_id:
+          type: string
+          format: uuid
+          description: The project the relation leaves.
+        target_id:
+          type: string
+          format: uuid
+          description: The project the relation reaches.
+        relation_type:
+          type: string
+          description: >-
+            What the relation means, infrastructure_tenant for example.
+        metadata:
+          type: object
+          description: >-
+            Whatever else was stored about the relation. It is the empty object
+            for a relation created without any.
+        valid_from:
+          type: string
+          format: date-time
+          description: When the relation starts being valid, the inclusive bound.
+        valid_to:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the relation stops being valid, the exclusive bound. It is
+            null while the relation is open.
+        created_at:
+          type: string
+          format: date-time
+          description: When the relation was written.
+
+    RelationList:
+      type: object
+      description: The relations of one project at one instant.
+      required: [items]
+      properties:
+        items:
+          type: array
+          description: >-
+            The relations valid at that instant, ordered by created_at and id.
+          items:
+            $ref: "#/components/schemas/Relation"
+
+    CreateRelation:
+      type: object
+      description: >-
+        The relation to create. It leaves the project the path names, so only
+        the other end is given here.
+      required: [target_id, relation_type]
+      properties:
+        target_id:
+          type: string
+          format: uuid
+          pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          description: >-
+            The project the relation reaches. It has to be registered, and it
+            cannot be the project the relation leaves.
+        relation_type:
+          type: string
+          minLength: 1
+          description: >-
+            What the relation means, infrastructure_tenant for example.
+        metadata:
+          type: object
+          description: >-
+            Whatever else is worth keeping about the relation. A creation that
+            leaves it out stores the empty object.
+        valid_from:
+          type: string
+          format: date-time
+          description: >-
+            When the relation starts being valid. It defaults to the instant
+            the relation is written.
+
+    UpdateRelation:
+      type: object
+      description: >-
+        What to change about a relation. A member the request leaves out stays
+        as it is, so at least one of them has to be present.
+      minProperties: 1
+      properties:
+        metadata:
+          type: object
+          description: >-
+            The metadata the relation carries from now on. It replaces the
+            stored object wholesale rather than being merged into it, so a
+            request carrying it carries every member the relation keeps.
+        valid_to:
+          type: string
+          format: date-time
+          description: >-
+            When the relation stops being valid. It has to be after
+            `valid_from`. The member is not nullable: an open relation is
+            closed here and a closed one gets its close instant corrected,
+            while reopening a closed relation is not supported.
+
+    RelatedProject:
+      type: object
+      description: One project a traversal reached.
+      required: [project, relation_type, depth, path]
+      properties:
+        project:
+          $ref: "#/components/schemas/Project"
+        relation_type:
+          type: string
+          description: The type of the relation the walk arrived on.
+        depth:
+          type: integer
+          description: >-
+            How many relations lie between the project the walk started from
+            and this one.
+        path:
+          type: array
+          description: >-
+            The relation ids from the start to this project in walk order, so
+            it holds `depth` of them.
+          items:
+            type: string
+            format: uuid
+
+    RelatedProjectList:
+      type: object
+      description: The projects one traversal reached.
+      required: [items]
+      properties:
+        items:
+          type: array
+          description: The projects the walk reached, in the order it visited them.
+          items:
+            $ref: "#/components/schemas/RelatedProject"
 
     # The name avoids RejectedEvent above, which is the ingest response's item
     # and a different shape: that one names the position in the submitted batch,

--- a/cmd/tally-reporting/.env.example
+++ b/cmd/tally-reporting/.env.example
@@ -44,3 +44,8 @@ TALLY_REPORTING_OIDC_JWKS_URL=
 # accepted unvalidated. Set it to true and such an event is rejected and
 # dead-lettered instead. The variable has no REPORTING infix by design.
 TALLY_INGEST_REQUIRE_SIZE_SCHEMA=false
+
+# Relation types that attribute cost, comma-separated. Creating a relation is
+# refused when it would close a cycle over these types. An explicitly empty
+# value disables that guard.
+TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES=infrastructure_tenant

--- a/cmd/tally-reporting/main.go
+++ b/cmd/tally-reporting/main.go
@@ -94,7 +94,7 @@ func run(ctx context.Context) error {
 	// The pipeline owns the registry, which caches compiled size schemas for the
 	// life of the process. Nothing else validates a size against a stored schema
 	// today.
-	pipeline := ingest.New(registry.New(), cfg.RequireSizeSchema)
+	pipeline := ingest.New(registry.New(), cfg.RequireSizeSchema, nil)
 
 	router, err := httpapi.NewRouter(httpapi.Options{
 		Logger:             logger,

--- a/cmd/tally-reporting/main.go
+++ b/cmd/tally-reporting/main.go
@@ -97,15 +97,16 @@ func run(ctx context.Context) error {
 	pipeline := ingest.New(registry.New(), cfg.RequireSizeSchema, nil)
 
 	router, err := httpapi.NewRouter(httpapi.Options{
-		Logger:             logger,
-		DB:                 db,
-		UnhealthyThreshold: time.Duration(cfg.UnhealthyThresholdSeconds) * time.Second,
-		Queries:            queries,
-		Store:              db,
-		AuthMode:           auth.Mode(cfg.AuthMode),
-		InternalToken:      cfg.InternalToken,
-		Authenticator:      auth.NewStaticTokenAuthenticator(queries),
-		Pipeline:           pipeline,
+		Logger:                   logger,
+		DB:                       db,
+		UnhealthyThreshold:       time.Duration(cfg.UnhealthyThresholdSeconds) * time.Second,
+		Queries:                  queries,
+		Store:                    db,
+		AuthMode:                 auth.Mode(cfg.AuthMode),
+		InternalToken:            cfg.InternalToken,
+		Authenticator:            auth.NewStaticTokenAuthenticator(queries),
+		Pipeline:                 pipeline,
+		AttributingRelationTypes: cfg.AttributingRelationTypes,
 	})
 	if err != nil {
 		return fmt.Errorf("building the router: %w", err)

--- a/internal/reporting/config/config.go
+++ b/internal/reporting/config/config.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/caarlos0/env/v11"
@@ -36,6 +37,7 @@ const (
 	envUnhealthyThreshold = "TALLY_REPORTING_UNHEALTHY_THRESHOLD_S"
 	envOIDCJWKSURL        = "TALLY_REPORTING_OIDC_JWKS_URL"
 	envRequireSizeSchema  = "TALLY_INGEST_REQUIRE_SIZE_SCHEMA"
+	envAttributingTypes   = "TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES"
 )
 
 // EnvNames is every variable this package reads, including the *_FILE
@@ -53,6 +55,7 @@ var EnvNames = []string{
 	envUnhealthyThreshold,
 	envOIDCJWKSURL,
 	envRequireSizeSchema,
+	envAttributingTypes,
 }
 
 // The accepted values of TALLY_REPORTING_AUTH_MODE.
@@ -108,6 +111,10 @@ type Config struct {
 	// The variable has no REPORTING infix because roadmap section WP 1.3 names
 	// it TALLY_INGEST_REQUIRE_SIZE_SCHEMA.
 	RequireSizeSchema bool `env:"TALLY_INGEST_REQUIRE_SIZE_SCHEMA" envDefault:"false"`
+	// AttributingRelationTypes are the relation types the cycle guard walks when
+	// a relation is created; an empty list disables the guard. Setting the
+	// variable to the empty string yields that empty list.
+	AttributingRelationTypes []string `env:"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES" envDefault:"infrastructure_tenant"`
 }
 
 // Load reads the environment, resolves the file-backed secrets, and checks the
@@ -141,6 +148,18 @@ func Load() (Config, error) {
 	}
 	if cfg.DBMaxConns <= 0 {
 		return Config{}, fmt.Errorf("%s: %d must be positive", envDBMaxConns, cfg.DBMaxConns)
+	}
+	// env applies the default to a variable set to the empty string, the same as
+	// to an unset one, so the raw value is what tells the two apart. Only the
+	// explicit empty value disables the cycle guard; anything else that parses
+	// into an empty entry is a stray comma, which would otherwise silently mean
+	// a relation type no relation has.
+	raw, isSet := os.LookupEnv(envAttributingTypes)
+	if isSet && raw == "" {
+		cfg.AttributingRelationTypes = []string{}
+	}
+	if slices.Contains(cfg.AttributingRelationTypes, "") {
+		return Config{}, fmt.Errorf("%s: %q must not contain an empty relation type", envAttributingTypes, raw)
 	}
 
 	return cfg, nil

--- a/internal/reporting/config/config_test.go
+++ b/internal/reporting/config/config_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/b42labs/tally/internal/reporting/config"
 )
 
-// setEnv applies vars and blanks every other variable the package reads, so a
+// setEnv applies vars and removes every other variable the package reads, so a
 // test never inherits a value from the developer's shell. t.Setenv restores the
-// previous environment when the test ends, and a variable set to the empty
-// string falls back to its default exactly as an unset one does.
+// previous environment when the test ends; removing a variable afterwards keeps
+// that restoration intact, and it lets a test set a variable to the empty
+// string to mean the empty value rather than the default.
 func setEnv(t *testing.T, vars map[string]string) {
 	t.Helper()
 
@@ -26,7 +27,14 @@ func setEnv(t *testing.T, vars map[string]string) {
 		}
 	}
 	for _, name := range config.EnvNames {
-		t.Setenv(name, vars[name])
+		value, set := vars[name]
+		t.Setenv(name, value)
+		if set {
+			continue
+		}
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("Unsetenv(%s): %v", name, err)
+		}
 	}
 }
 
@@ -73,6 +81,9 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if cfg.RequireSizeSchema {
 		t.Error("RequireSizeSchema = true, want false")
 	}
+	if want := []string{"infrastructure_tenant"}; !slices.Equal(cfg.AttributingRelationTypes, want) {
+		t.Errorf("AttributingRelationTypes = %q, want %q", cfg.AttributingRelationTypes, want)
+	}
 	if err := cfg.ValidateServer(); err != nil {
 		t.Errorf("ValidateServer() error = %v, want nil", err)
 	}
@@ -80,13 +91,14 @@ func TestLoadAppliesDefaults(t *testing.T) {
 
 func TestLoadReadsExplicitValues(t *testing.T) {
 	setEnv(t, map[string]string{
-		"TALLY_LOG_LEVEL":                       "DEBUG",
-		"TALLY_REPORTING_HTTP_PORT":             "9090",
-		"TALLY_REPORTING_DB_URL":                "postgres://tally@db/tally",
-		"TALLY_REPORTING_AUTH_MODE":             "disabled",
-		"TALLY_REPORTING_UNHEALTHY_THRESHOLD_S": "30",
-		"TALLY_REPORTING_DB_MAX_CONNS":          "4",
-		"TALLY_INGEST_REQUIRE_SIZE_SCHEMA":      "true",
+		"TALLY_LOG_LEVEL":                            "DEBUG",
+		"TALLY_REPORTING_HTTP_PORT":                  "9090",
+		"TALLY_REPORTING_DB_URL":                     "postgres://tally@db/tally",
+		"TALLY_REPORTING_AUTH_MODE":                  "disabled",
+		"TALLY_REPORTING_UNHEALTHY_THRESHOLD_S":      "30",
+		"TALLY_REPORTING_DB_MAX_CONNS":               "4",
+		"TALLY_INGEST_REQUIRE_SIZE_SCHEMA":           "true",
+		"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES": "infrastructure_tenant,same_owner",
 	})
 
 	cfg, err := config.Load()
@@ -99,6 +111,9 @@ func TestLoadReadsExplicitValues(t *testing.T) {
 	}
 	if !cfg.RequireSizeSchema {
 		t.Error("RequireSizeSchema = false, want true")
+	}
+	if want := []string{"infrastructure_tenant", "same_owner"}; !slices.Equal(cfg.AttributingRelationTypes, want) {
+		t.Errorf("AttributingRelationTypes = %q, want %q", cfg.AttributingRelationTypes, want)
 	}
 
 	if cfg.LogLevel != "DEBUG" {
@@ -229,9 +244,41 @@ func TestLoadRejectsNonPositiveBounds(t *testing.T) {
 	}
 }
 
+func TestLoadReadsAttributingRelationTypes(t *testing.T) {
+	t.Run("an explicitly empty value disables the cycle guard", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_REPORTING_DB_URL":                     "postgres://tally@localhost/tally",
+			"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES": "",
+		})
+
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if len(cfg.AttributingRelationTypes) != 0 {
+			t.Errorf("AttributingRelationTypes = %q, want the empty list", cfg.AttributingRelationTypes)
+		}
+	})
+
+	t.Run("a stray comma is rejected", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_REPORTING_DB_URL":                     "postgres://tally@localhost/tally",
+			"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES": "infrastructure_tenant,,same_owner",
+		})
+
+		_, err := config.Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES") {
+			t.Errorf("Load() error = %q, want it to name TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES", err)
+		}
+	})
+}
+
 // TestEnvNamesCoversEveryField keeps the exported list and the struct tags from
 // drifting apart. A variable missing from EnvNames is one the tests stop
-// blanking, which makes them depend on the shell they run in.
+// removing, which makes them depend on the shell they run in.
 func TestEnvNamesCoversEveryField(t *testing.T) {
 	fields := reflect.TypeFor[config.Config]()
 	tagged := make(map[string]bool, fields.NumField())

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -24,6 +24,15 @@ const resourceRoute = "/api/v1/resources/{cloud}/{resource_type}/{resource_id}"
 // be the pattern the generated wiring registers, letter for letter.
 const projectRoute = "/api/v1/projects/{id}"
 
+// The chi patterns the relation operations of one project are mounted under.
+// They are built from projectRoute because they hang off it, and each of them
+// has to be the pattern the generated wiring registers, letter for letter.
+const (
+	projectRelationsRoute = projectRoute + "/relations"
+	projectRelationRoute  = projectRelationsRoute + "/{relation_id}"
+	projectRelatedRoute   = projectRoute + "/related"
+)
+
 // newAuthDispatch builds the middleware that puts each route behind the guard
 // its class needs.
 //
@@ -56,6 +65,14 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodGet + " " + projectRoute:   auth.Query(opts.Authenticator, auth.RoleReadAll, opts.AuthMode, Logger),
 		http.MethodPost + " /api/v1/projects": auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
 		http.MethodPatch + " " + projectRoute: auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+
+		// The relations of a project are the same structure seen from one row of
+		// it, so they are guarded the way the registry itself is.
+		http.MethodGet + " " + projectRelationsRoute:   auth.Query(opts.Authenticator, auth.RoleReadAll, opts.AuthMode, Logger),
+		http.MethodGet + " " + projectRelatedRoute:     auth.Query(opts.Authenticator, auth.RoleReadAll, opts.AuthMode, Logger),
+		http.MethodPost + " " + projectRelationsRoute:  auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+		http.MethodPatch + " " + projectRelationRoute:  auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+		http.MethodDelete + " " + projectRelationRoute: auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
 
 		// The dead-letter list is admin-only like the two writes above and the
 		// registration below: a refused item carries whatever a collector sent,

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -19,6 +19,11 @@ const resourceTypeRoute = "/api/v1/resource-types/{platform}/{resource_type}"
 // the generated wiring registers, letter for letter.
 const resourceRoute = "/api/v1/resources/{cloud}/{resource_type}/{resource_id}"
 
+// projectRoute is the chi pattern the two per-project operations share. It is
+// named once because the dispatch table keys two methods on it, and it has to
+// be the pattern the generated wiring registers, letter for letter.
+const projectRoute = "/api/v1/projects/{id}"
+
 // newAuthDispatch builds the middleware that puts each route behind the guard
 // its class needs.
 //
@@ -44,7 +49,15 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodGet + " " + resourceRoute + "/events":    auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 		http.MethodGet + " " + resourceRoute + "/lifecycle": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 
-		// The dead-letter list is the second admin-only route, next to the
+		// The project registry is the organizational structure a project scope is
+		// built out of, so no project-scoped view of it exists: reading it takes
+		// read_all, and changing it is an operator's job.
+		http.MethodGet + " /api/v1/projects":  auth.Query(opts.Authenticator, auth.RoleReadAll, opts.AuthMode, Logger),
+		http.MethodGet + " " + projectRoute:   auth.Query(opts.Authenticator, auth.RoleReadAll, opts.AuthMode, Logger),
+		http.MethodPost + " /api/v1/projects": auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+		http.MethodPatch + " " + projectRoute: auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+
+		// The dead-letter list is admin-only like the two writes above and the
 		// registration below: a refused item carries whatever a collector sent,
 		// which no project scope narrows.
 		http.MethodGet + " /api/v1/rejected-events": auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -79,6 +79,39 @@ func TestAuthDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("puts the registry operations behind a credential", func(t *testing.T) {
+		// The four operations sit on two patterns, two methods each, so what says
+		// the table keyed the methods apart is every one of them meeting a guard
+		// rather than being refused as a route no rule covers. Which role each
+		// demands is the integration test's business.
+		for _, tc := range []struct{ method, pattern, path string }{
+			{method: http.MethodGet, pattern: "/api/v1/projects", path: "/api/v1/projects"},
+			{method: http.MethodPost, pattern: "/api/v1/projects", path: "/api/v1/projects"},
+			{
+				method:  http.MethodGet,
+				pattern: projectRoute,
+				path:    "/api/v1/projects/0f2a1c3e-5d70-4c31-8f6b-9b1d2b7e4d0a",
+			},
+			{
+				method:  http.MethodPatch,
+				pattern: projectRoute,
+				path:    "/api/v1/projects/0f2a1c3e-5d70-4c31-8f6b-9b1d2b7e4d0a",
+			},
+		} {
+			t.Run(tc.method+" "+tc.pattern, func(t *testing.T) {
+				ran := false
+				handler := dispatchOn(t, tc.method, tc.pattern, &ran)
+
+				rec := serve(handler, httptest.NewRequest(tc.method, tc.path, nil))
+
+				assertChallenged(t, rec)
+				if ran {
+					t.Error("the handler ran for a request carrying no credential")
+				}
+			})
+		}
+	})
+
 	t.Run("puts the resource reads behind a credential", func(t *testing.T) {
 		// The two per-resource routes are keyed on the pattern rather than on a
 		// path, so what says the table names them is a request whose path

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -112,6 +112,37 @@ func TestAuthDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("puts the relation operations behind a credential", func(t *testing.T) {
+		// The five operations sit on three patterns, and the two of them that
+		// carry a second path parameter are keyed on the pattern rather than on
+		// a path. What says the table names all of them is every one meeting a
+		// guard rather than being refused as a route no rule covers. Which role
+		// each demands is the integration test's business.
+		const (
+			project  = "/api/v1/projects/0f2a1c3e-5d70-4c31-8f6b-9b1d2b7e4d0a"
+			relation = project + "/relations/6c4b2a10-9e83-4d55-a2f1-7c0e5b3a9d64"
+		)
+		for _, tc := range []struct{ method, pattern, path string }{
+			{method: http.MethodGet, pattern: projectRelationsRoute, path: project + "/relations"},
+			{method: http.MethodPost, pattern: projectRelationsRoute, path: project + "/relations"},
+			{method: http.MethodGet, pattern: projectRelatedRoute, path: project + "/related"},
+			{method: http.MethodPatch, pattern: projectRelationRoute, path: relation},
+			{method: http.MethodDelete, pattern: projectRelationRoute, path: relation},
+		} {
+			t.Run(tc.method+" "+tc.pattern, func(t *testing.T) {
+				ran := false
+				handler := dispatchOn(t, tc.method, tc.pattern, &ran)
+
+				rec := serve(handler, httptest.NewRequest(tc.method, tc.path, nil))
+
+				assertChallenged(t, rec)
+				if ran {
+					t.Error("the handler ran for a request carrying no credential")
+				}
+			})
+		}
+	})
+
 	t.Run("puts the resource reads behind a credential", func(t *testing.T) {
 		// The two per-resource routes are keyed on the pattern rather than on a
 		// path, so what says the table names them is a request whose path

--- a/internal/reporting/httpapi/events_integration_test.go
+++ b/internal/reporting/httpapi/events_integration_test.go
@@ -523,7 +523,7 @@ func newAPIInMode(t *testing.T, s *store.Store, mode auth.Mode) api {
 		AuthMode:           mode,
 		InternalToken:      internalToken,
 		Authenticator:      auth.NewStaticTokenAuthenticator(q),
-		Pipeline:           ingest.New(registry.New(), false),
+		Pipeline:           ingest.New(registry.New(), false, nil),
 	})
 	if err != nil {
 		t.Fatalf("NewRouter() error = %v, want nil", err)

--- a/internal/reporting/httpapi/events_integration_test.go
+++ b/internal/reporting/httpapi/events_integration_test.go
@@ -509,21 +509,24 @@ func newAPI(t *testing.T, s *store.Store) api {
 // newAPIInMode builds the full router over s in the given authentication mode.
 // The credential seams are wired either way, so the mode is the only thing that
 // decides whether a request needs one. The pipeline is the lax one, so an
-// unregistered resource type is accepted rather than refused.
+// unregistered resource type is accepted rather than refused, and the
+// attributing relation types are the ones the configuration defaults to, so the
+// cycle guard of a relation creation is on.
 func newAPIInMode(t *testing.T, s *store.Store, mode auth.Mode) api {
 	t.Helper()
 
 	q := sqlcgen.New(s.Pool())
 	handler, err := NewRouter(Options{
-		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		DB:                 s,
-		UnhealthyThreshold: time.Minute,
-		Queries:            q,
-		Store:              s,
-		AuthMode:           mode,
-		InternalToken:      internalToken,
-		Authenticator:      auth.NewStaticTokenAuthenticator(q),
-		Pipeline:           ingest.New(registry.New(), false, nil),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                       s,
+		UnhealthyThreshold:       time.Minute,
+		Queries:                  q,
+		Store:                    s,
+		AuthMode:                 mode,
+		InternalToken:            internalToken,
+		Authenticator:            auth.NewStaticTokenAuthenticator(q),
+		Pipeline:                 ingest.New(registry.New(), false, nil),
+		AttributingRelationTypes: []string{attributingType},
 	})
 	if err != nil {
 		t.Fatalf("NewRouter() error = %v, want nil", err)

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -61,6 +61,24 @@ func (e ListResourcesParamsStatus) Valid() bool {
 	}
 }
 
+// CreateProject The project to register. Its `(cloud, external_id)` pair has to be one the registry does not hold yet.
+type CreateProject struct {
+	// Cloud The installation the project lives in, os-prod-eu1 for example.
+	Cloud string `json:"cloud"`
+
+	// ExternalId The project as its cloud names it.
+	ExternalId string `json:"external_id"`
+
+	// Metadata Whatever else is worth keeping about the project. A registration that leaves it out stores the empty object.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// Name What the project is called.
+	Name *string `json:"name,omitempty"`
+
+	// Platform The platform the project lives on, openstack for example.
+	Platform string `json:"platform"`
+}
+
 // DeadLetterList One page of dead-lettered events.
 type DeadLetterList struct {
 	// Items The refused items of this page, ordered by received_at and id.
@@ -205,6 +223,39 @@ type Problem struct {
 	Type string `json:"type"`
 }
 
+// Project One registered project. The registry is keyed by `(cloud, external_id)`, and `id` is what the other operations address the project by.
+type Project struct {
+	// Cloud The installation the project lives in, os-prod-eu1 for example.
+	Cloud string `json:"cloud"`
+
+	// CreatedAt When the project was registered.
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExternalId The project as its cloud names it, which is the id an event carries.
+	ExternalId string `json:"external_id"`
+
+	// Id The project, as this API names it.
+	Id openapi_types.UUID `json:"id"`
+
+	// Metadata Whatever else was stored about the project. It is the empty object for a project registered without any.
+	Metadata map[string]interface{} `json:"metadata"`
+
+	// Name What the project is called, null for a project registered without a name.
+	Name *string `json:"name"`
+
+	// Platform The platform the project lives on, openstack for example.
+	Platform string `json:"platform"`
+}
+
+// ProjectList One page of registered projects.
+type ProjectList struct {
+	// Items The projects of this page, ordered by cloud and external id.
+	Items []Project `json:"items"`
+
+	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
+	NextCursor *string `json:"next_cursor"`
+}
+
 // RebuildRequest Which resources to replay. A member left out filters nothing, so an empty object rebuilds every resource the events table knows.
 type RebuildRequest struct {
 	// Cloud Replay only the resources of this cloud.
@@ -346,6 +397,18 @@ type StoredEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// UpdateProject What to change about a project. A member the request leaves out stays as it is, so at least one of them has to be present.
+type UpdateProject struct {
+	// Metadata The metadata the project carries from now on. It replaces the stored object wholesale rather than being merged into it, so a request carrying it carries every member the project keeps.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// Name What the project is called from now on.
+	Name *string `json:"name,omitempty"`
+}
+
+// Uuid defines model for Uuid.
+type Uuid = openapi_types.UUID
+
 // Cursor defines model for Cursor.
 type Cursor = string
 
@@ -392,6 +455,24 @@ type IngestEventsJSONBody struct {
 
 // IngestEventsJSONBody1 defines parameters for IngestEvents.
 type IngestEventsJSONBody1 = []EventInput
+
+// ListProjectsParams defines parameters for ListProjects.
+type ListProjectsParams struct {
+	// Platform Serve only the projects of this platform.
+	Platform *string `form:"platform,omitempty" json:"platform,omitempty"`
+
+	// Cloud Serve only the projects of this cloud.
+	Cloud *string `form:"cloud,omitempty" json:"cloud,omitempty"`
+
+	// ExternalId Serve only the projects their cloud names this way. It is not a key on its own, so two clouds using the same external id are both served unless `cloud` narrows the answer.
+	ExternalId *string `form:"external_id,omitempty" json:"external_id,omitempty"`
+
+	// Limit How many projects one page carries at most.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor The `next_cursor` of the page before this one. It is opaque: a client passes it back as it received it and reads nothing out of it.
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
 
 // ListRejectedEventsParams defines parameters for ListRejectedEvents.
 type ListRejectedEventsParams struct {
@@ -440,6 +521,12 @@ type ListResourcesParamsStatus string
 
 // IngestEventsJSONRequestBody defines body for IngestEvents for application/json ContentType.
 type IngestEventsJSONRequestBody IngestEventsJSONBody
+
+// CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
+type CreateProjectJSONRequestBody = CreateProject
+
+// UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
+type UpdateProjectJSONRequestBody = UpdateProject
 
 // PutResourceTypeJSONRequestBody defines body for PutResourceType for application/json ContentType.
 type PutResourceTypeJSONRequestBody = RegisterResourceType
@@ -700,6 +787,18 @@ type ServerInterface interface {
 	// IngestEvents Ingest events
 	// (POST /api/v1/events)
 	IngestEvents(w http.ResponseWriter, r *http.Request)
+	// ListProjects List the registered projects
+	// (GET /api/v1/projects)
+	ListProjects(w http.ResponseWriter, r *http.Request, params ListProjectsParams)
+	// CreateProject Register a project
+	// (POST /api/v1/projects)
+	CreateProject(w http.ResponseWriter, r *http.Request)
+	// GetProject Read one registered project
+	// (GET /api/v1/projects/{id})
+	GetProject(w http.ResponseWriter, r *http.Request, id Uuid)
+	// UpdateProject Update one registered project
+	// (PATCH /api/v1/projects/{id})
+	UpdateProject(w http.ResponseWriter, r *http.Request, id Uuid)
 	// ListRejectedEvents List the dead-lettered events
 	// (GET /api/v1/rejected-events)
 	ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams)
@@ -745,6 +844,30 @@ func (_ Unimplemented) ListEvents(w http.ResponseWriter, r *http.Request, params
 // IngestEvents Ingest events
 // (POST /api/v1/events)
 func (_ Unimplemented) IngestEvents(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListProjects List the registered projects
+// (GET /api/v1/projects)
+func (_ Unimplemented) ListProjects(w http.ResponseWriter, r *http.Request, params ListProjectsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// CreateProject Register a project
+// (POST /api/v1/projects)
+func (_ Unimplemented) CreateProject(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// GetProject Read one registered project
+// (GET /api/v1/projects/{id})
+func (_ Unimplemented) GetProject(w http.ResponseWriter, r *http.Request, id Uuid) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// UpdateProject Update one registered project
+// (PATCH /api/v1/projects/{id})
+func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, id Uuid) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -972,6 +1095,157 @@ func (siw *ServerInterfaceWrapper) IngestEvents(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.IngestEvents(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProjects operation middleware
+func (siw *ServerInterfaceWrapper) ListProjects(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListProjectsParams
+
+	// ------------- Optional query parameter "platform" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "platform", r.URL.Query(), &params.Platform, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "platform"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "platform", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cloud" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cloud", r.URL.Query(), &params.Cloud, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cloud"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "external_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "external_id", r.URL.Query(), &params.ExternalId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "external_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "external_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProjects(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateProject operation middleware
+func (siw *ServerInterfaceWrapper) CreateProject(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateProject(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProject operation middleware
+func (siw *ServerInterfaceWrapper) GetProject(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProject(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProject operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProject(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProject(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1535,6 +1809,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/api/v1/resource-types/{platform}/{resource_type}", wrapper.PutResourceType)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/projects", wrapper.ListProjects)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/projects", wrapper.CreateProject)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/projects/{id}", wrapper.GetProject)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/v1/projects/{id}", wrapper.UpdateProject)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/rejected-events", wrapper.ListRejectedEvents)
 	})
 	r.Group(func(r chi.Router) {
@@ -1549,125 +1835,143 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H19jxs3kvdXIfQ8gDd4ejRjx9nnboL9w7ub3fUhSAzHe3dAHFhUd0niTovskOyRlWC++6GqSDb7RRrJ",
-	"Hjsv5/88VjdfqopVv3ph9c+z0mwbo0F7N7v+ebYBWYGlf76EH1tw/vlf8Y8KXGlV45XRs+vZX4y1UEv8",
-	"S6hKmJXwG+WE5Tfm4tUGhAN7C1bIyjTeCb8BYTQIKUpZ12CFA105IXUl1qDBSg+OHjB+A3anHHwplBey",
-	"aUBa/EXALdi9qM1a1AqfW9GYYcpCOCN+bI1Xeo3vKS2kcG3TGOvjM0I5sdtIL7wCXpDfGeHNGnDK+ayY",
-	"uXIDW4nb9fsGZtcz563S69nd3V0xa6SVW/CBOH9prTN2TBnc+ULDW/+mpCcWcaGNXINYwspYYGIZDXPx",
-	"nFZlGvljC9dInFqB9qKRzoHDjSxleSMk/dNCCeoWKqKLroQFWTmhjd/gpk3rcSrlcSMKl/JjC3Y/K2Za",
-	"bnEvvJ77dmnBNUY7oE2+sGZZwxb/WRrtQXv8p2yaWpXE/MuGn/h//3K4+5+zsf+vhdXsevZ/Ljv5uuRf",
-	"3WUcl2Yc0y/yayVVDRVL09JUe+Hk3omN2eEWM0H974sgqhcsq1NTh8cvO6G+o9nDkvC1v4KsvgbvwX6t",
-	"nB+z9lsduGhWogJZXdT0MFQomto7XFVjTQMWBQzfVx62blpGLKxaR7yErUsHCIcvhLEVDbvcJ56/kcxz",
-	"VRF747jHiNxtB6qvcIGzuyJyXFor9/h3Jqnjdf7XBkhYQeBjvHfnpfWuYAmtkngugrRHidZtXeOhxZdr",
-	"6fhlXDr+IJc1zK69baEYiSBK4I+tslDNrr8PG+0v84f0kln+C0ra1nivk9xTek16wMOW6f3sxfPIiQK3",
-	"gcvNWCs8LlVsTF25cLIGDK6muZuPYc1uLp71GC42Eg8uyw0q0LSYUmrhbRsUGik4s3vkhNmRoo0aDI90",
-	"XNHK2K30s+tZ26pqNqJoMbNyN71KWgrrlp10wrXLrfIeSbFTfiO++efXotxIK0tUesKVtl0uoRLSB0LO",
-	"xTdB+SgnSqOdt1JpqATKzTWvVIrS1DWU3pDK90IDVKi0xBKNwX989+03gvlYkIATJbawXYIVpbQWVTUO",
-	"hNo/LHROmwIZVM5QZvdhdWibItF92G2BVoHOh7hVJhiwlbEC3sptU0MhGgsr9Ta8spN7fpXlJupGYQHt",
-	"SmTAmODdoZ08VHokfGmBPYZW0sOFV1uY3XtOkPH5tIlAzP6pM0Pn5LluWlbqVaVwhbJ+kUk4n9HxQSql",
-	"NlqVsmYRZhXNXHNiCbXZCWnxGOCLKDNWoo0VfiN1LilfsnahDatbiLxBKGFktZXN5dXVRWk0TqKMdvNt",
-	"JRyUxLan4+NY1qY9cCKVdl7WgeMMHJxpbQmiVrd4lnQhjLtorKkuoH2cCwXJG+3zzdR5/3ttlrKu96LV",
-	"6scWhKpg2xgPutyLG9ijbn8svBFPvvhjdpzm4pnuzr+FdPj47OEKndyCQPY7L7eNKE2rvcPzKkXVsgnO",
-	"18YMHoub9GKDMErTwbY4iU67n0smJk0qtTANC4FoNtJBkZNBoI1pPcyJlLqEeWkBlwC6omU0cl8beYD+",
-	"xONa/QSVCM8J0LdQmwauebdeekDdYqyQK1K+G2AKFfTPFZoUC00tS9gi3Zz6CcQOj5PySFm9Ji2uq24X",
-	"Vu5EY82tqsCKSnrJC62lx0M2vdL465SUGJSSBpAA5c1IRhpr8HC9OWQVwu+ozFFp9sbvb1y5cLBYnfAz",
-	"B8dNg3Qv4hGSS9MORpiWERzjRmnC8fHRQkQ247puTd1uYbRhfvQYcODFlCjJK2u2wTPwJqEmIesdorqo",
-	"UgkqqwYI4/tNsjVkOcko5hallBpNyVbaG6F82DudEQul0aWqFZ940/qm7ekpsZV7tEE1rDz+/KWQ4lbW",
-	"LeAfTlUgFmmeBUnVoj/mIihvlylvRFjxwB5U/ZEq3al8/t234t/+ePU4HEM69D+hf0CKflpz349RczKf",
-	"B04DGQ+i0k4pIV2iFjsZmX5HC/u9Y9LnJLcvwbW1P6CXTYdJ0SsWlcrU/1L6chOx2Vrdgh7zUJYlNB4m",
-	"9MI/zE5spd5HXuKINAdLRYZblPawBotLTmbFHRmQPRZCytLLpXQgZI2+6F5soD4wsgUkC1SHgWi2xITI",
-	"kT6gvd0LkOXmZPl6GSY7IGEDfiYa9vafLXmKuV+rFZT7sobpI5hp0aiVxEYh6fcR5oJYKhY7gXSyt7J2",
-	"rPDCg2LFbof2Zo66h0dckGZnnekZZ8uBAUBcyS6LNtHmEBg2O9LgOIB2OzrMT6+e9rBZxAGwbfxe1HGX",
-	"89f6tX4VIiYbWaMtZIBnKSKBup1+q9RqBRa3y5t24N1cLFgIgxpN210QwmeIHTdNO/DmBjQpaJSrQuw2",
-	"qoYBDXxnUMPmCqJYXA2Hi3gVPUuLvlerERBoI1xpGpiLb3WfijIBijiHi84YU53CONFmSbFgKITQe8HT",
-	"p0gP0B7AotUPRiwKwEpZ9EYDOYIaQyRAsSkrtVtxXKp/6JmY0yeJQFJHSyCSCIvITvdU+OIPSYkXeZSh",
-	"EBHpfrZ4KIWeGD695slz0EmE2ja1AlcIZK7zTLW5eLUz3ZvMrEQ7Qs6MX7yoQd4i/uwIvQS/AzbF2wAp",
-	"Eu8DI4lHFdTg2eFlTc0DsvOuCbPJuj6ZSklnPA8LmaJVXMj9Oi48d1fMdtIioHQHrEwSg9K0NfveIcQw",
-	"0K/iWSL6bmNcFNAEKPFNGSiUnPPwxhuW3jeoQEzr3wTfIKfNyE8+qpYTIYoo8LkgZZs+qp4TqSfV9EbW",
-	"qwvE88I1UovF93h0C+HNZwthbsGi4ik3KcSaxI2QdU9qWFmMzyoOeAQIDs5+Ef6zrFuH7vDStLo6NSTw",
-	"fv4HbTdf0mRkA12u6bHJGRvo2eroqB23yPU7MCx5hb1xEQ4pfeKCvTmF+qCrQHt426d9Dh3ZCvVepNg9",
-	"6CIISkKW6QGzEhJ9R6R32oFyB3l6HhQl6aJNRiIGFvVkYeqAZJH9PnFe/u0v4t+ffvH/RYjsiwq8VPVc",
-	"fMX21Fpju0CYykJZwRVSTriNbKDgBFBFAYsDGYPxeeHZJtBnu5X6Ai0pHUB429RSs2vnGijVSpXCm5BY",
-	"KcvWWtAlTIoEbWFCV74Ae7FSUFdhyw534DnAEMAGEQThE3qKqgrhQ6nq1vZVXX9TtSnH031tyuCacn7I",
-	"rFagK5QT8kILAfP1nNIe8ywAMLmjrVsfUP3KiZ01et15FeziklWQXtRhEfN7I4y4B55pSpyGVgyFsT1g",
-	"7v/x6tULwQ+I0lSQZQ9ZqnAxIcowu356dTXlT3jlp7D3dxtjvdj0hcW12620+5SIC3zEQXtTzf6zz1SY",
-	"jKZPh1D++ZJiuUBiJ1QF2qvVPmrZw1O2Vl97Wdf7axLL606u7uUI/RopkUg+xZ2XsGxVXYXU15SooPKK",
-	"Uobwm+Nse0QEIVoSwyRipWpKBwSjyPgpOgw8p7A8oQsgPAPWKbbAmZUbbXbu5DjuS1qUMLre90xCF6mg",
-	"Fw/E5I+GwO4fOvJuzJTD9L7H9Q9kCsSegg/8hD/ijXcLRYeuN9Tw1IwAFo89LTFr5TzYiDJfHYwbkt0P",
-	"YXuSG36RHM3cpQrU628PX37TpYz7oz/j5NB3PHZl5cqLJ1dPri4ePxGVKdstJR7YPiNAxgMb3S5F/8uh",
-	"jpRJiy/RunCZls86BwAcvgFvZemDCHTBGXyolJrM2F7U0rNXNqDagLz53qZJnAcpDkQRspRhdBo5rxPj",
-	"QuGRA07iQSSYJR5DGpDhfAI8dFLpSLOgMz91TJ2if8wvkCcU8Q+lJ2PKrIK3KV8ZFKLqBUsnTim9dThG",
-	"9MiJxjjFZSdslbu8CcXLCk6TxCDAT2DNoYDU4fxhIkpG4X4q5HXO3mvx6LZsWveIoUEUAhEYsn89u9+8",
-	"8sazNFNa4bTsHIq858GnmNDOoiQxkx2Ss6PgFFdY8Omxar3xQnO1xQPm2SYZ38VPjuD1ngsQ3igmdhnC",
-	"QMqHuFT26iMUSFOn6EIP4LPO6qIn0gtNeWe3MTtEsmFSTiNkEwbfmIJJFeNQDvsQADA36CE4I8xJUSbl",
-	"4gEMnnaHW8i4qiyfQlqhsVBR+VQXbOKKAbBuo5qUiE8DOPJk8YxwNJDclugxP3J5hK4IFOgFuBpJ8k2Y",
-	"chGCJPjDu3o1xawb5FT2hzeK3DVTnoXs3deBztsbPoNHliL9IINzuoueTXA4F4e/RK5r2EGKwUTB1tHV",
-	"sXw6p6c5mo8dJmF5vrizIsI+lJDwz6xQJNhVFL7s4HBwVPoUfNbHsiudNnufdOz8oeMg+gBFT0/CKu+g",
-	"XhVMrwBJewU752LTqfTsA0RnkEO7g4xOuVQOcpM6HYODgPcnFGd6TRua/QECP4riPprLqWJstgvBhXhk",
-	"UgxdSCZUojqgkh3kTi/nERW18uiEhxowHCTm4O8z3mwOM0EesrQvPj0BHQVuMkvY04tj3TFUV4Njfww4",
-	"3J885hCK7/yLM6sbh+7TKIdMRCv6HkIR6lojw6szUn5dOPx3mk8+7osx8GPnKz8WZEui79Bz1sLf2Qkn",
-	"OOApsRfiEAh61hIx3Zj976K2aTVLqI1eO+HNu2rD/niIQ1Swy3Hag/rxoLvJ4yYCnuB7Tmm0tqnux7GB",
-	"A2hKSW5CUdY71v4d0Tr5hntru0++pvXDgEQ9LrybfuBXe3ohCU5PFcT4wVnKgE7KwymEeO5D9p2OvzeV",
-	"3F8HIaeYwj7AHwrwmJ1owA6VnDMpMJaFIVZodAnaUW6RMvTsaaSRa+U8LmaPfqZTel1DUKxdboKq/ulJ",
-	"VroM03m37sNppzwFPKmcQrWXGwcBB07poBS5qdsQNAjp15RwCPVNU3XZD++gHo+nDGs+uyKv3m647uDI",
-	"+L9sDecUlH7Hms5THIix7x0rYgNnQy5ZZBEm2YNmoYavX36M5gu98XFBOo4f3Z0bgMaFKgxA+ZNdoSjV",
-	"qS9hb4LZNDpmtlDsCMr/9hybQwWm71e/HjiV5P10T/icqlYYFbU+jBd16tCH61xRJlO5amNN1ZY5OYqs",
-	"VpXypnkBaZT/XSzSCH4KPmWrQdF891BQJlaUtVRbmD6351ehviP6yAKW3Zw9ddbzi6KrdI5/FMtAoi7q",
-	"C+gPU4F4B2Vrld8TgAulko16ZW5gIuT7TJMoc9FZwPwI95+1fmOs+omYdS3+DNKCFa/bq6vPS3qY/gmL",
-	"ufhKlhuB9oetCjv7XC/GYSkNULkvhQyT8A0JDrNmpXifpzuIuJ0lzdcxYON9wzHyNTh/eC+xoNQCBd1l",
-	"XQjlXItKGqz4Q2RGwR7YZxxCfJddP/ehRI8uWQaTjnqckbhUVsg6BIFO2JUHq2V9YF8UEthIpJOD0gKf",
-	"BborKl7R7YsOB3IRaarToHsApvXgyKAU77zZEOUNxPRGNO2yVmW40OpO2OYdbXQ1UZPyFSuhmG7K/GJF",
-	"l19S4WjrENMxzWNehgiARlC5LslVmlu0hlRJB7L2G8pCI9iG4VwRNiq0PKiBmJfdIhzPnWLEoVgm/nxB",
-	"blhEqUX/9hvcKth1NY95ySanP+cpiX09Y1a+TLt79uL5rJjhRphMV/PH8ysUF9OAlo2aXc8+n1/NPyft",
-	"4Dd00C9loy5vH192ZZJr8FMZX99aHVPUea18IbS0liL+yz3jDoqBx8x3du04Rp0YgZAXg2LSK67s6imF",
-	"dCXXeMzFYmXNNhTEerMQDtBMMLtSVdpO6crsBnVpufJO01x34En6lMYMkygXanG44i9/AKdmuZ6/1nyz",
-	"q66DTmIfhoIaYkF+wCJF2ToQz6ztX3nOjRp5UTRquNScRVJQIxL6G71O4+sqRsF3sr5hGvMzwWeQXTqQ",
-	"YtGhTg9qx15WYwGxXAjuxZveDJRZd0Se4oqhrkUFKwSM1wEZ8o8xNM60oSRwSCyhnosrMHonbeXmrzUd",
-	"RPLVIsy6CKmhftgxnB7+bS6eJfzGVoLvd+d1zFyVuejM4yLYGsMX4tGDjJmkgusIqwgE49WYYcQ0z5kj",
-	"No91x3gc5E7uQ7IL7EV6kRdGyx6VWVPp7U7uQ11tHE1szW3KUEXwZWjBGnZp4xHxb6QOC0cKR6r0ysRh",
-	"vBGu6ibDUFciWJ5klp9Xs+vZ18r5r2I5aX6j//tRKRGemK4gZHAlJhWaTN60DyDn8EX74rzZ8qjW1IQZ",
-	"wHq4OZnqBUlYdx12IqUhngWBle4mlQp0vki4TYUvsshMgJ7JTfVA4Ptui0t2D5f1TK1gFE57KNpyGIgv",
-	"1QUPvH+3bno9PVD93osh5Uy8HTkwhxaQoHg3Oeh2SzmQ6OcwPM/cnAyhn820oc8aYkCTddLJVpDRPLSF",
-	"UDLbbeA0n+e09ebtPXpLHZQVn7ZULut9z4UO74FFk54sufRia9zBriG12irfW0cFK0l1bY+vrorZVr5V",
-	"WxSBx1f0p9Lhz6n6s+mwbaeGL0NXlbsfBo1InlxdHWlCcl7zke725ET7kaP3Jx+i5Ugxe8p7mXoj7bnr",
-	"kILPPz7z+c/Pev6Ls9aTOddkNDu3+vsfkG2h2DaY2j4NKYRlpjILFD1GcMKXHs1q2GHAZV1gEFQpwlEm",
-	"xZU5ekgRfqq5Z6EWKJThsG3nfIONTQ8O8uTqiqq7Id4kSH2COEeMaEgGBzHcCIo1xUXXkyIUu6lbVbWy",
-	"DlcZK1VdZ+VyvWYPBDZvoPEh3nNB5jEVaE/W94XJYyZei0W8nbhA89sFmbbcsSJcUKusaVjRUM0TE5eg",
-	"K1rjZbtaERFDICzcvSS3iFH9tnWefF4L3u4JO/KsqYKvj674ymvCV4GefzbV/qzTazR8uyLpuvccc/8K",
-	"1CwnZYZ67wzyQj/c9WNb3rZw9wH1UO9+8IFOSMwxFITGmhKcG7dD2uXJAcbUvyFd9fhj6qpe5Gyorpgd",
-	"SVPdFSmQEIX+4qyIwrFeQ/nJL045+vSr3DHbJzr2jOIPvRudDxl7WGQjL3p1v/FS1aBwdhDFpm4dseqU",
-	"Ith032AjbyFJcac6U8uze4Mak0++T3SD/utTcGMiuAFZqBt9uWqr9AVC4esYCg0BbpyGfuU4uLTQd/zE",
-	"N+l+enANSZuCK8QSStk6SILPfaJWZIKyovjIMG2EhVpROjmOKL23atnG603jOECvAv/ceADb+XRGfyuO",
-	"Sn/Zv2Z/JTTG+1/vrgy6Et7jsxzqS/jJdTnbdRn0Asy8mB42yFIgp0KDrIYqS8f1ok2fcf6sr9WHJXx5",
-	"xyMLotxAedOv2JtSel1tFGP0DyS3o3Kyg80+jxSUPZTYPv51idXBPR+Rrcufo6jcXf7ck5W7TOz6DP87",
-	"9Pj9sdh9Lqt/OU4/vXr6q5CMlyCrAGOnSTS7uweenFxze7CBXTCojfSbycxC3zM+KwB9Ws1u1nLu/oWN",
-	"C0hOXd0PxSz0vBzqaCa9G+lZsyLeHNfVBRf4UHtCl5f5xuZYGWu50Joxf0rYn3KNVXbV29KLyoALpW70",
-	"Ht3ay7zG6DKE7jhjg/CiHeuHdwvZHFcNE5eJP3Kw5TT11KuZj/cgtdllvPv9gqmPG4s5pgvDFXI5VIET",
-	"tvF+yDXuE+Y4YpAXZj9EycfgQssbTvJlhW29IMzZ8Qhe+KdwxCAcMXETjEt7ERxTUzi+pkq3rBZdSy+k",
-	"Y3Z1VTjwc/HS7EL9MHAh5tbcJs3bv7irnFgjw7gaP/UaocsDHLGzpl1vaBnxrjGudqrEI7I31HdESeoS",
-	"4MEbmKjyCNXIXKOBz0RxqKBUFbiw9nT1F3fO3OAkPuUj0Bw5s4WOo2Fb4ZsCPqVNjvsU58ZQjvTv+DBl",
-	"FRPX0j5GZcXEtL+T4opfqp4i63pCRybeVuRbo71GHgrPwKb1ZrU6pcYi3cY8fW2hClzadFhWNQAecY5Q",
-	"z8VCll7dwoL/Hh34tGrEcun+alRP2VuGeq3SdQhSYLKu069L4zfzpOfoZ24JtCCNpnQFDeiKrpGzrk3d",
-	"lLW3slIlFVaREnFtuSHbQaP9iVf/ur26evJHHvNPaW17vj3RXQmOlyAPEbd10+G5Gc8yK1JJSfqPMNms",
-	"mMm6PqmcZKI9zqdIYu/y7z1xxMnrv5+CiO8U7RnRchrJXv5Mqn8U3cn+VtXdqWXNebFk8F87sHtuH1jR",
-	"L5xgdNTItdLSI4AzEcrGszVuvsvYeSv3wgEcwLHZxUr+Ykrs94EIbsuZCqmpqOOqX1nSN3tPnog/LIad",
-	"1WKfUm/Mm9ro9eKzXmZSCm9bXdKV5/Dol2Lx969eiX49+YKOiAsqMoN2r0LzFUKGNIzRvb4tgzY0g8bM",
-	"4c6IqbjrWh8mBjNBBj45/QjLGYseBIw5VXD6p1dPhdSi1Tfa7LoKZLEG74YoN0ILjmTgzKHZ/hKEx6kJ",
-	"lpvYpT8tC94q52O7yNACMl2xih1yxoXCccMdIs4NauoF7PlTOAn+xtJfdklISK5DHi4rPo4lwSnZ6E3j",
-	"ugY9vb4YYKG7raBhF45OXFWQtyB9TsXimTRXLlRd6U1qNzQpUpw/D9eO84WyK5MvNMp7asB1HJJntTi/",
-	"RDldcpG7U9V9uC1qI3bQesqAVMBvJir89MmTX08UObvZN63+Twolv9fnciYDtt3Nv/cKI5//nZIHDh8X",
-	"79f859ha1Hn0+eE9UESdf7/gXiCRma384wRdK6q8cGiinTvy697vOX1RcPwqDDiwj1EjZ8XrWWv7vDPR",
-	"iu3i4KoZtfe0rXapHWS3PA7aRPWrE36JXzfA+UuDPKRv2LzWi9h8PN6/2R3vsz7ojRQa/cfLLqmlei62",
-	"U4ACaZBZ0Ph1st7dnGQp3fkfhsDxDyAAwiGPYpChV8mTjPnTq6dF/6pRH8Xw9yzIGR2Y8Ue9u2TygyO/",
-	"ufibqcmkykjQjm7MzK4/QCcnUyjFNVLHTEHXVe86Qx+9XJ5yvY9U9JBDCGrGorpMyNKHJtyJohTEB7ZL",
-	"qHCy+z6dwd+WzLsY0jFBPvU6/5VSx3aDB7oNTnRJd7zK0YctxJ9VXTMdso6DYzyTZbG7z658QETTTXJP",
-	"oqjIo7sdaOz2rXz+EZdPeOZd8Uw4MslofYI0v2dIw9fVfzqCTFgb7jYQXC2I5fHCbcj2ovZGa6+p3vk5",
-	"f0rYcfy4+7ggeqcq9EJcAqBjzHPvidxoK3JPrjR6pdYt2zwLDk1pQBPUX5UUG32+OX0Yy7Ser+sHPR2y",
-	"ZmMd94+w53vVmoe3/rKppRootK6lvLmZqLOc1GNx/xR6UbcPWIfzxZkxvi/Oitnd9cNst6CR9dTegENr",
-	"se/DZWflLkO3AepcN3kHiVvAu2kHaqKRPUfRQ/G865BwZlkJzaTsbhkLOqrs098+L6eWtVi30krtAcQS",
-	"NipYlAyIuuvu6pEcWnECd8UgYpJB12C/6ZIndfpbSzVRHB36179Ig3+wwpDedwk+eklI3qX/oKnnFv0r",
-	"pZXb/KbKPz7y1Zpe+5axJWcy9s8HH1aqjjpP20fFheJMIUbUvauVKjNd3+HQpI2VE622IMtNvMNHHWLl",
-	"TUjJNaaKKW9rvExN1cLNcVThXN4wdWRoE7+U+uYKs5hwTNT4LerzlxTszBX63d3/BAAA//8=",
+	"7H1tk9w2kuZfQdRthMdx7OqWLM/ttGM/aGY9M7pw2ApZvrsIy6dCkVld2GYBNAB2qezo/76RmQAIssh6",
+	"kVqyrdE3tYokgEQi88lX/DorzaYxGrR3s+tfZ2uQFVj65wv4uQXnn/0n/lGBK61qvDJ6dj37m7EWaol/",
+	"CVUJsxJ+rZyw/MZcvFyDcGDvwApZmcY74dcgjAYhRSnrGqxwoCsnpK7EDWiw0oOjB4xfg90qB18J5YVs",
+	"GpAWfxFwB3YnanMjaoXPreibYchCOCN+bo1X+gbfU1pI4dqmMdbHZ4RyYruWXngFPCG/NcKbG8Ah57Ni",
+	"5so1bCQu1+8amF3PnLdK38zu7++LWSOt3IAPxPlba52x+5TBlS80vPGvS3piESfayBsQS1gZC0wso2Eu",
+	"ntGsTCN/buEaiVMr0F400jlwuJClLG+FpH9aKEHdQUV00ZWwICsntPFrXLRpPQ6lPC5E4VR+bsHuZsVM",
+	"yw2uhedzbJUWXGO0A1rkc2uWNWzwn6XRHrTHf8qmqVVJm3/Z8BP/878crv7X7Nv/ZmE1u579j8uOvy75",
+	"V3cZv0sj7tMv7tdKqhoq5qalqXbCyZ0Ta7PFJWaM+v8uAqteMK+ODR0ev+yY+p5GD1OiLbUgPTy35r+g",
+	"9OM72/CPwhth4UY5Dxb30InFn8ratFUh4I0Hq2X9WlWfL0QjlRVr6fCFJR8AZlp81+5EZYB2UKxNXYkd",
+	"0OY11jRgkUmJ8Pjd8dko7byswzH02fRqdYfcowth3EVjTXUB7SOxMlbAG7lpasBhNkp/A/rGr2fXj4oh",
+	"KxSzbCGHaUHM6QTNUyCvucCERwbYgJeV9HL/6/93LT2edgG1Azq1xvq1uAVokNPlEnk9W+9cPI0kjbSQ",
+	"XtQg7/gM4ePOGxtOPWwavxNmSa/O0sz4P3BmfGDGZtWjsnIsy6oTFtvU0q+M3UyQMvw6sokGN7EB3Ony",
+	"9qwtpMP8c6ssVLPrH7sZFIGl+lv80wgd/hNk9Q14D/Yb5UZOxHc6iDWzEhXI6qKmh6FCWa2922dm5WHj",
+	"xmlgYdU6Em6wcUmj4OcLYWxFn13ukhB8LVkIKqJ++u4hqdMtB6qvcYK4xrBoaa3c0d53onuMBcDyCcbH",
+	"eO3OS+tdwSK7SvJ6EcR/FPG6rWsRjmktHb+MU8cf5LKG2bW3LRzbRV5of5qHty6udXT3lL4hxehhw/R+",
+	"+vxZ3IkCl4HTzbZWeJwqSat4ygcbPCEs8m9Ys+UT2204yUhtmG8QUaTJlFILb9ug4Ul4mu1nTpgtIY+o",
+	"0nO5g1wu/ex61raqmo0cRiu3EwIVp8LKdiudcO1yo7xHUmyVX4tvf/hGlGtpZYkoQLjStsslVEL6QMi5",
+	"+DZoY5QNRqNAUhoqgXxzzTOVojR1DaU3hIG80AAV6YAloqP//f133wbZVBCDEyU2sFmCFaW0FrHLNgpI",
+	"nuicFgUy6OAhz+7C7FAyRqL7sNoCYRKdD3GnTFAlmZQpRGNhpd6EV7Zyx68y30SwICwg0IobsE/w7tCO",
+	"Hiq9x3xpgr0NraSHC682MDt6TnDj82ETgXj7x84MnZNnumkZ5VSVwhnK+nnG4XxG9w9SKbXRqpQ1szBj",
+	"Ft41J5ZQm62QFo8Bvog8YyWCTtRUOueUr1i60ILVHcS9QWxtZLWRzeXV1UVpNA6ijHbzTSUclLRtT94N",
+	"PFhwprUlnIIeEB/gFEbBwT9qs5R1vROtVj+3IFQFm8Z40OVO3MIOZfsjBESPv/xzdpzm4qnuzr+FdPj4",
+	"7OEMndyAwO13Xm4aUZpWe4fnVYqqZUyaz403eFSNr9Gu0HSwLQ6i0+rnkolJg0otTMNMIJq1dFDkZBCo",
+	"Y1oPcyKlLmFeEoKcg65oGo3c1UZO0J/2uFa/QCXCcwL0HdSmgWterZceULYYK+SKhC+CF1xaQf9coUqx",
+	"0NSyhA3SzalfQGzxOCmPlNU3JMV11a3Cyi0CjDtVgRWIvuZnopMBlxyAJ/fEjHi4jkJIs9UoNHvf7y9c",
+	"uXCwWJzwM5PfTR/pXsQjRMCx/4VxHsFv3CpNhm18tBBxm3Fed6ZuN7C3YH70EHDgyZTIyStrNsFURnAa",
+	"UJOQ9RbNnChSCRKqBsjoJWDLwpc0JynFXKOUUqMq2Uh7S6icgRieEQul0aWqFZ940/qm7ckpsZE71EE1",
+	"rAgyfyWkuJN1C/iHUxWIRRpnQVy16H9zEYS3y4Q3Iqx4YCdFf6RKdyqfff+d+Pc/Xz0Kx5AO/S9oMJOg",
+	"H5fcxzFqTubzwGkg4yQq7YQS0iVKsZOR6fc0sY8dkz4jvn0Brq39hFw2HSZF00pUKhP/S+nLdcRmN+oO",
+	"9P4eyrKExsOIXPin2YqN1Lu4l/hFGoO5IsMtSnu4AYtTTmrFHfggWyyElKWXS+lAyNqCrHZiDfXEly0g",
+	"WaCaBqLZFBMiR/qA9nYnQJbrk/nrRRhsgsMG+5lo2Ft/NuWxzf1GraDclTWMH8FMikapJNYKSb+LMBfE",
+	"UjHbCaSTvZO1Y4EXHhQrNju0N3OUPfzFBUl2lpmecbYcKADElWyyaBN1DoFhsyUJjh/QbkuH+cnVkx42",
+	"iziAnQZ1XOX8lX6lXwYX4lrWqAsZ4Fly0aFsp98qtVqBxeXyoh14NxcLZsIgRtNyF4TwGWLHRdMKvLkF",
+	"TQIa+aoQ27WqYUCDzHcQFlcQxeJs2H/Ks+hpWrS9Wo2AQBvhStPAXHyn+1SUCVDEMVw0xpjq5NeMOkuK",
+	"BUMhhN4LHj65PoHWABa1flBikQFWyqI1GsgRxJgIbhdvpXYrdtT2Dz0Tc/wkEUjqaAlEEmER2emeCF/8",
+	"KQnxIvcyFCIi3c8XDyXQ04aPz3n0HHQcoTZNrcAVAjfXeabaXLzcmu5N3qxEO0LOjF+CYwz3OhF6CX4L",
+	"rIo3AVKkvQ8bSXtUQQ2eDV6W1PxBNt41YTZZ1ydTKcmMZ2EiY7SKEzku48Jz98VsKy0CSnfAiUdsUJq2",
+	"Zts7uBgG8lU8TUTfro2LDJoAJb4pA4WScR7eeM3c+xoFiGn962Ab5LTZs5MPiuVEiCIyfM5I2aIPiudE",
+	"6lExvZb16gLxvHCN1GLxIx7dQnjz+UKYO7AoeMp1ijkkdmOXbM41LCz2zyp+8AAQHJz9IvxnWbcOzeGl",
+	"aXV1qkvg3ewPWm4+pVHPBppc498mY2wgZ6uDX+12i0y/ic+SVdj7LsIhpU+csDenUB90FWgPb/q0z6Ej",
+	"a6HeixTMAl0ERknIMj1gVkKi7Yj0TitQbnJPz4OixF20yEjEsEU9Xhg7IFmoq0+cF3//m/jLky//lwih",
+	"LlGBl6qei69Zn1prbOcIU5krK5hCygm3lg0UHBGtyGExEULbPy882gj6bDdSX6AmpQMIb5paajbtXAOl",
+	"WqlSeBMijWXZWgu6hFGWoCWMyMrnYC9WCuoqLNnhCjw7GALYIIIgfEJLUVXBfShV3dq+qOsvqjbl/nDf",
+	"mDKYphwwNasV6Ar5hKzQQsD8Zk5xwHnmABhd0cbdTIh+5cTWGn3TWRVs4pJWkF7UYRLzox5GXAOPNMZO",
+	"Qy2GzNhOqPt/vnz5XPADojQVZOF05qo5xWrIyzC7fnJ1NWZPeOXHsPf3a2O9WPeZxbWbjbS7FJkO+4gf",
+	"7Q01+z/9TYVRb/q4C+WHF+TLBWI7oSrQXq12UcpOD9lafe1lXe+uiS2vO746uiP0a6REIvnEYR+P8bKp",
+	"woHdDuqylyQFbZUTt7CLqHEs7lsEXF8tupyDdUhtQPnIYUonZFVZcD3oLpa7DxgD3tvMDrYfUBNxiC25",
+	"lSK1TlfL7xZajrolmDyqIvMsuNUIgo2u7MhYIdoVRPdZ4aRTA9kUUmIX1EgIm/XqMD5NGyYTQTLeDLhS",
+	"SL17kCB2wTr9+HhEnBO8RO8r6H1C4OdIrDsQJ9u5HuMfkBjHfYz70uM8T2Oyrid9jXwayM8Y1nSOqzGK",
+	"vo/XzfgClq2qq5DoM7YSlB4RQjjO5WlquUNzL7jCow9crFRNsd5g8bBxrPtH1PKALnhYMq9Jchxz2PxW",
+	"m607Wbq/oEkJo+tdD+93rEEvTgRcD8Y3jn86Kub9LZmm9xG/biBTIPaYbchP+AOu1m6iW2B/U/rUEBLt",
+	"Wc/87XGO4TMbXQgvJ4NCZNSFmGyWAxakZrfzgXr95eHLr7sEuf7Xn3Lk/3v+dmXlyovHV4+vLh49FpUp",
+	"2w1FlflA4bFGNBZ9aor+l1VLSpOIL9G8stwo9u46fAPeyNIHFug87/hQKTXZKDtRS88utwHVBuTN1zZO",
+	"4twDPYG7snyQ6BHkoH10+odHJjyAk3AiyyoJOR4MFKp9rcuMzvupY16MjMiiIjdXBkC265gPUcGbhPUC",
+	"2lW9SNgYJMG3pgMAnznRGKc4yZbFZxcUp2BIwTHw6OH9BayZijZMJ4ckomQU7se5X+Xbey0+uyub1n3G",
+	"dl9kAhE2ZPdqdoKSpoVnOQRphuO8MxVWzSMLMVspc4HHNKWQebMXeeB8Uj49Vt2svdCcW/qASRRvj7J7",
+	"/p3wRjGyyuDjVz4EHbJXP0OGNHVyHfc0MsuszjUuvdAEVt3abBGjhkHZ+skGDI5PihRU7GRgnz5Zd+YW",
+	"NAkhc1IIQbl4AIMbtTNKGZ9mwXKSCo2FipLFu0gCp4OBdWvVpCyrDOAuFQLcGOohGBLdoZ+5PPxSBAr0",
+	"oheNVBH/ikXwgOMPb+uyKmbdR07d/vBGkfvdVEDLbz8PBGOv+QwemIr0g/D86YZeNsB0ogX+EnddwxaS",
+	"gz0yto5+LMunc3yYg8k2wwwbHi+urIiwDzkk/DPLAgx6FZkvOzgc+ZI+RRb1IUzbSbN3ybWZP7STW09Q",
+	"9PQMG+Ud1KtiOgv8XGw6lnvzAK533KHt5EanRBmOYJI4PWKS9wRnek0bGv0BvPqKnPqac2Vj4K2Lr4Rg",
+	"UxIMnb891N04oHxM3J1eQDsKauWFWa1Cgi9+JCZYHVPe0aLOjOz+lvbZp8ege175TBP25OK+7BiKq8Gx",
+	"PwQcjlvt7B/3nX1xZur60HwaN9qLvoVQhCqeuOHVGfkcXazzo7XiD9liAz9tj6zJdugZa+Hv7IQTHPCU",
+	"tRGczAh6biRiuv3tfxuxTbNZQm30jRPevK007H8PcYgKejkOOykfJ83NzqFNBDzB9hyTaG1THcexYQdQ",
+	"lRLfhIzbt0zsPiB18gX35naMv8blw4BEvV14O/nAr/bkQmKcniiI/oOzhAGdlIcTCPHch9QqOv7eVHJ3",
+	"3S9hY/hDDh6zFQ3YoZBzJjnGMjfECpUuQTtKHKH0q0GcpVbO42R2aGc6pW9qCIK1CzxTjSM9yUKXYTqv",
+	"1r0/6ZTn94wKp5DK6/adgAOjdFBn0tRtcBqE3JoUkgiRA+U/hIF62J8yTOjvMnh7q+GksgPf/20T9Meg",
+	"9Fsm7J9iQOzb3jFqFXY2BlgyD5PsQbOQoN2vLUH1hdb4frURfj+aO7cAjQspdoD8J7sqACpCWsLOBLVp",
+	"NAwjYX88w2aqeuDdipPCTiV+P90SPqdkAfYqFh7Gijr109NFDMiTqRahsaZqy5wcRVaIQEkxeXVA5P8U",
+	"DQ92Cj5lq0FFVPdQECZWlLVUGxg/t+eXGLwl+sgclt2YPXE2Gnw8xz6KOX5RFvUZdEwZ/UBIZzKngUO+",
+	"JjjfUqpeVjsdJFbWTiEWT3PlNGng4CjlCBg94Diuw66bTVbm3lhw4XRslM7L5x4NVdd07JyFHP/a8whG",
+	"05c8gtpsReCtUAnlQvEUndRgsZMT1Mkaeky2BBQbG7A30cuUCmoiGSgdO1jLcVwGMxnN4sRIyD5ILL63",
+	"thPqvPdZomU5M8xdaCSeJRz8//94dfEXebF6evH3n3799/uL/M8n5/z56PH9v42eGwdla5XfkVkRqjMa",
+	"9dLcwkgg4qkmAct57sESRSP0aevXxqpfSIRci7+CtGDFq/bq6ouSHqZ/wmIuvpblusutCS4oTlFnZ6kG",
+	"qNxXQoZBuCiTnf9Z9v8XqQ8ILmdJ43XLW3vfcOTmBpyfXkusYbFAoSBZF0I51yJ0ACv+FEVEwX6Bz9mx",
+	"/TarfuZDVQA1OglAE9EF24dSWSHr4Jo8YVWcTzCxLnJUrSXSyUFpIU9qekkFn511wnUrKTWUSg9N68ER",
+	"zCneerEh9hCI6Y1o2mWtytBUxp2wzHta6GokDfZrVo0xCJp5axTV26ZaldahpcE0j9FCIgBCM+W60Gtp",
+	"7hCjUfI+yNqvKfENTUAYjhWNGZQwlMnLe9lNwvHYKXIR8nPjzxfkHIi2U9GTK93/9srw4U7Btiu+yGtH",
+	"OFQ/T9l01zPe4BdpzU+fP5sVM1weE+9q/mh+hUxkGtCyUbPr2Rfzq/kXLHTWdPwvZaMu7x5ddvUaN+DH",
+	"shN8a3UUtHnRXiG0tJaiU8sdY2SK18QsjVyDxVwwQstkcSPz9Ko8usIOIV3JyaZzsUDhGypzvFkIBzW1",
+	"fFnn6fFbpSuzHSTI50AjDXPdAX3pU8g9DKJcSArm0oP8ARyauX3+SnOJeV0HScX2NjngxIJs1kVST53B",
+	"GbIQe82IcgBGFj99NbQbyrx+KCfJUtl7nb6vqxix2cr6lmnMzwT7Vnaha4qbhIIBqB17BAJECKo19mBi",
+	"o44lStxTnDHUtahghcbNdbBi+McYxmHaUMJCCIKi9IszMHorbeXmrzQdT/IrRJPgIoQx+y7ycKb4N4RI",
+	"XeOfW9Ch81JeUMXlIYsOyi2CBgoISXmXop4FFzRU0WiJNbpD736e34F2ZCyAogTCrdyFwCzYi/QiT4ym",
+	"vVfvRTVAW7kLECd+TWzMXYqmRkPB0IQ1bLtcz2CdrqUOE0cKR6r06tVgfyFcXkbqoq5E0EdJWT+rZtez",
+	"b5TzX8e6lrzX1o97Oc14YrrkpUFtbkqKGu2BFQD5dAus4rzRcg/s2ICZMfBwY8aMVRyj68sxEn4TTwPD",
+	"Sneb0lo6uzmUdeOLzDIjUGh0UT2D5V2XxQbJdAra2Az2XL8PRVt2WXJ1f/AWDfNPx+bTMwDfeTIknGlv",
+	"94ztqQkks7EbHHS7oXhdtMnZlMxM8syaPHvThv6V4K8cLdhKuoKU5tQSQu1Ot4DT7PPT5ps33utNdVDf",
+	"dNpUub7oHSc6LEiPKj1pcunFxrjJfn612ijfm0cFK0k5mI+urorZRr5RG2SBR1f0p9Lhz7FcyfEQQyeG",
+	"L0O/w/ufBi0CH19dHWgPeF5bwK6Nw0hjwIONHB6iGWAxe8JrGXsjrbnrXYjPPzrz+S/Oev7Ls+aTmdyk",
+	"NDtj+8efcNtC1U9QtX0akrvVjEXBvue+eTJ0XzCrYasjl/VnRFCluMglxUDY003RKCr+Y6YWyJTRdTTn",
+	"UnpWPfiRx1dXVGYGdwO3VMhnQDQkg9kYSpNjcVPRNccKiZnqTlWtrENPhUpV11lqZ6/rlOPSnsYH3+QF",
+	"qcdUKTaaixoGj1kjWixim4QFqt/OIbrh1lmhUr6ypmFBQ/l5TFyCrqiNl+1qRUQMTtvQBILMIkb1m9Z5",
+	"soQteLsj7MijpmzTPrri3hsJXwV6/tVUu7NOr9Hw3Yq46+g55kZaKFlOimL23hnEMH+67/thvW3h/j3K",
+	"oV6jkokepbxjyAiNNSU4t9+odJsHshhT/4Fk1aMPKat6/rShuOLtSJLqvkiOhGhRHXUl+PVYXZ97CH/C",
+	"aN/Xzp1wtu3eze2T9d6z3kctxueRA86zGferrD6EHbc36nu2VfNOLcr2jEMannwIz7JOFtSdT5MKMlvO",
+	"4vZbwy860brosSBXQlZ9RlHopfHrWOLe6hoc8iO+uQinjLkvpHpMGVK9Mr0zlp7QdEfkf3k8nRctHkHU",
+	"E2WLn3D12bh6QtVMI+xYfRY49i1Lzq9RaEvFKY2x+xinGvWcOn8ZeDopZlqlsGfDzX56qVoMw80d2K1V",
+	"PrSf5dQbFMfGCtC8WLayA5yn8vfuxKdjqKiF+8kF8dwXNJc1NdIpdk4vxBJK2TrIJRVibTzVWfetXteq",
+	"6Ard1yn9HvBvD5QPHcv+GCdh20cPLROmYG2v8p4Vw3ZQ45/JhNiyYzxW+MOLbyLOiE2k4p4elu0fk6x5",
+	"cvWX34VsilKm8/+OIunLX1V1n8Hp/un4B/j8aLxftTV9O8Ref46PVlM9uXryO+EeWYUi7iHxZ/dHoPdJ",
+	"TTYIkDXSrzs8FspCc8FYnMhBlP5yj0to0Ewfub8mtMeLnnZh2F2UEo7Mqq+Nz02SItstfo0sr6hqJ5KR",
+	"OA3p3dOPXulvgwvO51mXOixwwl5F4E+tkVRIUgbLeaY7gvbJ6BwDJLxYmQUDCWjfcWsFqVnJs/FBJcN7",
+	"SnlfDfdT2t6PGu6P8YFdTGepYdTBzktduU+S7n1LOuaKSVmXqczocb04K53l0I0budu5OMXvTL/KLfsc",
+	"R+6t2HNW9fqaPmTiyyL78qLXICG2Fhx0GBik+4LOyvMp1Zekx1reQXKhdn77dBPW0Yya0SffJbWG/uuT",
+	"b24ksway7EuU89VG6Quj6911zM4LOZdkE+KvnJqJCqaXdSC+TV2aQ14CyVlwma0XGJ9vS1mRysy6h8QN",
+	"00ZYqBWptCRSvbdq2cYmf/suxV6rknMdixxkSmf0jxIl70/79xwsD9dD/cv79gZ3cx1x703dzvXJv/dW",
+	"/r0xcg6wQZaVeyo0yPBGliHeS3X6nH18fak+rHXO7/2wIMo1lLf90uYxodcVkbr3adzv1d0et/L3K28f",
+	"im0f/W7dxv01H+Cty18jq9xf/trjlYNunF7R8Afa7nO3+rfb6d+z26VHotOcL6c0JzjQcHPEN9Orwp/y",
+	"0BxV6qc1N8guXjo+sf1Ku1Nn91MxCze/TYVnhnI2+IgOy+qCKyHz0jR+OwZpsq3ljhSM+VMNySn9/mTX",
+	"5kL67lLZ8B57nzqrMZoM4Y6IfYXwvN2XDw/vfxntuviB3TCniadec5GTAiMfk2Pm0Re/twDGQASO6MbT",
+	"MoL6t+U49hjkHSweMD+oJxqyP981XYgn/skdMXBHjLTM4h4ICI7paiTu50ftqBbdxTZIx6zHn3Dg5+KF",
+	"2YZGC8AV6xtzl/nq8w6Hyokb3DCOB6SO+9RlhT121rQ3a5pGbMqIsx2rL4rbG4qLIid11RfBGhgpMQpt",
+	"G7hAiLICAjtUUKoKQhV3V3hcDfz0lAyL6siZDXQ7GpYVrprvZ/NM2xTn+lAONDp+P3lSI/27PkQ62Miw",
+	"H0llz29VzJO1h6YjE9u6cXu9Xsdj6mSwbr1ZrU4p8Elt606fW2iXIW06LKsagFoxkId6Lhay9OoOFvz3",
+	"3oFPs0Yslxr9RfGUvWXoxkHqG0MCTNZ1+nVp/Hqe5Bz9zBdjLEiiKV1BA7qifpssa9OdotpbWamSqvpI",
+	"iLi2XJPuoK/9B8/+VXt19fjP/M3/SHPbcZuZrndi7BY3RdzWjbvnZjzKrEj1TOk/wmCzYibr+qRappE+",
+	"4p88ib0uiUf8iKN9Ej85Ed/K27NHy3Eke/krif497072t6ruT62pzyt1g/3agd1zb0MU/aodRkeNvFFa",
+	"egRwJkLZfu5CfgUlY+eN3AkHMIFjsw50qPe6xsiI4DYcqZCaKoqu+mVNfbX3+LH402J4v1C8rc8b87o2",
+	"+mbxeS8yKYW3rS4peS08+pVY/OPrl6LfzGBBR8QFEZlBu5ehSzUhQ/rM4J6eQb/uwfWkIVvbVHw9RR8m",
+	"BjVBCj4Z/QjLGYtOAsacKjj8k6snQmrR6ltttl35u7gB74YoN0IL9mTgyOHK6SUIj0MTLDfxruo0LXij",
+	"nI+XpoUs8dSLKrYS369S71pYREScK9R0IyYnrHfwN9ads0lCTHId4nBZ5XusR0/BRm8a13Uy7zUQBgtd",
+	"qwwN23B04qwCvwXucypWbqWxcqbq6r5SX/ZRluL4eejPmE+UTZl8opHf000FhyF5Vgj2W9RyJhO5O1Vx",
+	"SztpxAZaTxiQCPjDeIWfPH78+/EiZy3QxsX/Sa7k4+0kD143NuKw7VqkvZMb+fzb+h/YfVy8W5f0Q3NR",
+	"59Hnp3dAEXV+i/cJFXVJbeVXdHc9+/PEoZFLjXG/jKw2srm8urooDXVZUka7+YZaTBGXfVmw/yp8cKAf",
+	"o0TOOidkFzznLdxXrBcHfY7oHiTbapfuzemmx06bKH51wi/xjm8cvzSb0Ipu/kov4hW8sfnL9vBtw4Mm",
+	"8uG66+6itZH+E2OAAmmQadCtDNVfeWOYpCnd+dejc3rnKAIgHPJZdDL0MnmSMn9y9aTo97npoxi+1Z2M",
+	"0YEa/6zXyEi+d+Q3F383NalUGQna0Y03s2uk2vHJGEpxjdQxUtBdP3KdoY9eLE+53lXtPeQQnJoxqS5j",
+	"snTdujuRlQL7wGYJFQ527AJ5onvvuhc6JrhPvStSSqnjvSwT17KM3BXseJZ717uLv6q6ZjpkV7Ps45ks",
+	"ip1ut36fiKYb5EigqMi9ux1o7NatfGB6FJOf8Mxb45lwZJLS+gRpPmZIwx0UfzmATFgabtfQ1T9wbwbh",
+	"1qR7UXqjtteU7/zM063Gjv3HMUuTGxOrcGnMEgANYx57R+RGXZFbcqXRK3XTss6z4FCVBjRBF1GRYFOI",
+	"vCvp5VI6UqHcQTLI6RA125dx/wxrPirWPLzxl00t1UCgdRcrm9uRPMtRORbXT64XdfeAeThfnunj+/Is",
+	"n9193812Bxq3njpusmsttiK97LTcZWh1SVd8TJTnIkZ04wbUyI2f7EUPyfOuQ8KZZiU0k6K7ZUzoqIyG",
+	"HLEmVpC1uGmlldoDiCWsVdAoGRB1113fGznU4gTuioHHJIOuQX9ThzGqH76RaiQ5Olz0+Tx9/L0lhvQu",
+	"cP3gKSH5daaTqp7vMl0prdz6D5X+8YH7uvQ6Cu9rciZj/3zwYaXsqPOkfRRcyM7kYkTZu1qpMpP1HQ5N",
+	"0lg50WoLslzHBlJ0lZa8jR1ZTBVD3tZ4mW6fCG0LUYRzesPYkaFF/FbimzPMYsAxUeOPKM9fkLMzF+j3",
+	"9/8dAAD//w==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -40,6 +40,27 @@ func (e ListEventsParamsSource) Valid() bool {
 	}
 }
 
+// Defines values for ListProjectRelationsParamsDirection.
+const (
+	Both     ListProjectRelationsParamsDirection = "both"
+	Incoming ListProjectRelationsParamsDirection = "incoming"
+	Outgoing ListProjectRelationsParamsDirection = "outgoing"
+)
+
+// Valid indicates whether the value is a known member of the ListProjectRelationsParamsDirection enum.
+func (e ListProjectRelationsParamsDirection) Valid() bool {
+	switch e {
+	case Both:
+		return true
+	case Incoming:
+		return true
+	case Outgoing:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListResourcesParamsStatus.
 const (
 	Active  ListResourcesParamsStatus = "active"
@@ -77,6 +98,21 @@ type CreateProject struct {
 
 	// Platform The platform the project lives on, openstack for example.
 	Platform string `json:"platform"`
+}
+
+// CreateRelation The relation to create. It leaves the project the path names, so only the other end is given here.
+type CreateRelation struct {
+	// Metadata Whatever else is worth keeping about the relation. A creation that leaves it out stores the empty object.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// RelationType What the relation means, infrastructure_tenant for example.
+	RelationType string `json:"relation_type"`
+
+	// TargetId The project the relation reaches. It has to be registered, and it cannot be the project the relation leaves.
+	TargetId openapi_types.UUID `json:"target_id"`
+
+	// ValidFrom When the relation starts being valid. It defaults to the instant the relation is written.
+	ValidFrom *time.Time `json:"valid_from,omitempty"`
 }
 
 // DeadLetterList One page of dead-lettered events.
@@ -289,6 +325,60 @@ type RejectedEvent struct {
 	Reason string `json:"reason"`
 }
 
+// RelatedProject One project a traversal reached.
+type RelatedProject struct {
+	// Depth How many relations lie between the project the walk started from and this one.
+	Depth int `json:"depth"`
+
+	// Path The relation ids from the start to this project in walk order, so it holds `depth` of them.
+	Path []openapi_types.UUID `json:"path"`
+
+	// Project One registered project. The registry is keyed by `(cloud, external_id)`, and `id` is what the other operations address the project by.
+	Project Project `json:"project"`
+
+	// RelationType The type of the relation the walk arrived on.
+	RelationType string `json:"relation_type"`
+}
+
+// RelatedProjectList The projects one traversal reached.
+type RelatedProjectList struct {
+	// Items The projects the walk reached, in the order it visited them.
+	Items []RelatedProject `json:"items"`
+}
+
+// Relation One relation between two projects. It is valid at `t` iff `valid_from <= t AND (valid_to IS NULL OR valid_to > t)`, and it is closed rather than deleted, so a read at an earlier instant still finds it.
+type Relation struct {
+	// CreatedAt When the relation was written.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Id The relation, as this API names it.
+	Id openapi_types.UUID `json:"id"`
+
+	// Metadata Whatever else was stored about the relation. It is the empty object for a relation created without any.
+	Metadata map[string]interface{} `json:"metadata"`
+
+	// RelationType What the relation means, infrastructure_tenant for example.
+	RelationType string `json:"relation_type"`
+
+	// SourceId The project the relation leaves.
+	SourceId openapi_types.UUID `json:"source_id"`
+
+	// TargetId The project the relation reaches.
+	TargetId openapi_types.UUID `json:"target_id"`
+
+	// ValidFrom When the relation starts being valid, the inclusive bound.
+	ValidFrom time.Time `json:"valid_from"`
+
+	// ValidTo When the relation stops being valid, the exclusive bound. It is null while the relation is open.
+	ValidTo *time.Time `json:"valid_to"`
+}
+
+// RelationList The relations of one project at one instant.
+type RelationList struct {
+	// Items The relations valid at that instant, ordered by created_at and id.
+	Items []Relation `json:"items"`
+}
+
 // Resource One resource as the projection holds it: what its event history says it is right now.
 type Resource struct {
 	// Cloud The installation the resource lives in.
@@ -406,6 +496,15 @@ type UpdateProject struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// UpdateRelation What to change about a relation. A member the request leaves out stays as it is, so at least one of them has to be present.
+type UpdateRelation struct {
+	// Metadata The metadata the relation carries from now on. It replaces the stored object wholesale rather than being merged into it, so a request carrying it carries every member the relation keeps.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// ValidTo When the relation stops being valid. It has to be after `valid_from`. The member is not nullable: an open relation is closed here and a closed one gets its close instant corrected, while reopening a closed relation is not supported.
+	ValidTo *time.Time `json:"valid_to,omitempty"`
+}
+
 // Uuid defines model for Uuid.
 type Uuid = openapi_types.UUID
 
@@ -474,6 +573,33 @@ type ListProjectsParams struct {
 	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
+// ListRelatedProjectsParams defines parameters for ListRelatedProjects.
+type ListRelatedProjectsParams struct {
+	// Depth How many relations out the walk goes.
+	Depth *int `form:"depth,omitempty" json:"depth,omitempty"`
+
+	// RelationType Walk only the relations of this type.
+	RelationType *string `form:"relation_type,omitempty" json:"relation_type,omitempty"`
+
+	// At The instant the answer describes. It defaults to now.
+	At *time.Time `form:"at,omitempty" json:"at,omitempty"`
+}
+
+// ListProjectRelationsParams defines parameters for ListProjectRelations.
+type ListProjectRelationsParams struct {
+	// Direction Which relations to serve: `outgoing` the ones leaving the project, `incoming` the ones reaching it, `both` either.
+	Direction *ListProjectRelationsParamsDirection `form:"direction,omitempty" json:"direction,omitempty"`
+
+	// RelationType Serve only the relations of this type.
+	RelationType *string `form:"relation_type,omitempty" json:"relation_type,omitempty"`
+
+	// At The instant the answer describes. It defaults to now.
+	At *time.Time `form:"at,omitempty" json:"at,omitempty"`
+}
+
+// ListProjectRelationsParamsDirection defines parameters for ListProjectRelations.
+type ListProjectRelationsParamsDirection string
+
 // ListRejectedEventsParams defines parameters for ListRejectedEvents.
 type ListRejectedEventsParams struct {
 	// From Serve only the items refused at or after this instant, the inclusive bound of the window.
@@ -527,6 +653,12 @@ type CreateProjectJSONRequestBody = CreateProject
 
 // UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
 type UpdateProjectJSONRequestBody = UpdateProject
+
+// CreateProjectRelationJSONRequestBody defines body for CreateProjectRelation for application/json ContentType.
+type CreateProjectRelationJSONRequestBody = CreateRelation
+
+// UpdateProjectRelationJSONRequestBody defines body for UpdateProjectRelation for application/json ContentType.
+type UpdateProjectRelationJSONRequestBody = UpdateRelation
 
 // PutResourceTypeJSONRequestBody defines body for PutResourceType for application/json ContentType.
 type PutResourceTypeJSONRequestBody = RegisterResourceType
@@ -799,6 +931,21 @@ type ServerInterface interface {
 	// UpdateProject Update one registered project
 	// (PATCH /api/v1/projects/{id})
 	UpdateProject(w http.ResponseWriter, r *http.Request, id Uuid)
+	// ListRelatedProjects List the projects one project reaches
+	// (GET /api/v1/projects/{id}/related)
+	ListRelatedProjects(w http.ResponseWriter, r *http.Request, id Uuid, params ListRelatedProjectsParams)
+	// ListProjectRelations List the relations of one project
+	// (GET /api/v1/projects/{id}/relations)
+	ListProjectRelations(w http.ResponseWriter, r *http.Request, id Uuid, params ListProjectRelationsParams)
+	// CreateProjectRelation Relate one project to another
+	// (POST /api/v1/projects/{id}/relations)
+	CreateProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid)
+	// DeleteProjectRelation Close one relation
+	// (DELETE /api/v1/projects/{id}/relations/{relation_id})
+	DeleteProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid, relationId Uuid)
+	// UpdateProjectRelation Update one relation
+	// (PATCH /api/v1/projects/{id}/relations/{relation_id})
+	UpdateProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid, relationId Uuid)
 	// ListRejectedEvents List the dead-lettered events
 	// (GET /api/v1/rejected-events)
 	ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams)
@@ -868,6 +1015,36 @@ func (_ Unimplemented) GetProject(w http.ResponseWriter, r *http.Request, id Uui
 // UpdateProject Update one registered project
 // (PATCH /api/v1/projects/{id})
 func (_ Unimplemented) UpdateProject(w http.ResponseWriter, r *http.Request, id Uuid) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListRelatedProjects List the projects one project reaches
+// (GET /api/v1/projects/{id}/related)
+func (_ Unimplemented) ListRelatedProjects(w http.ResponseWriter, r *http.Request, id Uuid, params ListRelatedProjectsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// ListProjectRelations List the relations of one project
+// (GET /api/v1/projects/{id}/relations)
+func (_ Unimplemented) ListProjectRelations(w http.ResponseWriter, r *http.Request, id Uuid, params ListProjectRelationsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// CreateProjectRelation Relate one project to another
+// (POST /api/v1/projects/{id}/relations)
+func (_ Unimplemented) CreateProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// DeleteProjectRelation Close one relation
+// (DELETE /api/v1/projects/{id}/relations/{relation_id})
+func (_ Unimplemented) DeleteProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid, relationId Uuid) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// UpdateProjectRelation Update one relation
+// (PATCH /api/v1/projects/{id}/relations/{relation_id})
+func (_ Unimplemented) UpdateProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid, relationId Uuid) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1246,6 +1423,238 @@ func (siw *ServerInterfaceWrapper) UpdateProject(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateProject(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListRelatedProjects operation middleware
+func (siw *ServerInterfaceWrapper) ListRelatedProjects(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListRelatedProjectsParams
+
+	// ------------- Optional query parameter "depth" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "depth", r.URL.Query(), &params.Depth, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "depth"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "depth", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "relation_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "relation_type", r.URL.Query(), &params.RelationType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "relation_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "relation_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "at" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "at", r.URL.Query(), &params.At, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "at"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "at", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListRelatedProjects(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProjectRelations operation middleware
+func (siw *ServerInterfaceWrapper) ListProjectRelations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListProjectRelationsParams
+
+	// ------------- Optional query parameter "direction" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "direction", r.URL.Query(), &params.Direction, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "direction"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "direction", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "relation_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "relation_type", r.URL.Query(), &params.RelationType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "relation_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "relation_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "at" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "at", r.URL.Query(), &params.At, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "at"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "at", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProjectRelations(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateProjectRelation operation middleware
+func (siw *ServerInterfaceWrapper) CreateProjectRelation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateProjectRelation(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProjectRelation operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProjectRelation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "relation_id" -------------
+	var relationId Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "relation_id", chi.URLParam(r, "relation_id"), &relationId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "relation_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProjectRelation(w, r, id, relationId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProjectRelation operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProjectRelation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "relation_id" -------------
+	var relationId Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "relation_id", chi.URLParam(r, "relation_id"), &relationId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "relation_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProjectRelation(w, r, id, relationId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1821,6 +2230,21 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Patch(options.BaseURL+"/api/v1/projects/{id}", wrapper.UpdateProject)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/projects/{id}/relations", wrapper.ListProjectRelations)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/projects/{id}/relations", wrapper.CreateProjectRelation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/api/v1/projects/{id}/relations/{relation_id}", wrapper.DeleteProjectRelation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/v1/projects/{id}/relations/{relation_id}", wrapper.UpdateProjectRelation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/projects/{id}/related", wrapper.ListRelatedProjects)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/rejected-events", wrapper.ListRejectedEvents)
 	})
 	r.Group(func(r chi.Router) {
@@ -1835,143 +2259,174 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H1tk9w2kuZfQdRthMdx7OqWLM/ttGM/aGY9M7pw2ApZvrsIy6dCkVld2GYBNAB2qezo/76RmQAIssh6",
-	"kVqyrdE3tYokgEQi88lX/DorzaYxGrR3s+tfZ2uQFVj65wv4uQXnn/0n/lGBK61qvDJ6dj37m7EWaol/",
-	"CVUJsxJ+rZyw/MZcvFyDcGDvwApZmcY74dcgjAYhRSnrGqxwoCsnpK7EDWiw0oOjB4xfg90qB18J5YVs",
-	"GpAWfxFwB3YnanMjaoXPreibYchCOCN+bo1X+gbfU1pI4dqmMdbHZ4RyYruWXngFPCG/NcKbG8Ah57Ni",
-	"5so1bCQu1+8amF3PnLdK38zu7++LWSOt3IAPxPlba52x+5TBlS80vPGvS3piESfayBsQS1gZC0wso2Eu",
-	"ntGsTCN/buEaiVMr0F400jlwuJClLG+FpH9aKEHdQUV00ZWwICsntPFrXLRpPQ6lPC5E4VR+bsHuZsVM",
-	"yw2uhedzbJUWXGO0A1rkc2uWNWzwn6XRHrTHf8qmqVVJm3/Z8BP/878crv7X7Nv/ZmE1u579j8uOvy75",
-	"V3cZv0sj7tMv7tdKqhoq5qalqXbCyZ0Ta7PFJWaM+v8uAqteMK+ODR0ev+yY+p5GD1OiLbUgPTy35r+g",
-	"9OM72/CPwhth4UY5Dxb30InFn8ratFUh4I0Hq2X9WlWfL0QjlRVr6fCFJR8AZlp81+5EZYB2UKxNXYkd",
-	"0OY11jRgkUmJ8Pjd8dko7byswzH02fRqdYfcowth3EVjTXUB7SOxMlbAG7lpasBhNkp/A/rGr2fXj4oh",
-	"KxSzbCGHaUHM6QTNUyCvucCERwbYgJeV9HL/6/93LT2edgG1Azq1xvq1uAVokNPlEnk9W+9cPI0kjbSQ",
-	"XtQg7/gM4ePOGxtOPWwavxNmSa/O0sz4P3BmfGDGZtWjsnIsy6oTFtvU0q+M3UyQMvw6sokGN7EB3Ony",
-	"9qwtpMP8c6ssVLPrH7sZFIGl+lv80wgd/hNk9Q14D/Yb5UZOxHc6iDWzEhXI6qKmh6FCWa2922dm5WHj",
-	"xmlgYdU6Em6wcUmj4OcLYWxFn13ukhB8LVkIKqJ++u4hqdMtB6qvcYK4xrBoaa3c0d53onuMBcDyCcbH",
-	"eO3OS+tdwSK7SvJ6EcR/FPG6rWsRjmktHb+MU8cf5LKG2bW3LRzbRV5of5qHty6udXT3lL4hxehhw/R+",
-	"+vxZ3IkCl4HTzbZWeJwqSat4ygcbPCEs8m9Ys+UT2204yUhtmG8QUaTJlFILb9ug4Ul4mu1nTpgtIY+o",
-	"0nO5g1wu/ex61raqmo0cRiu3EwIVp8LKdiudcO1yo7xHUmyVX4tvf/hGlGtpZYkoQLjStsslVEL6QMi5",
-	"+DZoY5QNRqNAUhoqgXxzzTOVojR1DaU3hIG80AAV6YAloqP//f133wbZVBCDEyU2sFmCFaW0FrHLNgpI",
-	"nuicFgUy6OAhz+7C7FAyRqL7sNoCYRKdD3GnTFAlmZQpRGNhpd6EV7Zyx68y30SwICwg0IobsE/w7tCO",
-	"Hiq9x3xpgr0NraSHC682MDt6TnDj82ETgXj7x84MnZNnumkZ5VSVwhnK+nnG4XxG9w9SKbXRqpQ1szBj",
-	"Ft41J5ZQm62QFo8Bvog8YyWCTtRUOueUr1i60ILVHcS9QWxtZLWRzeXV1UVpNA6ijHbzTSUclLRtT94N",
-	"PFhwprUlnIIeEB/gFEbBwT9qs5R1vROtVj+3IFQFm8Z40OVO3MIOZfsjBESPv/xzdpzm4qnuzr+FdPj4",
-	"7OEMndyAwO13Xm4aUZpWe4fnVYqqZUyaz403eFSNr9Gu0HSwLQ6i0+rnkolJg0otTMNMIJq1dFDkZBCo",
-	"Y1oPcyKlLmFeEoKcg65oGo3c1UZO0J/2uFa/QCXCcwL0HdSmgWterZceULYYK+SKhC+CF1xaQf9coUqx",
-	"0NSyhA3SzalfQGzxOCmPlNU3JMV11a3Cyi0CjDtVgRWIvuZnopMBlxyAJ/fEjHi4jkJIs9UoNHvf7y9c",
-	"uXCwWJzwM5PfTR/pXsQjRMCx/4VxHsFv3CpNhm18tBBxm3Fed6ZuN7C3YH70EHDgyZTIyStrNsFURnAa",
-	"UJOQ9RbNnChSCRKqBsjoJWDLwpc0JynFXKOUUqMq2Uh7S6icgRieEQul0aWqFZ940/qm7ckpsZE71EE1",
-	"rAgyfyWkuJN1C/iHUxWIRRpnQVy16H9zEYS3y4Q3Iqx4YCdFf6RKdyqfff+d+Pc/Xz0Kx5AO/S9oMJOg",
-	"H5fcxzFqTubzwGkg4yQq7YQS0iVKsZOR6fc0sY8dkz4jvn0Brq39hFw2HSZF00pUKhP/S+nLdcRmN+oO",
-	"9P4eyrKExsOIXPin2YqN1Lu4l/hFGoO5IsMtSnu4AYtTTmrFHfggWyyElKWXS+lAyNqCrHZiDfXEly0g",
-	"WaCaBqLZFBMiR/qA9nYnQJbrk/nrRRhsgsMG+5lo2Ft/NuWxzf1GraDclTWMH8FMikapJNYKSb+LMBfE",
-	"UjHbCaSTvZO1Y4EXHhQrNju0N3OUPfzFBUl2lpmecbYcKADElWyyaBN1DoFhsyUJjh/QbkuH+cnVkx42",
-	"iziAnQZ1XOX8lX6lXwYX4lrWqAsZ4Fly0aFsp98qtVqBxeXyoh14NxcLZsIgRtNyF4TwGWLHRdMKvLkF",
-	"TQIa+aoQ27WqYUCDzHcQFlcQxeJs2H/Ks+hpWrS9Wo2AQBvhStPAXHyn+1SUCVDEMVw0xpjq5NeMOkuK",
-	"BUMhhN4LHj65PoHWABa1flBikQFWyqI1GsgRxJgIbhdvpXYrdtT2Dz0Tc/wkEUjqaAlEEmER2emeCF/8",
-	"KQnxIvcyFCIi3c8XDyXQ04aPz3n0HHQcoTZNrcAVAjfXeabaXLzcmu5N3qxEO0LOjF+CYwz3OhF6CX4L",
-	"rIo3AVKkvQ8bSXtUQQ2eDV6W1PxBNt41YTZZ1ydTKcmMZ2EiY7SKEzku48Jz98VsKy0CSnfAiUdsUJq2",
-	"Zts7uBgG8lU8TUTfro2LDJoAJb4pA4WScR7eeM3c+xoFiGn962Ab5LTZs5MPiuVEiCIyfM5I2aIPiudE",
-	"6lExvZb16gLxvHCN1GLxIx7dQnjz+UKYO7AoeMp1ijkkdmOXbM41LCz2zyp+8AAQHJz9IvxnWbcOzeGl",
-	"aXV1qkvg3ewPWm4+pVHPBppc498mY2wgZ6uDX+12i0y/ic+SVdj7LsIhpU+csDenUB90FWgPb/q0z6Ej",
-	"a6HeixTMAl0ERknIMj1gVkKi7Yj0TitQbnJPz4OixF20yEjEsEU9Xhg7IFmoq0+cF3//m/jLky//lwih",
-	"LlGBl6qei69Zn1prbOcIU5krK5hCygm3lg0UHBGtyGExEULbPy882gj6bDdSX6AmpQMIb5paajbtXAOl",
-	"WqlSeBMijWXZWgu6hFGWoCWMyMrnYC9WCuoqLNnhCjw7GALYIIIgfEJLUVXBfShV3dq+qOsvqjbl/nDf",
-	"mDKYphwwNasV6Ar5hKzQQsD8Zk5xwHnmABhd0cbdTIh+5cTWGn3TWRVs4pJWkF7UYRLzox5GXAOPNMZO",
-	"Qy2GzNhOqPt/vnz5XPADojQVZOF05qo5xWrIyzC7fnJ1NWZPeOXHsPf3a2O9WPeZxbWbjbS7FJkO+4gf",
-	"7Q01+z/9TYVRb/q4C+WHF+TLBWI7oSrQXq12UcpOD9lafe1lXe+uiS2vO746uiP0a6REIvnEYR+P8bKp",
-	"woHdDuqylyQFbZUTt7CLqHEs7lsEXF8tupyDdUhtQPnIYUonZFVZcD3oLpa7DxgD3tvMDrYfUBNxiC25",
-	"lSK1TlfL7xZajrolmDyqIvMsuNUIgo2u7MhYIdoVRPdZ4aRTA9kUUmIX1EgIm/XqMD5NGyYTQTLeDLhS",
-	"SL17kCB2wTr9+HhEnBO8RO8r6H1C4OdIrDsQJ9u5HuMfkBjHfYz70uM8T2Oyrid9jXwayM8Y1nSOqzGK",
-	"vo/XzfgClq2qq5DoM7YSlB4RQjjO5WlquUNzL7jCow9crFRNsd5g8bBxrPtH1PKALnhYMq9Jchxz2PxW",
-	"m607Wbq/oEkJo+tdD+93rEEvTgRcD8Y3jn86Kub9LZmm9xG/biBTIPaYbchP+AOu1m6iW2B/U/rUEBLt",
-	"Wc/87XGO4TMbXQgvJ4NCZNSFmGyWAxakZrfzgXr95eHLr7sEuf7Xn3Lk/3v+dmXlyovHV4+vLh49FpUp",
-	"2w1FlflA4bFGNBZ9aor+l1VLSpOIL9G8stwo9u46fAPeyNIHFug87/hQKTXZKDtRS88utwHVBuTN1zZO",
-	"4twDPYG7snyQ6BHkoH10+odHJjyAk3AiyyoJOR4MFKp9rcuMzvupY16MjMiiIjdXBkC265gPUcGbhPUC",
-	"2lW9SNgYJMG3pgMAnznRGKc4yZbFZxcUp2BIwTHw6OH9BayZijZMJ4ckomQU7se5X+Xbey0+uyub1n3G",
-	"dl9kAhE2ZPdqdoKSpoVnOQRphuO8MxVWzSMLMVspc4HHNKWQebMXeeB8Uj49Vt2svdCcW/qASRRvj7J7",
-	"/p3wRjGyyuDjVz4EHbJXP0OGNHVyHfc0MsuszjUuvdAEVt3abBGjhkHZ+skGDI5PihRU7GRgnz5Zd+YW",
-	"NAkhc1IIQbl4AIMbtTNKGZ9mwXKSCo2FipLFu0gCp4OBdWvVpCyrDOAuFQLcGOohGBLdoZ+5PPxSBAr0",
-	"oheNVBH/ikXwgOMPb+uyKmbdR07d/vBGkfvdVEDLbz8PBGOv+QwemIr0g/D86YZeNsB0ogX+EnddwxaS",
-	"gz0yto5+LMunc3yYg8k2wwwbHi+urIiwDzkk/DPLAgx6FZkvOzgc+ZI+RRb1IUzbSbN3ybWZP7STW09Q",
-	"9PQMG+Ud1KtiOgv8XGw6lnvzAK533KHt5EanRBmOYJI4PWKS9wRnek0bGv0BvPqKnPqac2Vj4K2Lr4Rg",
-	"UxIMnb891N04oHxM3J1eQDsKauWFWa1Cgi9+JCZYHVPe0aLOjOz+lvbZp8ege175TBP25OK+7BiKq8Gx",
-	"PwQcjlvt7B/3nX1xZur60HwaN9qLvoVQhCqeuOHVGfkcXazzo7XiD9liAz9tj6zJdugZa+Hv7IQTHPCU",
-	"tRGczAh6biRiuv3tfxuxTbNZQm30jRPevK007H8PcYgKejkOOykfJ83NzqFNBDzB9hyTaG1THcexYQdQ",
-	"lRLfhIzbt0zsPiB18gX35naMv8blw4BEvV14O/nAr/bkQmKcniiI/oOzhAGdlIcTCPHch9QqOv7eVHJ3",
-	"3S9hY/hDDh6zFQ3YoZBzJjnGMjfECpUuQTtKHKH0q0GcpVbO42R2aGc6pW9qCIK1CzxTjSM9yUKXYTqv",
-	"1r0/6ZTn94wKp5DK6/adgAOjdFBn0tRtcBqE3JoUkgiRA+U/hIF62J8yTOjvMnh7q+GksgPf/20T9Meg",
-	"9Fsm7J9iQOzb3jFqFXY2BlgyD5PsQbOQoN2vLUH1hdb4frURfj+aO7cAjQspdoD8J7sqACpCWsLOBLVp",
-	"NAwjYX88w2aqeuDdipPCTiV+P90SPqdkAfYqFh7Gijr109NFDMiTqRahsaZqy5wcRVaIQEkxeXVA5P8U",
-	"DQ92Cj5lq0FFVPdQECZWlLVUGxg/t+eXGLwl+sgclt2YPXE2Gnw8xz6KOX5RFvUZdEwZ/UBIZzKngUO+",
-	"JjjfUqpeVjsdJFbWTiEWT3PlNGng4CjlCBg94Diuw66bTVbm3lhw4XRslM7L5x4NVdd07JyFHP/a8whG",
-	"05c8gtpsReCtUAnlQvEUndRgsZMT1Mkaeky2BBQbG7A30cuUCmoiGSgdO1jLcVwGMxnN4sRIyD5ILL63",
-	"thPqvPdZomU5M8xdaCSeJRz8//94dfEXebF6evH3n3799/uL/M8n5/z56PH9v42eGwdla5XfkVkRqjMa",
-	"9dLcwkgg4qkmAct57sESRSP0aevXxqpfSIRci7+CtGDFq/bq6ouSHqZ/wmIuvpblusutCS4oTlFnZ6kG",
-	"qNxXQoZBuCiTnf9Z9v8XqQ8ILmdJ43XLW3vfcOTmBpyfXkusYbFAoSBZF0I51yJ0ACv+FEVEwX6Bz9mx",
-	"/TarfuZDVQA1OglAE9EF24dSWSHr4Jo8YVWcTzCxLnJUrSXSyUFpIU9qekkFn511wnUrKTWUSg9N68ER",
-	"zCneerEh9hCI6Y1o2mWtytBUxp2wzHta6GokDfZrVo0xCJp5axTV26ZaldahpcE0j9FCIgBCM+W60Gtp",
-	"7hCjUfI+yNqvKfENTUAYjhWNGZQwlMnLe9lNwvHYKXIR8nPjzxfkHIi2U9GTK93/9srw4U7Btiu+yGtH",
-	"OFQ/T9l01zPe4BdpzU+fP5sVM1weE+9q/mh+hUxkGtCyUbPr2Rfzq/kXLHTWdPwvZaMu7x5ddvUaN+DH",
-	"shN8a3UUtHnRXiG0tJaiU8sdY2SK18QsjVyDxVwwQstkcSPz9Ko8usIOIV3JyaZzsUDhGypzvFkIBzW1",
-	"fFnn6fFbpSuzHSTI50AjDXPdAX3pU8g9DKJcSArm0oP8ARyauX3+SnOJeV0HScX2NjngxIJs1kVST53B",
-	"GbIQe82IcgBGFj99NbQbyrx+KCfJUtl7nb6vqxix2cr6lmnMzwT7Vnaha4qbhIIBqB17BAJECKo19mBi",
-	"o44lStxTnDHUtahghcbNdbBi+McYxmHaUMJCCIKi9IszMHorbeXmrzQdT/IrRJPgIoQx+y7ycKb4N4RI",
-	"XeOfW9Ch81JeUMXlIYsOyi2CBgoISXmXop4FFzRU0WiJNbpD736e34F2ZCyAogTCrdyFwCzYi/QiT4ym",
-	"vVfvRTVAW7kLECd+TWzMXYqmRkPB0IQ1bLtcz2CdrqUOE0cKR6r06tVgfyFcXkbqoq5E0EdJWT+rZtez",
-	"b5TzX8e6lrzX1o97Oc14YrrkpUFtbkqKGu2BFQD5dAus4rzRcg/s2ICZMfBwY8aMVRyj68sxEn4TTwPD",
-	"Sneb0lo6uzmUdeOLzDIjUGh0UT2D5V2XxQbJdAra2Az2XL8PRVt2WXJ1f/AWDfNPx+bTMwDfeTIknGlv",
-	"94ztqQkks7EbHHS7oXhdtMnZlMxM8syaPHvThv6V4K8cLdhKuoKU5tQSQu1Ot4DT7PPT5ps33utNdVDf",
-	"dNpUub7oHSc6LEiPKj1pcunFxrjJfn612ijfm0cFK0k5mI+urorZRr5RG2SBR1f0p9Lhz7FcyfEQQyeG",
-	"L0O/w/ufBi0CH19dHWgPeF5bwK6Nw0hjwIONHB6iGWAxe8JrGXsjrbnrXYjPPzrz+S/Oev7Ls+aTmdyk",
-	"NDtj+8efcNtC1U9QtX0akrvVjEXBvue+eTJ0XzCrYasjl/VnRFCluMglxUDY003RKCr+Y6YWyJTRdTTn",
-	"UnpWPfiRx1dXVGYGdwO3VMhnQDQkg9kYSpNjcVPRNccKiZnqTlWtrENPhUpV11lqZ6/rlOPSnsYH3+QF",
-	"qcdUKTaaixoGj1kjWixim4QFqt/OIbrh1lmhUr6ypmFBQ/l5TFyCrqiNl+1qRUQMTtvQBILMIkb1m9Z5",
-	"soQteLsj7MijpmzTPrri3hsJXwV6/tVUu7NOr9Hw3Yq46+g55kZaKFlOimL23hnEMH+67/thvW3h/j3K",
-	"oV6jkokepbxjyAiNNSU4t9+odJsHshhT/4Fk1aMPKat6/rShuOLtSJLqvkiOhGhRHXUl+PVYXZ97CH/C",
-	"aN/Xzp1wtu3eze2T9d6z3kctxueRA86zGferrD6EHbc36nu2VfNOLcr2jEMannwIz7JOFtSdT5MKMlvO",
-	"4vZbwy860brosSBXQlZ9RlHopfHrWOLe6hoc8iO+uQinjLkvpHpMGVK9Mr0zlp7QdEfkf3k8nRctHkHU",
-	"E2WLn3D12bh6QtVMI+xYfRY49i1Lzq9RaEvFKY2x+xinGvWcOn8ZeDopZlqlsGfDzX56qVoMw80d2K1V",
-	"PrSf5dQbFMfGCtC8WLayA5yn8vfuxKdjqKiF+8kF8dwXNJc1NdIpdk4vxBJK2TrIJRVibTzVWfetXteq",
-	"6Ard1yn9HvBvD5QPHcv+GCdh20cPLROmYG2v8p4Vw3ZQ45/JhNiyYzxW+MOLbyLOiE2k4p4elu0fk6x5",
-	"cvWX34VsilKm8/+OIunLX1V1n8Hp/un4B/j8aLxftTV9O8Ref46PVlM9uXryO+EeWYUi7iHxZ/dHoPdJ",
-	"TTYIkDXSrzs8FspCc8FYnMhBlP5yj0to0Ewfub8mtMeLnnZh2F2UEo7Mqq+Nz02SItstfo0sr6hqJ5KR",
-	"OA3p3dOPXulvgwvO51mXOixwwl5F4E+tkVRIUgbLeaY7gvbJ6BwDJLxYmQUDCWjfcWsFqVnJs/FBJcN7",
-	"SnlfDfdT2t6PGu6P8YFdTGepYdTBzktduU+S7n1LOuaKSVmXqczocb04K53l0I0budu5OMXvTL/KLfsc",
-	"R+6t2HNW9fqaPmTiyyL78qLXICG2Fhx0GBik+4LOyvMp1Zekx1reQXKhdn77dBPW0Yya0SffJbWG/uuT",
-	"b24ksway7EuU89VG6Quj6911zM4LOZdkE+KvnJqJCqaXdSC+TV2aQ14CyVlwma0XGJ9vS1mRysy6h8QN",
-	"00ZYqBWptCRSvbdq2cYmf/suxV6rknMdixxkSmf0jxIl70/79xwsD9dD/cv79gZ3cx1x703dzvXJv/dW",
-	"/r0xcg6wQZaVeyo0yPBGliHeS3X6nH18fak+rHXO7/2wIMo1lLf90uYxodcVkbr3adzv1d0et/L3K28f",
-	"im0f/W7dxv01H+Cty18jq9xf/trjlYNunF7R8Afa7nO3+rfb6d+z26VHotOcL6c0JzjQcHPEN9Orwp/y",
-	"0BxV6qc1N8guXjo+sf1Ku1Nn91MxCze/TYVnhnI2+IgOy+qCKyHz0jR+OwZpsq3ljhSM+VMNySn9/mTX",
-	"5kL67lLZ8B57nzqrMZoM4Y6IfYXwvN2XDw/vfxntuviB3TCniadec5GTAiMfk2Pm0Re/twDGQASO6MbT",
-	"MoL6t+U49hjkHSweMD+oJxqyP981XYgn/skdMXBHjLTM4h4ICI7paiTu50ftqBbdxTZIx6zHn3Dg5+KF",
-	"2YZGC8AV6xtzl/nq8w6Hyokb3DCOB6SO+9RlhT121rQ3a5pGbMqIsx2rL4rbG4qLIid11RfBGhgpMQpt",
-	"G7hAiLICAjtUUKoKQhV3V3hcDfz0lAyL6siZDXQ7GpYVrprvZ/NM2xTn+lAONDp+P3lSI/27PkQ62Miw",
-	"H0llz29VzJO1h6YjE9u6cXu9Xsdj6mSwbr1ZrU4p8Elt606fW2iXIW06LKsagFoxkId6Lhay9OoOFvz3",
-	"3oFPs0Yslxr9RfGUvWXoxkHqG0MCTNZ1+nVp/Hqe5Bz9zBdjLEiiKV1BA7qifpssa9OdotpbWamSqvpI",
-	"iLi2XJPuoK/9B8/+VXt19fjP/M3/SHPbcZuZrndi7BY3RdzWjbvnZjzKrEj1TOk/wmCzYibr+qRappE+",
-	"4p88ib0uiUf8iKN9Ej85Ed/K27NHy3Eke/krif497072t6ruT62pzyt1g/3agd1zb0MU/aodRkeNvFFa",
-	"egRwJkLZfu5CfgUlY+eN3AkHMIFjsw50qPe6xsiI4DYcqZCaKoqu+mVNfbX3+LH402J4v1C8rc8b87o2",
-	"+mbxeS8yKYW3rS4peS08+pVY/OPrl6LfzGBBR8QFEZlBu5ehSzUhQ/rM4J6eQb/uwfWkIVvbVHw9RR8m",
-	"BjVBCj4Z/QjLGYtOAsacKjj8k6snQmrR6ltttl35u7gB74YoN0IL9mTgyOHK6SUIj0MTLDfxruo0LXij",
-	"nI+XpoUs8dSLKrYS369S71pYREScK9R0IyYnrHfwN9ads0lCTHId4nBZ5XusR0/BRm8a13Uy7zUQBgtd",
-	"qwwN23B04qwCvwXucypWbqWxcqbq6r5SX/ZRluL4eejPmE+UTZl8opHf000FhyF5Vgj2W9RyJhO5O1Vx",
-	"SztpxAZaTxiQCPjDeIWfPH78+/EiZy3QxsX/Sa7k4+0kD143NuKw7VqkvZMb+fzb+h/YfVy8W5f0Q3NR",
-	"59Hnp3dAEXV+i/cJFXVJbeVXdHc9+/PEoZFLjXG/jKw2srm8urooDXVZUka7+YZaTBGXfVmw/yp8cKAf",
-	"o0TOOidkFzznLdxXrBcHfY7oHiTbapfuzemmx06bKH51wi/xjm8cvzSb0Ipu/kov4hW8sfnL9vBtw4Mm",
-	"8uG66+6itZH+E2OAAmmQadCtDNVfeWOYpCnd+dejc3rnKAIgHPJZdDL0MnmSMn9y9aTo97npoxi+1Z2M",
-	"0YEa/6zXyEi+d+Q3F383NalUGQna0Y03s2uk2vHJGEpxjdQxUtBdP3KdoY9eLE+53lXtPeQQnJoxqS5j",
-	"snTdujuRlQL7wGYJFQ527AJ5onvvuhc6JrhPvStSSqnjvSwT17KM3BXseJZ717uLv6q6ZjpkV7Ps45ks",
-	"ip1ut36fiKYb5EigqMi9ux1o7NatfGB6FJOf8Mxb45lwZJLS+gRpPmZIwx0UfzmATFgabtfQ1T9wbwbh",
-	"1qR7UXqjtteU7/zM063Gjv3HMUuTGxOrcGnMEgANYx57R+RGXZFbcqXRK3XTss6z4FCVBjRBF1GRYFOI",
-	"vCvp5VI6UqHcQTLI6RA125dx/wxrPirWPLzxl00t1UCgdRcrm9uRPMtRORbXT64XdfeAeThfnunj+/Is",
-	"n9193812Bxq3njpusmsttiK97LTcZWh1SVd8TJTnIkZ04wbUyI2f7EUPyfOuQ8KZZiU0k6K7ZUzoqIyG",
-	"HLEmVpC1uGmlldoDiCWsVdAoGRB1113fGznU4gTuioHHJIOuQX9ThzGqH76RaiQ5Olz0+Tx9/L0lhvQu",
-	"cP3gKSH5daaTqp7vMl0prdz6D5X+8YH7uvQ6Cu9rciZj/3zwYaXsqPOkfRRcyM7kYkTZu1qpMpP1HQ5N",
-	"0lg50WoLslzHBlJ0lZa8jR1ZTBVD3tZ4mW6fCG0LUYRzesPYkaFF/FbimzPMYsAxUeOPKM9fkLMzF+j3",
-	"9/8dAAD//w==",
+	"7H1tk9s28udXQen+VUnqOJqx4+z9V6l94d1kd33lSlyOc3tVcc6CyJaEHQpgAHBkxTXf/QrdAAhQpB48",
+	"M46T9Tt7RBJAo9H960e8m5Rq0ygJ0prJ7N1kDbwCjf98Cb+0YOyzb9x/KjClFo0VSk5mk78praHm7n9M",
+	"VEwtmV0LwzS9MWWv1sAM6BvQjFeqsYbZNTAlgXFW8roGzQzIyjAuK7YCCZpbMPiAsmvQW2HgayYs400D",
+	"XLtfGNyA3rFarVgt3HNL/KYfsmBGsV9aZYVcufeEZJyZtmmUtuEZJgzbrrllVgBNyG4Vs2oFbsjppJiY",
+	"cg0b7pZrdw1MZhNjtZCrye3tbTFpuOYbsJ44f2u1UXqfMm7lcwlv7ZsSn5iHiTZ8BWwBS6WBiKUkTNkz",
+	"nJVq+C8tzBxxagHSsoYbA8YtZMHLa8bxnxpKEDdQIV1kxTTwyjCp7NotWrXWDSWsW4hwU/mlBb2bFBPJ",
+	"N24tNJ9jq9RgGiUN4CJfaLWoYeP+WSppQVr3T940tShx8y8beuJ//tu41b9Lvv1fGpaT2eR/XHb8dUm/",
+	"msvwXRxxn35hv5Zc1FARNy1UtWOG7wxbq61bYsKo//fCs+oF8erQ0P7xy46pb3F0PyXcUg3cwgut/g2l",
+	"Hd7Zhn5kVjENK2EsaLeHhs0/L2vVVgWDtxa05PUbUX0xZw0Xmq25cS8s6AAQ07p39Y5VCnAH2VrVFdsB",
+	"bl6jVQPaMSkS3n13eDZCGstrfwxtMr1a3DjukQVT5qLRqrqA9hFbKs3gLd80NbhhNkI+B7my68nsUdFn",
+	"hWKSLOQwLZA5DcN5MsdrxjPhkQE2YHnFLd//+r/W3LrTzqA2gKdWabtm1wCN43S+cLyerHfKngaSBlpw",
+	"y2rgN3SG3OPGKu1PPWwau2Nqga9O4szoD25mdGCGZpVRWRiSZdUJi21qbpdKb0ZI6X8d2ETlNrEBt9Pl",
+	"9VlbiIf5l1ZoqCazn7oZFJ6l8i3+eYAOdCBeekE/PPWoBqxiJT6PQs0TP10PCUG7Jh5Bga1kvSPN4CQw",
+	"A1k5oq7EDUi2Bg37p+EemCbM2HENzvgeOCZ88w39Mso6kVob4NIUTMil5sbqtrSthjcWJJf2zINquV6B",
+	"PXpMs+E18HINBreqE09BpEFVoIIRlpVcOvG0gL2tjN8iqrmJOvbidjKbtK1w/NVw6xhsMpv8v5+uLv7M",
+	"L5ZPL/7+87v/vr1I//vknP8+enz7X5MBItzwWlRvllpthqgPMp+ysVxbwxbgOANfRUpUsORtbZEcNshX",
+	"2Vuu4ywtrAWZLbniFi6s2MDk2EHs9qvPN0Nn8Bvg1XNwdHwuzIBW+l56aKGWrAJeXdT4MFQOL0lr9o+Q",
+	"sLAxY4d52RoEGLAxEdW5zxdM6Qo/u9hFIPKGExARKAHjdw9p/m45UH3rJogcTIvmWvMdyt8OPg3upiZu",
+	"dI/R2mk/C4JNVcRMcw/BAsySbV0zryprbuhlN3X3A1/UMJlZ3cKxDaSF5tM8vHVhrYO7J+QKwamFDdH7",
+	"6YtnYScKtww33WRrmXVTRcQQNG1vg0ckQfoNrbakNbsNR0EgFfGNQ/VxMiWXzOrWo2w8DWr7mWFqi+g/",
+	"wOpU9/dFwd6B1Xw7AmrcVAjwbrlhpl1s3GmrCrYVds2++/E5K9dc89IhcWZK3S4WUDFuPSGn7DuPiJ1+",
+	"VtKBAiGhQoUyo5lyVqq6htIqtEMskwAV84KOs//9w/ffeWlPghApsYHNAjQrudbOftgGfUMTnZIa4GZI",
+	"Uf5rvfOzI+FLRLd+tYUzVfB8sBuhvJhJdEDBGg1L8da/suU7L52QbwJgZxqcsRM2YJ/g3aEdFZE588UJ",
+	"vqeg8xKuGzYSiLZ/6MzgOXkmm5YsjaoSboa8fpFwOJ3R/YNUcqmkKHlNLEx2A+2ak/W12jKu3TFwLzqe",
+	"0Rxhh11zmXLK1yRdcMHiBsLeOPtW8WrDm8urq4tSSTeIUNJMNxUzUOK2PbkbgNdgVKtLOAXBO4zupjCo",
+	"+f9RqwWv6x1rpfilBSYq2DTKgix37Bp2TrY/cmru8Vd/So7TlD2V3fnXEA8fnT03Q8M3wNz2G8s3DStV",
+	"K61x55WzqiW7MJ3bATy0dra9xINN+jSufsqJmDgol0w1xASsWXMDRUoG5nRMa2FKurqEqQehICucRsN3",
+	"teIj9Mc9rsWvUDH/HAN5A7VqYEartdyCky1KM75E4evgoFtagf9cOpWioal5CRtHNyN+BbZ1x8mhpzWX",
+	"q4Cm4io03zokdSMq0MyB2emZFkKPSw6YCLfIjO5wHcWHaiud0My+ny9cGH+wSJzQM6PfjR/pXnRHCHF4",
+	"/oVhHnHfuBYSnUvh0YKFbXbzulF1u4G9BdOjh4ADTaZ0nOwQo3dXObjvURPj9ZbvTBSpiH1FA+h4QlOB",
+	"hC9qTlSKqUbxmHnD9TVaxgTE3BnRUCpZilrQiVetbdpMTrEN3zkdVMMSjZCvGXf4tAX3HyMqYPM4zhy5",
+	"ap5/c+6Ft0mEt0NY4cAeQMe08u5UPvvhe/bff7p65I8hHvpflXREvh2T3Mcxakrm88CpJ+MoKu2EkqNL",
+	"kGInI9MfcGJ/dEz6DPn2JZi2tiNyWXWYtOR1zSqRiP8Ft+U6YDM01Pf3kJclNBYG5MI/1ZZtuNyFvXRf",
+	"xDGIKxLcIqSFFWg35ahWzIEPksWCSJlbvuAGGK818GrH1lCPfFmDIwtU40A0mWJE5I4+IK3eMWdEn8xf",
+	"L/1gIxzW289Iw2z9yZSHNve5WEK5K2sYPoKJFA1Sia2FI/0uwFxgC0Fsxxyd9A2vDQk8/yBbktkhrZo6",
+	"2UNfnKNkJ5lpCWfzngJwuJJMFqmCzkEwrLYowd0HpNniYX5y9STDZgEHkBumDqucvpav5Svvxl/z2ulC",
+	"Anga3eROtuNvlVguQbvl0qINWDNlc2JCL0bjcueI8Alih0XjCqy6BokC2vFVwbZrUUOPBomTxC+uQIqF",
+	"2VAMg2aRaVpne7XSAQKpmClVA1P2vcypyCOgCGOYYIwR1TG2EHQWZ3OCQg56z2n4GH4AXANop/W9EgsM",
+	"sBTaWaOeHMFV4v1XVnNplhQsyQ89EXP4JCFI6mgJSBKmHbKTmQiffx6FeJF6GQoWkO4X8/sS6HHDh+c8",
+	"eA46jhCbphZgCuY211ii2pS92qruTdqsSDtEzsGlhE4zt9eR0AuwWyBVvPGQIu6930jcowpqsGTwkqSm",
+	"D5LxLhGz8bo+mUpRZjzzExmiVZjIcRnnn7stJluuHaA0B7yhyAalamuyvb2LoSdf2dNI9O1amcCgEVC6",
+	"N7mnUDTO/RtviHvfOAGiWvvG2wYpbfbdqYfEciREERg+ZaRk0QfFcyT1oJhe83p54fA8Mw2XbP6TO7oF",
+	"s+qLOVM3oJ3gKdcx7hfZjTzcKdeQsNg/q0fcpL2zX/g/lnVrnDm8UK2sTnUJ3M3+wOWmUxr0bDiTa/jb",
+	"aIz15Gx18KvdbqHpN/JZtAqz7zo4JOSJE7bqFOqDrDzt4W1O+xQ6khbKXsSAMsjCM0pElvEBtWTc2Y6O",
+	"3nEFwozu6XlQFLkLFxmI6Lco44WhA5KEm3PivPz739ifn3z1v5gPN7MKLBf1lH1L+lRrpTtHmEhcWd4U",
+	"EoaZNW+goKyECh0WI2Hs/fNCow2gz3bD5YXTpHgA4W1Tc+kjDA2UYilKCiW4HSnLVmuQJQyyBC5hQFa+",
+	"AH2xFFBXfsnGrcCSg8GDDSSIg08UyfDuQy7qVueiLl9Urcr94Z6r0pumlLSglkuQlY+StFAwmK6mGIuf",
+	"Jg6AwRVtzGpE9GMERclVZ1WQiYtagVtW+0lMj3oY3RpopCF26msxx4ztiLr/56tXLxg9wEpVQZLSQlw1",
+	"xXgpehkmsydXV0P2hBV2CHv/sFbasnXOLKbdbLjexewQv4/uo9lQk/+TbyoMetOHXSg/vkRfLiDbMVGB",
+	"tGK5C1J2fMhWy5nldb2bIVvOOr46HtxyvwZKRJKPHPbhPAsyVUIksovxv0oTJ4Rh17ALqHEo96LwuL6a",
+	"d3k/MdLsDgIuyDBeVRpMHqpe7D5gHsbeZnaw/YCaCENs0a0UqHW6Wr5bekfQLd7kERWaZ96thhBscGVH",
+	"xvLRLi+6zwonnZoXgCElckENpJGQXu1H/HHDeCRIwpseVzIud/eSSFKQTj8+HhLnBC/RQyWenBD4OZJv",
+	"4omT7FzG+AckxnEf4770OM/TGK3rUV8jnQb0M/o1neNqDKLvj+tmfAmLVtSVT7YbWomTHgFCGMqna2q+",
+	"c+aed4UHHzhbihpjvd7iIeNY5kdU04DGe1gSr0l0HFPY/FqqrTlZur/ESXV5St2MA2vgiyMB14PxjeOf",
+	"Dop5f0vG6X3Er+vJ5Ik9ZBvSE/aAq7Wb6BbI3xQ/1YdEe9YzfXuYY+jMBhfCq9GgEBp1Piab5GF6qdnt",
+	"vKdevjz38psuSTX/+lOK/P9A3640X1r2+Orx1cWjx6xSZbvBqDIdKHesHRoLPjWBfyXVEtMkwks4ryQ/",
+	"kby7xr0Bb3lpQxZc9Ly7h0ou0UbZsZpbcrn1qNYjb7q2YRKnHugR3JXkgwSPIAXtg9PfPzLiARyFE0lW",
+	"ic/xIKBQ7WtdYnTaTxnyYnhAFhW6uRIAsl2HfIgK3kas59GuyCJhQ5DEvTUeAPjMsEYZQZlfJD67oDgG",
+	"QwqKgQcP76+g1Vi0YTw5JBIloXAe536dbu+MfXZTNq35jOy+wATMb8ju9eQEJY0LT3II4gyHeccxYXUQ",
+	"tEfEyKzmN6ANr32iYTVkUzd2fVDK1B6g1wJS52iWhLjl9TWpwED/mK6DkcqhfWj40MBZLquojI8erL2G",
+	"jXZ8xGySBkdQgAdeWB/gmOPaQuL/JoMFR4FsHxA0HcVPhBRHclExYLJrkgKKxHDBJbljdgMVO8UCD9Pr",
+	"D1v4DfbkPs5Sw6guR2MSTuGsU4BdXKv/ShEON26n28obYYSlHKjNGTG+7JQc8ybTN0dpM5hzTVLab1k8",
+	"FlvVIV0vT9FoZ9yyuZ0zsVyyeZcjy163V1dfln9hlj397hv2Of1iFXv2A/vux+fP2fcvWfwbPgvMBpOa",
+	"NF1ZK9NLofKRiRi84Di8Q2pc18KR1ccqjBXOyhFyJIHxJAM4EsGJzDMzcsct0fDV38oU7ZLTD9qicfEh",
+	"MnTMEn3QBPV9j/zh1KAz08jvNeP9lO/fNZn8jhGTcPJOG1w1A2OfFjFIc9qdqX9PAQAkascCxYGM98z8",
+	"T8ieEOGoWyDIynEN0mEJtUQtEpFKFkM9M1U+fDMKWp8Yht/KvQVxAeemy0c9cBdVMpYQl+aEhDzzJHkh",
+	"JJj7nOm9nBGqxiNtoMVqbZmkyrx7TH99f/9oFpnzbxQDq/TZGcJ2gC+8+pkzJVQdg/7ZKSI53CU1cMsk",
+	"ynazVlsn0mM11Kt8QB+yxhyPKlSaOGWJfnl1DdKXRp2S/CFMUBI+AN6FEwilJmmOyHuNhgpLbbscEErk",
+	"B23Woon58YlrciFqZ+f6JB10IIVA9mcmTZwpPAWyvJOGi+C5dMAYEYL74X1ljQOW4SOnbn8EJon8E97P",
+	"+f7zqLmxb8h6OjAVbnuJlafrgWSA06C8hC3E1IjA2DJYLppO5/AwB9Ok+7nRNF5YWREcdo5D/D+T+g3v",
+	"EXHMlxwcylniNuaEyUPeyE6a3SVLenrf6QlyhKKn50YLa6BeFuM1tOd6FYeypu8hacLt0HZ0o2OKM+We",
+	"oTg9AmAzwRlfkwpHv4d8DIHpGJKqnELKVJcZ49OEomDoMiV81wIDWEnjdiezcYKgFpap5dKXZrmPhNT4",
+	"Y+AoxEKS8Ei+pTn7ZAy6l0+RaMJMLu7Ljr646h37Q8DheLyFMhts5xk+E0n1Hd/D4ZYi9+0WvgdC2PBz",
+	"QFWXpfaHjb8c8qL3IuwZWaPXN3Oz+/8nJxzhgMV8W58e4EDPijtMt7/97yO2cTYLqJVcGWbV+0rD/HsO",
+	"hwivl8Owo/JxNFDQpSIgAU+IGgxJtLapjuNYvwNOlSLf3K32+IDUSRecze0Yfx2yu4Z57P3kA72ayYXI",
+	"OJkoCJGfs4QBnpT7Ewjh3PukeDz+VlV8N8sbgBD8wdCc2rIGdF/IGRVDmkkAaemULkI7TPnFxPlehkwt",
+	"jHWT2RnGmRFyVYMXrJ0DADvE4JMkdAmm02rNw0mnNDN7UDj5IiyzH77tGaW9CuGmbk2vct978LyjTdgP",
+	"YaAejoT1SzG72qtsNVQOcOD7v21p5RCUfs9Sy1MMiH3bO+Qb+Z0NDtAkNsgzaOZL6/KqYKe+nDW+Xyfu",
+	"vh/MnWuAxvjiCHD8x7v6TSwfX8BOebWpJPQdx78/w2as7vNuZeV+pyK/n24Jn1NsCnu1pvdjRZ366fHy",
+	"U8eTsYq00apqy5QcRVJCiunMaV1n4P+Yx+jtFPeUrnqBmO4hL0w0K2suNjB8bs8vDn1P9JGEmrsxM3E2",
+	"mDZ2jn0UqjOCLMoZdEgZ/YhIZzSwTZER5Z1vscgi6TzlJVbSjC40EqIuQqiBvaOUYmP4gCHfsw8SJ114",
+	"Gg3Gn46NkGnjg0end0MiIUe/Zh7BYPqiR1CqLfO85WvYjQ9540n1Fjs6QQ2vIWMyijlsQK+ClymWQgcy",
+	"YCGdt5bDuARmEpqFiaGQvZcsymxtJ3TJGmGJ8RjsCE+kjaV+H0zRhRE/Nq6IMxtnizuFyXqdr0jVJRHy",
+	"eVaV7332QYnPCDkhrOoiaD4ijiaBs0d4+Ivb0ZX3J9HfIj4tldaYkxVQuQb3XWxYFkPsyRgYOaCulmdJ",
+	"4X0Wb0mV/mYtu5ymhLLVwu7Qcval4414pa5h4Mw9lYghqAjXO1u4YfOnrV0rLX5FEs3YX4Fr0D6/AR+m",
+	"9IX5lH3Ly3WX+O+9rFQ/S/EACVCZrxn3g1DHGIpvJaXJX8ZGoW45CxyvW97a2obSylZg7PhaQoG9BsxT",
+	"43XBhDGtQ8eg2edBCxbk+vqCYjfvs+pn1pcsYydUb0s5AE0uEC4047X3vp+wKkp2HlkX+mLX3NHJQKkh",
+	"rbh4hd1oOgOciupj3Rr2RVGtBYNIvnjvxfpD4olpFWvaRS1K33XWnLDMW1zockCufEvoL2RoJg5Jgc2A",
+	"YiF9a5wxTTQPqYxIACdVhOnyQkt148wQrCwGXts1VuWAKQLS7MYK9roTl1hmSHvZTcLQ2DE454sHw88X",
+	"6P8K7oEiU53dX7MeYXAjYNtVhqeF7ZRHPI2lPrMJbfDLuOanL55NiolbHhHvavpoeuWYyAk43ojJbPLl",
+	"9Gr6pU8Rw+N/yRtxefPosismX4EdSp22rZZBa6QdRQomudYYgF3syAzEkGRIIU/1cShUQUHv875MXoLe",
+	"VZ0zbkqqhJuyOSoIKi+yas4M1CHdpKvd3QpZqW2vejfF0nGYWWfLchvzgf0gwviKRaqLTh9wQxO3T19L",
+	"6n9V115SkUsJfcxsjm6ZedS1nU/Fl0hl3YpTGwOdWvhV3484cWw7OYnG+N7r+H1ZhaDkltfXRGN6xrtw",
+	"eJdXi6FBX80MtSGnlwc8HieEJs3ktyCJEvbUzRjqmlWwdPb7zBvq9GOIVBJtMJvax/md9AszUHLLdWWm",
+	"ryUeT3SdBav3wkfq8yiQP1P0mwN8XWfga5C+NXPa7YFq1+edtTL3GsjjPYcNQmC/oNyhKtjloYFQP4CV",
+	"Jp9vHZbx3RkwpWzLdz73APRFfJEmhtPea0aBDQq2fOfxWvga26ibmDAQbGGFE5aw7QrRvANmzaWfuKNw",
+	"koqVNoDYWwj1vkB1UVchdzcq62fVZDZ5Loz9NhTdp824f9oruHQnpqus6DUOihUbg02yvc053iO7OG+0",
+	"NMgwNGBi797fmKGczo3RNQ0ciDCzp55hubmOOfeda8j3nHIvEssMQKHBRWU2+V2XRfbVeH3M0Az2ohv3",
+	"RVvyylPrMe8Q7adDDs0n83HceTIonHFv9/xJYxOInpFucJDtBkPSwe1E3pLE65Q4TM7etL4LMSbGDeRG",
+	"Rl2BSnNsCT4zsFvAacbPafNNO/NnU+2lUp42VWp+cMeJ9rtlBZUeNTm3bKPMaMP/WmyEzebhGxxPZo+u",
+	"rorJhr8VG8cCj67wv0L6/w4Vcg1H0ToxfOkvRLj9uXeHwOOrqwP3B5x3b0DXY27g5oCDXebu47aAYvKE",
+	"1jL0Rlxzd7mBe/7Rmc9/edbzX501n8TkRqXZGds//ey2zbck8Ko2pyFGFNRQoPcHapPOfWs4tez3YTXJ",
+	"BQ4OVAmqwI9hPgrmYMAVO5MQUzPHlLGEhvp8kepxH3l8dYU9MOCm52TzKTsODXFvNvq+SaHzQtF17vVV",
+	"Y+JGVC2vfcO3SlSzpO4sa4lrqO9AY737/QLVY2xjMVgo5wcPiVGSzUMPtzl2oI8+/w319fVtvCqtGhI0",
+	"mIJKxEXo6rTxol0ukYg+LuE71KFZRKh+0xqLlrAGq3eIHWnUWAqXoytqDBjxlafnX1W1O+v0KgnfL5G7",
+	"jp5j6vLrJMtJgfrsnV6Y/ufbPNRgdQu3DyiHsi6KI5eY0I45Rmi0KsGY/ZtMtmmsljD170hWPfqQsirz",
+	"p/XFFW1HlFS3RXQkBIvqqCvBroeajpj78CcMXgzTuRPOtt27uX2y3jPrfdBifBE44Dybcb8FxIew4/ZG",
+	"fWBbNa2HFDozDnF49CE8S9rsYetwiSpIbalQwW4VvWhYa4LHAl0JSWsMTLRYKLsO/bdaWYNx/OjenPtT",
+	"Rtzns5nGDKmsh8gZS49oOqsn/c/G02nt7RFEPdJT5ROuPhtXj6iacYQdWmOYtHbt7H5YMye0uaCs3dAa",
+	"mbLpMqfOn3ueTgwAd0W9DdWbZtmIBMPVDeitFtbfjeFjpJo7bAuSFktWtofz2JurO/HxGAq84+3kbl10",
+	"aUEqa2pHp3C1WsEWUPLWQCqpHNZ2pzppDZzVhgdX6L5OyS+Je3+gfOhY5mOchG0f3bdMGIO1WVswUgzb",
+	"XgOyRCaEfoLDscIfXz4POCPUMYc9PSzb/0iy5snVnz8K2RSkTOf/HUTSl+9EdZvA6fx0/ANsejQeVm2N",
+	"Xx+51zzwD6upnlw9+Ui4h1e+w1Sf+JPbI9D7pA6ACMiwl0jEY76ePBWMxYkchOkvt24JjTPTBy649b27",
+	"g6edKXIXxfSpvJL8/JQvtN3C19DyCqp2JLOKcqrunmH3Wn7nXXA2TSyWfoEj9qoD/v7mO8rDB02p1DuE",
+	"9tuuf8Q+ICl8OlQXDESgfUN937gkJU/GB/Yz2lPK+2o4z9p8GDWcj/GBXUxnqWGng43lsjKfJN1DSzri",
+	"ilFZN6YyLzX1Bhr1RP2L19f+muzWrhT15g49JvDIxFo77OrD7bxgbeOOUGg4lfS5aG2oj0xTZfZaZ8V7",
+	"QJ9maYYP0jvI98TrnPgof5SQ9kJIDIqxGwHbgAhXmjdrXEO8c8FQU6HFDj1alCTZcEPE8EYFLksYtnCP",
+	"2vUF3RbgPoMdnUwa3pZlrBWxoDdCYmcEzjB9Ct/pKj/iS8vuIlt/5XbitGDdxTGl2kDeVco6aYk9E31z",
+	"Ka8F3LfmaT5isu1+QVapa2p2yMs13oswGhohY6zhK1xOnptCDa0H757u3b8y7EzL+1sd9akNNHMLfY5w",
+	"VStFxTFDzpbQPmzI2ZK5Wo47WvbPWdp1M2kNc0JWQd685gz306vefbJ+w8JlhGbvAlo5Hl3m9vzo8kO6",
+	"kQY6uR1WW/sN2D7prQ/me8r9nzEDFBXBOVg9XAjk+/H5Nlh4od6D4fXD2tWd4xMjPdmphxyaDujZ7I6i",
+	"rutCwfBGoo9Qe0oQq/VC6bVS1flK9L61Sdat1VkKUNem6+GcTda3KmKtvJZqK8dNgCS68zLu/hH2DX2n",
+	"o4JVFJCYsXlAXfOujNOZb8ltCWSgzoUs1SZ/EE8PmWEFmy+U0+dkZI2qN6EplXpYxU3cNyZFTNEKk8Ov",
+	"0fCTgh56jxStT0rvvpReaDs36ok62CTuk9L7gAGX4RaAZyu87kNOTfhwRFqt/2COqsHYEIUKfAeJtJVm",
+	"T251RguVpH8IlYXGTVJSl5102xMN6WxCjxNKjbBaNDVl9fnrK6mfZLj+NpFOXaJEbHmRl+lhbzsnLDDz",
+	"mT5s/Z1EISjGS7z1uxcV+zq5/Zreo9xWHir6THdL34oLN/mnfsLvZX+5+dEyhc0fDe40/3OYPk6v11VM",
+	"Q/LRx49xTpEW/iCEAIySS7FqsXTAWi0WLWZvYM8VbwbHv2NvwqXSeNv+M+tXTr14gxPDUzH9Vm4FqiWb",
+	"x8agc7rVLywt6UnNIzZNV4gkzmn2+DH7fN6/uShyB5r08y9ilQKVggZGc8TGPno+4Z2uofJVIP0WuzEt",
+	"5nBsMJYPP2SMsOsP+mGDhPm4BzqpZ2HC7pbfu4QIY5n1f1KM8MmDxhSfPH78kUSR6uBb7eqpQoTgmG/V",
+	"SZbLd/HE+zAltYAZUJxOaufWoLOJDFiUVfOg0eYBllK+hdp2VtHRfufOosqanWcdvjNh3FdCvvY7lXCP",
+	"r56447SFuu5qMn2SdjLdqCs2ytk1eHKymnOet07HS7yDAsFuyCFSxLL5+ZjcgCpS4VL8+BvdbjviNu3r",
+	"pSFn4zdI2iFJmgm0J8fucQhV+Z+Q9kMfXTxPGQx9b2idtIJ/EDBdHOaZriXrqYHoROZ8mIh0F4XWacJu",
+	"Sv0PFpGevpaJ9DnUUiPxAjm0hkJ9Kwx0vfKMYlvqn7HX/OJYA42vPWGG+nWghD6rs0ZPNnvTKco3t+/D",
+	"WPUcEYj5sIflYBaCfmBE2et684Hj3Wciyk8R748XxWUR8rirHXYLlUgXZ7V58B1ThsqyqrQcqzilHgt/",
+	"5VuqxUl6DYbmi3tFHEkXMXL631dDiHny5XnmJw/3gfeuBet1egOZ3MyAXd5QAK+d9AmlRV09WxjseKeJ",
+	"wSfv0nIC//SpZmWg4wQkXYmcGqw2Ql4oWe9moWuN70WEfhX3K7Us6sHoL6fsu3gNlK/XR3kMJsmB9oyP",
+	"LYvxHvjsyr+wYdLpy1pgqld3WUp0/4xlByT3C55bcENJE/GM/l6qx/Npf8xF5DTTTzUv3wCvnmODo1PK",
+	"XpJ+SJ/qye8ehhkiZw8bJN2qToUGSR5e0jktawHyBdW+5FK93+Y+ucnCydZyDeV13tV+SOh1/cPN5EEB",
+	"cq/l+vHs9/2m6/fFto8+2nKqfM0HeOvyXWCV28t3Ga8cLG/I+sV/oO0+d6t/u53+mMsRMhKd5pw65V6K",
+	"A7fkD7iKsgsYxvxEJ+VVHL/XomChc/sJE9tvsnzq7H4uJk17sGyxL2e9q+qwrC6oCXbaf5beDi7yZGvp",
+	"MhLC/LG34imXdPPuhpPUeePfIx9YZzUGk4H6/g4UnL9o9+XD/TtqBq9K/+DumlPEU3avzEkFg38k982j",
+	"Lz+2wr6eCBzQjaflT6adQNXWkMcgvbzkHvtmZKIh+e9d22jQxD+5I3ruiIHb0ij7w4FjrbbevTbHm8jm",
+	"8WGkY3K9IzNgp+yl2vo7NoAuK9iomyRgml5uKQxbuQ2jqERo1tR107ZrrdrVGqcR7uN0sx3quxm21zfd",
+	"DJzUdSX01sBA682QHkXXHgod2aGCUlTge7V3PeerXv0aNoly6sioDXQ76pe1XzBy0KY414ey3yLxgfuH",
+	"DFzd9iHapAwM+wfpePlbNbnsxqUjE270o5sVhYkuYDengpl1a9VyeUrjy3hj4elz8zelcB0Py7IGsDFZ",
+	"e8rmlF02p//vHfg4a4flYpZGEE/JW+5h7BbhFQGv6/jrQtn1NMo5/Nn9uzVzlGhCVtCArPCqVZK1XjY4",
+	"fKV5JUrMt0chYtpyjboDv/YXmv3r9urq8Z/om3+Jc9vRDUPdtZnhosAx4rZmJIWcRkmSyOMf/GCTYsLr",
+	"+qQE8qSSKzLof7wnMbsg84gfcfCKzE9OxPfy9uzRchjJXr5D0b/n3Un+L6rbU3vNpx2sY6pFALtZeVDS",
+	"Pz6LGnbN5AlejBbZzPDrCNjymv6uVXfAzhu+YwZgBMcmlw9SMle4E9shuA1FKrjETptXebvPE1JrPTHe",
+	"WKXe1Equ5l9kkUnOrG5liRmb/tGv2fwf375ieZP/OR4R40VkAu1e+QvKERniZ0IqRpYyFK9qz22SUE6r",
+	"Kr7bb8/u1QQq+DwNG7HoKGBMqeKGf3L1JC1VigRegTV9lNvlFoeRSy7duAtg1g2NsHw/lw7eCmOn7Fu6",
+	"64C6p8VryMIt8vvd25PCPq9OUoUaq8GokVsHf0M/djJJkElmMdM9doQPfdpjsBGv14mX2Gd3R4OGLl1R",
+	"wtYfnTArz2+e+4wIHU3jWClTdf1Q45X8gyxF8XN/NWc6UTJl0okGfg92aHUYkicNUn+LHsfRRO5OVdjS",
+	"ThqRgZYJAxQBvxuv8MeTjsyr9Pa7YfF/kiv5+E2iBVPmotGquoD20QkO2+52vDu5kfvXHCZOY6V9n/sH",
+	"dR8Xd7sg/9BcxHn0+fkOKCLeunNi/XFUW4GplqquwpVpeeLQQlAWI12UdMNrNA614tWGN5dXVxelwtuH",
+	"hJJmusGrl5DLvirIf+U/2NOPQSInNwq4KTDNJeuum4x/3rv/p6n5julWmlia3E2PnDZB/MqIXyrQmFLk",
+	"xi/Vxt83N30t51uupZArE9pgRA8cDl6qtkYPmcMUWCWUXCbCbSg9DwU6nA3cyzAEKBwNEg265b4ranph",
+	"Slc3Pct9Vj4DjZx5UvXpS3fUVmMIAHHIZ8HJkGXyRGWOhdPZ/S85ilmSH1HDnhr/LLvghz848puyv6u6",
+	"otxaT9Ck3hw3s+uk0vHJEEoxDZchUuA4n6I7swR9ZLE8YcLJ8V7NBDl4p2ZIqkuYjNqxozv3NFby7AOb",
+	"BVRusHmYQHT4DhyvkFWMBMFj4vZp3rUPmDsIyBoNmC/pMxYr0J/hboI2a9Ekt3V3hMNZMm6z9U7ZX7HS",
+	"xNFhHp+d7+OZJIr9PIqtB0Q03SBHAkVF6t3tQGO3bmE90zsx+QnPvDee8UcmKq1PkOaPDGnoZsFfDyAT",
+	"kobbNXR9AenOAmbWqHud9HbaXmK+8zPLllw4HCLrXczSpDuphdOZ3LAFgDOMaewdktvpitSSS0qO7VqD",
+	"oYoyRBNUp+0Em3DIu+KWL7hBFUo3K3o57aNm+zLun37NR8Wahbf2sqm56Ak0zxuT2URdD+RZDsqxsH50",
+	"vYibe8zD+epMH99XZ/nsbnM32w1It/V4EyW51sIVnZedlrv0V0C6YcbaVjuMaIYNqJC4l9ytTl50nzxv",
+	"OiScaFZEMzG6W4aEjkpJSBFrZAVes1XLNZcWgC1gLbxGSYComXX3wfC+FkdwV/Q8Jgl09fobb97CvtpY",
+	"+b/HjC+JVC/ixx8sMQTH8bzz4VNC/OiHbkXxXMOWQgrz++r79YHvO8lu2t3X5ETG/HzQYcXsqPOkfRBc",
+	"jp3Rxehk73IpykTWdzg0SmNhWCuxO0O4WAlbKfLrcFOJqkLIWyvrS449svYinNIbho4MLuK3Et+UYRYC",
+	"jpEav0d5/hKdnalAv739/wEAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/problem/problem.go
+++ b/internal/reporting/httpapi/problem/problem.go
@@ -27,12 +27,19 @@ const (
 	TypeNotFound = "urn:tally:error:not_found"
 	// TypeMethodNotAllowed marks a known path addressed with the wrong method.
 	TypeMethodNotAllowed = "urn:tally:error:method_not_allowed"
+	// TypeConflict marks a write that collides with existing state, such as a
+	// project whose (cloud, external_id) is already registered or a relation
+	// triple that is already active.
+	TypeConflict = "urn:tally:error:conflict"
 	// TypePayloadTooLarge marks a request that carries more than the endpoint
 	// takes at once, such as an event batch above the item limit.
 	TypePayloadTooLarge = "urn:tally:error:payload_too_large"
 	// TypeHistoryTooLong marks a resource whose stored history is longer than
 	// the unpaginated per-resource reads answer at once.
 	TypeHistoryTooLong = "urn:tally:error:history_too_long"
+	// TypeRelationCycle marks a relation creation that would close a cycle over
+	// the relation types that attribute cost.
+	TypeRelationCycle = "urn:tally:error:relation_cycle"
 	// TypeInternal marks a failure the caller cannot do anything about.
 	TypeInternal = "urn:tally:error:internal"
 	// TypeUnavailable marks a dependency the service needs and cannot reach.

--- a/internal/reporting/httpapi/projectrelations.go
+++ b/internal/reporting/httpapi/projectrelations.go
@@ -1,0 +1,514 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/audit"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/projects"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// The audit trail the three writes of the relation graph leave. A close is its
+// own verb rather than an update: it is what ends a relation, and the row it
+// leaves is what an operator reads that end off.
+const (
+	auditObjectRelations = "project_relations"
+	actionCreateRelation = auditObjectRelations + ".create"
+	actionUpdateRelation = auditObjectRelations + ".update"
+	actionCloseRelation  = auditObjectRelations + ".close"
+)
+
+// unknownRelationDetail answers every request addressing a relation this API
+// does not hold under the project of the path. A relation that leaves another
+// project is answered with it too: a relation is addressed under the project it
+// leaves, so one that leaves another project is absent here rather than
+// someone else's row.
+const unknownRelationDetail = "this relation is not stored for this project"
+
+// duplicateRelationDetail answers a creation whose triple is already related.
+// It names the triple rather than the row, because that is what the caller has
+// to change to get through: the same triple is created again once the open
+// relation over it is closed.
+const duplicateRelationDetail = "a relation of this type between these projects is already active"
+
+// The details that answer a relation a caller has to correct before it can be
+// stored: one end that is the other, a target outside the registry, an end
+// instant that is not after the start, and a relation that would make
+// attribution circular.
+const (
+	selfRelationDetail = "a relation cannot leave and reach the same project"
+	closeBeforeStart   = "valid_to has to be after valid_from"
+	cycleDetail        = "this relation would close a cycle over the relation types that attribute cost"
+)
+
+// The unique index that holds one open relation per triple, as Postgres reports
+// it when a creation collides with it. Matching the name and not the code alone
+// is what keeps another unique violation from being answered as a duplicate
+// relation.
+const activeRelationConstraint = "uq_relations_active"
+
+// The details that answer a failure of one of these routes a caller can do
+// nothing about. Which operation failed is what they tell apart, so each is
+// spelled once rather than at every writeInternal of that operation.
+const (
+	relationsDetail       = "the relations could not be read"
+	relatedProjectsDetail = "the related projects could not be read"
+	createRelationDetail  = "the relation could not be created"
+	updateRelationDetail  = "the relation could not be updated"
+	closeRelationDetail   = "the relation could not be closed"
+)
+
+// What a write of the relation graph refuses its request for. The checks run
+// inside the transaction and the answer is written after it, so each of them
+// leaves the transaction as one of these and is routed by errors.Is once the
+// rollback has happened.
+var (
+	errUnknownSource    = errors.New("the project the relation leaves is not registered")
+	errSelfRelation     = errors.New("the relation leaves and reaches the same project")
+	errUnknownTarget    = errors.New("the project the relation reaches is not registered")
+	errClosedBeforeOpen = errors.New("the relation would end no later than it starts")
+)
+
+// CreateProjectRelation relates the project of the path to another one and
+// answers the relation under the id the other operations address it by.
+//
+// Everything the creation decides on happens in one transaction: the two
+// projects have to be registered, the walk that keeps attribution a forest runs
+// against the graph the insert lands in, and the audit row naming the relation
+// is written beside it. A creation the log does not account for never reaches
+// the database.
+//
+// The triple being active already is decided by the database rather than by a
+// read in front of the insert: two racing creations of one triple would both
+// pass such a read, and one of them would still have to be refused here.
+func (s *server) CreateProjectRelation(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	ctx := r.Context()
+
+	// The metadata is kept as it arrived rather than decoded into a map and
+	// marshalled again: the column takes the document itself.
+	var body struct {
+		TargetID     uuid.UUID       `json:"target_id"`
+		RelationType string          `json:"relation_type"`
+		Metadata     json.RawMessage `json:"metadata"`
+		ValidFrom    *time.Time      `json:"valid_from"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		// The validator checked this body against the contract before the
+		// request got here, so a failure now is this service disagreeing with
+		// itself rather than a caller error.
+		writeInternal(ctx, w, "decoding a relation the contract accepted", err,
+			createRelationDetail)
+		return
+	}
+	metadata := body.Metadata
+	if len(metadata) == 0 {
+		// The column is NOT NULL and the contract answers metadata as an object,
+		// so a creation that carries none stores the empty one.
+		metadata = []byte("{}")
+	}
+
+	// Only a type that attributes cost is walked, and only such a type is worth
+	// serializing the creations of.
+	attributing := slices.Contains(s.attributingTypes, body.RelationType)
+
+	var stored sqlcgen.ProjectRelation
+	if err := s.store.WithTx(ctx, func(tx pgx.Tx) error {
+		q := sqlcgen.New(tx)
+		if attributing {
+			// Two racing creations each walk a graph the other has not written
+			// to yet, so both could pass the walk and close a cycle together.
+			// The lock is held until this transaction ends, which puts the
+			// second walk behind the first insert.
+			if err := q.LockAttributingRelations(ctx); err != nil {
+				return fmt.Errorf("locking the attributing relations: %w", err)
+			}
+		}
+
+		if _, err := q.GetProject(ctx, id); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return errUnknownSource
+			}
+			return fmt.Errorf("reading the project %s a relation leaves: %w", id, err)
+		}
+		if body.TargetID == id {
+			// The table's CHECK (source_id <> target_id) refuses this as well,
+			// but as a failed write rather than as an answer naming the member
+			// the caller has to change.
+			return errSelfRelation
+		}
+		if _, err := q.GetProject(ctx, body.TargetID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return errUnknownTarget
+			}
+			return fmt.Errorf("reading the project %s a relation reaches: %w", body.TargetID, err)
+		}
+		if attributing {
+			if err := projects.GuardCycle(ctx, q, id, body.TargetID, s.attributingTypes); err != nil {
+				return err
+			}
+		}
+
+		var err error
+		if stored, err = q.InsertProjectRelation(ctx, sqlcgen.InsertProjectRelationParams{
+			SourceID:     id,
+			TargetID:     body.TargetID,
+			RelationType: body.RelationType,
+			Metadata:     metadata,
+			ValidFrom:    filterInstant(body.ValidFrom),
+		}); err != nil {
+			return fmt.Errorf("relating %s to %s: %w", id, body.TargetID, err)
+		}
+		return audit.Log(ctx, q, audit.Entry{
+			Actor:      queryActor(ctx),
+			Action:     actionCreateRelation,
+			ObjectType: auditObjectRelations,
+			ObjectID:   stored.ID.String(),
+		})
+	}); err != nil {
+		switch {
+		case errors.Is(err, errUnknownSource):
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownProjectDetail)
+		case errors.Is(err, errSelfRelation):
+			problem.Write(w, http.StatusUnprocessableEntity, problem.TypeValidation,
+				"Validation failed", selfRelationDetail,
+				problem.FieldError{Loc: "body.target_id", Msg: "this is the project the relation leaves"})
+		case errors.Is(err, errUnknownTarget):
+			problem.Write(w, http.StatusUnprocessableEntity, problem.TypeValidation,
+				"Validation failed", unknownProjectDetail)
+		case errors.Is(err, projects.ErrCycle):
+			problem.Write(w, http.StatusUnprocessableEntity, problem.TypeRelationCycle,
+				"Relation cycle", cycleDetail)
+		case violatesUnique(err, activeRelationConstraint):
+			problem.Write(w, http.StatusConflict, problem.TypeConflict,
+				"Conflict", duplicateRelationDetail)
+		default:
+			writeInternal(ctx, w, "creating a relation", err, createRelationDetail)
+		}
+		return
+	}
+
+	item, err := relationOf(stored)
+	if err != nil {
+		writeInternal(ctx, w, "rendering a relation", err, createRelationDetail)
+		return
+	}
+	// A 201 names where the created thing lives, which is the route that reads
+	// it back.
+	w.Header().Set("Location", "/api/v1/projects/"+id.String()+"/relations/"+item.Id.String())
+	writeJSONStatus(w, http.StatusCreated, item)
+}
+
+// ListProjectRelations answers the relations of one project as they stood at
+// one instant, which is now when the request names no instant.
+//
+// The project is read before the relations are: a project with no relation
+// valid at that instant answers the empty list, and one the registry does not
+// hold answers 404, so the two are told apart.
+func (s *server) ListProjectRelations(w http.ResponseWriter, r *http.Request, id uuid.UUID,
+	params ListProjectRelationsParams,
+) {
+	ctx := r.Context()
+
+	if !s.holdsProject(w, r, id, relationsDetail) {
+		return
+	}
+
+	// The contract bounds the direction to the three values below, so what
+	// reaches here is one of them or nothing at all.
+	outgoing, incoming := true, true
+	if params.Direction != nil {
+		outgoing = *params.Direction != Incoming
+		incoming = *params.Direction != Outgoing
+	}
+
+	rows, err := s.queries.ListProjectRelations(ctx, sqlcgen.ListProjectRelationsParams{
+		Outgoing:     outgoing,
+		ProjectID:    id,
+		Incoming:     incoming,
+		At:           pgtype.Timestamptz{Time: instantOr(params.At), Valid: true},
+		RelationType: filterText(params.RelationType),
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing the relations of a project", err, relationsDetail)
+		return
+	}
+
+	items := make([]Relation, len(rows))
+	for i, row := range rows {
+		if items[i], err = relationOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored relation", err, relationsDetail)
+			return
+		}
+	}
+	writeJSON(w, RelationList{Items: items})
+}
+
+// UpdateProjectRelation changes the metadata or the end of one relation and
+// answers it as it now stands. The row and the audit row naming it share one
+// transaction, so a change the log does not account for never reaches the
+// database.
+//
+// A member the request leaves out arrives at the query as NULL, which its
+// COALESCE reads as leaving the column alone. Setting valid_to on a relation
+// that is already closed corrects the instant it was closed at; the contract
+// types the member as not nullable, so reopening a closed relation is refused
+// in front of this.
+func (s *server) UpdateProjectRelation(w http.ResponseWriter, r *http.Request,
+	id uuid.UUID, relationID uuid.UUID,
+) {
+	ctx := r.Context()
+
+	var body struct {
+		Metadata json.RawMessage `json:"metadata"`
+		ValidTo  *time.Time      `json:"valid_to"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeInternal(ctx, w, "decoding an update the contract accepted", err,
+			updateRelationDetail)
+		return
+	}
+
+	var stored sqlcgen.ProjectRelation
+	if err := s.store.WithTx(ctx, func(tx pgx.Tx) error {
+		q := sqlcgen.New(tx)
+		current, err := q.GetProjectRelation(ctx, sqlcgen.GetProjectRelationParams{
+			ID:       relationID,
+			SourceID: id,
+		})
+		if err != nil {
+			return fmt.Errorf("reading the relation %s of %s: %w", relationID, id, err)
+		}
+		// A relation valid from its start up to its own start was never valid,
+		// and one ending before it starts is no span at all. The stored
+		// valid_from is what decides, so the check reads the row rather than
+		// trusting what the request thinks the relation starts at.
+		if body.ValidTo != nil && !body.ValidTo.After(current.ValidFrom.Time) {
+			return errClosedBeforeOpen
+		}
+
+		if stored, err = q.UpdateProjectRelation(ctx, sqlcgen.UpdateProjectRelationParams{
+			ID:       relationID,
+			SourceID: id,
+			Metadata: body.Metadata,
+			ValidTo:  filterInstant(body.ValidTo),
+		}); err != nil {
+			return fmt.Errorf("updating the relation %s of %s: %w", relationID, id, err)
+		}
+		return audit.Log(ctx, q, audit.Entry{
+			Actor:      queryActor(ctx),
+			Action:     actionUpdateRelation,
+			ObjectType: auditObjectRelations,
+			ObjectID:   stored.ID.String(),
+		})
+	}); err != nil {
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownRelationDetail)
+		case errors.Is(err, errClosedBeforeOpen):
+			problem.Write(w, http.StatusUnprocessableEntity, problem.TypeValidation,
+				"Validation failed", closeBeforeStart)
+		default:
+			writeInternal(ctx, w, "updating a relation", err, updateRelationDetail)
+		}
+		return
+	}
+
+	item, err := relationOf(stored)
+	if err != nil {
+		writeInternal(ctx, w, "rendering a relation", err, updateRelationDetail)
+		return
+	}
+	writeJSON(w, item)
+}
+
+// DeleteProjectRelation ends one relation by closing it at this instant. The
+// row stays, so a read at an earlier instant still finds the relation.
+//
+// A relation that is already closed is answered the same 204 and keeps the
+// instant it was closed at: what the caller asked for is a relation that is no
+// longer valid, and it is not. Nothing changed, so no audit row is written
+// either, which is what makes the log count the closes rather than the calls.
+func (s *server) DeleteProjectRelation(w http.ResponseWriter, r *http.Request,
+	id uuid.UUID, relationID uuid.UUID,
+) {
+	ctx := r.Context()
+
+	if err := s.store.WithTx(ctx, func(tx pgx.Tx) error {
+		q := sqlcgen.New(tx)
+		closed, err := q.CloseProjectRelation(ctx, sqlcgen.CloseProjectRelationParams{
+			ID:       relationID,
+			SourceID: id,
+		})
+		if err != nil {
+			return fmt.Errorf("closing the relation %s of %s: %w", relationID, id, err)
+		}
+		if closed == 0 {
+			// The close matches an open relation of this project alone, so a
+			// row count of zero is either a relation that is closed already or
+			// none this project has. The read is what tells the two apart.
+			if _, err := q.GetProjectRelation(ctx, sqlcgen.GetProjectRelationParams{
+				ID:       relationID,
+				SourceID: id,
+			}); err != nil {
+				return fmt.Errorf("reading the relation %s of %s: %w", relationID, id, err)
+			}
+			return nil
+		}
+		return audit.Log(ctx, q, audit.Entry{
+			Actor:      queryActor(ctx),
+			Action:     actionCloseRelation,
+			ObjectType: auditObjectRelations,
+			ObjectID:   relationID.String(),
+		})
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownRelationDetail)
+			return
+		}
+		writeInternal(ctx, w, "closing a relation", err, closeRelationDetail)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListRelatedProjects answers every project the walk out of one project reaches
+// over the relations valid at one instant, which is now when the request names
+// no instant.
+//
+// The walk yields ids, and the projects behind them are read in one batch
+// rather than one query per hop: the contract answers whole projects, and a
+// walk ten deep would otherwise cost a read per project it reached.
+func (s *server) ListRelatedProjects(w http.ResponseWriter, r *http.Request, id uuid.UUID,
+	params ListRelatedProjectsParams,
+) {
+	ctx := r.Context()
+
+	if !s.holdsProject(w, r, id, relatedProjectsDetail) {
+		return
+	}
+
+	// The contract bounds the depth between one and ten and defaults it to one,
+	// so what reaches here is either inside those bounds or absent.
+	depth := 1
+	if params.Depth != nil {
+		depth = *params.Depth
+	}
+
+	reached, err := projects.Traverse(ctx, s.queries, id, depth, params.RelationType,
+		instantOr(params.At))
+	if err != nil {
+		writeInternal(ctx, w, "walking the relations of a project", err, relatedProjectsDetail)
+		return
+	}
+
+	// The walk visits a project once, so the ids it yields are already distinct
+	// and the batch read holds one row per reached project.
+	ids := make([]uuid.UUID, len(reached))
+	for i, related := range reached {
+		ids[i] = related.ProjectID
+	}
+	rows, err := s.queries.GetProjectsByIDs(ctx, ids)
+	if err != nil {
+		writeInternal(ctx, w, "reading the projects a walk reached", err, relatedProjectsDetail)
+		return
+	}
+	byID := make(map[uuid.UUID]Project, len(rows))
+	for _, row := range rows {
+		item, err := projectOf(row)
+		if err != nil {
+			writeInternal(ctx, w, "decoding a stored project", err, relatedProjectsDetail)
+			return
+		}
+		byID[row.ID] = item
+	}
+
+	items := make([]RelatedProject, len(reached))
+	for i, related := range reached {
+		project, held := byID[related.ProjectID]
+		if !held {
+			// Both ends of a relation are foreign keys into the registry, so a
+			// walk cannot reach a project the batch read misses.
+			writeInternal(ctx, w, "walking the relations of a project",
+				fmt.Errorf("the walk reached the unregistered project %s", related.ProjectID),
+				relatedProjectsDetail)
+			return
+		}
+		items[i] = RelatedProject{
+			Project:      project,
+			RelationType: related.RelationType,
+			Depth:        related.Depth,
+			Path:         related.Path,
+		}
+	}
+	writeJSON(w, RelatedProjectList{Items: items})
+}
+
+// holdsProject reports whether the registry holds the project a relation read
+// is about, and answers the request itself when it does not. Both reads ask
+// before they walk anything, so that a project with nothing to answer is told
+// apart from one this API does not know.
+func (s *server) holdsProject(w http.ResponseWriter, r *http.Request, id uuid.UUID, detail string) bool {
+	ctx := r.Context()
+
+	if _, err := s.queries.GetProject(ctx, id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownProjectDetail)
+			return false
+		}
+		writeInternal(ctx, w, "reading the project a relation read is about", err, detail)
+		return false
+	}
+	return true
+}
+
+// relationOf renders one relation row as the answer the contract promises. The
+// instants come out in UTC, the zone this API states them in, and the metadata
+// is decoded rather than passed through, because the contract types it as an
+// object and a row written past this API could hold anything.
+//
+// An open relation renders valid_to as null, which is what the column holding
+// NULL means: it has no end yet, rather than one that has passed.
+func relationOf(row sqlcgen.ProjectRelation) (Relation, error) {
+	var metadata map[string]any
+	if err := json.Unmarshal(row.Metadata, &metadata); err != nil {
+		return Relation{}, fmt.Errorf("decoding the metadata of %s: %w", row.ID, err)
+	}
+
+	item := Relation{
+		Id:           row.ID,
+		SourceId:     row.SourceID,
+		TargetId:     row.TargetID,
+		RelationType: row.RelationType,
+		Metadata:     metadata,
+		ValidFrom:    row.ValidFrom.Time.UTC(),
+		CreatedAt:    row.CreatedAt.Time.UTC(),
+	}
+	if row.ValidTo.Valid {
+		at := row.ValidTo.Time.UTC()
+		item.ValidTo = &at
+	}
+	return item, nil
+}
+
+// instantOr resolves which instant a point-in-time read describes: the one the
+// request names, or now when it names none.
+func instantOr(at *time.Time) time.Time {
+	if at == nil {
+		return time.Now()
+	}
+	return *at
+}

--- a/internal/reporting/httpapi/projectrelations_integration_test.go
+++ b/internal/reporting/httpapi/projectrelations_integration_test.go
@@ -1,0 +1,999 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// attributingType is the relation type the harness configures the cycle guard
+// with, which is the one the configuration defaults to. plainType is a type
+// outside that list, so a relation of it is created wherever the graph holds
+// one at all.
+const (
+	attributingType = "infrastructure_tenant"
+	plainType       = "peer"
+)
+
+// The span the temporal subtests keep one relation valid over. The instants are
+// fixed rather than measured from now, so what a read answers depends on the
+// `at` it carries rather than on when the suite runs.
+var (
+	relationOpened = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	relationClosed = time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+)
+
+// TestProjectRelationsOverHTTP drives the five relation operations through the
+// whole stack: the contract validator, the role a route demands, the
+// transactions behind the writes, and the rows they leave. The subtests share
+// one database and register their projects under clouds of their own, so a
+// relation one of them creates stays out of what another walks.
+func TestProjectRelationsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	adminID, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+	_, projectToken := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{uuid.New()})
+
+	t.Run("relates two projects and answers the relation under the id that closes it", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-create", 2)
+		metadata := map[string]any{"owner": "team-a"}
+
+		rec := a.call(t, http.MethodPost, relationsPath(pair[0].Id), adminToken,
+			projectDocument(t, map[string]any{
+				"target_id": pair[1].Id, "relation_type": plainType, "metadata": metadata,
+			}))
+
+		created := createdRelation(t, rec)
+		if got, want := rec.Header().Get("Location"), relationTarget(pair[0].Id, created.Id); got != want {
+			t.Errorf("Location = %q, want %q", got, want)
+		}
+		if created.SourceId != pair[0].Id || created.TargetId != pair[1].Id ||
+			created.RelationType != plainType {
+			t.Errorf("relation = %+v, want %s to %s as %s",
+				created, pair[0].Id, pair[1].Id, plainType)
+		}
+		if !reflect.DeepEqual(created.Metadata, metadata) {
+			t.Errorf("metadata = %v, want %v", created.Metadata, metadata)
+		}
+		// A creation that names no start is valid from the instant it was
+		// written, which the database clock decides.
+		if since := time.Since(created.ValidFrom); since > time.Minute || since < -time.Minute {
+			t.Errorf("valid_from = %s, want about now", created.ValidFrom)
+		}
+		// An open relation renders its end as null rather than dropping the
+		// member: a client reads "still valid" off it.
+		if got := memberRaw(t, rec, "valid_to"); got != "null" {
+			t.Errorf("valid_to = %s, want null while the relation is open", got)
+		}
+		// The instant is read off the wire rather than off the model: time.Time
+		// has parsed the zone away by the time the model carries it.
+		if at := memberOnTheWire(t, rec, "valid_from"); !strings.HasSuffix(at, "Z") {
+			t.Errorf("valid_from = %q, want it stated in UTC", at)
+		}
+		// The answer names the row that was written rather than anything
+		// derived from the request.
+		if got, want := storedRelationIDs(t, a, pair[0].Id, pair[1].Id),
+			[]uuid.UUID{created.Id}; !slices.Equal(got, want) {
+			t.Errorf("stored relations = %v, want the answered %v", got, want)
+		}
+
+		rows := projectAudits(t, a, adminID.String(), actionCreateRelation, created.Id)
+		if len(rows) != 1 {
+			t.Fatalf("creation audit rows = %v, want exactly one", rows)
+		}
+		if got := rows[0].objectType; got != auditObjectRelations {
+			t.Errorf("audit object type = %q, want %q", got, auditObjectRelations)
+		}
+	})
+
+	t.Run("holds one open relation per source, target and type", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-conflict", 2)
+		first := relate(t, a, adminToken, pair[0].Id, pair[1].Id, plainType)
+
+		rec := a.call(t, http.MethodPost, relationsPath(pair[0].Id), adminToken,
+			relationDocument(t, pair[1].Id, plainType))
+
+		assertProblem(t, rec, http.StatusConflict, problem.TypeConflict)
+		if got, want := problemDetail(t, rec),
+			"a relation of this type between these projects is already active"; got != want {
+			t.Errorf("detail = %q, want %q", got, want)
+		}
+
+		// The index covers the open relations alone, so the same triple is
+		// related again once the first relation is closed.
+		closeRelation(t, a, adminToken, pair[0].Id, first.Id)
+		second := relate(t, a, adminToken, pair[0].Id, pair[1].Id, plainType)
+
+		if got, want := storedRelationIDs(t, a, pair[0].Id, pair[1].Id),
+			[]uuid.UUID{first.Id, second.Id}; !slices.Equal(got, want) {
+			t.Errorf("stored relations = %v, want the closed %s beside the new %s",
+				got, first.Id, second.Id)
+		}
+	})
+
+	t.Run("closes a relation and answers a repeated close the same way", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-close", 2)
+		relation := relate(t, a, adminToken, pair[0].Id, pair[1].Id, plainType)
+
+		closeRelation(t, a, adminToken, pair[0].Id, relation.Id)
+		closedAt := storedValidTo(t, a, relation.Id)
+		if closedAt == nil {
+			t.Fatal("the relation is still open, want the close to have ended it")
+		}
+
+		closeRelation(t, a, adminToken, pair[0].Id, relation.Id)
+
+		// The second call changed nothing: the instant the relation ended at is
+		// the one it was closed at, and no audit row claims a second close.
+		if got := storedValidTo(t, a, relation.Id); got == nil || !got.Equal(*closedAt) {
+			t.Errorf("valid_to = %v, want the %s the first close wrote", got, closedAt)
+		}
+		if rows := projectAudits(t, a, adminID.String(), actionCloseRelation, relation.Id); len(rows) != 1 {
+			t.Errorf("close audit rows = %v, want exactly one", rows)
+		}
+
+		// A relation is addressed under the project it leaves, so closing it
+		// through the project it reaches finds nothing.
+		rec := a.call(t, http.MethodDelete, relationTarget(pair[1].Id, relation.Id), adminToken, nil)
+
+		assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+		if got, want := problemDetail(t, rec),
+			"this relation is not stored for this project"; got != want {
+			t.Errorf("detail = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("refuses a relation it cannot store", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-refuse", 2)
+
+		t.Run("one that leaves and reaches the same project", func(t *testing.T) {
+			rec := a.call(t, http.MethodPost, relationsPath(pair[0].Id), adminToken,
+				relationDocument(t, pair[0].Id, plainType))
+
+			assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeValidation)
+			if got, want := problemDetail(t, rec),
+				"a relation cannot leave and reach the same project"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+			if got, want := fieldErrorLocations(t, rec), []string{"body.target_id"}; !slices.Equal(got, want) {
+				t.Errorf("field errors = %v, want %v", got, want)
+			}
+		})
+
+		t.Run("one reaching a project the registry does not hold", func(t *testing.T) {
+			rec := a.call(t, http.MethodPost, relationsPath(pair[0].Id), adminToken,
+				relationDocument(t, uuid.New(), plainType))
+
+			assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeValidation)
+			if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+		})
+
+		t.Run("one leaving a project the registry does not hold", func(t *testing.T) {
+			rec := a.call(t, http.MethodPost, relationsPath(uuid.New()), adminToken,
+				relationDocument(t, pair[1].Id, plainType))
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+			if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+		})
+	})
+
+	t.Run("tells an empty neighborhood from a project it does not hold", func(t *testing.T) {
+		alone := registerProjects(t, a, adminToken, "os-rel-empty", 1)[0]
+		unknown := uuid.New()
+
+		for _, tc := range []struct {
+			name  string
+			route func(uuid.UUID) string
+		}{
+			{name: "the relation list", route: relationsPath},
+			{name: "the traversal", route: relatedPath},
+		} {
+			t.Run(tc.name+" of a project with nothing to answer", func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, tc.route(alone.Id), adminToken, nil)
+
+				if got := rec.Code; got != http.StatusOK {
+					t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+				}
+				// The raw body rather than the decoded one: a client iterates
+				// items without a nil check, which null would break and [] does
+				// not.
+				if got, want := strings.TrimSpace(rec.Body.String()), `{"items":[]}`; got != want {
+					t.Errorf("body = %s, want %s", got, want)
+				}
+			})
+
+			t.Run(tc.name+" of a project the registry does not hold", func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, tc.route(unknown), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+				if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("serves the relations of one project by direction", func(t *testing.T) {
+		trio := registerProjects(t, a, adminToken, "os-rel-direction", 3)
+		named := namesOf(trio...)
+		// Created in this order, which is the order the answers hold them in.
+		relate(t, a, adminToken, trio[0].Id, trio[1].Id, plainType)
+		relate(t, a, adminToken, trio[2].Id, trio[0].Id, plainType)
+		relate(t, a, adminToken, trio[0].Id, trio[2].Id, attributingType)
+
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  []string
+		}{
+			{name: "the ones it leaves", query: "?direction=outgoing", want: []string{"p1->p2", "p1->p3"}},
+			{name: "the ones it reaches", query: "?direction=incoming", want: []string{"p3->p1"}},
+			{
+				name:  "either",
+				query: "?direction=both",
+				want:  []string{"p1->p2", "p3->p1", "p1->p3"},
+			},
+			{name: "either by default", want: []string{"p1->p2", "p3->p1", "p1->p3"}},
+			{
+				name:  "narrowed to one type",
+				query: "?relation_type=" + plainType,
+				want:  []string{"p1->p2", "p3->p1"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := relationListOf(t, a.call(t, http.MethodGet,
+					relationsPath(trio[0].Id)+tc.query, adminToken, nil))
+
+				if got := relationEdges(list.Items, named); !slices.Equal(got, tc.want) {
+					t.Errorf("served relations = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("answers the graph as it stood at one instant", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-temporal", 2)
+		relation := createdRelation(t, a.call(t, http.MethodPost, relationsPath(pair[0].Id), adminToken,
+			projectDocument(t, map[string]any{
+				"target_id": pair[1].Id, "relation_type": plainType, "valid_from": relationOpened,
+			})))
+		relationFrom(t, a.call(t, http.MethodPatch, relationTarget(pair[0].Id, relation.Id), adminToken,
+			projectDocument(t, map[string]any{"valid_to": relationClosed})))
+
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  int
+		}{
+			{name: "the instant it started", query: "?at=" + instant(relationOpened), want: 1},
+			{name: "inside the span", query: "?at=" + instant(relationOpened.AddDate(0, 0, 9)), want: 1},
+			// The end is the exclusive bound, so the relation is gone at the
+			// instant it was closed at rather than one moment later.
+			{name: "the instant it was closed at", query: "?at=" + instant(relationClosed), want: 0},
+			{name: "after the span", query: "?at=" + instant(relationClosed.AddDate(0, 0, 17)), want: 0},
+			{name: "now, which is what a request naming no instant asks for", want: 0},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := relationListOf(t, a.call(t, http.MethodGet,
+					relationsPath(pair[0].Id)+tc.query, adminToken, nil))
+				walk := relatedListOf(t, a.call(t, http.MethodGet,
+					relatedPath(pair[0].Id)+tc.query, adminToken, nil))
+
+				if got := len(list.Items); got != tc.want {
+					t.Errorf("listed relations = %d, want %d", got, tc.want)
+				}
+				if got := len(walk.Items); got != tc.want {
+					t.Errorf("walked projects = %d, want %d", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("updates a relation", func(t *testing.T) {
+		t.Run("ends it at the instant the request names", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-update", 2)
+			relation := createdRelation(t, a.call(t, http.MethodPost, relationsPath(pair[0].Id),
+				adminToken, projectDocument(t, map[string]any{
+					"target_id": pair[1].Id, "relation_type": plainType,
+					"valid_from": relationOpened,
+				})))
+
+			closed := relationFrom(t, a.call(t, http.MethodPatch,
+				relationTarget(pair[0].Id, relation.Id), adminToken,
+				projectDocument(t, map[string]any{"valid_to": relationClosed})))
+			if closed.ValidTo == nil || !closed.ValidTo.Equal(relationClosed) {
+				t.Errorf("valid_to = %v, want %s", closed.ValidTo, relationClosed)
+			}
+
+			// A relation that is closed already has the instant it ended at
+			// corrected rather than being refused.
+			corrected := relationClosed.AddDate(0, 0, 5)
+			again := relationFrom(t, a.call(t, http.MethodPatch,
+				relationTarget(pair[0].Id, relation.Id), adminToken,
+				projectDocument(t, map[string]any{"valid_to": corrected})))
+			if again.ValidTo == nil || !again.ValidTo.Equal(corrected) {
+				t.Errorf("valid_to = %v, want the corrected %s", again.ValidTo, corrected)
+			}
+
+			// A request that names the metadata alone leaves the end as it is.
+			metadata := map[string]any{"owner": "team-b"}
+			kept := relationFrom(t, a.call(t, http.MethodPatch,
+				relationTarget(pair[0].Id, relation.Id), adminToken,
+				projectDocument(t, map[string]any{"metadata": metadata})))
+			if !reflect.DeepEqual(kept.Metadata, metadata) {
+				t.Errorf("metadata = %v, want %v", kept.Metadata, metadata)
+			}
+			if kept.ValidTo == nil || !kept.ValidTo.Equal(corrected) {
+				t.Errorf("valid_to = %v, want the untouched %s", kept.ValidTo, corrected)
+			}
+
+			if rows := projectAudits(t, a, adminID.String(), actionUpdateRelation, relation.Id); len(rows) != 3 {
+				t.Errorf("update audit rows = %v, want one per update", rows)
+			}
+		})
+
+		t.Run("refuses an end that is not after the start", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-update-span", 2)
+			relation := createdRelation(t, a.call(t, http.MethodPost, relationsPath(pair[0].Id),
+				adminToken, projectDocument(t, map[string]any{
+					"target_id": pair[1].Id, "relation_type": plainType,
+					"valid_from": relationOpened,
+				})))
+
+			for _, tc := range []struct {
+				name    string
+				validTo time.Time
+			}{
+				{name: "before the start", validTo: relationOpened.AddDate(0, -1, 0)},
+				{
+					name:    "at the start, which is a relation that was never valid",
+					validTo: relationOpened,
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					rec := a.call(t, http.MethodPatch, relationTarget(pair[0].Id, relation.Id),
+						adminToken, projectDocument(t, map[string]any{"valid_to": tc.validTo}))
+
+					assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeValidation)
+					if got, want := problemDetail(t, rec),
+						"valid_to has to be after valid_from"; got != want {
+						t.Errorf("detail = %q, want %q", got, want)
+					}
+					if got := storedValidTo(t, a, relation.Id); got != nil {
+						t.Errorf("valid_to = %s, want a refused update to leave the relation open", got)
+					}
+				})
+			}
+		})
+
+		t.Run("refuses a relation that does not leave the project of the path", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-update-source", 2)
+			relation := relate(t, a, adminToken, pair[0].Id, pair[1].Id, plainType)
+
+			rec := a.call(t, http.MethodPatch, relationTarget(pair[1].Id, relation.Id), adminToken,
+				projectDocument(t, map[string]any{"metadata": map[string]any{"owner": "team-c"}}))
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+			if got, want := problemDetail(t, rec),
+				"this relation is not stored for this project"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+		})
+
+		t.Run("refuses a body that changes nothing", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-update-empty", 2)
+			relation := relate(t, a, adminToken, pair[0].Id, pair[1].Id, plainType)
+
+			// The contract asks an update for at least one member, so the empty
+			// object is refused rather than served as an update of nothing.
+			rec := a.call(t, http.MethodPatch, relationTarget(pair[0].Id, relation.Id),
+				adminToken, []byte(`{}`))
+
+			assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			if rows := projectAudits(t, a, adminID.String(), actionUpdateRelation, relation.Id); len(rows) != 0 {
+				t.Errorf("update audit rows = %v, want none for a refused update", rows)
+			}
+		})
+	})
+
+	t.Run("keeps the attributing relations a forest", func(t *testing.T) {
+		t.Run("refuses the relation that would close a cycle", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-cycle", 2)
+			relate(t, a, adminToken, pair[0].Id, pair[1].Id, attributingType)
+
+			rec := a.call(t, http.MethodPost, relationsPath(pair[1].Id), adminToken,
+				relationDocument(t, pair[0].Id, attributingType))
+
+			assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeRelationCycle)
+			if got, want := problemDetail(t, rec),
+				"this relation would close a cycle over the relation types that attribute cost"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+			if got := storedRelationIDs(t, a, pair[1].Id, pair[0].Id); len(got) != 0 {
+				t.Errorf("stored relations = %v, want a refused creation to write none", got)
+			}
+
+			// The walk covers the attributing types alone, so the same pair is
+			// related the other way round under a type that carries no cost.
+			back := relate(t, a, adminToken, pair[1].Id, pair[0].Id, plainType)
+			if got, want := storedRelationIDs(t, a, pair[1].Id, pair[0].Id),
+				[]uuid.UUID{back.Id}; !slices.Equal(got, want) {
+				t.Errorf("stored relations = %v, want %v", got, want)
+			}
+		})
+
+		t.Run("walks past the projects between the two ends", func(t *testing.T) {
+			chain := registerProjects(t, a, adminToken, "os-rel-cycle-deep", 3)
+			relate(t, a, adminToken, chain[0].Id, chain[1].Id, attributingType)
+			relate(t, a, adminToken, chain[1].Id, chain[2].Id, attributingType)
+
+			rec := a.call(t, http.MethodPost, relationsPath(chain[2].Id), adminToken,
+				relationDocument(t, chain[0].Id, attributingType))
+
+			assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeRelationCycle)
+			if got := storedRelationIDs(t, a, chain[2].Id, chain[0].Id); len(got) != 0 {
+				t.Errorf("stored relations = %v, want a refused creation to write none", got)
+			}
+		})
+
+		t.Run("lets one of two racing creations through", func(t *testing.T) {
+			pair := registerProjects(t, a, adminToken, "os-rel-cycle-race", 2)
+			// Each creation is fine on its own and the two are a cycle
+			// together. They are driven as real requests, so each runs on a
+			// connection of its own and the advisory lock is the only thing
+			// that can order them. One pair is enough: the lock makes the
+			// outcome the same whichever of the two gets there first.
+			targets := [2]string{relationsPath(pair[0].Id), relationsPath(pair[1].Id)}
+			bodies := [2][]byte{
+				relationDocument(t, pair[1].Id, attributingType),
+				relationDocument(t, pair[0].Id, attributingType),
+			}
+
+			var answers [2]*httptest.ResponseRecorder
+			var racing sync.WaitGroup
+			for i := range targets {
+				racing.Add(1)
+				go func() {
+					defer racing.Done()
+					answers[i] = a.call(t, http.MethodPost, targets[i], adminToken, bodies[i])
+				}()
+			}
+			racing.Wait()
+
+			created, refused := 0, 0
+			for _, rec := range answers {
+				switch rec.Code {
+				case http.StatusCreated:
+					created++
+				case http.StatusUnprocessableEntity:
+					refused++
+					assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeRelationCycle)
+				default:
+					t.Errorf("status = %d, want a creation or a refused cycle (body %q)",
+						rec.Code, rec.Body)
+				}
+			}
+			if created != 1 || refused != 1 {
+				t.Errorf("%d creations and %d refusals, want one of each", created, refused)
+			}
+
+			stored := append(storedRelationIDs(t, a, pair[0].Id, pair[1].Id),
+				storedRelationIDs(t, a, pair[1].Id, pair[0].Id)...)
+			if len(stored) != 1 {
+				t.Errorf("stored relations = %v, want the one creation that got through", stored)
+			}
+		})
+	})
+
+	t.Run("walks the graph out of one project", func(t *testing.T) {
+		chain := registerProjects(t, a, adminToken, "os-rel-walk", 3)
+		first := relate(t, a, adminToken, chain[0].Id, chain[1].Id, plainType)
+		second := relate(t, a, adminToken, chain[1].Id, chain[2].Id, plainType)
+
+		t.Run("one relation out when the request names no depth", func(t *testing.T) {
+			list := relatedListOf(t, a.call(t, http.MethodGet, relatedPath(chain[0].Id), adminToken, nil))
+
+			if got, want := walkSteps(list.Items), []string{"p2@1/1"}; !slices.Equal(got, want) {
+				t.Fatalf("walked projects = %v, want %v", got, want)
+			}
+			if got, want := list.Items[0].Path, []uuid.UUID{first.Id}; !slices.Equal(got, want) {
+				t.Errorf("path = %v, want the relation %v it was reached over", got, want)
+			}
+			if got := list.Items[0].RelationType; got != plainType {
+				t.Errorf("relation type = %q, want %q", got, plainType)
+			}
+		})
+
+		t.Run("as far out as the request asks", func(t *testing.T) {
+			list := relatedListOf(t, a.call(t, http.MethodGet,
+				relatedPath(chain[0].Id)+"?depth=2", adminToken, nil))
+
+			if got, want := walkSteps(list.Items), []string{"p2@1/1", "p3@2/2"}; !slices.Equal(got, want) {
+				t.Fatalf("walked projects = %v, want %v", got, want)
+			}
+			if got, want := list.Items[1].Path,
+				[]uuid.UUID{first.Id, second.Id}; !slices.Equal(got, want) {
+				t.Errorf("path = %v, want the relations %v in walk order", got, want)
+			}
+		})
+
+		t.Run("visiting a project once, so a cycle terminates", func(t *testing.T) {
+			cycle := registerProjects(t, a, adminToken, "os-rel-walk-cycle", 2)
+			relate(t, a, adminToken, cycle[0].Id, cycle[1].Id, plainType)
+			relate(t, a, adminToken, cycle[1].Id, cycle[0].Id, plainType)
+
+			list := relatedListOf(t, a.call(t, http.MethodGet,
+				relatedPath(cycle[0].Id)+"?depth=10", adminToken, nil))
+
+			// The relation back is walked and reaches the project the walk
+			// started from, which is where it stops rather than going round.
+			if got, want := walkSteps(list.Items), []string{"p2@1/1"}; !slices.Equal(got, want) {
+				t.Errorf("walked projects = %v, want %v", got, want)
+			}
+		})
+	})
+
+	t.Run("refuses a request the contract does not describe", func(t *testing.T) {
+		project := registerProjects(t, a, adminToken, "os-rel-contract", 1)[0]
+
+		for _, tc := range []struct {
+			name   string
+			method string
+			target string
+			body   []byte
+			want   []string
+		}{
+			{
+				name: "a walk of no relation at all", method: http.MethodGet,
+				target: relatedPath(project.Id) + "?depth=0", want: []string{"query.depth"},
+			},
+			{
+				name: "a walk past the bound", method: http.MethodGet,
+				target: relatedPath(project.Id) + "?depth=11", want: []string{"query.depth"},
+			},
+			{
+				name: "a direction the contract does not name", method: http.MethodGet,
+				target: relationsPath(project.Id) + "?direction=banana",
+				want:   []string{"query.direction"},
+			},
+			{
+				name: "an instant that is not one", method: http.MethodGet,
+				target: relationsPath(project.Id) + "?at=yesterday", want: []string{"query.at"},
+			},
+			{
+				// The contract carries the RFC 4122 pattern next to the format,
+				// so the validator refuses the id before the route is matched.
+				name: "a relation id that is not a UUID", method: http.MethodDelete,
+				target: relationsPath(project.Id) + "/not-a-uuid",
+				want:   []string{"path.relation_id"},
+			},
+			{
+				name: "a target that is not a UUID", method: http.MethodPost,
+				target: relationsPath(project.Id), want: []string{"body.target_id"},
+				body: projectDocument(t, map[string]any{
+					"target_id": "not-a-uuid", "relation_type": plainType,
+				}),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, tc.method, tc.target, adminToken, tc.body)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got := fieldErrorLocations(t, rec); !slices.Equal(got, tc.want) {
+					t.Errorf("field errors = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("puts every operation behind the role it needs", func(t *testing.T) {
+		pair := registerProjects(t, a, adminToken, "os-rel-roles", 2)
+		existing := relate(t, a, adminToken, pair[0].Id, pair[1].Id, "roles-existing")
+
+		t.Run("no token at all", func(t *testing.T) {
+			for _, op := range relationOperations(t, pair[0], pair[1], existing, "roles-anonymous") {
+				t.Run(op.name, func(t *testing.T) {
+					assertChallenged(t, a.call(t, op.method, op.target, "", op.body))
+				})
+			}
+		})
+
+		for _, tc := range []struct {
+			name string
+			// relationType is what this case's creation asks for, so the one
+			// case whose creation goes through collides with nothing.
+			relationType string
+			token        string
+			// reads says whether the token reaches the two reads, admin whether
+			// it reaches the three writes.
+			reads bool
+			admin bool
+		}{
+			{name: "a project token", relationType: "roles-project", token: projectToken},
+			{
+				name: "a read_all token", relationType: "roles-read-all",
+				token: readAllToken, reads: true,
+			},
+			{
+				name: "an admin token", relationType: "roles-admin",
+				token: adminToken, reads: true, admin: true,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, op := range relationOperations(t, pair[0], pair[1], existing, tc.relationType) {
+					t.Run(op.name, func(t *testing.T) {
+						allowed := tc.reads
+						if op.admin {
+							allowed = tc.admin
+						}
+						want := http.StatusForbidden
+						if allowed {
+							want = op.served
+						}
+
+						rec := a.call(t, op.method, op.target, tc.token, op.body)
+
+						if got := rec.Code; got != want {
+							t.Errorf("status = %d, want %d (body %q)", got, want, rec.Body)
+						}
+						if want == http.StatusForbidden {
+							assertProblem(t, rec, http.StatusForbidden, problem.TypeForbidden)
+						}
+					})
+				}
+			})
+		}
+
+		// The creations the matrix refused wrote nothing, so the pair holds the
+		// relation the setup created and the one the admin case created.
+		if got := storedRelationIDs(t, a, pair[0].Id, pair[1].Id); len(got) != 2 {
+			t.Errorf("stored relations = %v, want the seeded one beside the admin case's", got)
+		}
+	})
+}
+
+// TestProjectRelationsReportAFailedQuery drives the failure paths of the five
+// relation operations. With authentication disabled nothing reads the database
+// before the handler does, so a database that is gone stops the request inside
+// the handler rather than at the credential lookup in front of it.
+func TestProjectRelationsReportAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// The bodies and the paths are built while the database is still there, so
+	// nothing but the request itself runs after it is gone.
+	project, relation := uuid.New(), uuid.New()
+	creation := relationDocument(t, uuid.New(), plainType)
+	update := projectDocument(t, map[string]any{"metadata": map[string]any{"owner": "team-a"}})
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		target string
+		body   []byte
+		detail string
+	}{
+		{
+			// A project that cannot be read is not a project that is not there,
+			// so the answer is a 500 rather than the 404 of an unknown id.
+			name: "the relation list", method: http.MethodGet,
+			target: relationsPath(project), detail: "the relations could not be read",
+		},
+		{
+			name: "the traversal", method: http.MethodGet,
+			target: relatedPath(project), detail: "the related projects could not be read",
+		},
+		{
+			name: "the creation", method: http.MethodPost, target: relationsPath(project),
+			body: creation, detail: "the relation could not be created",
+		},
+		{
+			name: "the update", method: http.MethodPatch,
+			target: relationTarget(project, relation), body: update,
+			detail: "the relation could not be updated",
+		},
+		{
+			name: "the close", method: http.MethodDelete,
+			target: relationTarget(project, relation), detail: "the relation could not be closed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := a.call(t, tc.method, tc.target, "", tc.body)
+
+			assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+			if got := problemDetail(t, rec); got != tc.detail {
+				t.Errorf("detail = %q, want %q", got, tc.detail)
+			}
+		})
+	}
+}
+
+// relationOperation is one of the five relation operations as the role matrix
+// exercises it: which status a call that gets through answers, and whether the
+// route takes the admin role rather than read_all.
+type relationOperation struct {
+	name   string
+	method string
+	target string
+	body   []byte
+	admin  bool
+	served int
+}
+
+// relationOperations builds the five operations against one related pair. The
+// creation asks for relationType, so two cases of the matrix never ask for the
+// same triple.
+func relationOperations(t *testing.T, source, target Project, existing Relation,
+	relationType string,
+) []relationOperation {
+	t.Helper()
+
+	return []relationOperation{
+		{
+			name: "the relation list", method: http.MethodGet,
+			target: relationsPath(source.Id), served: http.StatusOK,
+		},
+		{
+			name: "the traversal", method: http.MethodGet,
+			target: relatedPath(source.Id), served: http.StatusOK,
+		},
+		{
+			name: "the creation", method: http.MethodPost, target: relationsPath(source.Id),
+			admin: true, served: http.StatusCreated,
+			body: relationDocument(t, target.Id, relationType),
+		},
+		{
+			name: "the update", method: http.MethodPatch,
+			target: relationTarget(source.Id, existing.Id), admin: true, served: http.StatusOK,
+			body: projectDocument(t, map[string]any{"metadata": map[string]any{"by": relationType}}),
+		},
+		{
+			name: "the close", method: http.MethodDelete,
+			target: relationTarget(source.Id, existing.Id), admin: true,
+			served: http.StatusNoContent,
+		},
+	}
+}
+
+// relationsPath is the route the relations of one project are listed and
+// created under.
+func relationsPath(id uuid.UUID) string {
+	return projectPath(id) + "/relations"
+}
+
+// relationTarget is the route one relation is updated and closed under.
+func relationTarget(project, relation uuid.UUID) string {
+	return relationsPath(project) + "/" + relation.String()
+}
+
+// relatedPath is the route the traversal out of one project answers under.
+func relatedPath(id uuid.UUID) string {
+	return projectPath(id) + "/related"
+}
+
+// registerProjects registers count projects under a cloud of the subtest's own,
+// named p1 to pN, so that a walk of one subtest never reaches the graph of
+// another.
+func registerProjects(t *testing.T, a api, token, cloud string, count int) []Project {
+	t.Helper()
+
+	registered := make([]Project, count)
+	for i := range registered {
+		registered[i] = registerProject(t, a, token, fixturePlatform, cloud, fmt.Sprintf("p%d", i+1))
+	}
+	return registered
+}
+
+// relate creates one relation over POST and returns it. The setup goes through
+// the API so that the rows the reads walk are the ones the write path wrote.
+func relate(t *testing.T, a api, token string, source, target uuid.UUID, relationType string) Relation {
+	t.Helper()
+
+	return createdRelation(t, a.call(t, http.MethodPost, relationsPath(source), token,
+		relationDocument(t, target, relationType)))
+}
+
+// closeRelation closes one relation over DELETE, which the contract promises is
+// a 204 carrying nothing.
+func closeRelation(t *testing.T, a api, token string, source, relation uuid.UUID) {
+	t.Helper()
+
+	rec := a.call(t, http.MethodDelete, relationTarget(source, relation), token, nil)
+	if got := rec.Code; got != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusNoContent, rec.Body)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want a 204 to carry none", rec.Body)
+	}
+}
+
+// relationDocument renders the body a creation carries.
+func relationDocument(t *testing.T, target uuid.UUID, relationType string) []byte {
+	t.Helper()
+
+	return projectDocument(t, map[string]any{
+		"target_id": target, "relation_type": relationType,
+	})
+}
+
+// createdRelation decodes the answer of a creation, which the contract promises
+// is a 201 carrying the relation.
+func createdRelation(t *testing.T, rec *httptest.ResponseRecorder) Relation {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusCreated, rec.Body)
+	}
+	return decodeRelation(t, rec)
+}
+
+// relationFrom decodes the answer of an update, which the contract promises is
+// a 200 carrying the relation as it now stands.
+func relationFrom(t *testing.T, rec *httptest.ResponseRecorder) Relation {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	return decodeRelation(t, rec)
+}
+
+// decodeRelation reads one relation out of an answer whose status a caller has
+// already checked.
+func decodeRelation(t *testing.T, rec *httptest.ResponseRecorder) Relation {
+	t.Helper()
+
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var got Relation
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	return got
+}
+
+// relationListOf decodes the answer of a relation list, which the contract
+// promises is a 200 carrying the relations valid at one instant.
+func relationListOf(t *testing.T, rec *httptest.ResponseRecorder) RelationList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+
+	var list RelationList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	return list
+}
+
+// relatedListOf decodes the answer of a traversal, which the contract promises
+// is a 200 carrying the projects the walk reached.
+func relatedListOf(t *testing.T, rec *httptest.ResponseRecorder) RelatedProjectList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+
+	var list RelatedProjectList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	return list
+}
+
+// namesOf indexes projects by id under the external id they are registered
+// with, so that a failure reads as p1 rather than as a UUID.
+func namesOf(registered ...Project) map[uuid.UUID]string {
+	named := make(map[uuid.UUID]string, len(registered))
+	for _, project := range registered {
+		named[project.Id] = project.ExternalId
+	}
+	return named
+}
+
+// relationEdges names the relations of an answer as source to target, in the
+// order they were served.
+func relationEdges(items []Relation, named map[uuid.UUID]string) []string {
+	edges := make([]string, len(items))
+	for i, item := range items {
+		edges[i] = named[item.SourceId] + "->" + named[item.TargetId]
+	}
+	return edges
+}
+
+// walkSteps names what a traversal answered: the project it reached, the depth
+// it sits at, and how many relations the walk took to get there.
+func walkSteps(items []RelatedProject) []string {
+	steps := make([]string, len(items))
+	for i, item := range items {
+		steps[i] = fmt.Sprintf("%s@%d/%d", item.Project.ExternalId, item.Depth, len(item.Path))
+	}
+	return steps
+}
+
+// memberRaw is one member of an answer as the answer spells it, which is what
+// tells a member that is null from one the answer does not carry at all.
+func memberRaw(t *testing.T, rec *httptest.ResponseRecorder, name string) string {
+	t.Helper()
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	raw, held := body[name]
+	if !held {
+		t.Fatalf("the body %q carries no %s", rec.Body.String(), name)
+	}
+	return string(raw)
+}
+
+// storedValidTo is the end the relation row carries, nil while it is open.
+func storedValidTo(t *testing.T, a api, relation uuid.UUID) *time.Time {
+	t.Helper()
+
+	var validTo *time.Time
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`SELECT valid_to FROM project_relations WHERE id = $1`, relation).Scan(&validTo); err != nil {
+		t.Fatalf("reading the stored valid_to of %s: %v", relation, err)
+	}
+	return validTo
+}
+
+// storedRelationIDs names every relation row between two projects, oldest
+// first, whatever its type and whether it is still open. It is what says a
+// refused write stored nothing, which no read of this API can answer.
+func storedRelationIDs(t *testing.T, a api, source, target uuid.UUID) []uuid.UUID {
+	t.Helper()
+
+	rows, err := a.store.Pool().Query(t.Context(),
+		`SELECT id FROM project_relations
+		 WHERE source_id = $1 AND target_id = $2 ORDER BY created_at, id`,
+		source, target)
+	if err != nil {
+		t.Fatalf("reading the relations from %s to %s: %v", source, target, err)
+	}
+	defer rows.Close()
+
+	var found []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scanning a relation row: %v", err)
+		}
+		found = append(found, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the relations from %s to %s: %v", source, target, err)
+	}
+	return found
+}

--- a/internal/reporting/httpapi/projects.go
+++ b/internal/reporting/httpapi/projects.go
@@ -1,0 +1,305 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/audit"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// The audit trail the two writes of the registry leave.
+const (
+	auditObjectProjects = "projects"
+	actionCreateProject = auditObjectProjects + ".create"
+	actionUpdateProject = auditObjectProjects + ".update"
+)
+
+// projectCursorKeys is how many parts the sort key of the project list has: the
+// two columns of the registry's unique key, in the order ORDER BY names them.
+const projectCursorKeys = 2
+
+// unknownProjectDetail answers every read and every write addressing a project
+// this registry does not hold.
+const unknownProjectDetail = "this project is not registered"
+
+// duplicateProjectDetail answers a registration whose key pair the registry
+// already holds. It names the pair rather than the row, because that pair is
+// what the caller has to change to get through.
+const duplicateProjectDetail = "a project with this cloud and external id is already registered"
+
+// The unique key of the registry, as Postgres reports it when a write collides
+// with it. Matching the name and not the code alone is what keeps another
+// unique violation from being answered as a duplicate registration.
+const (
+	uniqueViolation      = "23505"
+	projectKeyConstraint = "projects_cloud_external_id_key"
+)
+
+// The details that answer a failure of one of these routes a caller can do
+// nothing about. Which operation failed is what they tell apart, so each is
+// spelled once rather than at every writeInternal of that operation.
+const (
+	projectsDetail      = "the projects could not be read"
+	projectDetail       = "the project could not be read"
+	createProjectDetail = "the project could not be registered"
+	updateProjectDetail = "the project could not be updated"
+)
+
+// CreateProject registers one project and answers it under the id the other
+// operations address it by.
+//
+// The row and the audit row naming it share one transaction, so a registration
+// the log does not account for never reaches the database. The unique key over
+// (cloud, external_id) is what decides a duplicate, and it decides it in the
+// database rather than in a read before the insert: two racing registrations of
+// one pair would both pass such a read, and one of them would still have to be
+// refused here.
+func (s *server) CreateProject(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// The metadata is kept as it arrived rather than decoded into a map and
+	// marshalled again: the column takes the document itself.
+	var body struct {
+		Platform   string          `json:"platform"`
+		Cloud      string          `json:"cloud"`
+		ExternalID string          `json:"external_id"`
+		Name       *string         `json:"name"`
+		Metadata   json.RawMessage `json:"metadata"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		// The validator checked this body against the contract before the
+		// request got here, so a failure now is this service disagreeing with
+		// itself rather than a caller error.
+		writeInternal(ctx, w, "decoding a registration the contract accepted", err,
+			createProjectDetail)
+		return
+	}
+	metadata := body.Metadata
+	if len(metadata) == 0 {
+		// The column is NOT NULL and the contract answers metadata as an object,
+		// so a registration that carries none registers the empty one.
+		metadata = []byte("{}")
+	}
+
+	var stored sqlcgen.Project
+	if err := s.store.WithTx(ctx, func(tx pgx.Tx) error {
+		q := sqlcgen.New(tx)
+		var err error
+		if stored, err = q.InsertProject(ctx, sqlcgen.InsertProjectParams{
+			Platform:   body.Platform,
+			Cloud:      body.Cloud,
+			ExternalID: body.ExternalID,
+			Name:       filterText(body.Name),
+			Metadata:   metadata,
+		}); err != nil {
+			return fmt.Errorf("registering (%s, %s): %w", body.Cloud, body.ExternalID, err)
+		}
+		return audit.Log(ctx, q, audit.Entry{
+			Actor:      queryActor(ctx),
+			Action:     actionCreateProject,
+			ObjectType: auditObjectProjects,
+			ObjectID:   stored.ID.String(),
+		})
+	}); err != nil {
+		if violatesUnique(err, projectKeyConstraint) {
+			problem.Write(w, http.StatusConflict, problem.TypeConflict,
+				"Conflict", duplicateProjectDetail)
+			return
+		}
+		writeInternal(ctx, w, "registering a project", err, createProjectDetail)
+		return
+	}
+
+	item, err := projectOf(stored)
+	if err != nil {
+		writeInternal(ctx, w, "rendering a project", err, createProjectDetail)
+		return
+	}
+	// A 201 names where the created thing lives, which is the route that reads
+	// it back.
+	w.Header().Set("Location", "/api/v1/projects/"+item.Id.String())
+	writeJSONStatus(w, http.StatusCreated, item)
+}
+
+// ListProjects answers one page of the registry, narrowed by the filters the
+// request carries. The page is read one row longer than it is served, which is
+// what trimPage turns into the cursor decision.
+//
+// Nothing here reads a principal or resolves a scope. The registry is the
+// organizational structure a project scope is built out of, so there is no
+// project-scoped view of it: the dispatch table puts the reads behind read_all,
+// and every request that arrives may read the whole table.
+func (s *server) ListProjects(w http.ResponseWriter, r *http.Request, params ListProjectsParams) {
+	ctx := r.Context()
+
+	var cursorCloud, cursorExternalID pgtype.Text
+	if params.Cursor != nil {
+		keys, err := decodeCursor(*params.Cursor, projectCursorKeys)
+		if err != nil {
+			refuseCursor(ctx, w, err)
+			return
+		}
+		cursorCloud = pgtype.Text{String: keys[0], Valid: true}
+		cursorExternalID = pgtype.Text{String: keys[1], Valid: true}
+	}
+
+	limit := pageLimit(params.Limit)
+
+	rows, err := s.queries.ListProjects(ctx, sqlcgen.ListProjectsParams{
+		Platform:         filterText(params.Platform),
+		Cloud:            filterText(params.Cloud),
+		ExternalID:       filterText(params.ExternalId),
+		CursorCloud:      cursorCloud,
+		CursorExternalID: cursorExternalID,
+		PageSize:         int32(limit) + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing projects", err, projectsDetail)
+		return
+	}
+
+	rows, more := trimPage(rows, limit)
+	items := make([]Project, len(rows))
+	for i, row := range rows {
+		if items[i], err = projectOf(row); err != nil {
+			writeInternal(ctx, w, "decoding a stored project", err, projectsDetail)
+			return
+		}
+	}
+
+	list := ProjectList{Items: items}
+	if more {
+		// The cursor names the last item served, so the next page starts at the
+		// row after it. The two keys are the columns themselves, so nothing has
+		// to be formatted for the round trip.
+		last := items[len(items)-1]
+		cursor := encodeCursor([]string{last.Cloud, last.ExternalId})
+		list.NextCursor = &cursor
+	}
+	writeJSON(w, list)
+}
+
+// GetProject answers with one registered project.
+func (s *server) GetProject(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	ctx := r.Context()
+
+	row, err := s.queries.GetProject(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownProjectDetail)
+			return
+		}
+		writeInternal(ctx, w, "reading a project", err, projectDetail)
+		return
+	}
+
+	item, err := projectOf(row)
+	if err != nil {
+		writeInternal(ctx, w, "rendering a project", err, projectDetail)
+		return
+	}
+	writeJSON(w, item)
+}
+
+// UpdateProject changes the name or the metadata of one project and answers it
+// as it now stands. The row and the audit row naming it share one transaction,
+// so a change the log does not account for never reaches the database.
+//
+// A member the request leaves out arrives at the query as NULL, which its
+// COALESCE reads as leaving the column alone. The contract types neither member
+// as nullable, so an explicit null is refused in front of this and never has to
+// be told apart from an absent member.
+func (s *server) UpdateProject(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	ctx := r.Context()
+
+	var body struct {
+		Name     *string         `json:"name"`
+		Metadata json.RawMessage `json:"metadata"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeInternal(ctx, w, "decoding an update the contract accepted", err,
+			updateProjectDetail)
+		return
+	}
+
+	var stored sqlcgen.Project
+	if err := s.store.WithTx(ctx, func(tx pgx.Tx) error {
+		q := sqlcgen.New(tx)
+		var err error
+		if stored, err = q.UpdateProject(ctx, sqlcgen.UpdateProjectParams{
+			ID:       id,
+			Name:     filterText(body.Name),
+			Metadata: body.Metadata,
+		}); err != nil {
+			return fmt.Errorf("updating %s: %w", id, err)
+		}
+		return audit.Log(ctx, q, audit.Entry{
+			Actor:      queryActor(ctx),
+			Action:     actionUpdateProject,
+			ObjectType: auditObjectProjects,
+			ObjectID:   stored.ID.String(),
+		})
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+				"Not found", unknownProjectDetail)
+			return
+		}
+		writeInternal(ctx, w, "updating a project", err, updateProjectDetail)
+		return
+	}
+
+	item, err := projectOf(stored)
+	if err != nil {
+		writeInternal(ctx, w, "rendering a project", err, updateProjectDetail)
+		return
+	}
+	writeJSON(w, item)
+}
+
+// projectOf renders one registry row as the answer the contract promises. The
+// instant comes out in UTC, the zone this API states them in, and the metadata
+// is decoded rather than passed through, because the contract types it as an
+// object and a row written past this API could hold anything.
+//
+// A project registered without a name renders as a null member, which is what
+// the column holding NULL means; the empty string would claim a name of no
+// characters.
+func projectOf(row sqlcgen.Project) (Project, error) {
+	var metadata map[string]any
+	if err := json.Unmarshal(row.Metadata, &metadata); err != nil {
+		return Project{}, fmt.Errorf("decoding the metadata of %s: %w", row.ID, err)
+	}
+
+	item := Project{
+		Id:         row.ID,
+		Platform:   row.Platform,
+		Cloud:      row.Cloud,
+		ExternalId: row.ExternalID,
+		Metadata:   metadata,
+		CreatedAt:  row.CreatedAt.Time.UTC(),
+	}
+	if row.Name.Valid {
+		name := row.Name.String
+		item.Name = &name
+	}
+	return item, nil
+}
+
+// violatesUnique reports whether err is Postgres refusing a write against the
+// named unique constraint.
+func violatesUnique(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == uniqueViolation && pgErr.ConstraintName == constraint
+}

--- a/internal/reporting/httpapi/projects_integration_test.go
+++ b/internal/reporting/httpapi/projects_integration_test.go
@@ -1,0 +1,678 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// projectsRoute is the route the registry is listed and written under, spelled
+// once because every subtest addresses it.
+const projectsRoute = "/api/v1/projects"
+
+// TestProjectsOverHTTP drives the four registry operations through the whole
+// stack: the contract validator, the role a route demands, the transactions
+// behind the writes, and the rows they leave. The subtests share one database
+// and work on clouds of their own, so a project one of them registers stays out
+// of what another asserts about a list.
+func TestProjectsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	adminID, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+	_, projectToken := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{uuid.New()})
+
+	t.Run("registers a project and answers it under the id that reads it back", func(t *testing.T) {
+		const cloud = "os-reg-create"
+
+		rec := a.call(t, http.MethodPost, projectsRoute, adminToken, projectDocument(t, map[string]any{
+			"platform": fixturePlatform, "cloud": cloud, "external_id": "reg-create",
+			"name": "The first project",
+		}))
+
+		created := registeredProject(t, rec)
+		if got, want := rec.Header().Get("Location"), projectPath(created.Id); got != want {
+			t.Errorf("Location = %q, want %q", got, want)
+		}
+		if created.Name == nil || *created.Name != "The first project" {
+			t.Errorf("name = %v, want the registered one", created.Name)
+		}
+		// A registration that carries no metadata registers the empty object,
+		// which is what the contract types the member as.
+		if len(created.Metadata) != 0 {
+			t.Errorf("metadata = %v, want the empty object", created.Metadata)
+		}
+		// The instant is read off the wire rather than off the model: time.Time
+		// has parsed the zone away by the time the model carries it.
+		if at := memberOnTheWire(t, rec, "created_at"); !strings.HasSuffix(at, "Z") {
+			t.Errorf("created_at = %q, want it stated in UTC", at)
+		}
+
+		// The registration and the read answer the same bytes, which is what says
+		// the two renderers agree rather than merely both being valid.
+		read := a.call(t, http.MethodGet, projectPath(created.Id), adminToken, nil)
+		if got := read.Code; got != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, read.Body)
+		}
+		if got, want := read.Body.String(), rec.Body.String(); got != want {
+			t.Errorf("the read answered %s, want the registration's %s", got, want)
+		}
+
+		rows := projectAudits(t, a, adminID.String(), actionCreateProject, created.Id)
+		if len(rows) != 1 {
+			t.Fatalf("registration audit rows = %v, want exactly one", rows)
+		}
+		if got := rows[0].objectType; got != auditObjectProjects {
+			t.Errorf("audit object type = %q, want %q", got, auditObjectProjects)
+		}
+	})
+
+	t.Run("refuses a second registration of one cloud and external id", func(t *testing.T) {
+		const (
+			cloud      = "os-reg-conflict"
+			externalID = "reg-conflict"
+		)
+		first := registerProject(t, a, adminToken, fixturePlatform, cloud, externalID)
+
+		rec := a.call(t, http.MethodPost, projectsRoute, adminToken, projectDocument(t, map[string]any{
+			"platform": fixturePlatform, "cloud": cloud, "external_id": externalID,
+			"name": "The second registration of one pair",
+		}))
+
+		assertProblem(t, rec, http.StatusConflict, problem.TypeConflict)
+		if got, want := problemDetail(t, rec),
+			"a project with this cloud and external id is already registered"; got != want {
+			t.Errorf("detail = %q, want %q", got, want)
+		}
+		// The refusal leaves the registered project as it was rather than
+		// replacing its name with the one the second call carried.
+		got := projectFrom(t, a.call(t, http.MethodGet, projectPath(first.Id), adminToken, nil))
+		if !reflect.DeepEqual(got, first) {
+			t.Errorf("the registered project = %+v, want the unchanged %+v", got, first)
+		}
+
+		// The key is the pair, so the same external id under another cloud is a
+		// project of its own rather than a duplicate.
+		second := registerProject(t, a, adminToken, fixturePlatform, cloud+"-b", externalID)
+		if second.Id == first.Id {
+			t.Errorf("the second cloud reused the row %s, want a project of its own", first.Id)
+		}
+	})
+
+	t.Run("lists the registry", func(t *testing.T) {
+		const (
+			cloudA   = "os-reg-list-a"
+			cloudB   = "os-reg-list-b"
+			platform = "tallytest-list"
+		)
+		// Registered out of order, so what sorts the answer is the query rather
+		// than the order the rows were written in.
+		registerProject(t, a, adminToken, fixturePlatform, cloudB, "reg-list-2")
+		registerProject(t, a, adminToken, fixturePlatform, cloudA, "reg-list-3")
+		registerProject(t, a, adminToken, fixturePlatform, cloudA, "reg-list-1")
+		registerProject(t, a, adminToken, platform, cloudA, "reg-list-2")
+		registerProject(t, a, adminToken, fixturePlatform, cloudB, "reg-list-1")
+
+		t.Run("narrows it by the filters the request carries", func(t *testing.T) {
+			for _, tc := range []struct {
+				name  string
+				query string
+				want  []string
+			}{
+				{
+					name:  "by platform",
+					query: "platform=" + platform,
+					want:  []string{cloudA + ":reg-list-2"},
+				},
+				{
+					name:  "by cloud, ordered by external id",
+					query: "cloud=" + cloudA,
+					want: []string{
+						cloudA + ":reg-list-1", cloudA + ":reg-list-2", cloudA + ":reg-list-3",
+					},
+				},
+				{
+					// An external id is not a key on its own: two clouds naming a
+					// project the same way are two projects, and both are served.
+					name:  "by external id, which two clouds share",
+					query: "external_id=reg-list-1",
+					want:  []string{cloudA + ":reg-list-1", cloudB + ":reg-list-1"},
+				},
+				{
+					name:  "by the pair the registry is keyed by",
+					query: "cloud=" + cloudB + "&external_id=reg-list-2",
+					want:  []string{cloudB + ":reg-list-2"},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					list := projectListOf(t, a.call(t, http.MethodGet,
+						projectsRoute+"?"+tc.query, adminToken, nil))
+
+					if got := projectKeys(list.Items); !slices.Equal(got, tc.want) {
+						t.Errorf("served projects = %v, want %v", got, tc.want)
+					}
+					if list.NextCursor != nil {
+						t.Errorf("next_cursor = %q, want null on a page that holds everything",
+							*list.NextCursor)
+					}
+				})
+			}
+		})
+
+		t.Run("walks a filtered list page by page", func(t *testing.T) {
+			whole := projectListOf(t, a.call(t, http.MethodGet,
+				projectsRoute+"?cloud="+cloudA, adminToken, nil))
+			if len(whole.Items) != 3 {
+				t.Fatalf("the unpaginated answer holds %d projects, want 3", len(whole.Items))
+			}
+
+			for _, tc := range []struct {
+				name  string
+				limit int
+				sizes []int
+			}{
+				{name: "a page per project", limit: 1, sizes: []int{1, 1, 1}},
+				{name: "a last page shorter than the limit", limit: 2, sizes: []int{2, 1}},
+				// The whole list in one page: the last page is exactly full, which
+				// is what tells "the page is full" from "there is more".
+				{name: "a last page exactly as long as the limit", limit: 3, sizes: []int{3}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					page := fmt.Sprintf("%s?cloud=%s&limit=%d", projectsRoute, cloudA, tc.limit)
+
+					var walked []Project
+					var sizes []int
+					for count := 1; ; count++ {
+						if count > len(whole.Items) {
+							t.Fatalf("the walk had not ended after %d pages, want it over after %d",
+								count, len(tc.sizes))
+						}
+						list := projectListOf(t, a.call(t, http.MethodGet, page, adminToken, nil))
+
+						sizes = append(sizes, len(list.Items))
+						walked = append(walked, list.Items...)
+						if list.NextCursor == nil {
+							break
+						}
+						page = fmt.Sprintf("%s?cloud=%s&limit=%d&cursor=%s",
+							projectsRoute, cloudA, tc.limit, url.QueryEscape(*list.NextCursor))
+					}
+
+					if !slices.Equal(sizes, tc.sizes) {
+						t.Errorf("page sizes = %v, want %v", sizes, tc.sizes)
+					}
+					if !reflect.DeepEqual(walked, whole.Items) {
+						t.Errorf("the walk served %v, want the unpaginated %v",
+							projectKeys(walked), projectKeys(whole.Items))
+					}
+				})
+			}
+		})
+
+		t.Run("answers a filter nothing matches with the empty page", func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, projectsRoute+"?cloud=os-reg-list-nothing",
+				adminToken, nil)
+
+			if got := rec.Code; got != http.StatusOK {
+				t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+			}
+			// The raw body rather than the decoded one: a client iterates items
+			// without a nil check, which null would break and [] does not.
+			want := `{"items":[],"next_cursor":null}`
+			if got := strings.TrimSpace(rec.Body.String()); got != want {
+				t.Errorf("body = %s, want %s", got, want)
+			}
+		})
+	})
+
+	t.Run("refuses a cursor it did not issue", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			cursor string
+		}{
+			{name: "not base64url", cursor: "not base64!"},
+			{name: "one key where the sort key has two", cursor: encodeCursor([]string{"os-reg-list-a"})},
+			// The sort key of the resource list has three parts, so a cursor of
+			// that list resumes nothing here.
+			{
+				name:   "three keys where the sort key has two",
+				cursor: encodeCursor([]string{"os-reg-list-a", "volume", "vol-1"}),
+			},
+			{name: "an empty key", cursor: encodeCursor([]string{"os-reg-list-a", ""})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					projectsRoute+"?cursor="+url.QueryEscape(tc.cursor), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec), "the cursor is not one this API issued"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a read of a project it cannot serve", func(t *testing.T) {
+		t.Run("an id the registry does not hold", func(t *testing.T) {
+			rec := a.call(t, http.MethodGet, projectPath(uuid.New()), adminToken, nil)
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+			if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+		})
+
+		t.Run("an id that is not a UUID", func(t *testing.T) {
+			// The contract carries the RFC 4122 pattern next to the format, so the
+			// request validator refuses the id before the route is even matched:
+			// the answer is the contract's 400 rather than a failure of the
+			// generated binding behind it.
+			rec := a.call(t, http.MethodGet, projectsRoute+"/not-a-uuid", adminToken, nil)
+
+			assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			if got, want := fieldErrorLocations(t, rec), []string{"path.id"}; !slices.Equal(got, want) {
+				t.Errorf("field errors = %v, want %v", got, want)
+			}
+		})
+	})
+
+	t.Run("updates a project", func(t *testing.T) {
+		t.Run("changes the name and the metadata it names", func(t *testing.T) {
+			project := registerProject(t, a, adminToken, fixturePlatform, "os-reg-update", "reg-update")
+			metadata := map[string]any{"owner": "team-a", "tier": "gold"}
+
+			updated := projectFrom(t, a.call(t, http.MethodPatch, projectPath(project.Id), adminToken,
+				projectDocument(t, map[string]any{"name": "Renamed", "metadata": metadata})))
+
+			if updated.Name == nil || *updated.Name != "Renamed" {
+				t.Errorf("name = %v, want the updated one", updated.Name)
+			}
+			if !reflect.DeepEqual(updated.Metadata, metadata) {
+				t.Errorf("metadata = %v, want %v", updated.Metadata, metadata)
+			}
+			// The key and the registration instant are not writable here, so they
+			// come back as they were.
+			if updated.Cloud != project.Cloud || updated.ExternalId != project.ExternalId ||
+				!updated.CreatedAt.Equal(project.CreatedAt) {
+				t.Errorf("the updated project = %+v, want the key and created_at of %+v",
+					updated, project)
+			}
+
+			rows := projectAudits(t, a, adminID.String(), actionUpdateProject, project.Id)
+			if len(rows) != 1 {
+				t.Fatalf("update audit rows = %v, want exactly one", rows)
+			}
+			if got := rows[0].objectType; got != auditObjectProjects {
+				t.Errorf("audit object type = %q, want %q", got, auditObjectProjects)
+			}
+		})
+
+		t.Run("leaves the metadata of a request that names only the name", func(t *testing.T) {
+			project := registerProject(t, a, adminToken, fixturePlatform, "os-reg-update-name", "reg-update-name")
+			metadata := map[string]any{"owner": "team-b"}
+			stored := projectFrom(t, a.call(t, http.MethodPatch, projectPath(project.Id), adminToken,
+				projectDocument(t, map[string]any{"metadata": metadata})))
+			if !reflect.DeepEqual(stored.Metadata, metadata) {
+				t.Fatalf("metadata = %v, want the %v the setup wrote", stored.Metadata, metadata)
+			}
+
+			updated := projectFrom(t, a.call(t, http.MethodPatch, projectPath(project.Id), adminToken,
+				projectDocument(t, map[string]any{"name": "Renamed once more"})))
+
+			if updated.Name == nil || *updated.Name != "Renamed once more" {
+				t.Errorf("name = %v, want the updated one", updated.Name)
+			}
+			if !reflect.DeepEqual(updated.Metadata, metadata) {
+				t.Errorf("metadata = %v, want the untouched %v", updated.Metadata, metadata)
+			}
+		})
+
+		t.Run("refuses an id the registry does not hold", func(t *testing.T) {
+			rec := a.call(t, http.MethodPatch, projectPath(uuid.New()), adminToken,
+				projectDocument(t, map[string]any{"name": "Renamed"}))
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+			if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+				t.Errorf("detail = %q, want %q", got, want)
+			}
+		})
+
+		t.Run("refuses a body that changes nothing", func(t *testing.T) {
+			project := registerProject(t, a, adminToken, fixturePlatform, "os-reg-update-empty", "reg-update-empty")
+
+			// The contract asks an update for at least one member, so the empty
+			// object is refused rather than served as an update of nothing.
+			rec := a.call(t, http.MethodPatch, projectPath(project.Id), adminToken, []byte(`{}`))
+
+			assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			if rows := projectAudits(t, a, adminID.String(), actionUpdateProject, project.Id); len(rows) != 0 {
+				t.Errorf("update audit rows = %v, want none for a refused update", rows)
+			}
+		})
+	})
+
+	t.Run("puts every operation behind the role it needs", func(t *testing.T) {
+		existing := registerProject(t, a, adminToken, fixturePlatform, "os-reg-roles", "reg-roles")
+
+		t.Run("no token at all", func(t *testing.T) {
+			for _, op := range projectOperations(t, existing, "reg-roles-anonymous") {
+				t.Run(op.name, func(t *testing.T) {
+					assertChallenged(t, a.call(t, op.method, op.target, "", op.body))
+				})
+			}
+		})
+
+		for _, tc := range []struct {
+			name string
+			// pair is the external id this case's registration names, so that the
+			// one case whose registration goes through collides with nothing.
+			pair  string
+			token string
+			// reads says whether the token reaches the two reads, admin whether it
+			// reaches the two writes.
+			reads bool
+			admin bool
+		}{
+			{name: "a project token", pair: "reg-roles-project", token: projectToken},
+			{name: "a read_all token", pair: "reg-roles-read-all", token: readAllToken, reads: true},
+			{name: "an admin token", pair: "reg-roles-admin", token: adminToken, reads: true, admin: true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, op := range projectOperations(t, existing, tc.pair) {
+					t.Run(op.name, func(t *testing.T) {
+						allowed := tc.reads
+						if op.admin {
+							allowed = tc.admin
+						}
+						want := http.StatusForbidden
+						if allowed {
+							want = op.served
+						}
+
+						rec := a.call(t, op.method, op.target, tc.token, op.body)
+
+						if got := rec.Code; got != want {
+							t.Errorf("status = %d, want %d (body %q)", got, want, rec.Body)
+						}
+						if want == http.StatusForbidden {
+							assertProblem(t, rec, http.StatusForbidden, problem.TypeForbidden)
+						}
+					})
+				}
+			})
+		}
+
+		// The two registrations the matrix refused wrote nothing, which is only
+		// readable on pairs nothing else registers.
+		for _, pair := range []string{"reg-roles-anonymous", "reg-roles-project", "reg-roles-read-all"} {
+			list := projectListOf(t, a.call(t, http.MethodGet,
+				projectsRoute+"?external_id="+pair, adminToken, nil))
+			if len(list.Items) != 0 {
+				t.Errorf("%s is registered, want a refused registration to write nothing", pair)
+			}
+		}
+	})
+}
+
+// TestProjectRegistryReportsAFailedQuery drives the failure paths of the four
+// registry operations. With authentication disabled nothing reads the database
+// before the handler does, so a database that is gone stops the request inside
+// the handler rather than at the credential lookup in front of it.
+func TestProjectRegistryReportsAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// The bodies and the path are built while the database is still there, so
+	// nothing but the request itself runs after it is gone.
+	registration := projectDocument(t, map[string]any{
+		"platform": fixturePlatform, "cloud": "os-reg-outage", "external_id": "reg-outage",
+	})
+	update := projectDocument(t, map[string]any{"name": "Renamed during an outage"})
+	target := projectPath(uuid.New())
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		target string
+		body   []byte
+		detail string
+	}{
+		{
+			name: "the list", method: http.MethodGet, target: projectsRoute,
+			detail: "the projects could not be read",
+		},
+		{
+			// A project that cannot be read is not a project that is not there, so
+			// the answer is a 500 rather than the 404 of an unknown id.
+			name: "the read", method: http.MethodGet, target: target,
+			detail: "the project could not be read",
+		},
+		{
+			name: "the registration", method: http.MethodPost, target: projectsRoute,
+			body: registration, detail: "the project could not be registered",
+		},
+		{
+			name: "the update", method: http.MethodPatch, target: target,
+			body: update, detail: "the project could not be updated",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := a.call(t, tc.method, tc.target, "", tc.body)
+
+			assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+			if got := problemDetail(t, rec); got != tc.detail {
+				t.Errorf("detail = %q, want %q", got, tc.detail)
+			}
+		})
+	}
+}
+
+// projectOperation is one of the four registry operations as the role matrix
+// exercises it: which status a call that gets through answers, and whether the
+// route takes the admin role rather than read_all.
+type projectOperation struct {
+	name   string
+	method string
+	target string
+	body   []byte
+	admin  bool
+	served int
+}
+
+// projectOperations builds the four operations against one registered project.
+// The registration names externalID, so two cases of the matrix never ask for
+// the same pair.
+func projectOperations(t *testing.T, existing Project, externalID string) []projectOperation {
+	t.Helper()
+
+	return []projectOperation{
+		{
+			name: "the list", method: http.MethodGet, target: projectsRoute,
+			served: http.StatusOK,
+		},
+		{
+			name: "the read", method: http.MethodGet, target: projectPath(existing.Id),
+			served: http.StatusOK,
+		},
+		{
+			name: "the registration", method: http.MethodPost, target: projectsRoute,
+			admin: true, served: http.StatusCreated,
+			body: projectDocument(t, map[string]any{
+				"platform": fixturePlatform, "cloud": "os-reg-roles", "external_id": externalID,
+			}),
+		},
+		{
+			name: "the update", method: http.MethodPatch, target: projectPath(existing.Id),
+			admin: true, served: http.StatusOK,
+			body: projectDocument(t, map[string]any{"name": "Renamed by " + externalID}),
+		},
+	}
+}
+
+// projectPath is the route one project is read and updated under.
+func projectPath(id uuid.UUID) string {
+	return projectsRoute + "/" + id.String()
+}
+
+// projectDocument renders a request body from the members it carries. A body is
+// built member by member rather than from a generated model, because what an
+// update leaves out is part of what the tests assert.
+func projectDocument(t *testing.T, members map[string]any) []byte {
+	t.Helper()
+
+	raw, err := json.Marshal(members)
+	if err != nil {
+		t.Fatalf("marshaling the request body: %v", err)
+	}
+	return raw
+}
+
+// registerProject registers one project over POST and returns it. The setup goes
+// through the API so that the rows the reads walk are the ones the write path
+// wrote.
+func registerProject(t *testing.T, a api, token, platform, cloud, externalID string) Project {
+	t.Helper()
+
+	return registeredProject(t, a.call(t, http.MethodPost, projectsRoute, token,
+		projectDocument(t, map[string]any{
+			"platform": platform, "cloud": cloud, "external_id": externalID,
+		})))
+}
+
+// registeredProject decodes the answer of a registration, which the contract
+// promises is a 201 carrying the project.
+func registeredProject(t *testing.T, rec *httptest.ResponseRecorder) Project {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusCreated, rec.Body)
+	}
+	return decodeProject(t, rec)
+}
+
+// projectFrom decodes the answer of a read or an update, which the contract
+// promises is a 200 carrying one project.
+func projectFrom(t *testing.T, rec *httptest.ResponseRecorder) Project {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	return decodeProject(t, rec)
+}
+
+// decodeProject reads one project out of an answer whose status a caller has
+// already checked.
+func decodeProject(t *testing.T, rec *httptest.ResponseRecorder) Project {
+	t.Helper()
+
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var got Project
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	return got
+}
+
+// projectListOf decodes the answer of a list call, which the contract promises
+// is a 200 carrying one page.
+func projectListOf(t *testing.T, rec *httptest.ResponseRecorder) ProjectList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+
+	var list ProjectList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	return list
+}
+
+// projectKeys names the projects of a page by the pair the registry is keyed
+// by, in the order they were served.
+func projectKeys(items []Project) []string {
+	keys := make([]string, len(items))
+	for i, item := range items {
+		keys[i] = item.Cloud + ":" + item.ExternalId
+	}
+	return keys
+}
+
+// memberOnTheWire is one member of an answer as the answer spells it, before a
+// generated model has parsed it into a Go value.
+func memberOnTheWire(t *testing.T, rec *httptest.ResponseRecorder, name string) string {
+	t.Helper()
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	raw, ok := body[name]
+	if !ok {
+		t.Fatalf("the body %q carries no %s", rec.Body.String(), name)
+	}
+
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decoding %s of %q: %v", name, rec.Body.String(), err)
+	}
+	return value
+}
+
+// fieldErrorLocations names where a rejected request went wrong, which is what
+// separates a refusal of the path parameter from one of anything else.
+func fieldErrorLocations(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+
+	var body struct {
+		Errors []problem.FieldError `json:"errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+
+	locations := make([]string, len(body.Errors))
+	for i, entry := range body.Errors {
+		locations[i] = entry.Loc
+	}
+	return locations
+}
+
+// projectAudits returns every audit_log row actor left behind under action for
+// one project, oldest first.
+func projectAudits(t *testing.T, a api, actor, action string, id uuid.UUID) []auditRow {
+	t.Helper()
+
+	var found []auditRow
+	for _, row := range auditRows(t, a, actor, action) {
+		if row.objectID == id.String() {
+			found = append(found, row)
+		}
+	}
+	return found
+}

--- a/internal/reporting/httpapi/query.go
+++ b/internal/reporting/httpapi/query.go
@@ -133,7 +133,8 @@ func filterText(value *string) pgtype.Text {
 	return pgtype.Text{String: *value, Valid: true}
 }
 
-// filterInstant maps one bound of a time window onto its query parameter.
+// filterInstant maps one optional instant onto its query parameter, whether it
+// bounds a time window or writes a column.
 func filterInstant(value *time.Time) pgtype.Timestamptz {
 	if value == nil {
 		return pgtype.Timestamptz{}

--- a/internal/reporting/httpapi/query.go
+++ b/internal/reporting/httpapi/query.go
@@ -123,8 +123,9 @@ func reachesPair(scope auth.Scope, cloud, projectID string) bool {
 	})
 }
 
-// filterText maps one optional string filter onto its query parameter. A filter
-// the request left out becomes NULL, which the query reads as every value.
+// filterText maps one optional string onto its query parameter, whether the
+// request left it out of a filter or out of a written body. Absent becomes
+// NULL, which a read takes as every value and a write stores as such.
 func filterText(value *string) pgtype.Text {
 	if value == nil {
 		return pgtype.Text{}

--- a/internal/reporting/httpapi/router.go
+++ b/internal/reporting/httpapi/router.go
@@ -66,6 +66,11 @@ type Options struct {
 	// Pipeline ingests the batches POST /api/v1/events submits. The
 	// resource-type registry and the strict-mode flag travel inside it.
 	Pipeline *ingest.Pipeline
+	// AttributingRelationTypes are the relation types that attribute cost,
+	// which is what the cycle guard of a relation creation walks. It comes from
+	// TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES, and an empty list disables
+	// the guard.
+	AttributingRelationTypes []string
 }
 
 // NewRouter assembles the API: the middleware stack, the request validator, and
@@ -114,11 +119,12 @@ func NewRouter(opts Options) (http.Handler, error) {
 	r.Use(newValidator(spec))
 
 	srv := &server{
-		db:       opts.DB,
-		health:   newHealthTracker(now, opts.UnhealthyThreshold),
-		store:    opts.Store,
-		queries:  opts.Queries,
-		pipeline: opts.Pipeline,
+		db:               opts.DB,
+		health:           newHealthTracker(now, opts.UnhealthyThreshold),
+		store:            opts.Store,
+		queries:          opts.Queries,
+		pipeline:         opts.Pipeline,
+		attributingTypes: opts.AttributingRelationTypes,
 	}
 	// The dispatch middleware is handed to the generated wrapper rather than to
 	// chi, because it needs the route chi matched to know which guard applies.

--- a/internal/reporting/httpapi/server.go
+++ b/internal/reporting/httpapi/server.go
@@ -24,6 +24,9 @@ type server struct {
 	queries *sqlcgen.Queries
 	// pipeline is what a submitted event batch is put through.
 	pipeline *ingest.Pipeline
+	// attributingTypes are the relation types the cycle guard walks. An empty
+	// list disables the guard.
+	attributingTypes []string
 }
 
 // writeJSON sends one successful response body under the 200 almost every

--- a/internal/reporting/httpapi/server.go
+++ b/internal/reporting/httpapi/server.go
@@ -26,14 +26,21 @@ type server struct {
 	pipeline *ingest.Pipeline
 }
 
-// writeJSON sends one successful response body. Every success this API has is a
-// 200 carrying JSON, so the status is not a parameter.
+// writeJSON sends one successful response body under the 200 almost every
+// success of this API carries.
 //
 // The documents passed here are the generated response types, so encoding fails
 // only when the connection does, and the status line is already gone by then.
 func writeJSON(w http.ResponseWriter, document any) {
+	writeJSONStatus(w, http.StatusOK, document)
+}
+
+// writeJSONStatus is writeJSON for the successes that answer another status,
+// the 201 of a registration for example. A caller that has already set response
+// headers keeps them: nothing is written before the status line here.
+func writeJSONStatus(w http.ResponseWriter, status int, document any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(document)
 }
 

--- a/internal/reporting/ingest/ingest.go
+++ b/internal/reporting/ingest/ingest.go
@@ -86,11 +86,23 @@ type Outcome struct {
 	Rejected   []Rejected
 }
 
+// Hook runs once per newly stored event, after the batch was folded into the
+// projection and inside the ingest transaction. An error it returns fails the
+// whole batch, so what a hook writes lands together with the events it saw or
+// not at all.
+//
+// A hook sees reconciliation-sourced events as well as collected ones, so a
+// hook that is only about what a collector reported filters on e.Source.
+type Hook interface {
+	OnEvent(ctx context.Context, e event.Stored) error
+}
+
 // Pipeline ingests batches. Its zero value is not usable; New builds one. It is
 // safe for concurrent use.
 type Pipeline struct {
 	registry          *registry.Registry
 	requireSizeSchema bool
+	hook              Hook
 }
 
 // New returns a Pipeline that validates sizes through reg. requireSizeSchema is
@@ -98,8 +110,11 @@ type Pipeline struct {
 // unvalidated, so onboarding a resource type is not blocked on registering its
 // schema first, and true refuses it, which is what a production deployment runs
 // (decision D9).
-func New(reg *registry.Registry, requireSizeSchema bool) *Pipeline {
-	return &Pipeline{registry: reg, requireSizeSchema: requireSizeSchema}
+//
+// hook is called over the events a batch stores. A nil hook calls nothing,
+// which is what Phase 1 ingests with.
+func New(reg *registry.Registry, requireSizeSchema bool, hook Hook) *Pipeline {
+	return &Pipeline{registry: reg, requireSizeSchema: requireSizeSchema, hook: hook}
 }
 
 // Ingest runs the per-item pipeline over items, stores what survives it, and
@@ -141,6 +156,10 @@ func (p *Pipeline) Ingest(ctx context.Context, tx pgx.Tx, items []json.RawMessag
 	slices.SortFunc(screened, compareEvent)
 
 	grouped := map[projection.Key][]event.Stored{}
+	// What the hook is called over: the events this batch stored, in the order
+	// they were inserted in. A duplicate is not one of them, and neither is a
+	// refused item.
+	var newlyStored []event.Stored
 	for _, e := range screened {
 		stored, inserted, err := insert(ctx, q, e)
 		if err != nil {
@@ -151,6 +170,7 @@ func (p *Pipeline) Ingest(ctx context.Context, tx pgx.Tx, items []json.RawMessag
 			continue
 		}
 		out.Accepted++
+		newlyStored = append(newlyStored, stored)
 
 		key := projection.Key{Cloud: e.Cloud, ResourceType: e.ResourceType, ResourceID: e.ResourceID}
 		grouped[key] = append(grouped[key], stored)
@@ -159,6 +179,14 @@ func (p *Pipeline) Ingest(ctx context.Context, tx pgx.Tx, items []json.RawMessag
 	for _, key := range slices.SortedFunc(maps.Keys(grouped), projection.CompareKey) {
 		if err := projection.Apply(ctx, tx, key, grouped[key]); err != nil {
 			return Outcome{}, fmt.Errorf("folding the batch into the projection: %w", err)
+		}
+	}
+
+	if p.hook != nil {
+		for _, e := range newlyStored {
+			if err := p.hook.OnEvent(ctx, e); err != nil {
+				return Outcome{}, fmt.Errorf("running the post-ingest hook for event %s: %w", e.EventID, err)
+			}
 		}
 	}
 	return out, nil

--- a/internal/reporting/ingest/ingest_convergence_test.go
+++ b/internal/reporting/ingest/ingest_convergence_test.go
@@ -34,7 +34,7 @@ const historySteps = 5
 // the order or the batches they arrived in.
 func TestIngestConverges(t *testing.T) {
 	db := storetest.NewDB(t)
-	pipeline := ingest.New(registry.New(), false)
+	pipeline := ingest.New(registry.New(), false, nil)
 
 	t.Run("folds every arrival order of one history into the same row", func(t *testing.T) {
 		const (

--- a/internal/reporting/ingest/ingest_integration_test.go
+++ b/internal/reporting/ingest/ingest_integration_test.go
@@ -37,8 +37,8 @@ var (
 // one, so each of them works on a cloud and resource ids of its own.
 func TestIngest(t *testing.T) {
 	db := storetest.NewDB(t)
-	lax := ingest.New(registry.New(), false)
-	strict := ingest.New(registry.New(), true)
+	lax := ingest.New(registry.New(), false, nil)
+	strict := ingest.New(registry.New(), true, nil)
 
 	t.Run("stores the source the caller names, not the one the item claims", func(t *testing.T) {
 		res := resource{cloud: "os-ingest-source", resourceType: "volume", id: "vol-source"}

--- a/internal/reporting/ingest/ingest_integration_test.go
+++ b/internal/reporting/ingest/ingest_integration_test.go
@@ -1,6 +1,7 @@
 package ingest_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -405,6 +406,176 @@ func TestIngest(t *testing.T) {
 		}
 		assertOutcome(t, out, ingest.Outcome{})
 	})
+}
+
+// TestIngestCallsTheHookOncePerStoredEvent holds the hook to the events it is
+// promised: the ones the batch stored, in the order they were inserted in.
+// Neither a duplicate nor a refused item is one of them.
+func TestIngestCallsTheHookOncePerStoredEvent(t *testing.T) {
+	db := storetest.NewDB(t)
+	res := resource{cloud: "os-ingest-hook", resourceType: "volume", id: "vol-hook"}
+
+	// The event the batch below repeats is stored by a pipeline without a hook,
+	// so the recorder only ever sees that batch.
+	create := res.event("vol-hook-create", "volume.create", createTime,
+		payloadOf("available", volumeSize(10)))
+	assertOutcome(t, batch(t, db, ingest.New(registry.New(), false, nil),
+		[]json.RawMessage{item(t, create)}, event.SourceCollector, nil),
+		ingest.Outcome{Accepted: 1})
+
+	// The two fresh events are submitted in the reverse of the order their ids
+	// sort in, so what the hook sees is the order the pipeline inserted them in
+	// rather than the order they were submitted in.
+	hook := &recordingHook{}
+	items := []json.RawMessage{
+		item(t, res.event("vol-hook-resize", "volume.resize", updateTime,
+			payloadOf("available", volumeSize(20)))),
+		item(t, res.event("vol-hook-pause", "volume.update", deleteTime,
+			payloadOf("paused", nil))),
+		item(t, create),
+		item(t, res.event("vol-hook-refused", "volume-update", updateTime,
+			payloadOf("available", nil))),
+	}
+
+	out := batch(t, db, ingest.New(registry.New(), false, hook), items,
+		event.SourceCollector, nil)
+
+	if out.Accepted != 2 || out.Duplicates != 1 || len(out.Rejected) != 1 {
+		t.Fatalf("Ingest() = %+v, want 2 accepted, 1 duplicate and 1 refused item", out)
+	}
+	want := []string{"vol-hook-pause", "vol-hook-resize"}
+	if got := hook.seenIDs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("hook saw %v, want the stored events in insertion order, %v", got, want)
+	}
+	for _, e := range hook.seen {
+		if e.ReceivedAt.IsZero() {
+			t.Errorf("hook saw %s without a received_at, want the one the insert assigned",
+				e.EventID)
+		}
+		if e.Source != event.SourceCollector {
+			t.Errorf("hook saw %s as %q, want the source the caller named, %q",
+				e.EventID, e.Source, event.SourceCollector)
+		}
+	}
+}
+
+// TestIngestTakesTheBatchWithoutAHook covers the Phase 1 default: a pipeline
+// built with no hook takes the same batch, and calls nothing over it.
+func TestIngestTakesTheBatchWithoutAHook(t *testing.T) {
+	db := storetest.NewDB(t)
+	res := resource{cloud: "os-ingest-hookless", resourceType: "volume", id: "vol-hookless"}
+	pipeline := ingest.New(registry.New(), false, nil)
+
+	create := item(t, res.event("vol-hookless-create", "volume.create", createTime,
+		payloadOf("available", volumeSize(10))))
+	assertOutcome(t, batch(t, db, pipeline, []json.RawMessage{create}, event.SourceCollector, nil),
+		ingest.Outcome{Accepted: 1})
+
+	items := []json.RawMessage{
+		item(t, res.event("vol-hookless-resize", "volume.resize", updateTime,
+			payloadOf("available", volumeSize(20)))),
+		create,
+		item(t, res.event("vol-hookless-refused", "volume-update", updateTime,
+			payloadOf("available", nil))),
+	}
+
+	out := batch(t, db, pipeline, items, event.SourceCollector, nil)
+
+	if out.Accepted != 1 || out.Duplicates != 1 || len(out.Rejected) != 1 {
+		t.Fatalf("Ingest() = %+v, want 1 accepted, 1 duplicate and 1 refused item", out)
+	}
+	if got := storedEvents(t, db, res.cloud); got != 2 {
+		t.Errorf("events rows = %d, want the 2 the two batches stored", got)
+	}
+}
+
+// TestIngestFailsTheBatchWhenTheHookErrs holds the hook to the transaction it
+// runs in: what it refuses takes the whole batch down, the events stored before
+// it and the dead letter a refused item left included.
+func TestIngestFailsTheBatchWhenTheHookErrs(t *testing.T) {
+	db := storetest.NewDB(t)
+	res := resource{cloud: "os-ingest-hook-error", resourceType: "volume", id: "vol-hook-error"}
+	// The hook takes the first event and refuses the one after it, so the batch
+	// fails once it has already stored rows.
+	hook := &failingHook{succeed: 1}
+	pipeline := ingest.New(registry.New(), false, hook)
+
+	items := []json.RawMessage{
+		item(t, res.event("vol-hook-error-create", "volume.create", createTime,
+			payloadOf("available", volumeSize(10)))),
+		item(t, res.event("vol-hook-error-resize", "volume.resize", updateTime,
+			payloadOf("available", volumeSize(20)))),
+		item(t, res.event("vol-hook-error-pause", "volume.update", deleteTime,
+			payloadOf("paused", nil))),
+		item(t, res.event("vol-hook-error-refused", "volume-update", updateTime,
+			payloadOf("available", nil))),
+	}
+
+	err := db.Store.WithTx(t.Context(), func(tx pgx.Tx) error {
+		_, err := pipeline.Ingest(t.Context(), tx, items, event.SourceCollector, nil)
+		return err
+	})
+
+	if err == nil {
+		t.Fatal("Ingest() error = nil, want the error the hook refused the batch with")
+	}
+	// The events are inserted sorted by id, so the second one the hook sees, and
+	// the one it refuses, is the pause.
+	if want := "running the post-ingest hook for event vol-hook-error-pause"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Ingest() error = %v, want it naming the hook and the event, %q", err, want)
+	}
+	if !errors.Is(err, errHookRefused) {
+		t.Errorf("Ingest() error = %v, want it wrapping %v", err, errHookRefused)
+	}
+	if hook.calls != 2 {
+		t.Errorf("hook was called %d times, want it to stop at the event it refused, 2", hook.calls)
+	}
+	if got := storedEvents(t, db, res.cloud); got != 0 {
+		t.Errorf("events rows = %d, want the batch rolled back, 0", got)
+	}
+	if got := deadLetters(t, db, res.cloud); got != 0 {
+		t.Errorf("dead-letter rows = %d, want the batch rolled back, 0", got)
+	}
+}
+
+// recordingHook keeps every event it was called with, in the order the calls
+// came in.
+type recordingHook struct {
+	seen []event.Stored
+}
+
+func (h *recordingHook) OnEvent(_ context.Context, e event.Stored) error {
+	h.seen = append(h.seen, e)
+	return nil
+}
+
+// seenIDs is the ids of the events the hook was called with.
+func (h *recordingHook) seenIDs() []string {
+	ids := make([]string, 0, len(h.seen))
+	for _, e := range h.seen {
+		ids = append(ids, e.EventID)
+	}
+	return ids
+}
+
+// errHookRefused is what the failing hook takes a batch down with. The
+// assertions match on it rather than on its message, which is what the wrapping
+// the pipeline does has to keep intact.
+var errHookRefused = errors.New("the hook refused the event")
+
+// failingHook takes succeed events and refuses the one after them, which is a
+// hook failing in the middle of a batch rather than on its first event.
+type failingHook struct {
+	succeed int
+	calls   int
+}
+
+func (h *failingHook) OnEvent(_ context.Context, _ event.Stored) error {
+	h.calls++
+	if h.calls > h.succeed {
+		return errHookRefused
+	}
+	return nil
 }
 
 // resource is the fixture a subtest works on: one resource of one cloud, which

--- a/internal/reporting/projects/projects.go
+++ b/internal/reporting/projects/projects.go
@@ -1,0 +1,172 @@
+// Package projects holds the domain logic of the project registry graph: the
+// point-in-time traversal that answers what a project is related to, and the
+// cycle guard a new cost-attributing relation has to pass. Both are walks over
+// project_relations rather than reads of one row, so they live beside the
+// queries instead of in the handlers. Phase 3 attribution walks the same graph
+// and reuses this package.
+//
+// The normative specification is roadmap/01-phase-1-core-platform-openstack.md,
+// WP 1.9.
+package projects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// ErrCycle is what GuardCycle returns for a relation that would close a cycle
+// over the attributing relation types. Attribution is a forest, so a cycle in
+// it would bill the same cost twice.
+var ErrCycle = errors.New("the relation would close a cycle over the attributing relation types")
+
+// Related is one project a walk reached. RelationType is the type of the edge
+// that reached it, Depth the number of edges between it and the project the
+// walk started from, and Path the relation ids of those edges in walk order, so
+// len(Path) == Depth.
+type Related struct {
+	ProjectID    uuid.UUID
+	RelationType string
+	Depth        int
+	Path         []uuid.UUID
+}
+
+// step is one project of the current level together with the relations that led
+// to it. The path travels with the frontier, so it is dropped once the level it
+// belongs to is walked.
+type step struct {
+	project uuid.UUID
+	path    []uuid.UUID
+}
+
+// Traverse walks the outgoing relations of start that are valid at at, up to
+// depth edges out, and returns every project it reaches. A relationType that is
+// not nil narrows the walk to relations of that type.
+//
+// The walk is breadth-first and one query per level, so a depth of ten costs
+// ten queries whatever the graph looks like. First visit wins: a project the
+// walk has already reached is never reached again, which terminates a cycle and
+// keeps start itself out of the result. The projects come back in the order
+// they were visited, which is the order of the frontier over the order of the
+// query, and nothing comes back for a depth below one or for a project with no
+// outgoing relation valid at at.
+//
+// Bounding depth is the caller's business: the API caps it at ten.
+func Traverse(ctx context.Context, q *sqlcgen.Queries, start uuid.UUID, depth int,
+	relationType *string, at time.Time,
+) ([]Related, error) {
+	visited := map[uuid.UUID]bool{start: true}
+	frontier := []step{{project: start}}
+
+	var related []Related
+	for level := 1; level <= depth && len(frontier) > 0; level++ {
+		rows, err := q.ListRelationsValidAt(ctx, sqlcgen.ListRelationsValidAtParams{
+			SourceIds:    projectIDs(frontier),
+			At:           pgtype.Timestamptz{Time: at, Valid: true},
+			RelationType: relationTypeFilter(relationType),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing the relations at depth %d: %w", level, err)
+		}
+
+		// The query sorts by source id, the frontier holds the sources in the
+		// order they were visited: walking the frontier over the grouped rows is
+		// what makes the result depend on the graph rather than on how the ids
+		// happen to sort.
+		outgoing := bySource(rows)
+		var next []step
+		for _, from := range frontier {
+			for _, row := range outgoing[from.project] {
+				if visited[row.TargetID] {
+					continue
+				}
+				visited[row.TargetID] = true
+
+				path := make([]uuid.UUID, 0, len(from.path)+1)
+				path = append(append(path, from.path...), row.ID)
+				related = append(related, Related{
+					ProjectID:    row.TargetID,
+					RelationType: row.RelationType,
+					Depth:        level,
+					Path:         path,
+				})
+				next = append(next, step{project: row.TargetID, path: path})
+			}
+		}
+		frontier = next
+	}
+	return related, nil
+}
+
+// GuardCycle reports whether a relation from source to target would close a
+// cycle over attributingTypes. It walks the active relations of those types out
+// of target and returns ErrCycle as soon as source is among them, an edge
+// straight back to source included, and nil once the walk runs out of projects.
+//
+// Only active relations count: one that was closed carries no cost any more. An
+// empty attributingTypes finds no relation at all, so nothing is a cycle. The
+// walk needs no depth cap, because a project is only ever visited once.
+func GuardCycle(ctx context.Context, q *sqlcgen.Queries, source, target uuid.UUID,
+	attributingTypes []string,
+) error {
+	visited := map[uuid.UUID]bool{target: true}
+	frontier := []uuid.UUID{target}
+
+	for len(frontier) > 0 {
+		rows, err := q.ListActiveAttributingRelations(ctx, sqlcgen.ListActiveAttributingRelationsParams{
+			SourceIds:     frontier,
+			RelationTypes: attributingTypes,
+		})
+		if err != nil {
+			return fmt.Errorf("listing the active attributing relations: %w", err)
+		}
+
+		var next []uuid.UUID
+		for _, row := range rows {
+			if row.TargetID == source {
+				return ErrCycle
+			}
+			if visited[row.TargetID] {
+				continue
+			}
+			visited[row.TargetID] = true
+			next = append(next, row.TargetID)
+		}
+		frontier = next
+	}
+	return nil
+}
+
+// projectIDs is the projects of one frontier, as the queries take them.
+func projectIDs(frontier []step) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(frontier))
+	for _, from := range frontier {
+		ids = append(ids, from.project)
+	}
+	return ids
+}
+
+// bySource groups the relations of one level under the project they leave,
+// keeping the order the query returned them in.
+func bySource(rows []sqlcgen.ProjectRelation) map[uuid.UUID][]sqlcgen.ProjectRelation {
+	grouped := make(map[uuid.UUID][]sqlcgen.ProjectRelation)
+	for _, row := range rows {
+		grouped[row.SourceID] = append(grouped[row.SourceID], row)
+	}
+	return grouped
+}
+
+// relationTypeFilter maps the optional type filter onto its query parameter. A
+// walk that names no type passes NULL, which the query reads as every type.
+func relationTypeFilter(relationType *string) pgtype.Text {
+	if relationType == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *relationType, Valid: true}
+}

--- a/internal/reporting/projects/projects_integration_test.go
+++ b/internal/reporting/projects/projects_integration_test.go
@@ -1,0 +1,300 @@
+package projects_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/projects"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// Every fixture seeds one platform and two relation types: the type the default
+// configuration attributes cost along, and one it does not.
+const (
+	platform      = "openstack"
+	attributing   = "infrastructure_tenant"
+	informational = "parent"
+)
+
+// attributingTypes is the list the cycle guard is called with, as the default
+// configuration spells it.
+var attributingTypes = []string{attributing}
+
+// The instants the fixtures work with. A relation starts at relationStart and
+// every walk asks about walkAt, so a relation is invisible only when the
+// fixture closed it or dated it into the future on purpose.
+var (
+	relationStart = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	beforeClose   = time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	closedAt      = time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	walkAt        = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	futureStart   = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// TestTraverse walks real project_relations rows. The subtests share one
+// database, so each of them seeds its projects in a cloud of its own.
+func TestTraverse(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	t.Run("answers one more level per depth along a chain", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-chain", "a", "b", "c")
+		ab := relate(t, q, ids["a"], ids["b"], attributing)
+		bc := relate(t, q, ids["b"], ids["c"], attributing)
+
+		assertRelated(t, traverse(t, q, ids["a"], 1, nil, walkAt), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+		})
+		assertRelated(t, traverse(t, q, ids["a"], 2, nil, walkAt), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+			{ProjectID: ids["c"], RelationType: attributing, Depth: 2, Path: []uuid.UUID{ab, bc}},
+		})
+	})
+
+	t.Run("answers nothing below a depth of one", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-depth", "a", "b")
+		relate(t, q, ids["a"], ids["b"], attributing)
+
+		for _, depth := range []int{0, -1} {
+			if got := traverse(t, q, ids["a"], depth, nil, walkAt); len(got) != 0 {
+				t.Errorf("Traverse() at depth %d = %v, want nothing", depth, got)
+			}
+		}
+	})
+
+	t.Run("terminates on a cycle without answering the start", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-cycle", "a", "b")
+		ab := relate(t, q, ids["a"], ids["b"], attributing)
+		relate(t, q, ids["b"], ids["a"], attributing)
+
+		// The depth is deeper than the cycle is long, so the walk stops on the
+		// visited set rather than on the depth it was given.
+		assertRelated(t, traverse(t, q, ids["a"], 5, nil, walkAt), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+		})
+	})
+
+	t.Run("answers only the relations of the type the walk names", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-type", "a", "b", "c")
+		ab := relate(t, q, ids["a"], ids["b"], attributing)
+		ac := relate(t, q, ids["a"], ids["c"], informational)
+
+		assertRelated(t, traverse(t, q, ids["a"], 2, ref(attributing), walkAt), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+		})
+		assertRelated(t, traverse(t, q, ids["a"], 2, ref(informational), walkAt), []projects.Related{
+			{ProjectID: ids["c"], RelationType: informational, Depth: 1, Path: []uuid.UUID{ac}},
+		})
+	})
+
+	t.Run("walks neither a closed relation nor one that starts later", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-temporal", "a", "b", "c", "d")
+		ab := relate(t, q, ids["a"], ids["b"], attributing)
+		closeRelation(t, q, ab, ids["a"], closedAt)
+		relateFrom(t, q, ids["a"], ids["c"], attributing, futureStart)
+		ad := relate(t, q, ids["a"], ids["d"], attributing)
+
+		assertRelated(t, traverse(t, q, ids["a"], 2, nil, walkAt), []projects.Related{
+			{ProjectID: ids["d"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ad}},
+		})
+		// The same walk at an instant the closed relation was still valid at
+		// answers it, which is what closing rather than deleting is for.
+		assertRelated(t, traverse(t, q, ids["a"], 2, nil, beforeClose), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+			{ProjectID: ids["d"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ad}},
+		})
+	})
+
+	t.Run("answers a project two paths reach through the one visited first", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-diamond", "a", "b", "c", "d")
+		ab := relate(t, q, ids["a"], ids["b"], attributing)
+		ac := relate(t, q, ids["a"], ids["c"], attributing)
+		bd := relate(t, q, ids["b"], ids["d"], attributing)
+		relate(t, q, ids["c"], ids["d"], attributing)
+
+		// b was related before c, so the first level answers b before c and the
+		// second one reaches d through b.
+		assertRelated(t, traverse(t, q, ids["a"], 2, nil, walkAt), []projects.Related{
+			{ProjectID: ids["b"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ab}},
+			{ProjectID: ids["c"], RelationType: attributing, Depth: 1, Path: []uuid.UUID{ac}},
+			{ProjectID: ids["d"], RelationType: attributing, Depth: 2, Path: []uuid.UUID{ab, bd}},
+		})
+	})
+
+	t.Run("answers nothing for a project no relation leaves", func(t *testing.T) {
+		ids := seed(t, q, "os-projects-sink", "a", "b")
+		// The only relation reaches a rather than leaving it, and the walk is
+		// over outgoing relations.
+		relate(t, q, ids["b"], ids["a"], attributing)
+
+		if got := traverse(t, q, ids["a"], 2, nil, walkAt); len(got) != 0 {
+			t.Errorf("Traverse() = %v, want nothing for a project no relation leaves", got)
+		}
+	})
+}
+
+// TestGuardCycle drives the cycle guard over the shapes a relation creation
+// meets: the walk starts at the target of the proposed relation and asks
+// whether its source is reachable.
+func TestGuardCycle(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	t.Run("refuses a relation the target relates straight back through", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-direct", "a", "b")
+		relate(t, q, ids["b"], ids["a"], attributing)
+
+		err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], attributingTypes)
+
+		if !errors.Is(err, projects.ErrCycle) {
+			t.Errorf("GuardCycle() error = %v, want %v", err, projects.ErrCycle)
+		}
+	})
+
+	t.Run("refuses a relation a chain out of the target reaches back through", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-chain", "a", "b", "x")
+		relate(t, q, ids["b"], ids["x"], attributing)
+		relate(t, q, ids["x"], ids["a"], attributing)
+
+		err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], attributingTypes)
+
+		if !errors.Is(err, projects.ErrCycle) {
+			t.Errorf("GuardCycle() error = %v, want %v", err, projects.ErrCycle)
+		}
+	})
+
+	t.Run("takes a relation that closes no cycle", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-acyclic", "a", "b", "c", "x")
+		relate(t, q, ids["b"], ids["x"], attributing)
+		relate(t, q, ids["x"], ids["c"], attributing)
+
+		if err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], attributingTypes); err != nil {
+			t.Errorf("GuardCycle() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("walks no relation of a type that attributes no cost", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-type", "a", "b")
+		relate(t, q, ids["b"], ids["a"], informational)
+
+		if err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], attributingTypes); err != nil {
+			t.Errorf("GuardCycle() error = %v, want nil for a relation carrying no cost", err)
+		}
+	})
+
+	t.Run("walks no relation that was closed", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-closed", "a", "b")
+		ba := relate(t, q, ids["b"], ids["a"], attributing)
+		closeRelation(t, q, ba, ids["b"], closedAt)
+
+		if err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], attributingTypes); err != nil {
+			t.Errorf("GuardCycle() error = %v, want nil for a closed relation", err)
+		}
+	})
+
+	t.Run("finds no cycle when no type attributes cost", func(t *testing.T) {
+		ids := seed(t, q, "os-guard-empty", "a", "b")
+		relate(t, q, ids["b"], ids["a"], attributing)
+
+		for name, types := range map[string][]string{"nil": nil, "empty": {}} {
+			if err := projects.GuardCycle(t.Context(), q, ids["a"], ids["b"], types); err != nil {
+				t.Errorf("GuardCycle() with %s types error = %v, want nil", name, err)
+			}
+		}
+	})
+}
+
+// seed inserts one project per name into cloud and answers their ids by name.
+func seed(t *testing.T, q *sqlcgen.Queries, cloud string, names ...string) map[string]uuid.UUID {
+	t.Helper()
+
+	ids := make(map[string]uuid.UUID, len(names))
+	for _, name := range names {
+		project, err := q.InsertProject(t.Context(), sqlcgen.InsertProjectParams{
+			Platform:   platform,
+			Cloud:      cloud,
+			ExternalID: name,
+			Metadata:   []byte(`{}`),
+		})
+		if err != nil {
+			t.Fatalf("InsertProject(%s, %s) error = %v, want nil", cloud, name, err)
+		}
+		ids[name] = project.ID
+	}
+	return ids
+}
+
+// relate inserts an active relation valid from relationStart and answers its
+// id. The rows of one source are walked in the order they were written in, so
+// the order of these calls is what a subtest's assertions rest on.
+func relate(t *testing.T, q *sqlcgen.Queries, source, target uuid.UUID, relationType string) uuid.UUID {
+	t.Helper()
+
+	return relateFrom(t, q, source, target, relationType, relationStart)
+}
+
+// relateFrom inserts an active relation valid from validFrom.
+func relateFrom(t *testing.T, q *sqlcgen.Queries, source, target uuid.UUID,
+	relationType string, validFrom time.Time,
+) uuid.UUID {
+	t.Helper()
+
+	relation, err := q.InsertProjectRelation(t.Context(), sqlcgen.InsertProjectRelationParams{
+		SourceID:     source,
+		TargetID:     target,
+		RelationType: relationType,
+		Metadata:     []byte(`{}`),
+		ValidFrom:    pgtype.Timestamptz{Time: validFrom, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("InsertProjectRelation() error = %v, want nil", err)
+	}
+	return relation.ID
+}
+
+// closeRelation closes a relation at validTo, which is what a DELETE on it does
+// at an instant the test picks rather than at now.
+func closeRelation(t *testing.T, q *sqlcgen.Queries, id, source uuid.UUID, validTo time.Time) {
+	t.Helper()
+
+	if _, err := q.UpdateProjectRelation(t.Context(), sqlcgen.UpdateProjectRelationParams{
+		ID:       id,
+		SourceID: source,
+		ValidTo:  pgtype.Timestamptz{Time: validTo, Valid: true},
+	}); err != nil {
+		t.Fatalf("UpdateProjectRelation() error = %v, want nil", err)
+	}
+}
+
+// traverse runs one walk and fails the test when it errs.
+func traverse(t *testing.T, q *sqlcgen.Queries, start uuid.UUID, depth int,
+	relationType *string, at time.Time,
+) []projects.Related {
+	t.Helper()
+
+	got, err := projects.Traverse(t.Context(), q, start, depth, relationType, at)
+	if err != nil {
+		t.Fatalf("Traverse() error = %v, want nil", err)
+	}
+	return got
+}
+
+// assertRelated fails the test unless the walk answered want in that order.
+func assertRelated(t *testing.T, got, want []projects.Related) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Traverse() = %+v, want %+v", got, want)
+	}
+}
+
+// ref is the type filter of a walk that names one type.
+func ref(relationType string) *string {
+	return &relationType
+}

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -222,3 +222,124 @@ SELECT cloud, platform, resource_type, resource_id, project_id, state, size,
        created_at, deleted_at, last_event_type, last_event_at, last_payload
 FROM current_resources
 WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3;
+
+-- name: InsertProject :one
+INSERT INTO projects (platform, cloud, external_id, name, metadata)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, platform, cloud, external_id, name, metadata, created_at;
+
+-- name: GetProject :one
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE id = $1;
+
+-- The batch form of the read above, for the callers that resolve a whole set of
+-- ids at once. GetProjectRefsByIDs is the same read narrowed to the two columns
+-- an event needs.
+-- name: GetProjectsByIDs :many
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE id = ANY($1::uuid[]);
+
+-- name: ListProjects :many
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE (sqlc.narg('platform')::text IS NULL OR platform = sqlc.narg('platform'))
+  AND (sqlc.narg('cloud')::text IS NULL OR cloud = sqlc.narg('cloud'))
+  AND (sqlc.narg('external_id')::text IS NULL
+       OR external_id = sqlc.narg('external_id'))
+  -- Both bounds are cast, for the reason the events cursor above names.
+  AND (sqlc.narg('cursor_cloud')::text IS NULL
+       OR (cloud, external_id) > (sqlc.narg('cursor_cloud')::text,
+                                  sqlc.narg('cursor_external_id')::text))
+ORDER BY cloud, external_id
+LIMIT sqlc.arg('page_size');
+
+-- A NULL parameter leaves the column as it stands, so a request that carries
+-- one field updates that field alone.
+-- name: UpdateProject :one
+UPDATE projects
+SET name = COALESCE(sqlc.narg('name'), name),
+    metadata = COALESCE(sqlc.narg('metadata'), metadata)
+WHERE id = $1
+RETURNING id, platform, cloud, external_id, name, metadata, created_at;
+
+-- A NULL valid_from means the relation starts when it is written, which is what
+-- a request that names no start asks for.
+-- name: InsertProjectRelation :one
+INSERT INTO project_relations (source_id, target_id, relation_type, metadata,
+                               valid_from)
+VALUES ($1, $2, $3, $4, COALESCE(sqlc.narg('valid_from')::timestamptz, now()))
+RETURNING id, source_id, target_id, relation_type, metadata, valid_from,
+          valid_to, created_at;
+
+-- The source project is part of every single-relation key: a relation is
+-- addressed under the project it leaves, and an id that belongs to another
+-- project reads as absent rather than as someone else's row.
+-- name: GetProjectRelation :one
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE id = $1 AND source_id = $2;
+
+-- The relations of one project as they stood at one instant. The two direction
+-- flags are what the direction filter of the API comes down to: a relation
+-- counts when it leaves the project and outgoing is set, or reaches it and
+-- incoming is.
+-- name: ListProjectRelations :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE ((sqlc.arg('outgoing')::boolean AND source_id = sqlc.arg('project_id'))
+       OR (sqlc.arg('incoming')::boolean AND target_id = sqlc.arg('project_id')))
+  AND valid_from <= sqlc.arg('at')
+  AND (valid_to IS NULL OR valid_to > sqlc.arg('at'))
+  AND (sqlc.narg('relation_type')::text IS NULL
+       OR relation_type = sqlc.narg('relation_type'))
+ORDER BY created_at, id;
+
+-- name: UpdateProjectRelation :one
+UPDATE project_relations
+SET metadata = COALESCE(sqlc.narg('metadata'), metadata),
+    valid_to = COALESCE(sqlc.narg('valid_to'), valid_to)
+WHERE id = $1 AND source_id = $2
+RETURNING id, source_id, target_id, relation_type, metadata, valid_from,
+          valid_to, created_at;
+
+-- A relation is closed rather than deleted, so that a read at an earlier
+-- instant still finds it. The row count tells the close apart from the relation
+-- that was closed already, which no longer matches.
+-- name: CloseProjectRelation :execrows
+UPDATE project_relations
+SET valid_to = now()
+WHERE id = $1 AND source_id = $2 AND valid_to IS NULL;
+
+-- The relations of a whole set of projects at one instant, for the callers that
+-- walk the graph rather than serve one project's list.
+-- name: ListRelationsValidAt :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE source_id = ANY(sqlc.arg('source_ids')::uuid[])
+  AND valid_from <= sqlc.arg('at')
+  AND (valid_to IS NULL OR valid_to > sqlc.arg('at'))
+  AND (sqlc.narg('relation_type')::text IS NULL
+       OR relation_type = sqlc.narg('relation_type'))
+ORDER BY source_id, created_at, id;
+
+-- The walk the cycle check runs, which asks about the graph as it is rather
+-- than as it stood at some instant: only the open relations of the attributing
+-- types can carry cost, so only they can close a cycle that matters.
+-- name: ListActiveAttributingRelations :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE source_id = ANY(sqlc.arg('source_ids')::uuid[])
+  AND valid_to IS NULL
+  AND relation_type = ANY(sqlc.arg('relation_types')::text[])
+ORDER BY source_id, created_at, id;
+
+-- Serializes the creation of attributing relations, so that two racing inserts
+-- cannot each pass the cycle walk and leave a cycle behind.
+-- name: LockAttributingRelations :exec
+SELECT pg_advisory_xact_lock(hashtextextended('project_relations:attributing', 0));

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -12,6 +12,28 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const closeProjectRelation = `-- name: CloseProjectRelation :execrows
+UPDATE project_relations
+SET valid_to = now()
+WHERE id = $1 AND source_id = $2 AND valid_to IS NULL
+`
+
+type CloseProjectRelationParams struct {
+	ID       uuid.UUID
+	SourceID uuid.UUID
+}
+
+// A relation is closed rather than deleted, so that a read at an earlier
+// instant still finds it. The row count tells the close apart from the relation
+// that was closed already, which no longer matches.
+func (q *Queries) CloseProjectRelation(ctx context.Context, arg CloseProjectRelationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, closeProjectRelation, arg.ID, arg.SourceID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countEventsForResource = `-- name: CountEventsForResource :one
 SELECT count(*)
 FROM (
@@ -266,6 +288,27 @@ func (q *Queries) GetIngestCredentialForUpdate(ctx context.Context, id uuid.UUID
 	return i, err
 }
 
+const getProject = `-- name: GetProject :one
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE id = $1
+`
+
+func (q *Queries) GetProject(ctx context.Context, id uuid.UUID) (Project, error) {
+	row := q.db.QueryRow(ctx, getProject, id)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Platform,
+		&i.Cloud,
+		&i.ExternalID,
+		&i.Name,
+		&i.Metadata,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getProjectRefsByIDs = `-- name: GetProjectRefsByIDs :many
 SELECT id, cloud, external_id
 FROM projects
@@ -288,6 +331,74 @@ func (q *Queries) GetProjectRefsByIDs(ctx context.Context, dollar_1 []uuid.UUID)
 	for rows.Next() {
 		var i GetProjectRefsByIDsRow
 		if err := rows.Scan(&i.ID, &i.Cloud, &i.ExternalID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getProjectRelation = `-- name: GetProjectRelation :one
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE id = $1 AND source_id = $2
+`
+
+type GetProjectRelationParams struct {
+	ID       uuid.UUID
+	SourceID uuid.UUID
+}
+
+// The source project is part of every single-relation key: a relation is
+// addressed under the project it leaves, and an id that belongs to another
+// project reads as absent rather than as someone else's row.
+func (q *Queries) GetProjectRelation(ctx context.Context, arg GetProjectRelationParams) (ProjectRelation, error) {
+	row := q.db.QueryRow(ctx, getProjectRelation, arg.ID, arg.SourceID)
+	var i ProjectRelation
+	err := row.Scan(
+		&i.ID,
+		&i.SourceID,
+		&i.TargetID,
+		&i.RelationType,
+		&i.Metadata,
+		&i.ValidFrom,
+		&i.ValidTo,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getProjectsByIDs = `-- name: GetProjectsByIDs :many
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE id = ANY($1::uuid[])
+`
+
+// The batch form of the read above, for the callers that resolve a whole set of
+// ids at once. GetProjectRefsByIDs is the same read narrowed to the two columns
+// an event needs.
+func (q *Queries) GetProjectsByIDs(ctx context.Context, dollar_1 []uuid.UUID) ([]Project, error) {
+	rows, err := q.db.Query(ctx, getProjectsByIDs, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Project
+	for rows.Next() {
+		var i Project
+		if err := rows.Scan(
+			&i.ID,
+			&i.Platform,
+			&i.Cloud,
+			&i.ExternalID,
+			&i.Name,
+			&i.Metadata,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -384,6 +495,81 @@ func (q *Queries) InsertEvent(ctx context.Context, arg InsertEventParams) (pgtyp
 	return received_at, err
 }
 
+const insertProject = `-- name: InsertProject :one
+INSERT INTO projects (platform, cloud, external_id, name, metadata)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, platform, cloud, external_id, name, metadata, created_at
+`
+
+type InsertProjectParams struct {
+	Platform   string
+	Cloud      string
+	ExternalID string
+	Name       pgtype.Text
+	Metadata   []byte
+}
+
+func (q *Queries) InsertProject(ctx context.Context, arg InsertProjectParams) (Project, error) {
+	row := q.db.QueryRow(ctx, insertProject,
+		arg.Platform,
+		arg.Cloud,
+		arg.ExternalID,
+		arg.Name,
+		arg.Metadata,
+	)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Platform,
+		&i.Cloud,
+		&i.ExternalID,
+		&i.Name,
+		&i.Metadata,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const insertProjectRelation = `-- name: InsertProjectRelation :one
+INSERT INTO project_relations (source_id, target_id, relation_type, metadata,
+                               valid_from)
+VALUES ($1, $2, $3, $4, COALESCE($5::timestamptz, now()))
+RETURNING id, source_id, target_id, relation_type, metadata, valid_from,
+          valid_to, created_at
+`
+
+type InsertProjectRelationParams struct {
+	SourceID     uuid.UUID
+	TargetID     uuid.UUID
+	RelationType string
+	Metadata     []byte
+	ValidFrom    pgtype.Timestamptz
+}
+
+// A NULL valid_from means the relation starts when it is written, which is what
+// a request that names no start asks for.
+func (q *Queries) InsertProjectRelation(ctx context.Context, arg InsertProjectRelationParams) (ProjectRelation, error) {
+	row := q.db.QueryRow(ctx, insertProjectRelation,
+		arg.SourceID,
+		arg.TargetID,
+		arg.RelationType,
+		arg.Metadata,
+		arg.ValidFrom,
+	)
+	var i ProjectRelation
+	err := row.Scan(
+		&i.ID,
+		&i.SourceID,
+		&i.TargetID,
+		&i.RelationType,
+		&i.Metadata,
+		&i.ValidFrom,
+		&i.ValidTo,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const insertRejectedEvent = `-- name: InsertRejectedEvent :exec
 INSERT INTO rejected_events (reason, raw)
 VALUES ($1, $2)
@@ -397,6 +583,53 @@ type InsertRejectedEventParams struct {
 func (q *Queries) InsertRejectedEvent(ctx context.Context, arg InsertRejectedEventParams) error {
 	_, err := q.db.Exec(ctx, insertRejectedEvent, arg.Reason, arg.Raw)
 	return err
+}
+
+const listActiveAttributingRelations = `-- name: ListActiveAttributingRelations :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE source_id = ANY($1::uuid[])
+  AND valid_to IS NULL
+  AND relation_type = ANY($2::text[])
+ORDER BY source_id, created_at, id
+`
+
+type ListActiveAttributingRelationsParams struct {
+	SourceIds     []uuid.UUID
+	RelationTypes []string
+}
+
+// The walk the cycle check runs, which asks about the graph as it is rather
+// than as it stood at some instant: only the open relations of the attributing
+// types can carry cost, so only they can close a cycle that matters.
+func (q *Queries) ListActiveAttributingRelations(ctx context.Context, arg ListActiveAttributingRelationsParams) ([]ProjectRelation, error) {
+	rows, err := q.db.Query(ctx, listActiveAttributingRelations, arg.SourceIds, arg.RelationTypes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProjectRelation
+	for rows.Next() {
+		var i ProjectRelation
+		if err := rows.Scan(
+			&i.ID,
+			&i.SourceID,
+			&i.TargetID,
+			&i.RelationType,
+			&i.Metadata,
+			&i.ValidFrom,
+			&i.ValidTo,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listCurrentResources = `-- name: ListCurrentResources :many
@@ -641,6 +874,125 @@ func (q *Queries) ListEventsForResource(ctx context.Context, arg ListEventsForRe
 	return items, nil
 }
 
+const listProjectRelations = `-- name: ListProjectRelations :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE (($1::boolean AND source_id = $2)
+       OR ($3::boolean AND target_id = $2))
+  AND valid_from <= $4
+  AND (valid_to IS NULL OR valid_to > $4)
+  AND ($5::text IS NULL
+       OR relation_type = $5)
+ORDER BY created_at, id
+`
+
+type ListProjectRelationsParams struct {
+	Outgoing     bool
+	ProjectID    uuid.UUID
+	Incoming     bool
+	At           pgtype.Timestamptz
+	RelationType pgtype.Text
+}
+
+// The relations of one project as they stood at one instant. The two direction
+// flags are what the direction filter of the API comes down to: a relation
+// counts when it leaves the project and outgoing is set, or reaches it and
+// incoming is.
+func (q *Queries) ListProjectRelations(ctx context.Context, arg ListProjectRelationsParams) ([]ProjectRelation, error) {
+	rows, err := q.db.Query(ctx, listProjectRelations,
+		arg.Outgoing,
+		arg.ProjectID,
+		arg.Incoming,
+		arg.At,
+		arg.RelationType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProjectRelation
+	for rows.Next() {
+		var i ProjectRelation
+		if err := rows.Scan(
+			&i.ID,
+			&i.SourceID,
+			&i.TargetID,
+			&i.RelationType,
+			&i.Metadata,
+			&i.ValidFrom,
+			&i.ValidTo,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProjects = `-- name: ListProjects :many
+SELECT id, platform, cloud, external_id, name, metadata, created_at
+FROM projects
+WHERE ($1::text IS NULL OR platform = $1)
+  AND ($2::text IS NULL OR cloud = $2)
+  AND ($3::text IS NULL
+       OR external_id = $3)
+  -- Both bounds are cast, for the reason the events cursor above names.
+  AND ($4::text IS NULL
+       OR (cloud, external_id) > ($4::text,
+                                  $5::text))
+ORDER BY cloud, external_id
+LIMIT $6
+`
+
+type ListProjectsParams struct {
+	Platform         pgtype.Text
+	Cloud            pgtype.Text
+	ExternalID       pgtype.Text
+	CursorCloud      pgtype.Text
+	CursorExternalID pgtype.Text
+	PageSize         int32
+}
+
+func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]Project, error) {
+	rows, err := q.db.Query(ctx, listProjects,
+		arg.Platform,
+		arg.Cloud,
+		arg.ExternalID,
+		arg.CursorCloud,
+		arg.CursorExternalID,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Project
+	for rows.Next() {
+		var i Project
+		if err := rows.Scan(
+			&i.ID,
+			&i.Platform,
+			&i.Cloud,
+			&i.ExternalID,
+			&i.Name,
+			&i.Metadata,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRejectedEvents = `-- name: ListRejectedEvents :many
 SELECT id, received_at, reason, raw
 FROM rejected_events
@@ -681,6 +1033,55 @@ func (q *Queries) ListRejectedEvents(ctx context.Context, arg ListRejectedEvents
 			&i.ReceivedAt,
 			&i.Reason,
 			&i.Raw,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRelationsValidAt = `-- name: ListRelationsValidAt :many
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
+       created_at
+FROM project_relations
+WHERE source_id = ANY($1::uuid[])
+  AND valid_from <= $2
+  AND (valid_to IS NULL OR valid_to > $2)
+  AND ($3::text IS NULL
+       OR relation_type = $3)
+ORDER BY source_id, created_at, id
+`
+
+type ListRelationsValidAtParams struct {
+	SourceIds    []uuid.UUID
+	At           pgtype.Timestamptz
+	RelationType pgtype.Text
+}
+
+// The relations of a whole set of projects at one instant, for the callers that
+// walk the graph rather than serve one project's list.
+func (q *Queries) ListRelationsValidAt(ctx context.Context, arg ListRelationsValidAtParams) ([]ProjectRelation, error) {
+	rows, err := q.db.Query(ctx, listRelationsValidAt, arg.SourceIds, arg.At, arg.RelationType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProjectRelation
+	for rows.Next() {
+		var i ProjectRelation
+		if err := rows.Scan(
+			&i.ID,
+			&i.SourceID,
+			&i.TargetID,
+			&i.RelationType,
+			&i.Metadata,
+			&i.ValidFrom,
+			&i.ValidTo,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -762,6 +1163,17 @@ func (q *Queries) ListResourceTypes(ctx context.Context) ([]ResourceType, error)
 	return items, nil
 }
 
+const lockAttributingRelations = `-- name: LockAttributingRelations :exec
+SELECT pg_advisory_xact_lock(hashtextextended('project_relations:attributing', 0))
+`
+
+// Serializes the creation of attributing relations, so that two racing inserts
+// cannot each pass the cycle walk and leave a cycle behind.
+func (q *Queries) LockAttributingRelations(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, lockAttributingRelations)
+	return err
+}
+
 const lockResource = `-- name: LockResource :exec
 SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text || ':' || $3::text, 0))
 `
@@ -797,6 +1209,74 @@ WHERE id = $1 AND revoked_at IS NULL
 func (q *Queries) RevokeIngestCredential(ctx context.Context, id uuid.UUID) error {
 	_, err := q.db.Exec(ctx, revokeIngestCredential, id)
 	return err
+}
+
+const updateProject = `-- name: UpdateProject :one
+UPDATE projects
+SET name = COALESCE($2, name),
+    metadata = COALESCE($3, metadata)
+WHERE id = $1
+RETURNING id, platform, cloud, external_id, name, metadata, created_at
+`
+
+type UpdateProjectParams struct {
+	ID       uuid.UUID
+	Name     pgtype.Text
+	Metadata []byte
+}
+
+// A NULL parameter leaves the column as it stands, so a request that carries
+// one field updates that field alone.
+func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (Project, error) {
+	row := q.db.QueryRow(ctx, updateProject, arg.ID, arg.Name, arg.Metadata)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Platform,
+		&i.Cloud,
+		&i.ExternalID,
+		&i.Name,
+		&i.Metadata,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const updateProjectRelation = `-- name: UpdateProjectRelation :one
+UPDATE project_relations
+SET metadata = COALESCE($3, metadata),
+    valid_to = COALESCE($4, valid_to)
+WHERE id = $1 AND source_id = $2
+RETURNING id, source_id, target_id, relation_type, metadata, valid_from,
+          valid_to, created_at
+`
+
+type UpdateProjectRelationParams struct {
+	ID       uuid.UUID
+	SourceID uuid.UUID
+	Metadata []byte
+	ValidTo  pgtype.Timestamptz
+}
+
+func (q *Queries) UpdateProjectRelation(ctx context.Context, arg UpdateProjectRelationParams) (ProjectRelation, error) {
+	row := q.db.QueryRow(ctx, updateProjectRelation,
+		arg.ID,
+		arg.SourceID,
+		arg.Metadata,
+		arg.ValidTo,
+	)
+	var i ProjectRelation
+	err := row.Scan(
+		&i.ID,
+		&i.SourceID,
+		&i.TargetID,
+		&i.RelationType,
+		&i.Metadata,
+		&i.ValidFrom,
+		&i.ValidTo,
+		&i.CreatedAt,
+	)
+	return i, err
 }
 
 const upsertCurrentResource = `-- name: UpsertCurrentResource :exec


### PR DESCRIPTION
Closes #6

Adds the project registry to the Reporting API: CRUD for projects keyed by `(cloud, external_id)`, typed relations between projects that carry a validity interval, point-in-time relation reads, a bounded-depth traversal of a project's neighborhood, and a creation-time cycle guard over the relation types that attribute cost. Ingestion gains the post-ingest hook seam Phase 4 registers projects through, with a nil default. No migration: `projects` and `project_relations` landed with the WP 1.3 skeleton, and `migrations/reporting/embed.go` keeps `Version int64 = 4`.

## The change set in commit order

The branch is eleven commits, each declaration paired with the integration tests that pin it. Reading them in order is the shortest path through the diff.

**`8fd21da` Add the conflict and relation-cycle problem types** — Two RFC 9457 types the existing catalog could not name: `TypeConflict = "urn:tally:error:conflict"` (409) for a project or relation triple that already exists, and `TypeRelationCycle = "urn:tally:error:relation_cycle"` (422) for a relation whose creation would close a cycle. Clients match on the URN rather than on the status.

**`5651295` Parse the attributing relation types from the environment** — `TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES` names the relation types the cycle guard walks, `envDefault:"infrastructure_tenant"`. An explicitly empty value disables the guard; a stray comma (`"a,,b"`) fails `config.Load` rather than being read as a relation type no relation has. `caarlos0/env` applies `envDefault` to a variable set to the empty string just as it does to an unset one, so `Load` consults the raw value to tell the two apart — and the test helper now *removes* the variables a test does not name instead of blanking them, which is what makes that difference observable.

**`7330321` Add the post-ingest hook seam to the ingest pipeline** — `ingest.New` gains a `Hook` parameter. The hook is called once per newly stored event, after the batch was folded into the projection and inside the ingest transaction, in insertion order; an error it returns fails the whole batch, so what a future hook writes lands together with the events it saw or not at all. Duplicates and refused items never reach it; reconciliation-sourced events do, so a hook that only wants collector events filters on `e.Source`. Every call site passes `nil`, which is what Phase 1 ingests with.

**`cb811ed` Cover the post-ingest hook with integration tests** — One call per stored event in insertion order, nothing for a duplicate or a refused item, and an unchanged batch for a nil hook. The failure case refuses the second of three fresh events: the batch fails with the wrapped error, and the rollback leaves neither the events stored before the refusal nor the dead letter the refused item wrote.

**`fdc8b0a` Add the project registry queries** — The thirteen statements the endpoints and the traversal go through, rather than SQL at the call site. Relation reads carry the instant they are read at, because a relation is closed rather than deleted and stays readable at every instant it was valid at. `LockAttributingRelations` is a `pg_advisory_xact_lock` on a constant key, following the existing `LockResource` pattern; it serializes attributing relation creations so two racing inserts cannot each pass the cycle walk.

**`aa3ea22` Add the projects package with traversal and cycle guard** — `internal/reporting/projects` holds the graph semantics, because the `related` endpoint and the cycle check are the same breadth-first walk and Phase 3 attribution will walk it again from the metering run. `Traverse` asks one query per level with the whole frontier as the source set, so a depth of ten costs ten queries whatever the graph looks like; first visit wins, which terminates a cycle and keeps the start project out of the result, and iterating the frontier in visit order over rows grouped by source makes the result order follow the graph rather than the id sort. `GuardCycle` walks the active relations of the attributing types out of the target and reports `ErrCycle` once the source is reachable — no depth cap needed, since the visited set bounds the walk.

**`0eda1e5` Cover the projects package with integration tests** — Against a real database through the generated queries, not a stub. `Traverse` is held to a level per depth along a chain, to nothing below depth one, to termination on a cycle, to the type filter, and to two temporal cases: a relation closed before the instant and one starting after it are both invisible, and the closed one comes back at an instant it was still valid at. A diamond pins the order — the project both paths reach is answered once, through the neighbor visited first. `GuardCycle` is held to a direct relation back to the source and to a chain reaching it, and to the three shapes that are no cycle: an acyclic graph, a non-attributing type, and a closed relation. An empty type list finds nothing to walk.

**`bb8a9f4` Declare the project CRUD and serve it** — `POST/GET /api/v1/projects`, `GET/PATCH /api/v1/projects/{id}` in the contract, with handlers in `internal/reporting/httpapi/projects.go`. A registration and the audit row naming it share one transaction, and the `(cloud, external_id)` key decides a duplicate in the database (23505 → 409 `TypeConflict`) rather than in a read in front of the insert that two racing registrations would both pass. The `{id}` path parameter carries the RFC 4122 pattern next to its format, because the request validator checks the pattern and ignores an unregistered format — so a malformed id gets the contract's 400 before a handler runs. Reads take `read_all`, writes `admin`.

**`dbc865c` Cover the project CRUD with integration tests** — Through the whole stack, so what is pinned is wire behaviour: the 201 and its `Location`, a registration read back byte for byte, the 409, the filters and the cursor walk, the 404 of an unknown id, the 400 the RFC 4122 pattern produces before a handler runs, a `PATCH` that leaves the members it does not name, and the audit rows the two writes leave. The role matrix runs every operation under every token class, and the stopped-container case pins that a database failure answers 500 with the detail of the operation rather than with its cause.

**`fd43a78` Declare the relation endpoints and serve them** — The five remaining operations (`POST/GET .../relations`, `PATCH/DELETE .../relations/{relation_id}`, `GET .../related`) with handlers in `projectrelations.go`. A relation is valid at `t` iff `valid_from <= t AND (valid_to IS NULL OR valid_to > t)`; both reads answer that point-in-time view and a past `at` is how history is read. A close sets `valid_to` and never deletes the row, which is what leaves that history readable. A creation decides everything in one transaction: both projects must be registered, a self-relation is answered before the table's `CHECK` is reached, the active triple is decided by the partial unique index rather than by a read two racing creations would both pass, and an attributing type is walked first under the advisory lock, which puts a racing creation behind the first insert so the two cannot close a cycle together. The configured relation types travel from the router down to the server, which is what an operator turns the guard off with.

**`b9ee2c1` Cover the relation endpoints with integration tests** — The 201 and its `Location`, the null `valid_to` of an open relation, the 409 a second open relation on one triple gets and the creation that goes through once it is closed, the 404 of a relation addressed under a project it does not leave, and the audit rows the three writes leave. The temporal rule is pinned from both ends: a relation valid over March 2026 is served for an `at` inside that span, gone for the instant it was closed at, and gone for now. The cycle guard is pinned on a pair, on a chain running through a project between the two ends, and on two creations fired at once, which the advisory lock has to resolve into one relation and one refusal rather than into a stored cycle. Role matrix, contract-level refusals, and the stopped-container 500 case as above.

## Divergences from the issue

- **`RelatedProject` carries the whole project, not just its id.** The issue's Go-level sketch of `Related` names a `ProjectID`; the wire schema embeds a full `Project`, hydrated through `GetProjectsByIDs` — which the issue itself lists among the queries to add. The internal `projects.Related` type still carries `ProjectID`, so the traversal stays free of the resource shape.
- **Auth is stricter than the roadmap annotates.** WP 1.9 marks only `POST /projects`, `PATCH /projects/{id}` and `POST .../relations` as `role: admin`, leaving the relation `PATCH` and `DELETE` unannotated. All four mutations take `admin` here, and all five reads take `read_all` — no project-scoped view of the registry exists, since the registry is what a project scope is resolved from. This follows the plan's stated decision rather than the roadmap's silence.

The Non-Goals hold as written: no Gardener integration (only the nil-default seam), no interval-overlap cycle detection (the guard reads the active edge set, so a backdated `valid_from` can still form a cycle confined to a past window — Phase 3 re-rating must not assume the forest property for arbitrary past instants), no scoped registry reads, no reopening a closed relation, no project deletion, no pagination on the relation and related lists, and no schema change.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
