### PR TITLE
Build the provider-agnostic reconciliation framework

### DIFF
--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -1105,6 +1105,54 @@ paths:
         "500":
           $ref: "#/components/responses/Problem"
 
+  # This route is not part of the public API either: whatever drives the sync
+  # schedule calls it with the shared internal token. It is described here for
+  # the same reason the rebuild above is, that the request validator refuses a
+  # path the contract does not carry.
+  /internal/sync/{cloud}:
+    parameters:
+      - name: cloud
+        in: path
+        required: true
+        description: The installation to reconcile, os-prod-eu1 for example.
+        schema:
+          type: string
+    post:
+      operationId: syncCloud
+      summary: Reconcile one cloud
+      description: >-
+        Runs one sync of the cloud. A sync asks the platform's adapter what the
+        cloud currently holds, diffs that observation against the projection,
+        and feeds the difference back as synthetic events through the ordinary
+        ingest path, so a resource a run corrected ends up with the same kind of
+        history as one that was never missed.
+
+        The run is synchronous: the answer carries the stats of the run that
+        just happened rather than a handle to poll. A cloud the configuration
+        does not name is answered 404, and a cloud another run is holding is
+        answered 409, because two syncs of one cloud would diff the same
+        projection rows against two overlapping observations.
+      security:
+        - internalToken: []
+      responses:
+        "200":
+          description: The sync run finished.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncResult"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
 components:
   responses:
     # Every error response of this API is this one, so operations reference it
@@ -1301,7 +1349,11 @@ components:
           type: string
           description: >-
             What happened, written resource.action with an optional phase, for
-            example compute.instance.create.end.
+            example compute.instance.create.end. The reconciliation framework
+            writes the second family, `sync.create`, `sync.update`, and
+            `sync.delete`: a correction is about no one service, so it names
+            none. `source` is the member to branch on rather than the prefix —
+            it is `reconciliation` for exactly those events.
         platform:
           type: string
           description: The platform the resource lives on.
@@ -1407,7 +1459,11 @@ components:
           description: When the resource was deleted, null while it lives.
         last_event_type:
           type: string
-          description: The type of the newest event folded into this row.
+          description: >-
+            The type of the newest event folded into this row. It is a
+            `sync.create`, `sync.update`, or `sync.delete` when the newest thing
+            that happened to the resource was a correction by the reconciliation
+            framework rather than a report by a collector.
         last_event_at:
           type: string
           format: date-time
@@ -1884,6 +1940,42 @@ components:
         rebuilt:
           type: integer
           description: How many resources were replayed.
+
+    SyncResult:
+      type: object
+      description: What one sync run did.
+      required: [sync_run_id, stats]
+      properties:
+        sync_run_id:
+          type: string
+          description: >-
+            The id of the `sync_runs` row this run wrote. It is what an operator
+            reads the run back by, and what the synthetic event ids of the run
+            are derived from.
+        stats:
+          $ref: "#/components/schemas/SyncStats"
+
+    # What went wrong is deliberately not a member here. A run that recorded any
+    # error at all is answered 500, so a member for it could only ever be empty
+    # in a document a caller gets to see, and the reasons carry platform detail
+    # that an error response does not hand out. The `sync_runs` row of the run
+    # keeps them, which is what an operator reads them back from.
+    SyncStats:
+      type: object
+      description: The tally of one sync run, which is one that finished clean.
+      required: [created, updated, deleted]
+      properties:
+        created:
+          type: integer
+          description: >-
+            How many resources the run reported to the projection as new, one
+            synthetic event each.
+        updated:
+          type: integer
+          description: How many it corrected the state, size, or owner of.
+        deleted:
+          type: integer
+          description: How many it reported as gone.
 
   securitySchemes:
     # Referenced per operation by the authenticated endpoints. The health probes

--- a/cmd/tally-reporting/.env.example
+++ b/cmd/tally-reporting/.env.example
@@ -49,3 +49,11 @@ TALLY_INGEST_REQUIRE_SIZE_SCHEMA=false
 # refused when it would close a cycle over these types. An explicitly empty
 # value disables that guard.
 TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES=infrastructure_tenant
+
+# Path to the clouds YAML the reconciliation framework reads at startup: a
+# clouds: list of cloud, platform, adapter, and adapter_config entries. Unset
+# means no clouds are configured and every POST /internal/sync/{cloud} answers
+# 404. The adapter registry is empty until the first provider adapter lands
+# (issue #10), so a non-empty list refuses startup today with an unknown
+# adapter, which is intended: nothing could serve such a cloud yet.
+TALLY_REPORTING_CLOUDS_CONFIG=

--- a/cmd/tally-reporting/main.go
+++ b/cmd/tally-reporting/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/b42labs/tally/internal/reporting/config"
 	"github.com/b42labs/tally/internal/reporting/httpapi"
 	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
 	"github.com/b42labs/tally/internal/reporting/registry"
 	"github.com/b42labs/tally/internal/reporting/store"
 	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
@@ -96,6 +97,18 @@ func run(ctx context.Context) error {
 	// today.
 	pipeline := ingest.New(registry.New(), cfg.RequireSizeSchema, nil)
 
+	// The clouds file is read here rather than per sync run, so a broken one
+	// refuses the process instead of failing every request that reaches the sync
+	// endpoint. The adapter registry stays empty until the first provider adapter
+	// lands (issue #10), which is why a non-empty file refuses startup today: no
+	// adapter it names is registered, and none exists that could serve it.
+	adapters := map[string]reconciliation.Adapter{}
+	cloudsCfg, err := reconciliation.LoadConfig(cfg.CloudsConfigPath, adapters)
+	if err != nil {
+		return fmt.Errorf("loading the clouds config: %w", err)
+	}
+	syncer := reconciliation.New(db, pipeline, cloudsCfg, adapters, time.Now)
+
 	router, err := httpapi.NewRouter(httpapi.Options{
 		Logger:                   logger,
 		DB:                       db,
@@ -107,6 +120,7 @@ func run(ctx context.Context) error {
 		Authenticator:            auth.NewStaticTokenAuthenticator(queries),
 		Pipeline:                 pipeline,
 		AttributingRelationTypes: cfg.AttributingRelationTypes,
+		Syncer:                   syncer,
 	})
 	if err != nil {
 		return fmt.Errorf("building the router: %w", err)

--- a/cmd/tally-reporting/main_test.go
+++ b/cmd/tally-reporting/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -98,6 +99,14 @@ func TestRunRefusesToStart(t *testing.T) {
 		setEnv(t, env)
 
 		assertRunFails(t, "TALLY_REPORTING_DB_URL")
+	})
+
+	t.Run("when the clouds config cannot be read", func(t *testing.T) {
+		env := serverEnv(freePort(t))
+		env["TALLY_REPORTING_CLOUDS_CONFIG"] = filepath.Join(t.TempDir(), "absent.yaml")
+		setEnv(t, env)
+
+		assertRunFails(t, "loading the clouds config")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/testcontainers/testcontainers-go v0.43.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -83,5 +84,4 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/core/timeline/timeline.go
+++ b/internal/core/timeline/timeline.go
@@ -67,9 +67,17 @@ func Build(events []event.Stored) Timeline {
 		if i == 0 && category != event.CategoryCreate {
 			tl.Warnings = append(tl.Warnings, WarningHistoryStartsWithoutCreate)
 		}
-		if category == event.CategoryCreate && tl.CreatedAt == nil {
-			ts := e.Timestamp
-			tl.CreatedAt = &ts
+		// A create that follows a delete is the resource coming back, so the
+		// deletion it superseded stops being what the timeline reports: the fold
+		// takes a resource's fate from its newest lifecycle event, which is how
+		// the projection's incremental fold reads one as well. Both fold one
+		// history into one answer, so neither may be delete-dominant on its own.
+		if category == event.CategoryCreate {
+			if tl.CreatedAt == nil {
+				ts := e.Timestamp
+				tl.CreatedAt = &ts
+			}
+			tl.DeletedAt = nil
 		}
 
 		// A delete closes the running interval and opens nothing: a deleted

--- a/internal/core/timeline/timeline_test.go
+++ b/internal/core/timeline/timeline_test.go
@@ -288,6 +288,33 @@ func TestBuildLoneDelete(t *testing.T) {
 	}
 }
 
+func TestBuildCreateAfterDeleteStartsASecondLife(t *testing.T) {
+	size := map[string]any{"vcpus": 2}
+
+	got := timeline.Build([]event.Stored{
+		ev("e1", "compute.instance.create.end", t0, withState("active"), withSize(size)),
+		ev("e2", "compute.instance.delete.end", t1),
+		ev("e3", "compute.instance.create.end", t2, withState("active"), withSize(size)),
+	})
+
+	// The resource is back, so the delete it superseded is history rather than
+	// what the timeline reports. A fold that kept it would tell the projection's
+	// replay path that a resource its incremental path holds live is deleted.
+	if got.DeletedAt != nil {
+		t.Errorf("DeletedAt = %v, want nil: the resource came back at %v", got.DeletedAt, t2)
+	}
+	if got.CreatedAt == nil || !got.CreatedAt.Equal(t0) {
+		t.Errorf("CreatedAt = %v, want the first create %v", got.CreatedAt, t0)
+	}
+	if len(got.Intervals) != 2 {
+		t.Fatalf("got %d intervals, want 2: %+v", len(got.Intervals), got.Intervals)
+	}
+	if !got.Intervals[1].Start.Equal(t2) || got.Intervals[1].End != nil {
+		t.Errorf("second interval = %+v, want one open from the second create %v",
+			got.Intervals[1], t2)
+	}
+}
+
 func TestBuildDoesNotMutateInput(t *testing.T) {
 	events := []event.Stored{
 		ev("e2", "compute.instance.delete.end", t1),

--- a/internal/reporting/config/config.go
+++ b/internal/reporting/config/config.go
@@ -38,6 +38,7 @@ const (
 	envOIDCJWKSURL        = "TALLY_REPORTING_OIDC_JWKS_URL"
 	envRequireSizeSchema  = "TALLY_INGEST_REQUIRE_SIZE_SCHEMA"
 	envAttributingTypes   = "TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES"
+	envCloudsConfig       = "TALLY_REPORTING_CLOUDS_CONFIG"
 )
 
 // EnvNames is every variable this package reads, including the *_FILE
@@ -56,6 +57,7 @@ var EnvNames = []string{
 	envOIDCJWKSURL,
 	envRequireSizeSchema,
 	envAttributingTypes,
+	envCloudsConfig,
 }
 
 // The accepted values of TALLY_REPORTING_AUTH_MODE.
@@ -115,6 +117,13 @@ type Config struct {
 	// a relation is created; an empty list disables the guard. Setting the
 	// variable to the empty string yields that empty list.
 	AttributingRelationTypes []string `env:"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES" envDefault:"infrastructure_tenant"`
+	// CloudsConfigPath is the path to the deployment's clouds YAML, the file the
+	// reconciliation framework reads at startup to learn which clouds it can
+	// sync. It has no *_FILE companion because the value is a path already, not
+	// a secret. Unset is valid and means no clouds are configured, so every sync
+	// answers 404. Whether the file exists and parses is checked by
+	// reconciliation.LoadConfig, not here.
+	CloudsConfigPath string `env:"TALLY_REPORTING_CLOUDS_CONFIG"`
 }
 
 // Load reads the environment, resolves the file-backed secrets, and checks the

--- a/internal/reporting/config/config_test.go
+++ b/internal/reporting/config/config_test.go
@@ -84,6 +84,9 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if want := []string{"infrastructure_tenant"}; !slices.Equal(cfg.AttributingRelationTypes, want) {
 		t.Errorf("AttributingRelationTypes = %q, want %q", cfg.AttributingRelationTypes, want)
 	}
+	if cfg.CloudsConfigPath != "" {
+		t.Errorf("CloudsConfigPath = %q, want empty", cfg.CloudsConfigPath)
+	}
 	if err := cfg.ValidateServer(); err != nil {
 		t.Errorf("ValidateServer() error = %v, want nil", err)
 	}
@@ -99,6 +102,7 @@ func TestLoadReadsExplicitValues(t *testing.T) {
 		"TALLY_REPORTING_DB_MAX_CONNS":               "4",
 		"TALLY_INGEST_REQUIRE_SIZE_SCHEMA":           "true",
 		"TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES": "infrastructure_tenant,same_owner",
+		"TALLY_REPORTING_CLOUDS_CONFIG":              "/etc/tally/clouds.yaml",
 	})
 
 	cfg, err := config.Load()
@@ -127,6 +131,9 @@ func TestLoadReadsExplicitValues(t *testing.T) {
 	}
 	if cfg.UnhealthyThresholdSeconds != 30 {
 		t.Errorf("UnhealthyThresholdSeconds = %d, want 30", cfg.UnhealthyThresholdSeconds)
+	}
+	if want := "/etc/tally/clouds.yaml"; cfg.CloudsConfigPath != want {
+		t.Errorf("CloudsConfigPath = %q, want %q", cfg.CloudsConfigPath, want)
 	}
 }
 

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -84,6 +84,7 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodPut + " " + resourceTypeRoute:   auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
 
 		http.MethodPost + " /internal/projection/rebuild": auth.Internal(opts.InternalToken, opts.AuthMode),
+		http.MethodPost + " /internal/sync/{cloud}":       auth.Internal(opts.InternalToken, opts.AuthMode),
 	}
 
 	return func(next http.Handler) http.Handler {

--- a/internal/reporting/httpapi/events_integration_test.go
+++ b/internal/reporting/httpapi/events_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/b42labs/tally/internal/reporting/auth"
 	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
 	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
 	"github.com/b42labs/tally/internal/reporting/registry"
 	"github.com/b42labs/tally/internal/reporting/store"
 	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
@@ -527,6 +528,8 @@ func newAPIInMode(t *testing.T, s *store.Store, mode auth.Mode) api {
 		Authenticator:            auth.NewStaticTokenAuthenticator(q),
 		Pipeline:                 ingest.New(registry.New(), false, nil),
 		AttributingRelationTypes: []string{attributingType},
+		Syncer: reconciliation.New(s, ingest.New(registry.New(), false, nil),
+			reconciliation.Config{}, map[string]reconciliation.Adapter{}, time.Now),
 	})
 	if err != nil {
 		t.Fatalf("NewRouter() error = %v, want nil", err)

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -393,7 +393,7 @@ type Resource struct {
 	// LastEventAt When that event happened.
 	LastEventAt time.Time `json:"last_event_at"`
 
-	// LastEventType The type of the newest event folded into this row.
+	// LastEventType The type of the newest event folded into this row. It is a `sync.create`, `sync.update`, or `sync.delete` when the newest thing that happened to the resource was a correction by the reconciliation framework rather than a report by a collector.
 	LastEventType string `json:"last_event_type"`
 
 	// LastPayload The payload envelope of that event, member for member as it was stored, and null for a row that holds none.
@@ -459,7 +459,7 @@ type StoredEvent struct {
 	// EventId The idempotency key the event was submitted under.
 	EventId string `json:"event_id"`
 
-	// EventType What happened, written resource.action with an optional phase, for example compute.instance.create.end.
+	// EventType What happened, written resource.action with an optional phase, for example compute.instance.create.end. The reconciliation framework writes the second family, `sync.create`, `sync.update`, and `sync.delete`: a correction is about no one service, so it names none. `source` is the member to branch on rather than the prefix — it is `reconciliation` for exactly those events.
 	EventType string `json:"event_type"`
 
 	// Payload The normalized payload envelope, member for member as it was stored. It is null for an event stored without one, which a delete event may be. The members are not constrained here: an envelope keeps the fields a provider sent beyond the ones this API names.
@@ -485,6 +485,27 @@ type StoredEvent struct {
 
 	// Timestamp When the event happened.
 	Timestamp time.Time `json:"timestamp"`
+}
+
+// SyncResult What one sync run did.
+type SyncResult struct {
+	// Stats The tally of one sync run, which is one that finished clean.
+	Stats SyncStats `json:"stats"`
+
+	// SyncRunId The id of the `sync_runs` row this run wrote. It is what an operator reads the run back by, and what the synthetic event ids of the run are derived from.
+	SyncRunId string `json:"sync_run_id"`
+}
+
+// SyncStats The tally of one sync run, which is one that finished clean.
+type SyncStats struct {
+	// Created How many resources the run reported to the projection as new, one synthetic event each.
+	Created int `json:"created"`
+
+	// Deleted How many it reported as gone.
+	Deleted int `json:"deleted"`
+
+	// Updated How many it corrected the state, size, or owner of.
+	Updated int `json:"updated"`
 }
 
 // UpdateProject What to change about a project. A member the request leaves out stays as it is, so at least one of them has to be present.
@@ -973,6 +994,9 @@ type ServerInterface interface {
 	// RebuildProjection Rebuild the projection
 	// (POST /internal/projection/rebuild)
 	RebuildProjection(w http.ResponseWriter, r *http.Request)
+	// SyncCloud Reconcile one cloud
+	// (POST /internal/sync/{cloud})
+	SyncCloud(w http.ResponseWriter, r *http.Request, cloud string)
 	// Readyz Readiness probe
 	// (GET /readyz)
 	Readyz(w http.ResponseWriter, r *http.Request)
@@ -1099,6 +1123,12 @@ func (_ Unimplemented) Healthz(w http.ResponseWriter, r *http.Request) {
 // RebuildProjection Rebuild the projection
 // (POST /internal/projection/rebuild)
 func (_ Unimplemented) RebuildProjection(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// SyncCloud Reconcile one cloud
+// (POST /internal/sync/{cloud})
+func (_ Unimplemented) SyncCloud(w http.ResponseWriter, r *http.Request, cloud string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2060,6 +2090,32 @@ func (siw *ServerInterfaceWrapper) RebuildProjection(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// SyncCloud operation middleware
+func (siw *ServerInterfaceWrapper) SyncCloud(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "cloud" -------------
+	var cloud string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "cloud", chi.URLParam(r, "cloud"), &cloud, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cloud", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SyncCloud(w, r, cloud)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // Readyz operation middleware
 func (siw *ServerInterfaceWrapper) Readyz(w http.ResponseWriter, r *http.Request) {
 
@@ -2250,6 +2306,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/internal/projection/rebuild", wrapper.RebuildProjection)
 	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/internal/sync/{cloud}", wrapper.SyncCloud)
+	})
 
 	return r
 }
@@ -2259,174 +2318,185 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H1tk9s28udXQen+VUnqOJqx4+z9V6l94d1kd33lSlyOc3tVcc6CyJaEHQpgAHBkxTXf/QrdAAhQpB48",
-	"M46T9Tt7RBJAo9H960e8m5Rq0ygJ0prJ7N1kDbwCjf98Cb+0YOyzb9x/KjClFo0VSk5mk78praHm7n9M",
-	"VEwtmV0LwzS9MWWv1sAM6BvQjFeqsYbZNTAlgXFW8roGzQzIyjAuK7YCCZpbMPiAsmvQW2HgayYs400D",
-	"XLtfGNyA3rFarVgt3HNL/KYfsmBGsV9aZYVcufeEZJyZtmmUtuEZJgzbrrllVgBNyG4Vs2oFbsjppJiY",
-	"cg0b7pZrdw1MZhNjtZCrye3tbTFpuOYbsJ44f2u1UXqfMm7lcwlv7ZsSn5iHiTZ8BWwBS6WBiKUkTNkz",
-	"nJVq+C8tzBxxagHSsoYbA8YtZMHLa8bxnxpKEDdQIV1kxTTwyjCp7NotWrXWDSWsW4hwU/mlBb2bFBPJ",
-	"N24tNJ9jq9RgGiUN4CJfaLWoYeP+WSppQVr3T940tShx8y8beuJ//tu41b9Lvv1fGpaT2eR/XHb8dUm/",
-	"msvwXRxxn35hv5Zc1FARNy1UtWOG7wxbq61bYsKo//fCs+oF8erQ0P7xy46pb3F0PyXcUg3cwgut/g2l",
-	"Hd7Zhn5kVjENK2EsaLeHhs0/L2vVVgWDtxa05PUbUX0xZw0Xmq25cS8s6AAQ07p39Y5VCnAH2VrVFdsB",
-	"bl6jVQPaMSkS3n13eDZCGstrfwxtMr1a3DjukQVT5qLRqrqA9hFbKs3gLd80NbhhNkI+B7my68nsUdFn",
-	"hWKSLOQwLZA5DcN5MsdrxjPhkQE2YHnFLd//+r/W3LrTzqA2gKdWabtm1wCN43S+cLyerHfKngaSBlpw",
-	"y2rgN3SG3OPGKu1PPWwau2Nqga9O4szoD25mdGCGZpVRWRiSZdUJi21qbpdKb0ZI6X8d2ETlNrEBt9Pl",
-	"9VlbiIf5l1ZoqCazn7oZFJ6l8i3+eYAOdCBeekE/PPWoBqxiJT6PQs0TP10PCUG7Jh5Bga1kvSPN4CQw",
-	"A1k5oq7EDUi2Bg37p+EemCbM2HENzvgeOCZ88w39Mso6kVob4NIUTMil5sbqtrSthjcWJJf2zINquV6B",
-	"PXpMs+E18HINBreqE09BpEFVoIIRlpVcOvG0gL2tjN8iqrmJOvbidjKbtK1w/NVw6xhsMpv8v5+uLv7M",
-	"L5ZPL/7+87v/vr1I//vknP8+enz7X5MBItzwWlRvllpthqgPMp+ysVxbwxbgOANfRUpUsORtbZEcNshX",
-	"2Vuu4ywtrAWZLbniFi6s2MDk2EHs9qvPN0Nn8Bvg1XNwdHwuzIBW+l56aKGWrAJeXdT4MFQOL0lr9o+Q",
-	"sLAxY4d52RoEGLAxEdW5zxdM6Qo/u9hFIPKGExARKAHjdw9p/m45UH3rJogcTIvmWvMdyt8OPg3upiZu",
-	"dI/R2mk/C4JNVcRMcw/BAsySbV0zryprbuhlN3X3A1/UMJlZ3cKxDaSF5tM8vHVhrYO7J+QKwamFDdH7",
-	"6YtnYScKtww33WRrmXVTRcQQNG1vg0ckQfoNrbakNbsNR0EgFfGNQ/VxMiWXzOrWo2w8DWr7mWFqi+g/",
-	"wOpU9/dFwd6B1Xw7AmrcVAjwbrlhpl1s3GmrCrYVds2++/E5K9dc89IhcWZK3S4WUDFuPSGn7DuPiJ1+",
-	"VtKBAiGhQoUyo5lyVqq6htIqtEMskwAV84KOs//9w/ffeWlPghApsYHNAjQrudbOftgGfUMTnZIa4GZI",
-	"Uf5rvfOzI+FLRLd+tYUzVfB8sBuhvJhJdEDBGg1L8da/suU7L52QbwJgZxqcsRM2YJ/g3aEdFZE588UJ",
-	"vqeg8xKuGzYSiLZ/6MzgOXkmm5YsjaoSboa8fpFwOJ3R/YNUcqmkKHlNLEx2A+2ak/W12jKu3TFwLzqe",
-	"0Rxhh11zmXLK1yRdcMHiBsLeOPtW8WrDm8urq4tSSTeIUNJMNxUzUOK2PbkbgNdgVKtLOAXBO4zupjCo",
-	"+f9RqwWv6x1rpfilBSYq2DTKgix37Bp2TrY/cmru8Vd/So7TlD2V3fnXEA8fnT03Q8M3wNz2G8s3DStV",
-	"K61x55WzqiW7MJ3bATy0dra9xINN+jSufsqJmDgol0w1xASsWXMDRUoG5nRMa2FKurqEqQehICucRsN3",
-	"teIj9Mc9rsWvUDH/HAN5A7VqYEartdyCky1KM75E4evgoFtagf9cOpWioal5CRtHNyN+BbZ1x8mhpzWX",
-	"q4Cm4io03zokdSMq0MyB2emZFkKPSw6YCLfIjO5wHcWHaiud0My+ny9cGH+wSJzQM6PfjR/pXnRHCHF4",
-	"/oVhHnHfuBYSnUvh0YKFbXbzulF1u4G9BdOjh4ADTaZ0nOwQo3dXObjvURPj9ZbvTBSpiH1FA+h4QlOB",
-	"hC9qTlSKqUbxmHnD9TVaxgTE3BnRUCpZilrQiVetbdpMTrEN3zkdVMMSjZCvGXf4tAX3HyMqYPM4zhy5",
-	"ap5/c+6Ft0mEt0NY4cAeQMe08u5UPvvhe/bff7p65I8hHvpflXREvh2T3Mcxakrm88CpJ+MoKu2EkqNL",
-	"kGInI9MfcGJ/dEz6DPn2JZi2tiNyWXWYtOR1zSqRiP8Ft+U6YDM01Pf3kJclNBYG5MI/1ZZtuNyFvXRf",
-	"xDGIKxLcIqSFFWg35ahWzIEPksWCSJlbvuAGGK818GrH1lCPfFmDIwtU40A0mWJE5I4+IK3eMWdEn8xf",
-	"L/1gIxzW289Iw2z9yZSHNve5WEK5K2sYPoKJFA1Sia2FI/0uwFxgC0Fsxxyd9A2vDQk8/yBbktkhrZo6",
-	"2UNfnKNkJ5lpCWfzngJwuJJMFqmCzkEwrLYowd0HpNniYX5y9STDZgEHkBumDqucvpav5Svvxl/z2ulC",
-	"Anga3eROtuNvlVguQbvl0qINWDNlc2JCL0bjcueI8Alih0XjCqy6BokC2vFVwbZrUUOPBomTxC+uQIqF",
-	"2VAMg2aRaVpne7XSAQKpmClVA1P2vcypyCOgCGOYYIwR1TG2EHQWZ3OCQg56z2n4GH4AXANop/W9EgsM",
-	"sBTaWaOeHMFV4v1XVnNplhQsyQ89EXP4JCFI6mgJSBKmHbKTmQiffx6FeJF6GQoWkO4X8/sS6HHDh+c8",
-	"eA46jhCbphZgCuY211ii2pS92qruTdqsSDtEzsGlhE4zt9eR0AuwWyBVvPGQIu6930jcowpqsGTwkqSm",
-	"D5LxLhGz8bo+mUpRZjzzExmiVZjIcRnnn7stJluuHaA0B7yhyAalamuyvb2LoSdf2dNI9O1amcCgEVC6",
-	"N7mnUDTO/RtviHvfOAGiWvvG2wYpbfbdqYfEciREERg+ZaRk0QfFcyT1oJhe83p54fA8Mw2XbP6TO7oF",
-	"s+qLOVM3oJ3gKdcx7hfZjTzcKdeQsNg/q0fcpL2zX/g/lnVrnDm8UK2sTnUJ3M3+wOWmUxr0bDiTa/jb",
-	"aIz15Gx18KvdbqHpN/JZtAqz7zo4JOSJE7bqFOqDrDzt4W1O+xQ6khbKXsSAMsjCM0pElvEBtWTc2Y6O",
-	"3nEFwozu6XlQFLkLFxmI6Lco44WhA5KEm3PivPz739ifn3z1v5gPN7MKLBf1lH1L+lRrpTtHmEhcWd4U",
-	"EoaZNW+goKyECh0WI2Hs/fNCow2gz3bD5YXTpHgA4W1Tc+kjDA2UYilKCiW4HSnLVmuQJQyyBC5hQFa+",
-	"AH2xFFBXfsnGrcCSg8GDDSSIg08UyfDuQy7qVueiLl9Urcr94Z6r0pumlLSglkuQlY+StFAwmK6mGIuf",
-	"Jg6AwRVtzGpE9GMERclVZ1WQiYtagVtW+0lMj3oY3RpopCF26msxx4ztiLr/56tXLxg9wEpVQZLSQlw1",
-	"xXgpehkmsydXV0P2hBV2CHv/sFbasnXOLKbdbLjexewQv4/uo9lQk/+TbyoMetOHXSg/vkRfLiDbMVGB",
-	"tGK5C1J2fMhWy5nldb2bIVvOOr46HtxyvwZKRJKPHPbhPAsyVUIksovxv0oTJ4Rh17ALqHEo96LwuL6a",
-	"d3k/MdLsDgIuyDBeVRpMHqpe7D5gHsbeZnaw/YCaCENs0a0UqHW6Wr5bekfQLd7kERWaZ96thhBscGVH",
-	"xvLRLi+6zwonnZoXgCElckENpJGQXu1H/HHDeCRIwpseVzIud/eSSFKQTj8+HhLnBC/RQyWenBD4OZJv",
-	"4omT7FzG+AckxnEf4770OM/TGK3rUV8jnQb0M/o1neNqDKLvj+tmfAmLVtSVT7YbWomTHgFCGMqna2q+",
-	"c+aed4UHHzhbihpjvd7iIeNY5kdU04DGe1gSr0l0HFPY/FqqrTlZur/ESXV5St2MA2vgiyMB14PxjeOf",
-	"Dop5f0vG6X3Er+vJ5Ik9ZBvSE/aAq7Wb6BbI3xQ/1YdEe9YzfXuYY+jMBhfCq9GgEBp1Piab5GF6qdnt",
-	"vKdevjz38psuSTX/+lOK/P9A3640X1r2+Orx1cWjx6xSZbvBqDIdKHesHRoLPjWBfyXVEtMkwks4ryQ/",
-	"kby7xr0Bb3lpQxZc9Ly7h0ou0UbZsZpbcrn1qNYjb7q2YRKnHugR3JXkgwSPIAXtg9PfPzLiARyFE0lW",
-	"ic/xIKBQ7WtdYnTaTxnyYnhAFhW6uRIAsl2HfIgK3kas59GuyCJhQ5DEvTUeAPjMsEYZQZlfJD67oDgG",
-	"QwqKgQcP76+g1Vi0YTw5JBIloXAe536dbu+MfXZTNq35jOy+wATMb8ju9eQEJY0LT3II4gyHeccxYXUQ",
-	"tEfEyKzmN6ANr32iYTVkUzd2fVDK1B6g1wJS52iWhLjl9TWpwED/mK6DkcqhfWj40MBZLquojI8erL2G",
-	"jXZ8xGySBkdQgAdeWB/gmOPaQuL/JoMFR4FsHxA0HcVPhBRHclExYLJrkgKKxHDBJbljdgMVO8UCD9Pr",
-	"D1v4DfbkPs5Sw6guR2MSTuGsU4BdXKv/ShEON26n28obYYSlHKjNGTG+7JQc8ybTN0dpM5hzTVLab1k8",
-	"FlvVIV0vT9FoZ9yyuZ0zsVyyeZcjy163V1dfln9hlj397hv2Of1iFXv2A/vux+fP2fcvWfwbPgvMBpOa",
-	"NF1ZK9NLofKRiRi84Di8Q2pc18KR1ccqjBXOyhFyJIHxJAM4EsGJzDMzcsct0fDV38oU7ZLTD9qicfEh",
-	"MnTMEn3QBPV9j/zh1KAz08jvNeP9lO/fNZn8jhGTcPJOG1w1A2OfFjFIc9qdqX9PAQAkascCxYGM98z8",
-	"T8ieEOGoWyDIynEN0mEJtUQtEpFKFkM9M1U+fDMKWp8Yht/KvQVxAeemy0c9cBdVMpYQl+aEhDzzJHkh",
-	"JJj7nOm9nBGqxiNtoMVqbZmkyrx7TH99f/9oFpnzbxQDq/TZGcJ2gC+8+pkzJVQdg/7ZKSI53CU1cMsk",
-	"ynazVlsn0mM11Kt8QB+yxhyPKlSaOGWJfnl1DdKXRp2S/CFMUBI+AN6FEwilJmmOyHuNhgpLbbscEErk",
-	"B23Woon58YlrciFqZ+f6JB10IIVA9mcmTZwpPAWyvJOGi+C5dMAYEYL74X1ljQOW4SOnbn8EJon8E97P",
-	"+f7zqLmxb8h6OjAVbnuJlafrgWSA06C8hC3E1IjA2DJYLppO5/AwB9Ok+7nRNF5YWREcdo5D/D+T+g3v",
-	"EXHMlxwcylniNuaEyUPeyE6a3SVLenrf6QlyhKKn50YLa6BeFuM1tOd6FYeypu8hacLt0HZ0o2OKM+We",
-	"oTg9AmAzwRlfkwpHv4d8DIHpGJKqnELKVJcZ49OEomDoMiV81wIDWEnjdiezcYKgFpap5dKXZrmPhNT4",
-	"Y+AoxEKS8Ei+pTn7ZAy6l0+RaMJMLu7Ljr646h37Q8DheLyFMhts5xk+E0n1Hd/D4ZYi9+0WvgdC2PBz",
-	"QFWXpfaHjb8c8qL3IuwZWaPXN3Oz+/8nJxzhgMV8W58e4EDPijtMt7/97yO2cTYLqJVcGWbV+0rD/HsO",
-	"hwivl8Owo/JxNFDQpSIgAU+IGgxJtLapjuNYvwNOlSLf3K32+IDUSRecze0Yfx2yu4Z57P3kA72ayYXI",
-	"OJkoCJGfs4QBnpT7Ewjh3PukeDz+VlV8N8sbgBD8wdCc2rIGdF/IGRVDmkkAaemULkI7TPnFxPlehkwt",
-	"jHWT2RnGmRFyVYMXrJ0DADvE4JMkdAmm02rNw0mnNDN7UDj5IiyzH77tGaW9CuGmbk2vct978LyjTdgP",
-	"YaAejoT1SzG72qtsNVQOcOD7v21p5RCUfs9Sy1MMiH3bO+Qb+Z0NDtAkNsgzaOZL6/KqYKe+nDW+Xyfu",
-	"vh/MnWuAxvjiCHD8x7v6TSwfX8BOebWpJPQdx78/w2as7vNuZeV+pyK/n24Jn1NsCnu1pvdjRZ366fHy",
-	"U8eTsYq00apqy5QcRVJCiunMaV1n4P+Yx+jtFPeUrnqBmO4hL0w0K2suNjB8bs8vDn1P9JGEmrsxM3E2",
-	"mDZ2jn0UqjOCLMoZdEgZ/YhIZzSwTZER5Z1vscgi6TzlJVbSjC40EqIuQqiBvaOUYmP4gCHfsw8SJ114",
-	"Gg3Gn46NkGnjg0end0MiIUe/Zh7BYPqiR1CqLfO85WvYjQ9540n1Fjs6QQ2vIWMyijlsQK+ClymWQgcy",
-	"YCGdt5bDuARmEpqFiaGQvZcsymxtJ3TJGmGJ8RjsCE+kjaV+H0zRhRE/Nq6IMxtnizuFyXqdr0jVJRHy",
-	"eVaV7332QYnPCDkhrOoiaD4ijiaBs0d4+Ivb0ZX3J9HfIj4tldaYkxVQuQb3XWxYFkPsyRgYOaCulmdJ",
-	"4X0Wb0mV/mYtu5ymhLLVwu7Qcval4414pa5h4Mw9lYghqAjXO1u4YfOnrV0rLX5FEs3YX4Fr0D6/AR+m",
-	"9IX5lH3Ly3WX+O+9rFQ/S/EACVCZrxn3g1DHGIpvJaXJX8ZGoW45CxyvW97a2obSylZg7PhaQoG9BsxT",
-	"43XBhDGtQ8eg2edBCxbk+vqCYjfvs+pn1pcsYydUb0s5AE0uEC4047X3vp+wKkp2HlkX+mLX3NHJQKkh",
-	"rbh4hd1oOgOciupj3Rr2RVGtBYNIvnjvxfpD4olpFWvaRS1K33XWnLDMW1zockCufEvoL2RoJg5Jgc2A",
-	"YiF9a5wxTTQPqYxIACdVhOnyQkt148wQrCwGXts1VuWAKQLS7MYK9roTl1hmSHvZTcLQ2DE454sHw88X",
-	"6P8K7oEiU53dX7MeYXAjYNtVhqeF7ZRHPI2lPrMJbfDLuOanL55NiolbHhHvavpoeuWYyAk43ojJbPLl",
-	"9Gr6pU8Rw+N/yRtxefPosismX4EdSp22rZZBa6QdRQomudYYgF3syAzEkGRIIU/1cShUQUHv875MXoLe",
-	"VZ0zbkqqhJuyOSoIKi+yas4M1CHdpKvd3QpZqW2vejfF0nGYWWfLchvzgf0gwviKRaqLTh9wQxO3T19L",
-	"6n9V115SkUsJfcxsjm6ZedS1nU/Fl0hl3YpTGwOdWvhV3484cWw7OYnG+N7r+H1ZhaDkltfXRGN6xrtw",
-	"eJdXi6FBX80MtSGnlwc8HieEJs3ktyCJEvbUzRjqmlWwdPb7zBvq9GOIVBJtMJvax/md9AszUHLLdWWm",
-	"ryUeT3SdBav3wkfq8yiQP1P0mwN8XWfga5C+NXPa7YFq1+edtTL3GsjjPYcNQmC/oNyhKtjloYFQP4CV",
-	"Jp9vHZbx3RkwpWzLdz73APRFfJEmhtPea0aBDQq2fOfxWvga26ibmDAQbGGFE5aw7QrRvANmzaWfuKNw",
-	"koqVNoDYWwj1vkB1UVchdzcq62fVZDZ5Loz9NhTdp824f9oruHQnpqus6DUOihUbg02yvc053iO7OG+0",
-	"NMgwNGBi797fmKGczo3RNQ0ciDCzp55hubmOOfeda8j3nHIvEssMQKHBRWU2+V2XRfbVeH3M0Az2ohv3",
-	"RVvyylPrMe8Q7adDDs0n83HceTIonHFv9/xJYxOInpFucJDtBkPSwe1E3pLE65Q4TM7etL4LMSbGDeRG",
-	"Rl2BSnNsCT4zsFvAacbPafNNO/NnU+2lUp42VWp+cMeJ9rtlBZUeNTm3bKPMaMP/WmyEzebhGxxPZo+u",
-	"rorJhr8VG8cCj67wv0L6/w4Vcg1H0ToxfOkvRLj9uXeHwOOrqwP3B5x3b0DXY27g5oCDXebu47aAYvKE",
-	"1jL0Rlxzd7mBe/7Rmc9/edbzX501n8TkRqXZGds//ey2zbck8Ko2pyFGFNRQoPcHapPOfWs4tez3YTXJ",
-	"BQ4OVAmqwI9hPgrmYMAVO5MQUzPHlLGEhvp8kepxH3l8dYU9MOCm52TzKTsODXFvNvq+SaHzQtF17vVV",
-	"Y+JGVC2vfcO3SlSzpO4sa4lrqO9AY737/QLVY2xjMVgo5wcPiVGSzUMPtzl2oI8+/w319fVtvCqtGhI0",
-	"mIJKxEXo6rTxol0ukYg+LuE71KFZRKh+0xqLlrAGq3eIHWnUWAqXoytqDBjxlafnX1W1O+v0KgnfL5G7",
-	"jp5j6vLrJMtJgfrsnV6Y/ufbPNRgdQu3DyiHsi6KI5eY0I45Rmi0KsGY/ZtMtmmsljD170hWPfqQsirz",
-	"p/XFFW1HlFS3RXQkBIvqqCvBroeajpj78CcMXgzTuRPOtt27uX2y3jPrfdBifBE44Dybcb8FxIew4/ZG",
-	"fWBbNa2HFDozDnF49CE8S9rsYetwiSpIbalQwW4VvWhYa4LHAl0JSWsMTLRYKLsO/bdaWYNx/OjenPtT",
-	"Rtzns5nGDKmsh8gZS49oOqsn/c/G02nt7RFEPdJT5ROuPhtXj6iacYQdWmOYtHbt7H5YMye0uaCs3dAa",
-	"mbLpMqfOn3ueTgwAd0W9DdWbZtmIBMPVDeitFtbfjeFjpJo7bAuSFktWtofz2JurO/HxGAq84+3kbl10",
-	"aUEqa2pHp3C1WsEWUPLWQCqpHNZ2pzppDZzVhgdX6L5OyS+Je3+gfOhY5mOchG0f3bdMGIO1WVswUgzb",
-	"XgOyRCaEfoLDscIfXz4POCPUMYc9PSzb/0iy5snVnz8K2RSkTOf/HUTSl+9EdZvA6fx0/ANsejQeVm2N",
-	"Xx+51zzwD6upnlw9+Ui4h1e+w1Sf+JPbI9D7pA6ACMiwl0jEY76ePBWMxYkchOkvt24JjTPTBy649b27",
-	"g6edKXIXxfSpvJL8/JQvtN3C19DyCqp2JLOKcqrunmH3Wn7nXXA2TSyWfoEj9qoD/v7mO8rDB02p1DuE",
-	"9tuuf8Q+ICl8OlQXDESgfUN937gkJU/GB/Yz2lPK+2o4z9p8GDWcj/GBXUxnqWGng43lsjKfJN1DSzri",
-	"ilFZN6YyLzX1Bhr1RP2L19f+muzWrhT15g49JvDIxFo77OrD7bxgbeOOUGg4lfS5aG2oj0xTZfZaZ8V7",
-	"QJ9maYYP0jvI98TrnPgof5SQ9kJIDIqxGwHbgAhXmjdrXEO8c8FQU6HFDj1alCTZcEPE8EYFLksYtnCP",
-	"2vUF3RbgPoMdnUwa3pZlrBWxoDdCYmcEzjB9Ct/pKj/iS8vuIlt/5XbitGDdxTGl2kDeVco6aYk9E31z",
-	"Ka8F3LfmaT5isu1+QVapa2p2yMs13oswGhohY6zhK1xOnptCDa0H757u3b8y7EzL+1sd9akNNHMLfY5w",
-	"VStFxTFDzpbQPmzI2ZK5Wo47WvbPWdp1M2kNc0JWQd685gz306vefbJ+w8JlhGbvAlo5Hl3m9vzo8kO6",
-	"kQY6uR1WW/sN2D7prQ/me8r9nzEDFBXBOVg9XAjk+/H5Nlh4od6D4fXD2tWd4xMjPdmphxyaDujZ7I6i",
-	"rutCwfBGoo9Qe0oQq/VC6bVS1flK9L61Sdat1VkKUNem6+GcTda3KmKtvJZqK8dNgCS68zLu/hH2DX2n",
-	"o4JVFJCYsXlAXfOujNOZb8ltCWSgzoUs1SZ/EE8PmWEFmy+U0+dkZI2qN6EplXpYxU3cNyZFTNEKk8Ov",
-	"0fCTgh56jxStT0rvvpReaDs36ok62CTuk9L7gAGX4RaAZyu87kNOTfhwRFqt/2COqsHYEIUKfAeJtJVm",
-	"T251RguVpH8IlYXGTVJSl5102xMN6WxCjxNKjbBaNDVl9fnrK6mfZLj+NpFOXaJEbHmRl+lhbzsnLDDz",
-	"mT5s/Z1EISjGS7z1uxcV+zq5/Zreo9xWHir6THdL34oLN/mnfsLvZX+5+dEyhc0fDe40/3OYPk6v11VM",
-	"Q/LRx49xTpEW/iCEAIySS7FqsXTAWi0WLWZvYM8VbwbHv2NvwqXSeNv+M+tXTr14gxPDUzH9Vm4FqiWb",
-	"x8agc7rVLywt6UnNIzZNV4gkzmn2+DH7fN6/uShyB5r08y9ilQKVggZGc8TGPno+4Z2uofJVIP0WuzEt",
-	"5nBsMJYPP2SMsOsP+mGDhPm4BzqpZ2HC7pbfu4QIY5n1f1KM8MmDxhSfPH78kUSR6uBb7eqpQoTgmG/V",
-	"SZbLd/HE+zAltYAZUJxOaufWoLOJDFiUVfOg0eYBllK+hdp2VtHRfufOosqanWcdvjNh3FdCvvY7lXCP",
-	"r56447SFuu5qMn2SdjLdqCs2ytk1eHKymnOet07HS7yDAsFuyCFSxLL5+ZjcgCpS4VL8+BvdbjviNu3r",
-	"pSFn4zdI2iFJmgm0J8fucQhV+Z+Q9kMfXTxPGQx9b2idtIJ/EDBdHOaZriXrqYHoROZ8mIh0F4XWacJu",
-	"Sv0PFpGevpaJ9DnUUiPxAjm0hkJ9Kwx0vfKMYlvqn7HX/OJYA42vPWGG+nWghD6rs0ZPNnvTKco3t+/D",
-	"WPUcEYj5sIflYBaCfmBE2et684Hj3Wciyk8R748XxWUR8rirHXYLlUgXZ7V58B1ThsqyqrQcqzilHgt/",
-	"5VuqxUl6DYbmi3tFHEkXMXL631dDiHny5XnmJw/3gfeuBet1egOZ3MyAXd5QAK+d9AmlRV09WxjseKeJ",
-	"wSfv0nIC//SpZmWg4wQkXYmcGqw2Ql4oWe9moWuN70WEfhX3K7Us6sHoL6fsu3gNlK/XR3kMJsmB9oyP",
-	"LYvxHvjsyr+wYdLpy1pgqld3WUp0/4xlByT3C55bcENJE/GM/l6qx/Npf8xF5DTTTzUv3wCvnmODo1PK",
-	"XpJ+SJ/qye8ehhkiZw8bJN2qToUGSR5e0jktawHyBdW+5FK93+Y+ucnCydZyDeV13tV+SOh1/cPN5EEB",
-	"cq/l+vHs9/2m6/fFto8+2nKqfM0HeOvyXWCV28t3Ga8cLG/I+sV/oO0+d6t/u53+mMsRMhKd5pw65V6K",
-	"A7fkD7iKsgsYxvxEJ+VVHL/XomChc/sJE9tvsnzq7H4uJk17sGyxL2e9q+qwrC6oCXbaf5beDi7yZGvp",
-	"MhLC/LG34imXdPPuhpPUeePfIx9YZzUGk4H6/g4UnL9o9+XD/TtqBq9K/+DumlPEU3avzEkFg38k982j",
-	"Lz+2wr6eCBzQjaflT6adQNXWkMcgvbzkHvtmZKIh+e9d22jQxD+5I3ruiIHb0ij7w4FjrbbevTbHm8jm",
-	"8WGkY3K9IzNgp+yl2vo7NoAuK9iomyRgml5uKQxbuQ2jqERo1tR107ZrrdrVGqcR7uN0sx3quxm21zfd",
-	"DJzUdSX01sBA682QHkXXHgod2aGCUlTge7V3PeerXv0aNoly6sioDXQ76pe1XzBy0KY414ey3yLxgfuH",
-	"DFzd9iHapAwM+wfpePlbNbnsxqUjE270o5sVhYkuYDengpl1a9VyeUrjy3hj4elz8zelcB0Py7IGsDFZ",
-	"e8rmlF02p//vHfg4a4flYpZGEE/JW+5h7BbhFQGv6/jrQtn1NMo5/Nn9uzVzlGhCVtCArPCqVZK1XjY4",
-	"fKV5JUrMt0chYtpyjboDv/YXmv3r9urq8Z/om3+Jc9vRDUPdtZnhosAx4rZmJIWcRkmSyOMf/GCTYsLr",
-	"+qQE8qSSKzLof7wnMbsg84gfcfCKzE9OxPfy9uzRchjJXr5D0b/n3Un+L6rbU3vNpx2sY6pFALtZeVDS",
-	"Pz6LGnbN5AlejBbZzPDrCNjymv6uVXfAzhu+YwZgBMcmlw9SMle4E9shuA1FKrjETptXebvPE1JrPTHe",
-	"WKXe1Equ5l9kkUnOrG5liRmb/tGv2fwf375ieZP/OR4R40VkAu1e+QvKERniZ0IqRpYyFK9qz22SUE6r",
-	"Kr7bb8/u1QQq+DwNG7HoKGBMqeKGf3L1JC1VigRegTV9lNvlFoeRSy7duAtg1g2NsHw/lw7eCmOn7Fu6",
-	"64C6p8VryMIt8vvd25PCPq9OUoUaq8GokVsHf0M/djJJkElmMdM9doQPfdpjsBGv14mX2Gd3R4OGLl1R",
-	"wtYfnTArz2+e+4wIHU3jWClTdf1Q45X8gyxF8XN/NWc6UTJl0okGfg92aHUYkicNUn+LHsfRRO5OVdjS",
-	"ThqRgZYJAxQBvxuv8MeTjsyr9Pa7YfF/kiv5+E2iBVPmotGquoD20QkO2+52vDu5kfvXHCZOY6V9n/sH",
-	"dR8Xd7sg/9BcxHn0+fkOKCLeunNi/XFUW4GplqquwpVpeeLQQlAWI12UdMNrNA614tWGN5dXVxelwtuH",
-	"hJJmusGrl5DLvirIf+U/2NOPQSInNwq4KTDNJeuum4x/3rv/p6n5julWmlia3E2PnDZB/MqIXyrQmFLk",
-	"xi/Vxt83N30t51uupZArE9pgRA8cDl6qtkYPmcMUWCWUXCbCbSg9DwU6nA3cyzAEKBwNEg265b4ranph",
-	"Slc3Pct9Vj4DjZx5UvXpS3fUVmMIAHHIZ8HJkGXyRGWOhdPZ/S85ilmSH1HDnhr/LLvghz848puyv6u6",
-	"otxaT9Ck3hw3s+uk0vHJEEoxDZchUuA4n6I7swR9ZLE8YcLJ8V7NBDl4p2ZIqkuYjNqxozv3NFby7AOb",
-	"BVRusHmYQHT4DhyvkFWMBMFj4vZp3rUPmDsIyBoNmC/pMxYr0J/hboI2a9Ekt3V3hMNZMm6z9U7ZX7HS",
-	"xNFhHp+d7+OZJIr9PIqtB0Q03SBHAkVF6t3tQGO3bmE90zsx+QnPvDee8UcmKq1PkOaPDGnoZsFfDyAT",
-	"kobbNXR9AenOAmbWqHud9HbaXmK+8zPLllw4HCLrXczSpDuphdOZ3LAFgDOMaewdktvpitSSS0qO7VqD",
-	"oYoyRBNUp+0Em3DIu+KWL7hBFUo3K3o57aNm+zLun37NR8Wahbf2sqm56Ak0zxuT2URdD+RZDsqxsH50",
-	"vYibe8zD+epMH99XZ/nsbnM32w1It/V4EyW51sIVnZedlrv0V0C6YcbaVjuMaIYNqJC4l9ytTl50nzxv",
-	"OiScaFZEMzG6W4aEjkpJSBFrZAVes1XLNZcWgC1gLbxGSYComXX3wfC+FkdwV/Q8Jgl09fobb97CvtpY",
-	"+b/HjC+JVC/ixx8sMQTH8bzz4VNC/OiHbkXxXMOWQgrz++r79YHvO8lu2t3X5ETG/HzQYcXsqPOkfRBc",
-	"jp3Rxehk73IpykTWdzg0SmNhWCuxO0O4WAlbKfLrcFOJqkLIWyvrS449svYinNIbho4MLuK3Et+UYRYC",
-	"jpEav0d5/hKdnalAv739/wEAAP//",
+	"7L3tjhs31id+K4T+D+AJ/tXqtuPMPqNgPnhmMjNeGIlhOzsLxFmLqqIkTpfICslqWQka2IvYK9wrWfCc",
+	"QxZZqtKLu9tx8vib3aoqvh2e8zvvv0xKvWm0EsrZyeyXyVrwShj45yvxUyuse/43/59K2NLIxkmtJrPJ",
+	"X7Uxoub+f0xWTC+ZW0vLDL4xZW/WgllhboRhvNKNs8ytBdNKMM5KXtfCMCtUZRlXFVsJJQx3wsID2q2F",
+	"2UorvmbSMd40ghv/CxM3wuxYrVeslv65JXyThiyY1eynVjupVv49qRhntm0abVx4hknLtmvumJMCJ+S2",
+	"mjm9En7I6aSY2HItNtwv1+0aMZlNrDNSrSa3t7fFpOGGb4Sjzflra6w2+zvjVz5X4r17V8IT8zDRhq8E",
+	"W4ilNgI3SysxZc9hVrrhP7Vi5jenlkI51nBrhfULWfDymnH4pxGlkDeign1RFTOCV5Yp7dZ+0bp1fijp",
+	"/EKkn8pPrTC7STFRfOPXgvM5tkojbKOVFbDIl0YvarHx/yy1ckI5/0/eNLUs4fAvG3zi//+39av/Jfn2",
+	"fxixnMwm/99lR1+X+Ku9DN+FEff3L5zXkstaVEhNC13tmOU7y9Z665eYEOr/vCBSvUBaHRqaHr/siPoW",
+	"RqcpwZEawZ14afS/RemGT7bBH5nTzIiVtE4Yf4aWzf9Q1rqtCibeO2EUr9/J6os5a7g0bM2tf2GBFwCJ",
+	"1r9rdqzSAk6QrXVdsZ2Aw2uMboTxRAob7787PBuprOM1XUOXTK+WN556VMG0vWiMri5E+5gttWHiPd80",
+	"tfDDbKR6IdTKrSezx0WfFIpJspDDewHEaRnMk3las0SERwbYCMcr7vj+1/+15s7fdiZqK+DWauPW7FqI",
+	"xlM6X3haT9Y7Zc/Cloa94I7Vgt/gHfKPW6cN3XqxadyO6QW8Ookzwz/4meGFGZpVtsvSIi+rTlhsU3O3",
+	"1GYzspX068Ahan+IjfAnXV6fdYRwmX9qpRHVZPZDN4OCSCo/4h8H9gEvxCti9MNTj2LAaVbC88DUaPPT",
+	"9SATdGukEWDYWtU7lAyeAzOhKr+pK3kjFFsLI/Zvwz0QTZixpxqY8T1QTPjmO/xllHTibm0EV7ZgUi0N",
+	"t860pWuNeOeE4sqdeVEdNyvhjl7TbHgjeLkWFo6qY0+BpYmqAAEjHSu58uxpIfaOMn4Ld81P1JMXd5PZ",
+	"pG2lp6+GO09gk9nkf/1wdfEnfrF8dvH3H3/5z9uL9L9Pz/nv4ye3/zEZ2IQbXsvq3dLozdDuC5VP2Tpu",
+	"nGUL4SkDXoWdqMSSt7WD7XCBv6recj1lGemcUNmSK+7EhZMbMTl2Ebvz6tPN0B38m+DVC+H38YW0A1Lp",
+	"O0XQQi9ZJXh1UcPDovJ4STm7f4WkExs7dpmXrQWAITY2ojr/+YJpU8FnF7sIRN5xBCISOGD87iHJ3y1H",
+	"VN/4CQIF46K5MXwH/LeDT4OnaZAa/WO4djzPAmFTFTHTnCBYgFmqrWtGorLmFl/2U/c/8EUtJjNnWnHs",
+	"AHGh+TQPH11Y6+DpSbUCcOrEBvf72cvn4SQKvww/3eRomfNTBcQQJG3vgEc4QfoNo7coNbsDB0agNNKN",
+	"R/VxMiVXzJmWUDbcBr19ZJneAvoPsDqV/X1WsHdhDd+OgBo/FQS8W26ZbRcbf9uqgm2lW7Nvv3/ByjU3",
+	"vPRInNnStIuFqBh3tJFT9i0hYi+ftfKgQCpRgUCZ4Uw5K3Vdi9Jp0EMcU0JUjBgdZ//99XffErdHRgg7",
+	"sRGbhTCs5MZ4/WEb5A1OdIpigNshQfmv9Y5mh8wXN93RaguvqsD9YDdSE5tJZEDBGiOW8j29suU74k5A",
+	"NwGwMyO8shMOYH/Du0s7yiJz4osT/EBGRxyuGzZuEB7/0J2Be/JcNS1qGlUl/Qx5/TKhcLyj+xep5Eor",
+	"WfIaSRj1Bjw1z+trvWXc+GvgX/Q0YzjADrfmKqWUr5G7wILljQhn4/VbzasNby6vri5KrfwgUis73VTM",
+	"ihKO7endALwRVremFKcgeI/R/RQGJf8/ar3gdb1jrZI/tYLJSmwa7YQqd+xa7Dxvf+zF3JOv/phcpyl7",
+	"prr7b0S8fHj3/Awt3wjmj986vmlYqVvlrL+vnFUt6oXp3A7gobXX7RVcbJSncfVTjpsJg3LFdINEwJo1",
+	"t6JIt4F5GdM6MUVZXYopgVChKphGw3e15iP7D2dcy59Fxeg5JtSNqHUjZrhax53wvEUbxpfAfD0c9Esr",
+	"4J9LL1KMaGpeio3fNyt/Fmzrr5NHT2uuVgFNxVUYvvVI6kZWwjAPZqdnagg9KjmgItwCMfrLdRQf6q3y",
+	"TDP7fr5waeliITvBZ0a/Gz/SveivEODw/AvDNOK/cS0VGJfCowULx+zndaPrdiP2FoyPHgIOOJnSU7JH",
+	"jGSu8nCfUBPj9ZbvbGSpgH1lI8DwBKoCMl+QnCAUU4lCmHnDzTVoxgjE/B0xotSqlLXEG69b17QZn2Ib",
+	"vvMyqBZLUEK+Ztzj01b4/1hZCTaP48yBqub5N+fEvG3CvD3CChf2ADrGlXe38vnr79h//vHqMV1DuPQ/",
+	"a+U3+XaMcx/HqOk2nwdOaRtHUWnHlPy+BC52MjJ9DRP7vWPS50C3r4RtazfCl3WHSUte16ySCftfcFeu",
+	"AzYDRX3/DHlZisaJAb7wT71lG6524Sz9F2EMpIoEt0jlxEoYP+UoVuyBD6LGAkiZO77gVjBeG8GrHVuL",
+	"euTLRvhtEdU4EE2mGBG53x+hnNkxr0SfTF+vaLARCuudZ9zDbP3JlIcO94VcinJX1mL4CiZcNHAltpZ+",
+	"63cB5gq2kEh2zO+TueG1RYZHD7Ilqh3K6annPfjFOXB25JkOcTbvCQCPK1FlUTrIHADDegsc3H9A2S1c",
+	"5qdXTzNsFnAAmmHqsMrpW/VWvSEz/prXXhYiwDNgJve8HX6r5HIpjF8uLtoKZ6dsjkRIbDQudw4IHyF2",
+	"WDSswOlroYBBe7oq2HYta9Hbg8RIQosrYMfCbNCHgbPIJK3XvVrlAYHSzJa6EVP2ncp3kUdAEcawQRnD",
+	"XQffQpBZnM0RCnnoPcfho/tBwBqE8VKfhFgggKU0Xhul7QimErJfOcOVXaKzJL/0uJnDNwlAUreXAraE",
+	"GY/sVMbC53+ITLxIrQwFC0j3i/l9MfR44MNzHrwHHUXITVNLYQvmD9c63LUpe7PV3Zt4WHHvADkHkxIY",
+	"zfxZx41eCLcVKIo3BCni2dNBwhlVohYOFV7k1PhBVN4VYDZe1yfvUuQZz2kiQ3sVJnKcx9Fzt8Vky40H",
+	"lPaANRTIoNRtjbo3mRh6/JU9i5u+XWsbCDQCSv8mpx2Kyjm98Q6p951nILp170g3SPdm35x6iC3HjSgC",
+	"waeElCz6IHuOWz3Ipte8Xl54PM9swxWb/+CvbsGc/mLO9I0wnvGU6+j3i+SGFu6UapBZ7N/VI2bS3t0v",
+	"6I9l3VqvDi90q6pTTQJ30z9guemUBi0bXuUa/jYoYz0+Wx38andaoPqNfBa0wuy7Hg5JdeKEnT5l94Wq",
+	"aO/F+3zvU+iIUih7ERzKQhVEKBFZxgf0knGvO/r9jiuQdvRMz4OiQF2wyLCJdEQZLQxdkMTdnG/Oq7//",
+	"lf3p6Vf/jZG7mVXCcVlP2TcoT43RpjOEycSURaqQtMyueSMKjEqowGAx4sbevy842gD6bDdcXXhJChdQ",
+	"vG9qrsjD0IhSLmWJrgR/ImXZGiNUKQZJApYwwCtfCnOxlKKuaMnWr8ChgYHABmyIh0/oySDzIZd1a3JW",
+	"ly+q1uX+cC90SaopBi3o5VKoirwkrSiYmK6m4IufJgaAwRVt7GqE9YMHRatVp1WgigtSgTtW0ySmRy2M",
+	"fg040hA59aWYJ8Z2RNz/882blwwfYKWuRBLSglQ1BX8pWBkms6dXV0P6hJNuCHu/Xmvj2DonFttuNtzs",
+	"YnQInaP/aDbU5H/khyoGrenDJpTvX4EtVwDZMVkJ5eRyF7js+JCtUTPH63o3A7KcdXR13Lnlfw07Ebd8",
+	"5LIPx1mgqhI8kZ2P/00aOCEtuxa7gBqHYi8KwvXVvIv7iZ5mfxFgQZbxqjLC5q7qxe4jxmHsHWYH2w+I",
+	"iTDEFsxKYbdOF8t3C+8IsoVUHlmBekZmNYBggys7MhZ5u4h1n+VOOjUuAFxKaIIaCCNBudr3+MOB8bgh",
+	"CW0SrmRc7e4lkKRAmX58PNicE6xEDxV4coLj50i8CW1OcnIZ4R/gGMdtjPvc4zxLY9SuR22NeBvAzkhr",
+	"OsfUGFjf79fM+EosWllXFGw3tBLPPQKEsBhP19R859U9MoUHGzhbyhp8vaTxoHKs8itqcEBLFpbEahIN",
+	"x+g2v1Z6a0/m7q9gUl2cUjfjQBrw4ojD9aB/4/ing2DeP5Lx/T5i16Vtos0e0g3xCXfA1NpNdCvQ3hQ/",
+	"1YdEe9ozfnuYYvDOBhPCm1GnECh15JNN4jCJa3YnT7uXL8+//K4LUs2//gw9/6/x25XhS8eeXD25unj8",
+	"hFW6bDfgVcYL5a+1R2PBpibhryhaYphEeAnmlcQnonXX+jfEe166EAUXLe/+oZIr0FF2rOYOTW69Xett",
+	"b7q24S1OLdAjuCuJBwkWQXTaB6M/PTJiARyFE0lUCcV4IFCo9qUuEjqepwpxMTwgiwrMXAkA2a5DPEQl",
+	"3kesR2hXZp6wIUji3xp3ADyyrNFWYuQXss/OKQ7OkAJ94MHC+7MweszbMB4cEjcl2eHcz/02Pd4Ze3RT",
+	"Nq19hHpfIAJGB7J7OzlBSMPCkxiCOMNh2vFEWB0E7RExMmf4jTCW1xRoWA3p1I1bH+QyNQH0WorUOJoF",
+	"IW55fY0iMOx/DNcBT+XQOTR8aOAsllVWlrwHa5KwUY+PmE3h4AAK4MJLRw6OOawtBP5vMlhwFMj2AUHT",
+	"7fiJkOJILCo4THZNkkCRKC6wJH/NbkTFTtHAw/T6wxZ0wLTdx0lqGNXlaEyJUyjrFGAX10pfKcLlhuP0",
+	"R3kjrXQYA7U5w8eX3ZJj1mT85ujeDMZcI5emI4vXYqs7pEv8FJR2xh2buzmTyyWbdzGy7G17dfVl+Wfm",
+	"2LNv/8b+gL84zZ6/Zt9+/+IF++4Vi3+DZwVzQaVGSVfW2vZCqMgzEZ0XHIb3SI2bWvptJV+FddJrOVKN",
+	"BDCepADHTfAs88yI3HFNNHz111JFu+D0g7poXHzwDB3TRB80QH3fIn84NOjMMPJ7jXg/5ft3DSa/o8ck",
+	"3LzTBtfNwNineQzSmHav6t+TAwA2tSOB4kDEe6b+J9uebMJRs0DgleMSpMMSeglSJCKVzId6Zqh8+GZk",
+	"tBQYBt/KrQVxAeeGy0c5cBdRMhYQl8aEhDjzJHghBJhTzPRezAhm46E0MHK1dkxhZt49hr9+uH0088zR",
+	"G8XAKik6Q7oO8IVXH3lVQtfR6Z/dIuTDXVADd0wBb7drvfUsPWZDvckHJJc1xHhUIdPEC0uwy+troSg1",
+	"6pTgD2mDkCAHeOdOQJSahDkC7TVGVJBq28WAYCC/MHYtmxgfn5gmF7L2ei4F6YABKTiyH9k0cKagHcji",
+	"Thoug+XSA2NACP6HD+U1HliGj5x6/BGYJPxPkp3zw+dRc+veofZ0YCrc9QIrT5cDyQCnQXkltiKGRgTC",
+	"VkFzgZQPpGDO5nanSoqVnhf037ap8L/a0F9w5+adv5GGwNADl4Zxd6Sc7DxnpTaGKH8RDF1ZEOzS8I3Y",
+	"anOdYUlOcUz+pSS2djq6TwfjvPvB3bhh4WiKYHH0JE7/TBJQyKTjb09y8zHoirsY1KYOmVM7dnyXMO/p",
+	"fcdXEMMeN10eDe6Wzop6WYwnAZ9rFh0K+76HqA9/QtvRg44x2kh0IA+OIPCM88fXlIbR7yGgREI8icI0",
+	"rRDz1YX2UJxT5GxdqAeVXbACUoH86WQXK0ga6ZheLim3zH8kxPYfQ3fBmZP4d/IjzcknI9C9gJBElGeM",
+	"fZ/59flt79ofQj7HHUYYmuE60/aZULBvuR/2FxW5cbqgIg7hwM9BhV2Y3e/WgXTIDdALEci2NZqtMz8B",
+	"/T+54YBnHAQMU3yDR20r7kHp/vF/CNuG2SxErdXKMqc/lBvm3/NAShKwCMOO8sdRT0cXSwEbeILbY4ij",
+	"IV44gsToBLwoBbq5W/L0Aa6TLjib2zH6OqQ4DtPYh/EHfDXjC5FwMlYQXFdnMQO4KffHECJUxKh+uP5O",
+	"V3w3yyuYIPwB36LeskaYPpOzOvpkEw/Y0gtdwKYQswyR/70Qn1pa5yez8zDSSrWqBTHWzoIBJW7gSWS6",
+	"qGfgau3Dcac0tHyQOVEWmd33P/e06l6Kc1O3tld6gEyQZCmU7mNo2Iddef1c0i55LFsN5jMc+P6vmhtK",
+	"tDaiivhRSUm2/pmKLflG1rviiOIEIWep5jTLVaCQAOmBoid8D9ZkKYL/CIEz6BJs3ksrIbzqNFsYrsq1",
+	"F8YpsEO1Xyzle/Z///f/IbvMXnYgbQ+5nLUVSSbevmrxgbmzpyhU+8aUEEBGlB4s2omzl2dQlXIl8zRv",
+	"L86VdgOJ//77Qf27FqKxlO0i/H3kXUIu1ANYiJ0mGKGV6HsCfnuK3lgi793qBNBJxft/umnjnOxhsZc8",
+	"fD9a5amfHs8n9jQZ04Ibo6u2TLejSHKCIT49vYqB/mNgKult/ilT9Txr3UPEXA0ray43Yjjy6Pxs3w9E",
+	"Y0nsQDdmxt4H4wDP0RdDuk3gRTmBDgrnnSqPBkJ5Hs1Mq1glB1zIXks9nl+2U+VreNATyU6V70yrDgjN",
+	"YKWbh2ftnKxI0sJUtkY7kdEFyDdhuAPy4RWZbVuFatqC8jY78tgptxZOljHcxkY3f6v2kiOPK/vpsgra",
+	"lrE9fx02bcBICaUoyPkStj4J4dEhrX4plbRrUbGyFlyNeoZPik4Lq44aHxkoE1s8t0yJbRGmle1dSO4d",
+	"SEhGO8XBbORuVG7ZajQWhbSUw58i/ECsBSwoBWizYKgF2z3TyxPi78LudeN2ixk61e/hqdGYH3Qaa/JL",
+	"xPyzpChfwCxJTUeqsYYF1gDbkw8JwwbgAYt3lOJnkgJljRGW5MxGqrQmzOPTC8UhXMBfM2dJMKqBs0Tp",
+	"LSMuTeU9CA6izCNbIPiHLK9Fxq7RHbsRZhUM8LFKRNgGyDEmO1wYF9WkZM/CxACu3EuAeba2EwoIjpDE",
+	"eHjKCE2kNfd+G0TRRVh8alQRZzZOFneKIOgVBUTQmAQPzbOCJeTODHB4RjJLZcEFFCwExgYvsHj4iz/R",
+	"FVmq8W9R841cL+j7RvjvQi3HGH2UjAFOVSz4exae2SfxFmX4r1bN0MMJUbZGuh3Y5KiqRiPf6GsxcOee",
+	"KUDjWJ+AzLjcsvmz1q21kT/DFs3YXwQ3wlDoFzyMkV3zKfuGe30y5ESRGoqlBdBVqoSo7NeM0yBYTAtV",
+	"zKRqw5exhrJfzgLG65a3dq7BiNuVsG58LaH2iBEQwsvrgklrW69nCsP+EPBkgUb1L9Ct/SGrfu6omgM4",
+	"GslK41VRNK5yaRivSXSfsCrMAxlZF3h51tzvkxWlEWky2htARx3CxHojMaUXSkbp1gkLOnHxwYulS0Kb",
+	"6TRr2kUtSyrIbU9Y5i0sdDnAV75BvBmC1xNXh4Q6abHGSGv5KhSpCFHesAGeq0jbhcyX+sYr9FB0QfDa",
+	"rSFhUdgiYNturGAJ9OwSMrDxLLtJWBw7xi1QXnX4+QIs68HwWGSis/trVj5R3EgPHIOvIa35gSkW05gF",
+	"OZvgAb+Ka3728vmkmPjl4eZdTR9PrzwReQbHGzmZTb6cXk2/pOhZuP6XvJGXN48vuzobK+GGskpca1SQ",
+	"GmmxpYIpbgzEpix2CL0hWiNk16TyOOTwAaOnkFibV+foCnIwbktMEp6yOQgINIM5PWdW1CESrytrsJWq",
+	"0tteYYNUK43DzDqrEHfRbkWDSEvJ3Ijf0wf80Ejt07cKSwPWNXEq1DbAe8XmYPCdR1nbWWvJlJcVck+1",
+	"dTCXw1epVHviMvN8Esxae6/D91XUBLe8vsY9xmfIOMy7lAMIOqBCD6K2aCgkwEM4IdSvR4socpRwpn7G",
+	"oq5ZJZZSiWpGJi/8McRA4N5AogmFQHnuF2ag1Zabyk7fKrieYJQP9qMLCmLK/ct0p/A3D/i6ounXQpEe",
+	"mxbCwbIe807vn5MEIrznsUGIeSowrLIKFq5QW63vGk/zcrYey1DhGoi23fIdhWUJcxFfxInBtPfq9EDt",
+	"li3fEV4LX2MbfRNjqYJVScOEldh2ObpkylxzVcW4mTRKNa2Ns7cQLAsE4qKuQlpDFNbPq8ls8kJa902o",
+	"R5L2KfhhLxfd35gu6axXUy0msw32DyDrzXj7gOK80VL35dCAieXo/sYMmcZ+jK6e6kDsCntGBMvtdUxH",
+	"6oysVI7Pv4gkMwCFBheVWbfuuizUr8ZTB4dmsOc3va+9RX8fVmUkD0k/UnxoPpm18M6TAeYMZ7tnmR2b",
+	"QLQxdoML1W7AYhIMuGh3TOy3icHk7EPrG+NjzPBA2HiUFSA0x5ZAQdPdAk5Tfk6bb9q0JJtqL8r8tKli",
+	"XZg7TrRfSDCI9CjJuWMbbUd7odRyI102D6r9Ppk9vroqJhv+Xm48CTy+gv9KRf8dsrENm4k7NnxJvWJu",
+	"f+y1V3lydXWgtcp5LVW68psDTVUOFuC8j0YqxeQprmXojbjmru+Lf/7xmc9/edbzX501n0TlBqHZKds/",
+	"/OiPjaq1kKjN9xB8c3oohOQ1dpDgVDVTL/slqm3S28aDKonFSWIAAbpFIZQDijYhUTNPlDG7EEsgoujx",
+	"H3lydQXhuuKmZ2SjYEAIyyW1kUrKhaI0RVfUnBJq5Y2sWl5TLcxKVrMkJTerFm6xJEvjyJF1AeIxVvgZ",
+	"zCGmwUPIpWLzUN5yDs05ovdsgyXPqcJhZXSDjAai83FzAbp6abxol0vYRPLwUfFOUIsQ1W9a60ATNsKZ",
+	"HWBHHDVmCefoCmumRnxF+/kXXe3Our1aie+WQF1H7zEWQPec5aQQoOydXgDQj7e5F8CZVtw+IB/KCsyO",
+	"9HfCE/OE0BhdCmv3mzxt+6HlGPjyG+FVjz8mr8rsaX12hccROdVtEQ0JQaM6akpw66F6TPY+7AmDPbM6",
+	"c8LZuns3t8/ae6a9D2qMLwMFnKcz7lfH+Rh63N6oD6yrpqni0mTKIQwPNoTnSQVS6KqgQATpLeZwua3G",
+	"Fy1rbbBYgCkhqRoEXvmFdutQmrBVtbCeHv2bc7plSH0UJzmmSGXllc5YekTTWar9f208nZYlOIKoR8pN",
+	"fcbVZ+PqEVEzjrBD1SCbpvWeXSpw5pk2l5gPEKrGY5xuZtT5U8/SCQ7grt5Bg6n4WZwzwnB9IwyFlO7F",
+	"9QiFi0Utm+A8lC3sbny8hhLaX55cyBD7uaS8pvb7FLpOFmwhSt5akXIqj7X9rU6qpmdlM4IpdF+m5P0z",
+	"PxwoH7qW+RgnYdvH980TxmBtVjERBcO2V5sx4Qmh1Oqwr/D7Vy8CzgglHsKZHubtvyde8/TqT58Ebwpc",
+	"prP/DiLpy19kdZvA6fx2/EO49Go8rNga76y7V1f1dyupnl49/USoh1dUfK+/+ZPbI9D7pOKoAMigzFLE",
+	"Y1RqI2WMxYkUBOEvt34JjVfTB3p/U1uDYGln2lCCAoVP5UU2zg/5At0tfA00ryBqRyKrMKbq7hF2b9W3",
+	"ZIJzaYi+ogWO6Kse+FNTUMzwEQaTEnYA7bddaZ19QFJQOFTnDASgfYMlMblCIY/KB+Tt7wnlfTGcR20+",
+	"jBjOx/jIJqazxLCXwdZxVdnPnO6hOR1SxSivGxOZlwbLpo1aov7F62vkN7p1K41tC0L5HbgyMYsXCp5x",
+	"Ny9Y2/grFGrxJSWAWhcyr9NQmb2qgrFF8rMszPBByqpRudDOiA/8R0vlLqQCpxi7kWIbEOHK8GYNa4jt",
+	"aCzWW1vswKKFQZINt7gZpFTAsqRlC/+oW19gIxX/GSh2Z1P3tipj1pUTZiMVFI3hDMKn4J0uhyq+tOx6",
+	"fEPm1jI1WrCup1apNyIvuOc8t4RyslR3j6SA/9Y8jUdMjp0W5LS+xjqwvFxD1P6oawSVsYavYDl5bArW",
+	"+h9sy99rTTVsTMtL/x21qQ3UuQwl4GBVK41pZkPGllBZccjYkplajhta9u9ZWpA4qZp1QlRBXtfrDPPT",
+	"m16rbTqw0KfV7vXmVuPeZe7O9y4/pBlpoMjlYbG1X5vys9z6aLan3P4ZI0BBEJyD1UOvNCpVShUCQ8rV",
+	"w+D1w9LV3+MTPT3ZrRc5NB2Qs1n7tq6eS8GgWdsnKD2VkKv1Qpu11tX5QvS+pUlWyNprCqKubVfePpss",
+	"VXFjrbpWeqvGVYDEu/Mqnv4R8g0l+aOA1eiQmLF5QF3zLiHaq29JIxlUUOdSlXqTPwi3B9Wwgs0X2stz",
+	"VLJGxZukbPlhETfx35gUMUQrTA6+hsNPCnzoA0K0Pgu9+xJ6oSLnqCXqYP3Mz0LvIzpchqujni3wug95",
+	"MUHuiLQOyIMZqgZ9Q+gqoNo0aZXhHt/qlBYs7vAxRBYoN0lKXXbTXY81pLMJ1ZMwNMIZ2dQY1UedfbHU",
+	"bugMnnCnLlAiFtPJ0/Sg7KdnFhD5jB921K4tOMV46eRNP9T5T193fiF6D2Nbecjos10D0xWXfvLPaMIf",
+	"pH/5+eEypcsfDeY0+jlMH6bXq1doRPLRJ09gTnEv6CIEB4xWS7lqIXXAOSMXLURvQDUnUoPj36Fs61Ib",
+	"YaGAIK0cy5QHIwbtYvqtXAvUSzaPNZPn2PA0LC0p188jNk1XCFuc79mTJ+wP835Tt0gdoNLPv4hZCpgK",
+	"GgjNbzaUGKWAd+zQR1kg/erjMSzmsG8wpg8/pI+wK538cZ2E+bgHmkxkbsKuAfpdXIQxzfq/ko/w6YP6",
+	"FJ8+efKJeJHqYFvt8qmCh+CYbdVzlstf4o0nNyWWfhgQnJ5r59qg14mscMCr5kGizQMsxXgLve20oqOt",
+	"ILxGlfWByJofZMy4L4Qo9zvlcE+unvrrtBV13eVkUpB2Mt0oKzba6zVwc7Kcc553lVjJG6GCAIFC8cFT",
+	"xLL5kU9uQBTFwibxN2z8PWI27culIWPj32BrhzhpxtCeHmtxE7LyPyPth766cJ8yGPrB0DrpkvEgYLo4",
+	"TDNdsedTHdEJz/k4HunOC23SgN109z+aR3r6ViXc51BJjcQK5NEaMPWttKKrwmk122L9jL3iF8cKaHyd",
+	"1g/s1esADn1WZY0ebybVKfI3f+7DWPUcFgjxsIf5YOaCfmBE2at685H93Wciys8e708XxWUe8niqHXYL",
+	"mUgXZ5V5oIopQ2lZVZqOVZySjwW/8i3m4iRVO0NZ170kjqQeHxr976sgxDz58jyzk1MNo37HxF7NRKGS",
+	"pjVQLxEY8Npzn5Ba1OWzhcGOV5oYfPIuJSfgT59zVgYqToikKpEXg9VGqgut6t0sVK2hWkRgV/G/Ysmi",
+	"Hoz+csq+jR3yKF8f+LGwSQw0ET4UQ9dLkF9JN9RwYMrLy1pCqFfXRyqaf8aiA5LWq+cm3GDQRLyjv5Xs",
+	"8Xzan3ISOc70c87L3wSvXkCBo1PSXpJ6SJ/zye/uhhnazh42SKpVnQoNkji8pHJaVgLkC8x9ybl6v4FG",
+	"0iPH89ZyLcrrvF/GENPrOhPYyYMC5F4zh+PR7/vtHO6LbB9/sulU+ZoP0NblL4FUbi9/yWjlYHpD1oni",
+	"Ix33uUf96530p5yOkG3RacapUzreFOBitI6X14OFgHJTUdbaZcxOdFJcxfGOOQULPSFOmNh+ufJTZ/dj",
+	"MWnag2mLfT5LpqrDvLrAcvJp/Vl8O5jIk6PFNkeI+WNtRQkxuI2sszppsmt2B2b72DspNd7Qe2gD67TG",
+	"oDJg3d+BhPOX7T5/uH9DTdjYfRbxMc01p7CnrGPVSQmDvyfzzeMvP7XEvh4LHJCNp8VPppVA9daixSBt",
+	"i3SPdTMy1pD8965lNHDin80RPXPEQB9GjP7w4NjoLZnX5lChfx4fhn1MOt8yK9yUvdJb6lYjsO3HRt8k",
+	"DtO076/EDgLklQjFmrpq2m5tdLtawzRCq2I/26G6m+F4qehmoKSuKiFpAwOlN0N4FDZUlSaSQyVKWQmq",
+	"1d7VnK96+WtQJMqLI6s3ojtRWtZ+wshBneJcG8p+icQHrh8y0BTyY5RJGRj2d1Lx8tcqctmNi1cm9ArF",
+	"nq3SJu20oF/BunV6uTyl8GXshXr63KjnEDfxsixrIVwM1p6yOUaXzfH/exc+ztpjuRilEdhT8pZ/GKpF",
+	"kCDgdR1/XWi3nkY+hz3PHHetnQNHk6oSjVAVdKFGXku8weMrwytZQrw9MBHblmuQHfC1P+Ps37ZXV0/+",
+	"iN/8c5zbDnt1dQ15QwvSsc1t7UgIOY6SBJHHP4R2KMWE1/VJAeQDnWc+WxKz1rtH7IiDzXc/GxE/yNqz",
+	"t5fDSPbyF2D9e9ad5P+yuj211nxawTqGWgSwm6UHJfXjM69hV0we4cVoks0Mvg6ALc/p70p1B+y84Ttm",
+	"hRjBsUlbUwzmCk3rPYLboKeCK6i0eZWX+zwhtJY2453T+l2t1Wr+Ra+3vTOtKiFikx79ms3/8c0blhf5",
+	"n8MVscQiE2iHGiSHGLgVfCaEYmQhQ7ikR7ank4R0Wl3x3X55dhITIODzMGzAoqOAMd0VP/zTq6dpqlLc",
+	"4JVwto9yu9jiMHLJlR93IZjzQwMs34+lE++ldVP2DfY6wOppsaEf1aYfqN6eJPaROEkFaswGw0JuHfwN",
+	"9dhRJQEimcVI91gRPtRpj85GaK8Tuq7nXemFEV24ohJbujphVkRvRH1Whoqmcax++0+shxroZJik0H9O",
+	"TX/TiaIqk0400HvQQ6vDkDwpkPpr1DiOKnJ3q2Lvu8iNUEHLmAGwgN+MVfjTCUfmVdpHcpj9n2RKPt6j",
+	"uGDaXjRGVxeifXyCwbbrM3knM3K/YWhiNNaG6tw/qPn4sHE7icYcUOaOzEWetz8/3gFFxK47J+YfR7EV",
+	"iGqp6yq0TMsDhxYSoxixUdINr0E5NJpXG95cXl1dlBq6D0mt7HQDrZeAyr4q0H613xHSy8fAkZOOAn4K",
+	"zHDFusat8c97/X+amu+YaZWNqcnd9NBoE9ivivgltOX045d6Q/3mpm/VfMuNkmplQxmMaIGDwUvd1mAh",
+	"85gCsoSSZiLchdTzkKDD2UBfhiFA4fcgkaBbTlVR04YpXd70LLdZUQQaGvOU7u8vdnuuxhAA4JBHwciQ",
+	"RfJEYQ6J01n/lxzFLNGOaMSeGH+UNfjhD478puzvuq4wtpY2NMk3h8PsKql0dDKEUmzDVfAUeMpH784s",
+	"QR+ZL0/acHPIqpkgBzJqhqC6hMiwHDuYc08jJSIfsVmIyg82DxOIBt+B6xWiimFDqPu5ZfOufMDcQ0DW",
+	"GAHxkhSxWAnzyGLDU7uWDfUFzDcOZsm4y9Y7ZX+BTBO/D/P47HwfzyRe7BeRbT0goukGOeIoKlLrbgca",
+	"u3VLR0Tv2eRnPPPBeIauTBRanyHN7xnSYGfBnw8gE+SG27Xo6gJizwJm1yB7Pff20l5BvPNzx5Zcehyi",
+	"6l2M0sTu7tLLTG7ZQgivGOPYO9huLytSTS5JOXZrIyxmlAGawDxtz9ikR94Vd3zBLYhQ7KxIfJq8Zvs8",
+	"7p+05qNszYn37rKpuewxNKKNyWyirwfiLAf5WFg/mF7kzT3G4Xx1po3vq7Nsdre5me1GKH/00IkSTWuh",
+	"RedlJ+UuqQWkH2asbLXHiHZYgQqBexFOBY8lBc/bDgmnrcw9mone3TIEdFRaiRSxRlLgNVu13HDlhGAL",
+	"sZYkURIgamddPxjel+IA7oqexSSBriS/ofMW1NWGzP89YnyFW/UyfvzBAkNgHKKdjx8SQqMf6opCVBN7",
+	"4H/udzLW7yTrtLsvyXEb8/vRu6x2p8qgvsI1PU+iaxaawYmHF+SjBU5etQp9TX41sRQAuLXZM/wjt1Rz",
+	"IjiXH1nGK954bhIVSRSz5Dqod+FqV3K5pPKaeuH5NyWZYchvb38Rki6FIF0l1KktBVvw8tpLdLtTbi2c",
+	"LDvFGuMWqAykVLzLZcJUwNxMzL2Y7dIamVCVZW2TBCx71TBAnMCVuO0sx1sePAobCV2HSPVtIbvE79ja",
+	"aKVbOxsqvo9J5dzF0mj+Pfjuv1ubdCvKbf1rrqoa2oI2Gp0NuN+pmMedzXIo9+uExcbpbRdZQTNfk4rZ",
+	"K8yS1/f3y4s1fvAzW0Aw/qy6/esFMHXnvdXQx6DmTePHSmhiINzv9U6Vf42k/kBs1Q9ymKfCJfCb9BBM",
+	"9fEnVajigZkqsbuOeJCjQrzpefg5QEEPEMBp49HscinLBD13mn3Et9KyVkG9m9CqDorT8uvQ+0lXIYjI",
+	"aEdFHMhWQaAYA8aGQAgs4tcCxBizG0I44m78FhHyK3AfpRD59vb/BQAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/router.go
+++ b/internal/reporting/httpapi/router.go
@@ -32,6 +32,7 @@ import (
 	"github.com/b42labs/tally/internal/reporting/auth"
 	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
 	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
 	"github.com/b42labs/tally/internal/reporting/store"
 	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
 )
@@ -71,6 +72,11 @@ type Options struct {
 	// TALLY_REPORTING_ATTRIBUTING_RELATION_TYPES, and an empty list disables
 	// the guard.
 	AttributingRelationTypes []string
+	// Syncer is the orchestrator behind POST /internal/sync/{cloud}. It is
+	// required: a deployment that configured no clouds passes a Syncer built
+	// over the empty configuration, which answers every cloud 404, so the
+	// handler behind the route needs no nil check.
+	Syncer *reconciliation.Syncer
 }
 
 // NewRouter assembles the API: the middleware stack, the request validator, and
@@ -125,6 +131,7 @@ func NewRouter(opts Options) (http.Handler, error) {
 		queries:          opts.Queries,
 		pipeline:         opts.Pipeline,
 		attributingTypes: opts.AttributingRelationTypes,
+		syncer:           opts.Syncer,
 	}
 	// The dispatch middleware is handed to the generated wrapper rather than to
 	// chi, because it needs the route chi matched to know which guard applies.

--- a/internal/reporting/httpapi/server.go
+++ b/internal/reporting/httpapi/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
 	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
 	"github.com/b42labs/tally/internal/reporting/store"
 	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
 )
@@ -27,6 +28,9 @@ type server struct {
 	// attributingTypes are the relation types the cycle guard walks. An empty
 	// list disables the guard.
 	attributingTypes []string
+	// syncer runs the reconciliation of one cloud the internal sync route asks
+	// for.
+	syncer *reconciliation.Syncer
 }
 
 // writeJSON sends one successful response body under the 200 almost every

--- a/internal/reporting/httpapi/sync.go
+++ b/internal/reporting/httpapi/sync.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+)
+
+// syncBudget is how long a sync run may take. It stays under the server's write
+// timeout for the same reason rebuildBudget does: the run has to end while the
+// connection that asked for it is still there to be answered, and a run that
+// outlives its response is one nobody learns the outcome of while it goes on
+// holding the cloud's advisory lock against the next attempt.
+const syncBudget = 45 * time.Second
+
+// SyncCloud reconciles one cloud and answers with what the run did.
+//
+// It runs synchronously, so whatever drives the sync schedule learns the
+// outcome from the response instead of polling for it, and it is bounded by
+// syncBudget, so a run that cannot finish inside the time the response has ends
+// instead of outliving it. A run that ended on the budget is answered 500 like
+// any other failed run; the sync_runs row it leaves says the same.
+//
+// No audit row is written here. sync_runs is the operational record of a run,
+// and keeping one run in two places would only let the two drift apart; the
+// package documentation of reconciliation states that deviation from the
+// rebuild next door.
+func (s *server) SyncCloud(w http.ResponseWriter, r *http.Request, cloud string) {
+	ctx := r.Context()
+
+	runCtx, cancel := context.WithTimeout(ctx, syncBudget)
+	defer cancel()
+
+	result, err := s.syncer.Sync(runCtx, cloud)
+	switch {
+	case errors.Is(err, reconciliation.ErrUnknownCloud):
+		problem.Write(w, http.StatusNotFound, problem.TypeNotFound,
+			"Not found", "the configuration names no such cloud")
+		return
+	case errors.Is(err, reconciliation.ErrAlreadyRunning):
+		problem.Write(w, http.StatusConflict, problem.TypeConflict,
+			"Conflict", "a sync for this cloud is already running")
+		return
+	case err != nil:
+		// What the run did before it failed is what tells a run that got nowhere
+		// from one that corrected most of a fleet, and the run id is what an
+		// operator reads the rest of the record back by. The caller gets none of
+		// it: the errors carry platform detail.
+		Logger(ctx).Error("syncing a cloud", "error", err, "cloud", cloud,
+			"sync_run_id", result.RunID, "errors", result.Stats.Errors)
+		problem.Write(w, http.StatusInternalServerError, problem.TypeInternal,
+			"Internal error", "the sync run failed")
+		return
+	}
+
+	writeJSON(w, SyncResult{
+		SyncRunId: result.RunID,
+		Stats: SyncStats{
+			Created: result.Stats.Created,
+			Updated: result.Stats.Updated,
+			Deleted: result.Stats.Deleted,
+		},
+	})
+}

--- a/internal/reporting/httpapi/sync_integration_test.go
+++ b/internal/reporting/httpapi/sync_integration_test.go
@@ -1,0 +1,351 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"iter"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	"github.com/b42labs/tally/internal/reporting/store"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// syncAdapterName is the key the configured cloud of these tests reaches its
+// adapter under.
+const syncAdapterName = "fake"
+
+// syncResourceType is the type the fake enumerates. It is one of the seeded
+// OpenStack types, so a correction is measured against the size schema an
+// operator would meet.
+const syncResourceType = "volume"
+
+// errPlatformDown stands in for whatever a platform client returns when it
+// cannot be reached at all. It is not an EnumerationError, so it ends the run
+// rather than costing it one resource type.
+var errPlatformDown = errors.New("connection refused")
+
+// TestSyncCloudOverHTTP drives POST /internal/sync/{cloud} through the whole
+// stack: the contract validator, the internal-token guard, and the
+// reconciliation framework behind them. The subtests share one database, so
+// each of them works on a cloud of its own: a sync reads the projection, the
+// run history, and the advisory lock all by cloud.
+func TestSyncCloudOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+
+	t.Run("answers a run that corrected the projection with its stats", func(t *testing.T) {
+		const cloud = "os-http-sync-drift"
+		// The projection holds nothing for this cloud, so the observed resource
+		// is drift the run has to report as a creation.
+		fake := &syncFake{observed: []reconciliation.ObservedResource{{
+			ResourceType: syncResourceType,
+			ResourceID:   "vol-drifted",
+			ProjectID:    fixtureProject,
+			State:        "available",
+			Size:         map[string]any{"size_gb": 10, "type": "ssd"},
+		}}}
+		a := newSyncAPI(t, db.Store, syncerOver(db.Store, cloud, fake))
+		before := auditCount(t, a)
+
+		rec := a.call(t, http.MethodPost, syncRoute(cloud), internalToken, nil)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %q)", rec.Code, http.StatusOK, rec.Body)
+		}
+		// A sync leaves no audit row by design: sync_runs is the operational
+		// record of a run, and the same run kept in two places would only let the
+		// two drift apart. The rebuild next door does audit, so the absence here
+		// has to be asserted rather than assumed.
+		if after := auditCount(t, a); after != before {
+			t.Errorf("audit rows = %d, want them unchanged at %d: sync_runs is the record of a sync",
+				after, before)
+		}
+		var got SyncResult
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+		}
+		if got.SyncRunId == "" {
+			t.Error("sync_run_id is empty, want the id of the run's row")
+		}
+		want := SyncStats{Created: 1}
+		if !reflect.DeepEqual(got.Stats, want) {
+			t.Errorf("stats = %+v, want %+v", got.Stats, want)
+		}
+
+		// The answer and the row are one record: what an operator reads back in
+		// sync_runs is what the caller was told.
+		row := runRow(t, a, got.SyncRunId)
+		if row.Status != "completed" {
+			t.Errorf("run status = %q, want %q", row.Status, "completed")
+		}
+		if !row.CompletedAt.Valid {
+			t.Error("completed at = NULL, want the instant the run ended")
+		}
+		var stored SyncStats
+		if err := json.Unmarshal(row.Stats, &stored); err != nil {
+			t.Fatalf("decoding the stored stats %q: %v", row.Stats, err)
+		}
+		if !reflect.DeepEqual(stored, got.Stats) {
+			t.Errorf("stored stats = %+v, want the ones the caller got, %+v", stored, got.Stats)
+		}
+	})
+
+	t.Run("refuses a request that does not carry the internal token", func(t *testing.T) {
+		a := newAPI(t, db.Store)
+
+		for name, token := range map[string]string{
+			"no token":      "",
+			"a wrong token": internalToken + "-not",
+		} {
+			t.Run(name, func(t *testing.T) {
+				rec := a.call(t, http.MethodPost, syncRoute("os-http-sync-guarded"), token, nil)
+
+				assertChallenged(t, rec)
+			})
+		}
+	})
+
+	t.Run("answers a cloud the configuration does not name with 404", func(t *testing.T) {
+		t.Run("a configuration that names another cloud", func(t *testing.T) {
+			a := newSyncAPI(t, db.Store,
+				syncerOver(db.Store, "os-http-sync-configured", &syncFake{}))
+
+			rec := a.call(t, http.MethodPost, syncRoute("os-http-sync-misspelled"), internalToken, nil)
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+		})
+
+		// A deployment that only receives collector events configures no cloud at
+		// all, which is the harness every other route test runs on.
+		t.Run("a configuration that names no cloud", func(t *testing.T) {
+			a := newAPI(t, db.Store)
+
+			rec := a.call(t, http.MethodPost, syncRoute("os-http-sync-anything"), internalToken, nil)
+
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+		})
+	})
+
+	t.Run("refuses a second sync of a cloud a run is holding", func(t *testing.T) {
+		const cloud = "os-http-sync-lock"
+		fake := blockingSyncFake()
+		a := newSyncAPI(t, db.Store, syncerOver(db.Store, cloud, fake))
+
+		held := make(chan *httptest.ResponseRecorder, 1)
+		go func() { held <- a.call(t, http.MethodPost, syncRoute(cloud), internalToken, nil) }()
+		// The fake signals from inside the listing, which the run reaches only
+		// after it has taken the lock and written its row.
+		<-fake.entered
+		defer func() {
+			close(fake.released)
+			if rec := <-held; rec.Code != http.StatusOK {
+				t.Errorf("the holding request's status = %d, want %d (body %q)",
+					rec.Code, http.StatusOK, rec.Body)
+			}
+		}()
+
+		rec := a.call(t, http.MethodPost, syncRoute(cloud), internalToken, nil)
+
+		assertProblem(t, rec, http.StatusConflict, problem.TypeConflict)
+		// The refused request steps aside before anything is recorded, so the run
+		// it competed with is the only one in the history of this cloud.
+		if got := runsOf(t, a, cloud); got != 1 {
+			t.Errorf("sync_runs rows = %d, want only the holding run's, 1", got)
+		}
+	})
+
+	t.Run("answers a run that failed with 500", func(t *testing.T) {
+		const cloud = "os-http-sync-failed"
+		fake := &syncFake{err: errPlatformDown}
+		a := newSyncAPI(t, db.Store, syncerOver(db.Store, cloud, fake))
+
+		rec := a.call(t, http.MethodPost, syncRoute(cloud), internalToken, nil)
+
+		assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+		}
+		if got, want := body["detail"], "the sync run failed"; got != want {
+			t.Errorf("body detail = %v, want %v", got, want)
+		}
+		// The caller is told nothing about the platform, so the run's row is
+		// where the reason for the failure is kept.
+		row := runRow(t, a, latestRunID(t, a, cloud))
+		if row.Status != "failed" {
+			t.Errorf("run status = %q, want %q", row.Status, "failed")
+		}
+		// The row carries more than the answer's stats do, so it is read back as
+		// the record it is rather than as the document a 200 would have carried.
+		var stored reconciliation.Stats
+		if err := json.Unmarshal(row.Stats, &stored); err != nil {
+			t.Fatalf("decoding the stored stats %q: %v", row.Stats, err)
+		}
+		if !strings.Contains(strings.Join(stored.Errors, "; "), errPlatformDown.Error()) {
+			t.Errorf("stored errors = %v, want them to carry %q", stored.Errors, errPlatformDown)
+		}
+	})
+}
+
+// syncRoute is the route of one cloud, which the other Tally components call
+// with the shared internal token.
+func syncRoute(cloud string) string {
+	return "/internal/sync/" + cloud
+}
+
+// syncFake is the platform half of these tests: what one listing observes,
+// whether it fails outright, and whether it stops halfway so that a second
+// request can compete with a run that is in flight.
+type syncFake struct {
+	observed []reconciliation.ObservedResource
+	err      error
+
+	// entered is closed when a blocking listing starts and released is what
+	// holds it there. Both are nil for a fake that does not block.
+	entered  chan struct{}
+	released chan struct{}
+}
+
+// blockingSyncFake is a fake whose listing stops before it observes anything,
+// until the test releases it or the request's budget runs out.
+func blockingSyncFake() *syncFake {
+	return &syncFake{entered: make(chan struct{}), released: make(chan struct{})}
+}
+
+func (f *syncFake) Platform() string { return fixturePlatform }
+
+func (f *syncFake) ResourceTypes(map[string]any) ([]string, error) {
+	return []string{syncResourceType}, nil
+}
+
+func (f *syncFake) ListResources(ctx context.Context, _ map[string]any, _ *time.Time,
+) iter.Seq2[reconciliation.ObservedResource, error] {
+	return func(yield func(reconciliation.ObservedResource, error) bool) {
+		if f.released != nil {
+			close(f.entered)
+			select {
+			case <-f.released:
+			case <-ctx.Done():
+				yield(reconciliation.ObservedResource{}, ctx.Err())
+				return
+			}
+		}
+		if f.err != nil {
+			yield(reconciliation.ObservedResource{}, f.err)
+			return
+		}
+		for _, obs := range f.observed {
+			if !yield(obs, nil) {
+				return
+			}
+		}
+	}
+}
+
+// syncerOver builds a Syncer serving one cloud through fake. The pipeline is
+// the lax one the rest of the harness uses, so a correction is stored the way a
+// collector's event of the same resource would be.
+func syncerOver(s *store.Store, cloud string, fake *syncFake) *reconciliation.Syncer {
+	cfg := reconciliation.Config{Clouds: []reconciliation.CloudConfig{{
+		Cloud: cloud, Platform: fixturePlatform, Adapter: syncAdapterName,
+	}}}
+	return reconciliation.New(s, ingest.New(registry.New(), false, nil), cfg,
+		map[string]reconciliation.Adapter{syncAdapterName: fake}, time.Now)
+}
+
+// newSyncAPI builds the full router over s with authentication enforced and
+// syncer behind the sync route. The shared harness wires a Syncer over the
+// empty configuration, which answers every cloud 404, so a test that needs a
+// configured cloud builds its router here.
+func newSyncAPI(t *testing.T, s *store.Store, syncer *reconciliation.Syncer) api {
+	t.Helper()
+
+	q := sqlcgen.New(s.Pool())
+	handler, err := NewRouter(Options{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                 s,
+		UnhealthyThreshold: time.Minute,
+		Queries:            q,
+		Store:              s,
+		AuthMode:           auth.ModeEnforced,
+		InternalToken:      internalToken,
+		Authenticator:      auth.NewStaticTokenAuthenticator(q),
+		Pipeline:           ingest.New(registry.New(), false, nil),
+		Syncer:             syncer,
+	})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v, want nil", err)
+	}
+	return api{store: s, queries: q, handler: handler}
+}
+
+// runRow reads one sync_runs row back, which is the record an operator works
+// from once the request that started the run is over.
+func runRow(t *testing.T, a api, id string) sqlcgen.SyncRun {
+	t.Helper()
+
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		t.Fatalf("parsing the run id %q: %v", id, err)
+	}
+	row, err := a.queries.GetSyncRun(t.Context(), parsed)
+	if err != nil {
+		t.Fatalf("reading sync run %s: %v", id, err)
+	}
+	return row
+}
+
+// latestRunID is the id of the last run of the cloud. A failed run is answered
+// with a problem rather than with its id, so this is how the row it left behind
+// is found.
+func latestRunID(t *testing.T, a api, cloud string) string {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`SELECT id FROM sync_runs WHERE cloud = $1 ORDER BY started_at DESC LIMIT 1`,
+		cloud).Scan(&id); err != nil {
+		t.Fatalf("reading the last sync run of %s: %v", cloud, err)
+	}
+	return id.String()
+}
+
+// runsOf is how many runs the cloud has a row for.
+func runsOf(t *testing.T, a api, cloud string) int {
+	t.Helper()
+
+	var found int
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`SELECT count(*) FROM sync_runs WHERE cloud = $1`, cloud).Scan(&found); err != nil {
+		t.Fatalf("counting the sync runs of %s: %v", cloud, err)
+	}
+	return found
+}
+
+// auditCount is how many audit rows exist at all, which is what a handler that
+// writes none is measured against.
+func auditCount(t *testing.T, a api) int {
+	t.Helper()
+
+	var found int
+	if err := a.store.Pool().QueryRow(t.Context(),
+		`SELECT count(*) FROM audit_log`).Scan(&found); err != nil {
+		t.Fatalf("counting the audit rows: %v", err)
+	}
+	return found
+}

--- a/internal/reporting/reconciliation/config.go
+++ b/internal/reporting/reconciliation/config.go
@@ -1,0 +1,96 @@
+package reconciliation
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CloudConfig is one syncable cloud: which platform it belongs to, which
+// adapter observes it, and the settings that adapter needs.
+type CloudConfig struct {
+	// Cloud is the cloud name. It is the same name the events carry and the
+	// same one the internal sync endpoint takes as its path segment.
+	Cloud string `yaml:"cloud"`
+	// Platform is the platform the cloud belongs to. It is stated here as well
+	// as implied by the adapter, so that a cloud wired to the wrong adapter is
+	// caught when the file is read rather than when the events land.
+	Platform string `yaml:"platform"`
+	// Adapter is the key of the adapter in the registry the process passes to
+	// LoadConfig.
+	Adapter string `yaml:"adapter"`
+	// AdapterConfig is handed to the adapter unchanged. It stays uninterpreted
+	// here because only the adapter knows what belongs in it, which is what
+	// lets a new provider add settings without touching the framework.
+	AdapterConfig map[string]any `yaml:"adapter_config"`
+}
+
+// Config is the set of clouds a deployment can reconcile. Having none is a
+// valid configuration: the sync endpoint then answers 404 for every cloud,
+// which is what a deployment that only receives collector events wants.
+type Config struct {
+	// Clouds is every configured cloud, in file order.
+	Clouds []CloudConfig `yaml:"clouds"`
+}
+
+// LoadConfig reads the clouds configuration at path and checks every entry
+// against the adapters compiled into the process. An empty path yields the zero
+// Config and no error, so a deployment without clouds starts normally.
+//
+// The checks run here rather than at sync time, so that a typo stops startup
+// instead of surfacing hours later as a cron job that keeps failing.
+func LoadConfig(path string, adapters map[string]Adapter) (Config, error) {
+	if path == "" {
+		return Config{}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("reading the clouds config %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parsing the clouds config %s: %w", path, err)
+	}
+
+	seen := make(map[string]bool, len(cfg.Clouds))
+	for i, cloud := range cfg.Clouds {
+		// An entry without a name cannot be reported by it, so the position in
+		// the list is what points the operator at the right block.
+		entry := fmt.Sprintf("clouds[%d]", i)
+		if cloud.Cloud != "" {
+			entry = fmt.Sprintf("cloud %q", cloud.Cloud)
+		}
+
+		if cloud.Cloud == "" {
+			return Config{}, fmt.Errorf("%s: cloud must be set", entry)
+		}
+		// Two entries under one name would each claim the same projection rows
+		// and the same advisory lock, so the second sync would look like a
+		// duplicate of the first rather than a configuration mistake.
+		if seen[cloud.Cloud] {
+			return Config{}, fmt.Errorf("%s: configured twice", entry)
+		}
+		seen[cloud.Cloud] = true
+
+		if cloud.Platform == "" {
+			return Config{}, fmt.Errorf("%s: platform must be set", entry)
+		}
+		if cloud.Adapter == "" {
+			return Config{}, fmt.Errorf("%s: adapter must be set", entry)
+		}
+
+		adapter, ok := adapters[cloud.Adapter]
+		if !ok {
+			return Config{}, fmt.Errorf("%s: no adapter named %q is registered", entry, cloud.Adapter)
+		}
+		if adapter.Platform() != cloud.Platform {
+			return Config{}, fmt.Errorf("%s: adapter %q observes platform %q, not %q",
+				entry, cloud.Adapter, adapter.Platform(), cloud.Platform)
+		}
+	}
+
+	return cfg, nil
+}

--- a/internal/reporting/reconciliation/config_test.go
+++ b/internal/reporting/reconciliation/config_test.go
@@ -1,0 +1,228 @@
+package reconciliation_test
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+)
+
+// stubAdapter answers Platform and nothing else. LoadConfig calls no other
+// method, so leaving the streaming half empty keeps the configuration tests
+// free of a fake inventory.
+type stubAdapter struct {
+	platform string
+}
+
+func (a stubAdapter) Platform() string { return a.platform }
+
+func (a stubAdapter) ResourceTypes(map[string]any) ([]string, error) { return nil, nil }
+
+func (a stubAdapter) ListResources(context.Context, map[string]any, *time.Time,
+) iter.Seq2[reconciliation.ObservedResource, error] {
+	return nil
+}
+
+// testAdapters is the registry the tests load against: two platforms, so a
+// mismatch between an entry's platform and its adapter is a case the registry
+// can actually produce.
+func testAdapters() map[string]reconciliation.Adapter {
+	return map[string]reconciliation.Adapter{
+		"openstack": stubAdapter{platform: "openstack"},
+		"hetzner":   stubAdapter{platform: "hetzner"},
+	}
+}
+
+// writeConfig writes a clouds configuration and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "clouds.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfigReadsAValidFile(t *testing.T) {
+	path := writeConfig(t, `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: openstack
+    adapter_config:
+      os_cloud: os-prod-eu1
+      include_octavia: false
+  - cloud: hz-prod
+    platform: hetzner
+    adapter: hetzner
+`)
+
+	cfg, err := reconciliation.LoadConfig(path, testAdapters())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if len(cfg.Clouds) != 2 {
+		t.Fatalf("Clouds = %d entries, want 2", len(cfg.Clouds))
+	}
+
+	first := cfg.Clouds[0]
+	if first.Cloud != "os-prod-eu1" {
+		t.Errorf("Clouds[0].Cloud = %q, want %q", first.Cloud, "os-prod-eu1")
+	}
+	if first.Platform != "openstack" {
+		t.Errorf("Clouds[0].Platform = %q, want %q", first.Platform, "openstack")
+	}
+	if first.Adapter != "openstack" {
+		t.Errorf("Clouds[0].Adapter = %q, want %q", first.Adapter, "openstack")
+	}
+	if osCloud, ok := first.AdapterConfig["os_cloud"].(string); !ok || osCloud != "os-prod-eu1" {
+		t.Errorf("AdapterConfig[os_cloud] = %#v, want the string %q",
+			first.AdapterConfig["os_cloud"], "os-prod-eu1")
+	}
+	if octavia, ok := first.AdapterConfig["include_octavia"].(bool); !ok || octavia {
+		t.Errorf("AdapterConfig[include_octavia] = %#v, want the boolean false",
+			first.AdapterConfig["include_octavia"])
+	}
+
+	// An entry without adapter_config keeps the nil map, which the adapter has
+	// to accept: an empty configuration is not a missing one.
+	if second := cfg.Clouds[1]; second.AdapterConfig != nil {
+		t.Errorf("Clouds[1].AdapterConfig = %#v, want nil", second.AdapterConfig)
+	}
+}
+
+func TestLoadConfigAcceptsNoClouds(t *testing.T) {
+	t.Run("an empty path configures no cloud at all", func(t *testing.T) {
+		cfg, err := reconciliation.LoadConfig("", testAdapters())
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v, want nil", err)
+		}
+		if len(cfg.Clouds) != 0 {
+			t.Errorf("Clouds = %#v, want none", cfg.Clouds)
+		}
+	})
+
+	t.Run("a file with an empty list is a valid file", func(t *testing.T) {
+		cfg, err := reconciliation.LoadConfig(writeConfig(t, "clouds: []\n"), testAdapters())
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v, want nil", err)
+		}
+		if len(cfg.Clouds) != 0 {
+			t.Errorf("Clouds = %#v, want none", cfg.Clouds)
+		}
+	})
+}
+
+func TestLoadConfigRejectsAnUnreadableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.yaml")
+
+	_, err := reconciliation.LoadConfig(path, testAdapters())
+	if err == nil {
+		t.Fatal("LoadConfig() error = nil, want an error")
+	}
+	if prefix := "reading the clouds config"; !strings.HasPrefix(err.Error(), prefix) {
+		t.Errorf("LoadConfig() error = %q, want it to start with %q", err, prefix)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("LoadConfig() error = %v, want it to wrap os.ErrNotExist", err)
+	}
+}
+
+func TestLoadConfigRejectsMalformedYAML(t *testing.T) {
+	path := writeConfig(t, "clouds:\n  - cloud: os-prod-eu1\n   platform: openstack\n")
+
+	_, err := reconciliation.LoadConfig(path, testAdapters())
+	if err == nil {
+		t.Fatal("LoadConfig() error = nil, want an error")
+	}
+	if prefix := "parsing the clouds config"; !strings.HasPrefix(err.Error(), prefix) {
+		t.Errorf("LoadConfig() error = %q, want it to start with %q", err, prefix)
+	}
+}
+
+func TestLoadConfigRejectsInvalidEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantTexts []string
+	}{
+		{
+			name: "the same cloud configured twice",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: openstack
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: openstack
+`,
+			wantTexts: []string{"os-prod-eu1"},
+		},
+		{
+			name: "an entry without a cloud name is reported by its position",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: openstack
+  - platform: openstack
+    adapter: openstack
+`,
+			wantTexts: []string{"clouds[1]"},
+		},
+		{
+			name: "an entry without a platform",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    adapter: openstack
+`,
+			wantTexts: []string{"os-prod-eu1", "platform"},
+		},
+		{
+			name: "an entry without an adapter",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+`,
+			wantTexts: []string{"os-prod-eu1", "adapter"},
+		},
+		{
+			name: "an adapter the registry does not hold",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: vsphere
+`,
+			wantTexts: []string{"os-prod-eu1", "vsphere"},
+		},
+		{
+			name: "an adapter that observes another platform",
+			content: `clouds:
+  - cloud: os-prod-eu1
+    platform: openstack
+    adapter: hetzner
+`,
+			wantTexts: []string{"os-prod-eu1", "hetzner", "openstack"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := reconciliation.LoadConfig(writeConfig(t, tc.content), testAdapters())
+			if err == nil {
+				t.Fatal("LoadConfig() error = nil, want an error")
+			}
+			for _, want := range tc.wantTexts {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("LoadConfig() error = %q, want it to name %q", err, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/reporting/reconciliation/reconciliation.go
+++ b/internal/reporting/reconciliation/reconciliation.go
@@ -1,0 +1,104 @@
+// Package reconciliation is the loop that keeps the projection honest. It asks
+// a platform what it currently holds, diffs that observed reality against the
+// projection, and feeds the difference back as ordinary events through the
+// ingest pipeline. The difference gets no special path: the synthetic events
+// take the same deduplication, storage, and projection route a collector's
+// events take, so a resource the sync corrected ends up with the same kind of
+// history as one that was never missed.
+//
+// A platform API that stops answering must read as "no information", never as
+// "everything was deleted". An adapter that cannot enumerate a resource type
+// says so with an EnumerationError and carries on with its remaining types, and
+// the missed-delete pass then runs only over the types that finished without
+// one. A type that legitimately holds nothing is still a type that finished, so
+// the pass needs the positive set of attempted types rather than the set of
+// failures, which is what ResourceTypes reports.
+//
+// A run abandoned by a process crash keeps status='running' in sync_runs
+// forever, because nothing is left to rewrite the row. The advisory lock that
+// guards the cloud is session-scoped, so the database drops it when the
+// connection dies and the next run of that cloud proceeds; the stale row is a
+// signal for an operator, not a gate. A sync writes no audit row by design:
+// sync_runs is the operational record, and the same run kept in two places
+// would only drift apart. That is a deliberate deviation from the rebuild
+// handler in internal/reporting/httpapi/rebuild.go, which does audit, because a
+// rebuild is an operator's manual act on the projection while a sync is the
+// service's own schedule.
+//
+// The normative specification is roadmap/01-phase-1-core-platform-openstack.md,
+// WP 1.10.
+package reconciliation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"time"
+)
+
+// ErrUnknownCloud is what a sync of a cloud the configuration does not name
+// returns. An operator who misspells a cloud learns that instead of getting a
+// successful run that reconciled nothing.
+var ErrUnknownCloud = errors.New("the configuration names no such cloud")
+
+// ErrAlreadyRunning is what a sync of a cloud whose lock another session holds
+// returns. Two syncs of one cloud would diff the same projection rows against
+// two overlapping observations, so the second one steps aside rather than
+// queuing behind the first: the cron job that asked for it comes back anyway.
+var ErrAlreadyRunning = errors.New("a sync of this cloud is already running")
+
+// ObservedResource is one resource as the platform reported it. The adapter has
+// already normalized it, so State and Size speak Tally's vocabulary and the
+// diff can compare the resource against a projection row without knowing which
+// platform it came from.
+type ObservedResource struct {
+	ResourceType string
+	ResourceID   string
+	ProjectID    string
+	State        string // normalized tally state
+	Size         map[string]any
+	CreatedAt    *time.Time // real creation time if the API exposes it
+	DeletedAt    *time.Time // set only for resources reported as deleted
+}
+
+// Adapter is the platform-specific half of a sync, and the only half. What the
+// framework does with an adapter's answer (the diff, the synthetic events, the
+// run bookkeeping) is identical for every platform, which is what keeps a new
+// provider down to one implementation of this interface.
+type Adapter interface {
+	// Platform is the platform the adapter speaks for. LoadConfig checks it
+	// against each configured cloud, so a cloud cannot be wired to an adapter
+	// that observes a different platform.
+	Platform() string
+	// ResourceTypes is the set of resource types this adapter enumerates under
+	// cfg. The missed-delete pass runs only over types in this set that
+	// finished without an EnumerationError.
+	ResourceTypes(cfg map[string]any) ([]string, error)
+	// ListResources streams the full live inventory; it MAY also yield
+	// recently deleted resources (DeletedAt set) when the platform exposes
+	// them. since bounds only that optional deleted listing, never the live
+	// one: the diff treats the live stream as complete.
+	ListResources(ctx context.Context, cfg map[string]any, since *time.Time,
+	) iter.Seq2[ObservedResource, error]
+}
+
+// EnumerationError reports that one resource type could not be fully
+// enumerated. An adapter yields it through the error side of the stream and
+// continues with its remaining types; any other error aborts the run.
+type EnumerationError struct {
+	ResourceType string
+	Err          error
+}
+
+// Error names the resource type that stayed incomplete, because that is what
+// decides which rows the run leaves alone.
+func (e *EnumerationError) Error() string {
+	return fmt.Sprintf("enumerating %s: %v", e.ResourceType, e.Err)
+}
+
+// Unwrap exposes the platform's own error, so a caller can still match it with
+// errors.Is or errors.As.
+func (e *EnumerationError) Unwrap() error {
+	return e.Err
+}

--- a/internal/reporting/reconciliation/reconciliation_integration_test.go
+++ b/internal/reporting/reconciliation/reconciliation_integration_test.go
@@ -1,0 +1,1555 @@
+package reconciliation_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/ids"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/projection"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// The fixtures every subtest builds its cloud from. The resource types are
+// registered in no size schema, so a size a subtest invents is measured against
+// nothing; the subtest about a refused correction registers a type of its own
+// for exactly that.
+const (
+	platform    = "openstack"
+	adapterName = "fake"
+	projectA    = "project-a"
+	projectB    = "project-b"
+	typeShare   = "share"
+	typeRouter  = "router"
+	typeQuota   = "quota"
+)
+
+// The statuses a finished run leaves in sync_runs.
+const (
+	statusCompleted = "completed"
+	statusFailed    = "failed"
+)
+
+// The instants the fixtures work with. They are whole seconds, so what
+// PostgreSQL stores reads back as what the test passed in.
+var (
+	// createTime and deleteTime are the platform's own instants, which a
+	// correction carries whenever the adapter exposes them.
+	createTime = time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	deleteTime = time.Date(2026, 4, 2, 9, 0, 0, 0, time.UTC)
+	// pollTime is what the injected clock answers. It is what a correction the
+	// platform gave no instant for is dated at.
+	pollTime = time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+)
+
+// errManilaDown stands in for whatever a platform client returns when one of
+// its services is unreachable.
+var errManilaDown = errors.New("connection refused")
+
+// TestSync drives the reconciliation framework against a real database. The
+// subtests share one, so each of them works on a cloud of its own: a sync reads
+// the projection, the run history, and the advisory lock all by cloud.
+func TestSync(t *testing.T) {
+	db := storetest.NewDB(t)
+	pipeline := ingest.New(registry.New(), false, nil)
+
+	t.Run("creates what the projection does not hold yet", func(t *testing.T) {
+		const cloud = "os-sync-create"
+		dated := seen(typeShare, "share-dated", projectA, "available", map[string]any{"size_gb": 50})
+		dated.CreatedAt = &createTime
+		// The platform exposes no creation time for this one, so the correction
+		// is dated at the poll instead: the concept's accepted approximation.
+		fresh := seen(typeShare, "share-fresh", projectA, "available", nil)
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(dated, fresh)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(2, 0, 0))
+		assertRun(t, db, res, statusCompleted)
+		want := []correction{
+			{
+				eventType: "sync.create", resourceType: typeShare, resourceID: "share-dated",
+				projectID: projectA, at: rfc(createTime), state: "available",
+				size: map[string]any{"size_gb": 50.0},
+			},
+			{
+				eventType: "sync.create", resourceType: typeShare, resourceID: "share-fresh",
+				projectID: projectA, at: rfc(pollTime), state: "available",
+				// A create reports the size the resource starts with, and the
+				// adapter reported none: the event carries the empty object rather
+				// than being invalid.
+				size: map[string]any{},
+			},
+		}
+		assertCorrections(t, db, cloud, want)
+		assertRows(t, db, cloud, []projectionRow{
+			{
+				resourceType: typeShare, resourceID: "share-dated", projectID: projectA,
+				state: "available", size: map[string]any{"size_gb": 50.0}, createdAt: rfc(createTime),
+			},
+			{
+				resourceType: typeShare, resourceID: "share-fresh", projectID: projectA,
+				state: "available", size: map[string]any{}, createdAt: rfc(pollTime),
+			},
+		})
+	})
+
+	t.Run("creates a resource the projection holds as deleted again", func(t *testing.T) {
+		const cloud = "os-sync-resurrection"
+		alive := seen(typeShare, "share-back", projectA, "available", map[string]any{"size_gb": 10})
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(alive)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+		mustSync(t, syncer, cloud)
+
+		// The platform reports the resource as gone, which puts the row into the
+		// state a resurrection starts from.
+		fake.steps = stream(vanished(typeShare, "share-back", deleteTime))
+		mustSync(t, syncer, cloud)
+		if row := rowOf(t, db, cloud, typeShare, "share-back"); row.state != "deleted" {
+			t.Fatalf("state after the deletion = %q, want %q", row.state, "deleted")
+		}
+
+		fake.steps = stream(alive)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(1, 0, 0))
+		row := rowOf(t, db, cloud, typeShare, "share-back")
+		if row.state != "available" || row.deletedAt != "" {
+			t.Errorf("row after the resurrection = %+v, want it live again", row)
+		}
+		// Three runs, three corrections: the second create is a new life rather
+		// than a repeat of the first.
+		if got := len(corrections(t, db, cloud)); got != 3 {
+			t.Errorf("stored corrections = %d, want the create, the delete and the create, 3", got)
+		}
+	})
+
+	t.Run("dates a resurrection at the poll rather than at the platform's create", func(t *testing.T) {
+		const cloud = "os-sync-resurrection-dated"
+		alive := seen(typeShare, "share-back", projectA, "available", map[string]any{"size_gb": 10})
+		// This platform exposes the resource's own creation time, and it predates
+		// the deletion the projection comes to hold.
+		alive.CreatedAt = &createTime
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(alive)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+		mustSync(t, syncer, cloud)
+
+		fake.steps = stream(vanished(typeShare, "share-back", deleteTime))
+		mustSync(t, syncer, cloud)
+
+		fake.steps = stream(alive)
+		res := mustSync(t, syncer, cloud)
+
+		// A create ordered before the delete would revive nothing: the fold takes
+		// the state from the last delete whatever precedes it, so the correction
+		// would count, change nothing, and be written again by every later run.
+		assertStats(t, res.Stats, tally(1, 0, 0))
+		row := rowOf(t, db, cloud, typeShare, "share-back")
+		if row.state != "available" || row.deletedAt != "" {
+			t.Errorf("row after the resurrection = %+v, want it live again", row)
+		}
+	})
+
+	t.Run("dates a resurrection past a delete the platform dated ahead of the poll", func(t *testing.T) {
+		const cloud = "os-sync-resurrection-ahead"
+		// A platform whose clock runs ahead of this service's dates its deletion
+		// in Tally's future, and the projection takes the instant the platform
+		// gave. A create dated at the poll is ordered before that delete, and the
+		// fold takes the state from the last delete whatever precedes it: the row
+		// would stay deleted and every later run would mint one more event id for
+		// the same drift.
+		ahead := pollTime.Add(20 * time.Minute)
+		alive := seen(typeShare, "share-back", projectA, "available", map[string]any{"size_gb": 10})
+		fake, syncer := seedFleet(t, db, pipeline, cloud, alive)
+
+		fake.steps = stream(vanished(typeShare, "share-back", ahead))
+		mustSync(t, syncer, cloud)
+
+		fake.steps = stream(alive)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(1, 0, 0))
+		row := rowOf(t, db, cloud, typeShare, "share-back")
+		if row.state != "available" || row.deletedAt != "" {
+			t.Errorf("row after the resurrection = %+v, want it live again", row)
+		}
+		assertCorrections(t, db, cloud, []correction{
+			{
+				eventType: "sync.create", resourceType: typeShare, resourceID: "share-back",
+				projectID: projectA, at: rfc(pollTime), state: "available",
+				size: map[string]any{"size_gb": 10.0},
+			},
+			{
+				eventType: "sync.delete", resourceType: typeShare, resourceID: "share-back",
+				projectID: projectA, at: rfc(ahead),
+			},
+			{
+				// One instant past the delete rather than at the poll, which is what
+				// makes the correction the row's newest event.
+				eventType: "sync.create", resourceType: typeShare, resourceID: "share-back",
+				projectID: projectA, at: rfc(ahead.Add(time.Microsecond)), state: "available",
+				size: map[string]any{"size_gb": 10.0},
+			},
+		})
+
+		// The run that follows finds the projection corrected and emits nothing:
+		// the resurrection converged rather than repeating for the life of the
+		// resource.
+		res = mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		if got := len(corrections(t, db, cloud)); got != 3 {
+			t.Errorf("stored corrections = %d, want the create, the delete and the create, 3", got)
+		}
+	})
+
+	t.Run("keeps a resurrection a rebuild folds again", func(t *testing.T) {
+		const cloud = "os-sync-resurrection-rebuilt"
+		alive := seen(typeShare, "share-back", projectA, "available", map[string]any{"size_gb": 10})
+		alive.CreatedAt = &createTime
+		fake, syncer := seedFleet(t, db, pipeline, cloud, alive)
+
+		fake.steps = stream(vanished(typeShare, "share-back", deleteTime))
+		mustSync(t, syncer, cloud)
+		fake.steps = stream(alive)
+		mustSync(t, syncer, cloud)
+
+		// The row is derived state: a rebuild folds the same history through the
+		// replay path, and what that path writes has to be what the incremental
+		// one wrote. A replay that read the resurrection as a deletion would send
+		// the next run around the same drift, under one more event id every time.
+		if _, err := projection.Rebuild(t.Context(), db.Store,
+			projection.Filter{Cloud: cloud}); err != nil {
+			t.Fatalf("Rebuild() error = %v, want nil", err)
+		}
+		row := rowOf(t, db, cloud, typeShare, "share-back")
+		if row.state != "available" || row.deletedAt != "" {
+			t.Errorf("row after the rebuild = %+v, want the resurrection kept", row)
+		}
+
+		fake.steps = stream(alive)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		if got := len(corrections(t, db, cloud)); got != 3 {
+			t.Errorf("stored corrections = %d, want the create, the delete and the create, 3", got)
+		}
+	})
+
+	t.Run("updates a resource whose state drifted", func(t *testing.T) {
+		const cloud = "os-sync-update-state"
+		fake, syncer := seedFleet(t, db, pipeline, cloud,
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10}))
+
+		fake.steps = stream(seen(typeShare, "share-1", projectA, "in-use", map[string]any{"size_gb": 10}))
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 1, 0))
+		assertCorrection(t, db, cloud, "sync.update", correction{
+			eventType: "sync.update", resourceType: typeShare, resourceID: "share-1",
+			projectID: projectA, at: rfc(pollTime), state: "in-use",
+			size: map[string]any{"size_gb": 10.0},
+		})
+		if row := rowOf(t, db, cloud, typeShare, "share-1"); row.state != "in-use" {
+			t.Errorf("state = %q, want the observed %q", row.state, "in-use")
+		}
+	})
+
+	t.Run("updates a resource whose size drifted", func(t *testing.T) {
+		const cloud = "os-sync-update-size"
+		fake, syncer := seedFleet(t, db, pipeline, cloud,
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10}))
+
+		fake.steps = stream(seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 20}))
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 1, 0))
+		assertCorrection(t, db, cloud, "sync.update", correction{
+			eventType: "sync.update", resourceType: typeShare, resourceID: "share-1",
+			projectID: projectA, at: rfc(pollTime), state: "available",
+			size: map[string]any{"size_gb": 20.0},
+		})
+		if row := rowOf(t, db, cloud, typeShare, "share-1"); !reflect.DeepEqual(row.size, map[string]any{"size_gb": 20.0}) {
+			t.Errorf("size = %v, want the observed one", row.size)
+		}
+	})
+
+	t.Run("updates a resource that changed hands", func(t *testing.T) {
+		const cloud = "os-sync-update-owner"
+		fake, syncer := seedFleet(t, db, pipeline, cloud,
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10}))
+
+		// A transfer is drift like any other, and the correction names the owner
+		// the platform reports rather than the one the row still holds.
+		fake.steps = stream(seen(typeShare, "share-1", projectB, "available", map[string]any{"size_gb": 10}))
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 1, 0))
+		assertCorrection(t, db, cloud, "sync.update", correction{
+			eventType: "sync.update", resourceType: typeShare, resourceID: "share-1",
+			projectID: projectB, at: rfc(pollTime), state: "available",
+			size: map[string]any{"size_gb": 10.0},
+		})
+		if row := rowOf(t, db, cloud, typeShare, "share-1"); row.projectID != projectB {
+			t.Errorf("project id = %q, want the observed %q", row.projectID, projectB)
+		}
+	})
+
+	t.Run("takes the last word of a resource the adapter listed twice", func(t *testing.T) {
+		const cloud = "os-sync-duplicate-observation"
+		fake, syncer := seedFleet(t, db, pipeline, cloud,
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10}))
+
+		// A resource an adapter lists twice states its final word rather than two
+		// facts, so the run corrects the projection to the last report.
+		fake.steps = stream(
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10}),
+			seen(typeShare, "share-1", projectA, "in-use", map[string]any{"size_gb": 10}))
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 1, 0))
+		if row := rowOf(t, db, cloud, typeShare, "share-1"); row.state != "in-use" {
+			t.Errorf("state = %q, want the last report %q", row.state, "in-use")
+		}
+	})
+
+	t.Run("reads two spellings of one size as one size", func(t *testing.T) {
+		const cloud = "os-sync-size-equality"
+		fake, syncer := seedFleet(t, db, pipeline, cloud,
+			seen(typeShare, "share-1", projectA, "available", map[string]any{"gb": 100}))
+
+		// The adapter builds the size from an int and the database returns it as
+		// a JSON number. Comparing the two documents rather than their bytes is
+		// what keeps that from reading as drift.
+		fake.steps = stream(seen(typeShare, "share-1", projectA, "available", map[string]any{"gb": 100}))
+		res := mustSync(t, syncer, cloud)
+		assertStats(t, res.Stats, tally(0, 0, 0))
+
+		// An adapter that reports no size reports no evidence about the size, so
+		// the stored one is not drift either.
+		fake.steps = stream(seen(typeShare, "share-1", projectA, "available", nil))
+		res = mustSync(t, syncer, cloud)
+		assertStats(t, res.Stats, tally(0, 0, 0))
+
+		if got := len(corrections(t, db, cloud)); got != 1 {
+			t.Errorf("stored corrections = %d, want only the create the fleet was seeded with", got)
+		}
+	})
+
+	t.Run("deletes what the platform reports as gone", func(t *testing.T) {
+		const cloud = "os-sync-observed-delete"
+		live := seen(typeShare, "share-live", projectA, "available", map[string]any{"size_gb": 10})
+		doomed := seen(typeShare, "share-doomed", projectB, "available", map[string]any{"size_gb": 20})
+		// This platform exposes the resource's own creation time, so the deletion
+		// it reports falls past the row's create and is carried verbatim.
+		doomed.CreatedAt = &createTime
+		fake, syncer := seedFleet(t, db, pipeline, cloud, live, doomed)
+
+		fake.steps = stream(live, vanished(typeShare, "share-doomed", deleteTime))
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 1))
+		assertCorrection(t, db, cloud, "sync.delete", correction{
+			eventType: "sync.delete", resourceType: typeShare, resourceID: "share-doomed",
+			// The owner is the row's: who held the resource is settled history by
+			// the time the platform reports it gone.
+			projectID: projectB, at: rfc(deleteTime),
+		})
+		row := rowOf(t, db, cloud, typeShare, "share-doomed")
+		if row.state != "deleted" || row.deletedAt != rfc(deleteTime) {
+			t.Errorf("row = %+v, want it deleted at the platform's instant %s", row, rfc(deleteTime))
+		}
+
+		// A deletion of a row that already holds one, and one of a resource the
+		// projection never held, both correct nothing.
+		before := len(corrections(t, db, cloud))
+		fake.steps = stream(live,
+			vanished(typeShare, "share-doomed", deleteTime),
+			vanished(typeShare, "share-unknown", deleteTime))
+		res = mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		if got := len(corrections(t, db, cloud)); got != before {
+			t.Errorf("stored corrections = %d, want them unchanged at %d", got, before)
+		}
+	})
+
+	t.Run("dates a deletion the platform put before the row's newest event past it", func(t *testing.T) {
+		const cloud = "os-sync-observed-delete-behind"
+		// This platform exposes no creation time, so the row's create is dated at
+		// the poll. The deletion it reports predates that: a history saying the
+		// resource was gone before it existed, which the fold would order the
+		// correction underneath, leaving the row live for every later run to
+		// correct again under a new event id.
+		doomed := seen(typeShare, "share-doomed", projectB, "available", map[string]any{"size_gb": 20})
+		fake, syncer := seedFleet(t, db, pipeline, cloud, doomed)
+
+		fake.steps = stream(vanished(typeShare, "share-doomed", deleteTime))
+		res := mustSync(t, syncer, cloud)
+
+		corrected := rfc(pollTime.Add(time.Microsecond))
+		assertStats(t, res.Stats, tally(0, 0, 1))
+		assertCorrection(t, db, cloud, "sync.delete", correction{
+			eventType: "sync.delete", resourceType: typeShare, resourceID: "share-doomed",
+			projectID: projectB, at: corrected,
+		})
+		if row := rowOf(t, db, cloud, typeShare, "share-doomed"); row.state != "deleted" ||
+			row.deletedAt != corrected {
+			t.Errorf("row = %+v, want it deleted at the corrected instant %s", row, corrected)
+		}
+
+		// The run that follows finds the projection corrected and emits nothing:
+		// the deletion converged rather than repeating for the life of the row.
+		fake.steps = stream(vanished(typeShare, "share-doomed", deleteTime))
+		res = mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		if got := len(corrections(t, db, cloud)); got != 2 {
+			t.Errorf("stored corrections = %d, want the create and the delete, 2", got)
+		}
+	})
+
+	t.Run("deletes what an enumerated type no longer holds", func(t *testing.T) {
+		const cloud = "os-sync-missed-delete"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		missed := seen(typeShare, "share-missed", projectB, "available", map[string]any{"size_gb": 20})
+		router := seen(typeRouter, "router-1", projectA, "active", nil)
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share, missed, router)
+
+		// Only the shares are enumerated this time, so the router's absence says
+		// nothing about the router.
+		fake.types, fake.steps = []string{typeShare}, stream(share)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 1))
+		assertCorrection(t, db, cloud, "sync.delete", correction{
+			eventType: "sync.delete", resourceType: typeShare, resourceID: "share-missed",
+			projectID: projectB, at: rfc(pollTime),
+		})
+		if row := rowOf(t, db, cloud, typeRouter, "router-1"); row.state != "active" {
+			t.Errorf("router state = %q, want the unenumerated type left alone", row.state)
+		}
+
+		// A type enumerated to its end that holds nothing deletes every live row
+		// it has: an empty answer is an answer.
+		fake.types, fake.steps = []string{typeShare, typeRouter}, nil
+		res = mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 2))
+		for _, key := range [][2]string{{typeShare, "share-1"}, {typeRouter, "router-1"}} {
+			if row := rowOf(t, db, cloud, key[0], key[1]); row.state != "deleted" {
+				t.Errorf("%s %s state = %q, want %q", key[0], key[1], row.state, "deleted")
+			}
+		}
+	})
+
+	t.Run("emits nothing when the platform matches the projection", func(t *testing.T) {
+		const cloud = "os-sync-clean"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share)
+		before := len(corrections(t, db, cloud))
+
+		fake.steps = stream(share)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		assertRun(t, db, res, statusCompleted)
+		if got := len(corrections(t, db, cloud)); got != before {
+			t.Errorf("stored corrections = %d, want them unchanged at %d", got, before)
+		}
+	})
+
+	t.Run("emits nothing for a cloud that holds nothing", func(t *testing.T) {
+		const cloud = "os-sync-empty"
+		fake := &fakeAdapter{types: []string{typeShare}}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		assertRun(t, db, res, statusCompleted)
+		if got := corrections(t, db, cloud); len(got) != 0 {
+			t.Errorf("stored corrections = %+v, want none", got)
+		}
+	})
+
+	t.Run("derives every event id from the run it belongs to", func(t *testing.T) {
+		const cloud = "os-sync-event-ids"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(share)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+		created := mustSync(t, syncer, cloud)
+
+		fake.steps = stream(seen(typeShare, "share-1", projectA, "in-use", map[string]any{"size_gb": 10}))
+		updated := mustSync(t, syncer, cloud)
+
+		fake.steps = nil
+		deleted := mustSync(t, syncer, cloud)
+
+		want := []string{
+			ids.SyntheticEventID(created.RunID, cloud, typeShare, "share-1", "create"),
+			ids.SyntheticEventID(updated.RunID, cloud, typeShare, "share-1", "update"),
+			ids.SyntheticEventID(deleted.RunID, cloud, typeShare, "share-1", "delete"),
+		}
+		slices.Sort(want)
+		if got := storedEventIDs(t, db, cloud); !reflect.DeepEqual(got, want) {
+			t.Errorf("stored event ids = %v, want the ones the runs derive, %v", got, want)
+		}
+	})
+
+	t.Run("keeps the rows of a type it could not enumerate", func(t *testing.T) {
+		const cloud = "os-sync-enumeration-error"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		router := seen(typeRouter, "router-1", projectA, "active", nil)
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share, router)
+
+		// The shares stay unknown, the routers are enumerated to their end: the
+		// fleet loses the router that is gone and gains the one that is new,
+		// while the share nobody could list is left exactly as it was.
+		fresh := seen(typeRouter, "router-2", projectB, "active", nil)
+		fake.steps = []step{
+			{err: &reconciliation.EnumerationError{ResourceType: typeShare, Err: errManilaDown}},
+			{resource: fresh},
+		}
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting that it did not finish clean")
+		}
+		if res.Stats.Created != 1 || res.Stats.Deleted != 1 || res.Stats.Updated != 0 {
+			t.Errorf("stats = %+v, want the create of router-2 and the delete of router-1", res.Stats)
+		}
+		if len(res.Stats.Errors) != 1 || !strings.Contains(res.Stats.Errors[0], typeShare) {
+			t.Errorf("stats errors = %v, want the enumeration failure of %s", res.Stats.Errors, typeShare)
+		}
+		if !strings.Contains(res.Stats.Errors[0], errManilaDown.Error()) {
+			t.Errorf("stats errors = %v, want the platform's own message", res.Stats.Errors)
+		}
+		assertRun(t, db, res, statusFailed)
+		if row := rowOf(t, db, cloud, typeShare, "share-1"); row.state != "available" {
+			t.Errorf("share state = %q, want the incomplete type left alone", row.state)
+		}
+		if row := rowOf(t, db, cloud, typeRouter, "router-1"); row.state != "deleted" {
+			t.Errorf("router state = %q, want the enumerated type reconciled", row.state)
+		}
+	})
+
+	t.Run("writes nothing when the stream fails outright", func(t *testing.T) {
+		const cloud = "os-sync-stream-error"
+		fake := &fakeAdapter{types: []string{typeShare}, steps: []step{
+			{resource: seen(typeShare, "share-1", projectA, "available", nil)},
+			{err: errManilaDown},
+		}}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if !errors.Is(err, errManilaDown) {
+			t.Fatalf("Sync() error = %v, want it wrapping %v", err, errManilaDown)
+		}
+		assertRun(t, db, res, statusFailed)
+		if len(res.Stats.Errors) != 1 || !strings.Contains(res.Stats.Errors[0], errManilaDown.Error()) {
+			t.Errorf("stats errors = %v, want the error that ended the run", res.Stats.Errors)
+		}
+		// The resource the stream did report is not a correction: a run that
+		// stopped mid-inventory knows nothing about the rest of the fleet.
+		if got := corrections(t, db, cloud); len(got) != 0 {
+			t.Errorf("stored corrections = %+v, want none", got)
+		}
+	})
+
+	t.Run("keeps the fleet when the stream stops without saying why", func(t *testing.T) {
+		const cloud = "os-sync-truncated-stream"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		unreached := seen(typeShare, "share-2", projectB, "available", map[string]any{"size_gb": 20})
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share, unreached)
+		before := len(corrections(t, db, cloud))
+
+		// The adapter returns on the cancelled context without yielding an error,
+		// which is what a range-over-func selecting on ctx.Done() does. What it
+		// listed is half the fleet, and reading that as the inventory would delete
+		// the other half.
+		fake.steps, fake.truncates = stream(share), true
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+		defer cancel()
+		res, err := syncer.Sync(ctx, cloud)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Sync() error = %v, want it wrapping %v", err, context.DeadlineExceeded)
+		}
+		if len(res.Stats.Errors) != 1 || !strings.Contains(res.Stats.Errors[0], "stream ended early") {
+			t.Errorf("stats errors = %v, want one naming the listing that stopped", res.Stats.Errors)
+		}
+		assertRun(t, db, res, statusFailed)
+		if row := rowOf(t, db, cloud, typeShare, "share-2"); row.state != "available" {
+			t.Errorf("state = %q, want the resource the run never reached left alone", row.state)
+		}
+		if got := len(corrections(t, db, cloud)); got != before {
+			t.Errorf("stored corrections = %d, want them unchanged at %d", got, before)
+		}
+	})
+
+	t.Run("writes nothing when the resource types cannot be read", func(t *testing.T) {
+		const cloud = "os-sync-types-error"
+		fake := &fakeAdapter{
+			typesErr: errManilaDown,
+			steps:    stream(seen(typeShare, "share-1", projectA, "available", nil)),
+		}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if !errors.Is(err, errManilaDown) {
+			t.Fatalf("Sync() error = %v, want it wrapping %v", err, errManilaDown)
+		}
+		assertRun(t, db, res, statusFailed)
+		if got := corrections(t, db, cloud); len(got) != 0 {
+			t.Errorf("stored corrections = %+v, want none", got)
+		}
+	})
+
+	t.Run("skips an observation the adapter reported incompletely", func(t *testing.T) {
+		// Each case drops the one field it names, which leaves an item that
+		// cannot be diffed. The type it belongs to is treated as incomplete for
+		// it, so the row the run failed to see keeps its life.
+		cases := []struct {
+			name    string
+			cloud   string
+			broken  reconciliation.ObservedResource
+			missing string
+		}{
+			{
+				name: "without a resource id", cloud: "os-sync-invalid-id",
+				broken:  seen(typeShare, "", projectA, "available", nil),
+				missing: "resource id",
+			},
+			{
+				name: "without a state", cloud: "os-sync-invalid-state",
+				broken:  seen(typeShare, "share-broken", projectA, "", nil),
+				missing: "state",
+			},
+			{
+				name: "without a project id", cloud: "os-sync-invalid-project",
+				broken:  seen(typeShare, "share-broken", "", "available", nil),
+				missing: "project id",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+				fake, syncer := seedFleet(t, db, pipeline, tc.cloud, share)
+				before := len(corrections(t, db, tc.cloud))
+
+				fake.steps = stream(tc.broken)
+				res, err := syncer.Sync(t.Context(), tc.cloud)
+
+				if err == nil {
+					t.Fatal("Sync() error = nil, want the run reporting the broken observation")
+				}
+				assertStats(t, res.Stats, reconciliation.Stats{
+					Errors: res.Stats.Errors, ErrorCount: len(res.Stats.Errors),
+				})
+				if len(res.Stats.Errors) != 1 || !strings.Contains(res.Stats.Errors[0], tc.missing) {
+					t.Errorf("stats errors = %v, want one naming the missing %s", res.Stats.Errors, tc.missing)
+				}
+				assertRun(t, db, res, statusFailed)
+				if row := rowOf(t, db, tc.cloud, typeShare, "share-1"); row.state != "available" {
+					t.Errorf("state = %q, want the row left alone", row.state)
+				}
+				if got := len(corrections(t, db, tc.cloud)); got != before {
+					t.Errorf("stored corrections = %d, want them unchanged at %d", got, before)
+				}
+			})
+		}
+	})
+
+	t.Run("deletes nothing for a run that met an observation without a type", func(t *testing.T) {
+		const cloud = "os-sync-invalid-type"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		router := seen(typeRouter, "router-1", projectA, "active", nil)
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share, router)
+
+		// An item that names no type is missing information about the inventory
+		// as a whole rather than about one type of it: there is no type to hold
+		// the missed-delete pass back for, so no type may conclude a deletion.
+		fake.steps = stream(share, seen("", "orphan", projectA, "available", nil))
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting the broken observation")
+		}
+		if res.Stats.Deleted != 0 {
+			t.Errorf("stats = %+v, want no deletion from a run that lost track of a type", res.Stats)
+		}
+		assertRun(t, db, res, statusFailed)
+		if row := rowOf(t, db, cloud, typeRouter, "router-1"); row.state != "active" {
+			t.Errorf("router state = %q, want the unobserved type left alone", row.state)
+		}
+	})
+
+	t.Run("records a correction the pipeline refused", func(t *testing.T) {
+		const cloud = "os-sync-rejected"
+		registerSizeSchema(t, db, typeQuota, `{
+			"type": "object",
+			"required": ["slots"],
+			"properties": {"slots": {"type": "integer"}}
+		}`)
+		strict := ingest.New(registry.New(), true, nil)
+		// The second quota is what tells a dead-lettered correction from a batch
+		// that was thrown away whole: its siblings have to land.
+		fake := &fakeAdapter{
+			types: []string{typeQuota},
+			steps: stream(
+				seen(typeQuota, "quota-1", projectA, "active", map[string]any{"slots": "many"}),
+				seen(typeQuota, "quota-2", projectA, "active", map[string]any{"slots": 4})),
+		}
+		syncer := newSyncer(t, db, strict, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting the refused correction")
+		}
+		// The tally counts what the committed batch carried, and the errors say
+		// what became of it: the correction was dead-lettered rather than stored.
+		if res.Stats.Created != 2 {
+			t.Errorf("stats = %+v, want both emitted creates counted", res.Stats)
+		}
+		wantPrefix := "event " + ids.SyntheticEventID(res.RunID, cloud, typeQuota, "quota-1", "create") + " rejected: "
+		if len(res.Stats.Errors) != 1 || !strings.HasPrefix(res.Stats.Errors[0], wantPrefix) {
+			t.Errorf("stats errors = %v, want one prefixed %q", res.Stats.Errors, wantPrefix)
+		}
+		if !strings.Contains(res.Stats.Errors[0], "size_schema") {
+			t.Errorf("stats errors = %v, want the reason the schema gave", res.Stats.Errors)
+		}
+		assertRun(t, db, res, statusFailed)
+		got := rows(t, db, cloud)
+		if len(got) != 1 || got[0].resourceID != "quota-2" {
+			t.Errorf("projection rows = %+v, want only the accepted correction's", got)
+		}
+	})
+
+	t.Run("records a platform error text a jsonb column cannot hold", func(t *testing.T) {
+		const cloud = "os-sync-error-text"
+		// An HTTP client hands the response body back verbatim, and a misbehaving
+		// proxy puts whatever it likes in one. PostgreSQL holds no NUL in a jsonb
+		// document, so an unscreened one would fail the write that records why the
+		// run ended and leave the row at 'running' for a run that is over.
+		fake := &fakeAdapter{types: []string{typeShare}, steps: []step{{
+			err: &reconciliation.EnumerationError{
+				ResourceType: typeShare,
+				Err:          errors.New("bad gateway: <html>\x00</html>"),
+			},
+		}}}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting the enumeration failure")
+		}
+		assertRun(t, db, res, statusFailed)
+		if len(res.Stats.Errors) != 1 || strings.ContainsRune(res.Stats.Errors[0], 0) {
+			t.Fatalf("stats errors = %q, want one carrying no NUL", res.Stats.Errors)
+		}
+		if !strings.Contains(res.Stats.Errors[0], `\x00`) {
+			t.Errorf("stats errors = %q, want what the platform sent to stay legible", res.Stats.Errors)
+		}
+	})
+
+	t.Run("keeps the head of a platform error text nothing bounds", func(t *testing.T) {
+		const cloud = "os-sync-error-size"
+		// An HTTP client hands the response body back verbatim, and a load
+		// balancer answering a paginated listing with an error page makes that
+		// body megabytes long. The reason is held for the run, written into a
+		// jsonb column, answered to the caller, and logged, so only its head is
+		// kept.
+		const (
+			body = 5 << 20 // what the platform sent
+			kept = 4 << 10 // the package's maxErrorBytes
+		)
+		fake := &fakeAdapter{types: []string{typeShare}, steps: []step{{
+			err: &reconciliation.EnumerationError{
+				ResourceType: typeShare,
+				Err:          errors.New(strings.Repeat("x", body)),
+			},
+		}}}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting the enumeration failure")
+		}
+		if len(res.Stats.Errors) != 1 {
+			t.Fatalf("stats errors = %d entries, want one", len(res.Stats.Errors))
+		}
+		reason := res.Stats.Errors[0]
+		if want := kept + len("… (truncated)"); len(reason) != want {
+			t.Errorf("recorded reason = %d bytes, want its head and the marker, %d", len(reason), want)
+		}
+		// What the platform sent stays legible as far as it is kept: the type that
+		// failed is named at the front, and the end says the rest was dropped.
+		if !strings.HasPrefix(reason, "enumerating "+typeShare) {
+			t.Errorf("recorded reason = %q…, want it naming the type that failed", reason[:32])
+		}
+		if !strings.HasSuffix(reason, "(truncated)") {
+			t.Errorf("recorded reason = …%q, want it marked as truncated", reason[len(reason)-32:])
+		}
+		assertRun(t, db, res, statusFailed)
+	})
+
+	t.Run("keeps the first of a flood of reasons and counts them all", func(t *testing.T) {
+		const cloud = "os-sync-error-flood"
+		// Nothing bounds how many reasons an adapter produces, and they are stored
+		// in a jsonb column, answered to the caller, and joined into one string.
+		const (
+			failures = 250
+			kept     = 100 // the package's maxRecordedErrors
+		)
+		steps := make([]step, failures)
+		for i := range steps {
+			steps[i] = step{err: &reconciliation.EnumerationError{
+				ResourceType: typeShare, Err: fmt.Errorf("listing page %d", i),
+			}}
+		}
+		fake := &fakeAdapter{types: []string{typeShare}, steps: steps}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil {
+			t.Fatal("Sync() error = nil, want the run reporting the enumeration failures")
+		}
+		if len(res.Stats.Errors) != kept {
+			t.Errorf("stats errors = %d entries, want them capped at %d", len(res.Stats.Errors), kept)
+		}
+		if res.Stats.ErrorCount != failures {
+			t.Errorf("error count = %d, want every reason counted, %d", res.Stats.ErrorCount, failures)
+		}
+		assertRun(t, db, res, statusFailed)
+	})
+
+	t.Run("commits a fleet that does not fit in one transaction", func(t *testing.T) {
+		const cloud = "os-sync-batched"
+		// The first sync of a cloud emits one correction per resource it holds,
+		// and the ingest pipeline holds an advisory lock per resource until its
+		// transaction commits. More resources than one batch carries is what
+		// exercises the chunking that keeps the run off the shared lock table.
+		const fleet = 250
+		observed := make([]reconciliation.ObservedResource, fleet)
+		for i := range observed {
+			observed[i] = seen(typeShare, fmt.Sprintf("share-%03d", i), projectA,
+				"available", map[string]any{"size_gb": 10})
+		}
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(observed...)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(fleet, 0, 0))
+		if got := len(corrections(t, db, cloud)); got != fleet {
+			t.Errorf("stored corrections = %d, want one per resource, %d", got, fleet)
+		}
+		if got := len(rows(t, db, cloud)); got != fleet {
+			t.Errorf("projection rows = %d, want one per resource, %d", got, fleet)
+		}
+	})
+
+	t.Run("refuses a cloud whose adapter is not registered", func(t *testing.T) {
+		const cloud = "os-sync-no-adapter"
+		// New takes the configuration and the adapters independently, so a cloud
+		// naming an adapter nobody registered reaches the run rather than being
+		// caught when the configuration was loaded.
+		cfg := reconciliation.Config{Clouds: []reconciliation.CloudConfig{{
+			Cloud: cloud, Platform: platform, Adapter: "absent",
+		}}}
+		syncer := reconciliation.New(db.Store, pipeline, cfg,
+			map[string]reconciliation.Adapter{}, func() time.Time { return pollTime })
+
+		res, err := syncer.Sync(t.Context(), cloud)
+
+		if err == nil || !strings.Contains(err.Error(), "absent") {
+			t.Errorf("Sync() error = %v, want it naming the adapter that is missing", err)
+		}
+		if res.RunID != "" {
+			t.Errorf("Result = %+v, want the zero one for a cloud that cannot be synced", res)
+		}
+		if got := runsOf(t, db, cloud); got != 0 {
+			t.Errorf("sync_runs rows = %d, want none for a run that never started", got)
+		}
+	})
+
+	t.Run("takes its own corrections a second time as duplicates", func(t *testing.T) {
+		const cloud = "os-sync-replay"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		fake, syncer := seedFleet(t, db, pipeline, cloud, share)
+		items := storedItems(t, db, cloud)
+		before := rows(t, db, cloud)
+
+		var out ingest.Outcome
+		if err := db.Store.WithTx(t.Context(), func(tx pgx.Tx) error {
+			var err error
+			out, err = pipeline.Ingest(t.Context(), tx, items, event.SourceReconciliation, nil)
+			return err
+		}); err != nil {
+			t.Fatalf("Ingest() error = %v, want nil", err)
+		}
+
+		if out.Accepted != 0 || out.Duplicates != len(items) || len(out.Rejected) != 0 {
+			t.Errorf("Ingest() = %+v, want the %d corrections as duplicates", out, len(items))
+		}
+		if after := rows(t, db, cloud); !reflect.DeepEqual(after, before) {
+			t.Errorf("projection rows = %+v, want them unchanged at %+v", after, before)
+		}
+
+		// The other half of the same guarantee: a run over an unchanged platform
+		// has nothing to correct.
+		fake.steps = stream(share)
+		res := mustSync(t, syncer, cloud)
+
+		assertStats(t, res.Stats, tally(0, 0, 0))
+		if after := rows(t, db, cloud); !reflect.DeepEqual(after, before) {
+			t.Errorf("projection rows = %+v, want them unchanged at %+v", after, before)
+		}
+	})
+
+	t.Run("bounds the next run by the last completed one", func(t *testing.T) {
+		const cloud = "os-sync-window"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(share)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+
+		first := mustSync(t, syncer, cloud)
+		if fake.since != nil {
+			// A cloud that never completed a run has no window to start from, so
+			// its first run is a full one.
+			t.Errorf("since = %s, want none for the first run of a cloud", fake.since)
+		}
+
+		fake.steps = stream(share)
+		second := mustSync(t, syncer, cloud)
+		started := runRow(t, db, first.RunID).StartedAt.Time
+		if fake.since == nil || !fake.since.Equal(started) {
+			t.Fatalf("since = %v, want the started_at of the completed run, %s", fake.since, started)
+		}
+
+		// A failed run does not move the window: what it could not enumerate is
+		// exactly what it may have missed, so the next run walks that window
+		// again from where the last completed run started.
+		fake.steps = []step{{err: errManilaDown}}
+		if _, err := syncer.Sync(t.Context(), cloud); err == nil {
+			t.Fatal("Sync() error = nil, want the failing run to fail")
+		}
+		fake.steps = stream(share)
+		mustSync(t, syncer, cloud)
+
+		completed := runRow(t, db, second.RunID).StartedAt.Time
+		if fake.since == nil || !fake.since.Equal(completed) {
+			t.Errorf("since = %v, want the last completed run's start, %s, rather than the failed run's",
+				fake.since, completed)
+		}
+	})
+
+	t.Run("refuses a second sync of a cloud a run is holding", func(t *testing.T) {
+		const cloud = "os-sync-lock"
+		held := blockingAdapter()
+		holder := newSyncer(t, db, pipeline, cloud, held)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := holder.Sync(context.Background(), cloud); err != nil {
+				t.Errorf("the holding Sync() error = %v, want nil", err)
+			}
+		}()
+		<-held.entered
+
+		refused := newSyncer(t, db, pipeline, cloud, &fakeAdapter{types: []string{typeShare}})
+		res, err := refused.Sync(t.Context(), cloud)
+
+		if !errors.Is(err, reconciliation.ErrAlreadyRunning) {
+			t.Errorf("Sync() error = %v, want %v", err, reconciliation.ErrAlreadyRunning)
+		}
+		if res.RunID != "" {
+			t.Errorf("Result = %+v, want the zero one for a refused sync", res)
+		}
+		// The refused call writes no row at all: the run it stepped aside for is
+		// the only one there is.
+		if got := runsOf(t, db, cloud); got != 1 {
+			t.Errorf("sync_runs rows = %d, want only the holding run's, 1", got)
+		}
+
+		close(held.released)
+		wg.Wait()
+	})
+
+	t.Run("frees the lock after a run that finished, failed, or crashed", func(t *testing.T) {
+		const cloud = "os-sync-lock-release"
+		share := seen(typeShare, "share-1", projectA, "available", map[string]any{"size_gb": 10})
+		fake := &fakeAdapter{types: []string{typeShare}, steps: stream(share)}
+		syncer := newSyncer(t, db, pipeline, cloud, fake)
+		mustSync(t, syncer, cloud)
+
+		fake.steps = []step{{err: errManilaDown}}
+		if _, err := syncer.Sync(t.Context(), cloud); err == nil {
+			t.Fatal("Sync() error = nil, want the failing run to fail")
+		}
+
+		fake.steps = []step{{panics: true}}
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Error("Sync() returned, want the adapter's panic to reach the caller")
+				}
+			}()
+			_, _ = syncer.Sync(t.Context(), cloud)
+		}()
+
+		// The lock is session-scoped, so a run that ended any of those three ways
+		// has to have given it back before the next one asks.
+		fake.steps = stream(share)
+		if _, err := syncer.Sync(t.Context(), cloud); err != nil {
+			t.Fatalf("Sync() error = %v, want the lock free again", err)
+		}
+	})
+
+	t.Run("records the run and frees the lock when the caller's deadline passes", func(t *testing.T) {
+		const cloud = "os-sync-deadline"
+		blocked := blockingAdapter()
+		syncer := newSyncer(t, db, pipeline, cloud, blocked)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+		defer cancel()
+		res, err := syncer.Sync(ctx, cloud)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Sync() error = %v, want it wrapping %v", err, context.DeadlineExceeded)
+		}
+		// The completion runs on a context of its own, so the row says the run is
+		// over rather than staying at 'running' forever.
+		assertRun(t, db, res, statusFailed)
+
+		free := newSyncer(t, db, pipeline, cloud, &fakeAdapter{types: []string{typeShare}})
+		if _, err := free.Sync(t.Context(), cloud); err != nil {
+			t.Errorf("Sync() error = %v, want the lock free again", err)
+		}
+	})
+
+	t.Run("refuses a cloud the configuration does not name", func(t *testing.T) {
+		syncer := newSyncer(t, db, pipeline, "os-sync-configured", &fakeAdapter{})
+
+		res, err := syncer.Sync(t.Context(), "os-sync-unconfigured")
+
+		if !errors.Is(err, reconciliation.ErrUnknownCloud) {
+			t.Errorf("Sync() error = %v, want %v", err, reconciliation.ErrUnknownCloud)
+		}
+		if res.RunID != "" {
+			t.Errorf("Result = %+v, want the zero one for an unknown cloud", res)
+		}
+	})
+}
+
+// step is one entry of a scripted stream: a resource the platform holds, an
+// error it answers with, or a crash in the middle of the listing.
+type step struct {
+	resource reconciliation.ObservedResource
+	err      error
+	panics   bool
+}
+
+// fakeAdapter is the platform half of these tests. What it yields, in which
+// order, and what it says about the types it enumerates is scripted per
+// subtest, which is what lets one adapter cover a clean inventory, a partial
+// enumeration failure, and a run that never gets going.
+type fakeAdapter struct {
+	steps    []step
+	types    []string
+	typesErr error
+
+	// truncates makes the stream stop after its steps once the context ends,
+	// without yielding an error, which is what a range-over-func selecting on
+	// ctx.Done() does. What it listed is then a partial inventory that says
+	// nothing about the rest of the fleet.
+	truncates bool
+
+	// since is the window the last listing was given, which is what the
+	// incremental-window assertions read.
+	since *time.Time
+
+	// entered is closed when a blocking stream starts and released is what holds
+	// it there, so a test can compete with a run it knows is in flight. Both are
+	// nil for a fake that does not block.
+	entered  chan struct{}
+	released chan struct{}
+}
+
+// blockingAdapter is a fake whose stream stops before its first step until the
+// test releases it or the context ends.
+func blockingAdapter() *fakeAdapter {
+	return &fakeAdapter{
+		types:    []string{typeShare},
+		entered:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+}
+
+func (a *fakeAdapter) Platform() string { return platform }
+
+func (a *fakeAdapter) ResourceTypes(map[string]any) ([]string, error) {
+	if a.typesErr != nil {
+		return nil, a.typesErr
+	}
+	return a.types, nil
+}
+
+func (a *fakeAdapter) ListResources(ctx context.Context, _ map[string]any, since *time.Time,
+) iter.Seq2[reconciliation.ObservedResource, error] {
+	a.since = since
+	return func(yield func(reconciliation.ObservedResource, error) bool) {
+		if a.released != nil {
+			close(a.entered)
+			select {
+			case <-a.released:
+			case <-ctx.Done():
+				yield(reconciliation.ObservedResource{}, ctx.Err())
+				return
+			}
+		}
+		for _, s := range a.steps {
+			if s.panics {
+				panic("the adapter crashed while listing")
+			}
+			if !yield(s.resource, s.err) {
+				return
+			}
+		}
+		if a.truncates {
+			<-ctx.Done()
+		}
+	}
+}
+
+// seen is a live resource as the platform reports it.
+func seen(resourceType, id, project, state string, size map[string]any) reconciliation.ObservedResource {
+	return reconciliation.ObservedResource{
+		ResourceType: resourceType,
+		ResourceID:   id,
+		ProjectID:    project,
+		State:        state,
+		Size:         size,
+	}
+}
+
+// vanished is a resource the platform reports as deleted at ts. It carries the
+// key and the instant only, which is all an adapter knows about a resource that
+// is gone.
+func vanished(resourceType, id string, ts time.Time) reconciliation.ObservedResource {
+	return reconciliation.ObservedResource{ResourceType: resourceType, ResourceID: id, DeletedAt: &ts}
+}
+
+// stream turns resources into the steps a listing that goes well yields.
+func stream(resources ...reconciliation.ObservedResource) []step {
+	steps := make([]step, len(resources))
+	for i, resource := range resources {
+		steps[i] = step{resource: resource}
+	}
+	return steps
+}
+
+// newSyncer builds a Syncer serving one cloud through fake, on a clock that
+// always answers pollTime so that a correction dated at the poll is one a test
+// can name.
+func newSyncer(t *testing.T, db storetest.DB, pipeline *ingest.Pipeline, cloud string,
+	fake *fakeAdapter,
+) *reconciliation.Syncer {
+	t.Helper()
+
+	cfg := reconciliation.Config{Clouds: []reconciliation.CloudConfig{{
+		Cloud: cloud, Platform: platform, Adapter: adapterName,
+	}}}
+	return reconciliation.New(db.Store, pipeline, cfg,
+		map[string]reconciliation.Adapter{adapterName: fake},
+		func() time.Time { return pollTime })
+}
+
+// seedFleet puts resources into the projection by running one sync over them,
+// which is the shortest route to a projection the next run can drift from. It
+// hands back the fake and the syncer so that the subtest scripts what the
+// platform holds next.
+func seedFleet(t *testing.T, db storetest.DB, pipeline *ingest.Pipeline, cloud string,
+	resources ...reconciliation.ObservedResource,
+) (*fakeAdapter, *reconciliation.Syncer) {
+	t.Helper()
+
+	types := map[string]bool{}
+	for _, resource := range resources {
+		types[resource.ResourceType] = true
+	}
+	fake := &fakeAdapter{types: slices.Sorted(maps.Keys(types)), steps: stream(resources...)}
+	syncer := newSyncer(t, db, pipeline, cloud, fake)
+	if res := mustSync(t, syncer, cloud); res.Stats.Created != len(resources) {
+		t.Fatalf("seeding %s created %d resources, want %d", cloud, res.Stats.Created, len(resources))
+	}
+	return fake, syncer
+}
+
+// mustSync runs one sync and fails the test unless it finished clean.
+func mustSync(t *testing.T, syncer *reconciliation.Syncer, cloud string) reconciliation.Result {
+	t.Helper()
+
+	res, err := syncer.Sync(t.Context(), cloud)
+	if err != nil {
+		t.Fatalf("Sync() error = %v, want nil", err)
+	}
+	return res
+}
+
+// tally is the stats of a run that recorded no error.
+func tally(created, updated, deleted int) reconciliation.Stats {
+	return reconciliation.Stats{
+		Created: created, Updated: updated, Deleted: deleted, Errors: []string{},
+	}
+}
+
+// assertStats fails the test unless the run did exactly what want describes.
+func assertStats(t *testing.T, got, want reconciliation.Stats) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("stats = %+v, want %+v", got, want)
+	}
+}
+
+// assertRun fails the test unless the stored run row ended at status carrying
+// the stats the caller was handed. The two are one record: what an operator
+// reads in sync_runs is what the caller of the sync was told.
+func assertRun(t *testing.T, db storetest.DB, res reconciliation.Result, status string) {
+	t.Helper()
+
+	row := runRow(t, db, res.RunID)
+	if row.Status != status {
+		t.Errorf("run status = %q, want %q", row.Status, status)
+	}
+	if !row.CompletedAt.Valid {
+		t.Error("completed at = NULL, want the instant the run ended")
+	}
+
+	var stored reconciliation.Stats
+	if err := json.Unmarshal(row.Stats, &stored); err != nil {
+		t.Fatalf("decoding the stored stats: %v", err)
+	}
+	if !reflect.DeepEqual(stored, res.Stats) {
+		t.Errorf("stored stats = %+v, want the ones the caller got, %+v", stored, res.Stats)
+	}
+
+	// The stored document says "errors": [] rather than null, so that every run
+	// reads the same way whatever it did.
+	var raw map[string]any
+	if err := json.Unmarshal(row.Stats, &raw); err != nil {
+		t.Fatalf("decoding the stored stats: %v", err)
+	}
+	if errs, ok := raw["errors"].([]any); !ok || len(errs) != len(res.Stats.Errors) {
+		t.Errorf("stored errors = %v, want the %d the run recorded, as a list",
+			raw["errors"], len(res.Stats.Errors))
+	}
+}
+
+// runRow reads the sync_runs row of a run back.
+func runRow(t *testing.T, db storetest.DB, runID string) sqlcgen.SyncRun {
+	t.Helper()
+
+	id, err := uuid.Parse(runID)
+	if err != nil {
+		t.Fatalf("parsing the run id %q: %v", runID, err)
+	}
+	row, err := sqlcgen.New(db.Store.Pool()).GetSyncRun(t.Context(), id)
+	if err != nil {
+		t.Fatalf("reading sync run %s: %v", runID, err)
+	}
+	return row
+}
+
+// runsOf is how many sync_runs rows cloud has, which is what a refused sync is
+// measured against.
+func runsOf(t *testing.T, db storetest.DB, cloud string) int {
+	t.Helper()
+
+	var found int
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		`SELECT count(*) FROM sync_runs WHERE cloud = $1`, cloud).Scan(&found); err != nil {
+		t.Fatalf("counting the sync runs of %s: %v", cloud, err)
+	}
+	return found
+}
+
+// correction is a stored synthetic event as the assertions compare it. The
+// instant is kept as text so that a whole batch compares in one DeepEqual.
+type correction struct {
+	eventType    string
+	resourceType string
+	resourceID   string
+	projectID    string
+	at           string
+	state        string
+	size         map[string]any
+}
+
+// corrections is every synthetic event stored for cloud, ordered by the
+// resource it belongs to and the instant it carries.
+func corrections(t *testing.T, db storetest.DB, cloud string) []correction {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT event_type, resource_type, resource_id, project_id, timestamp, payload
+		 FROM events
+		 WHERE cloud = $1 AND source = 'reconciliation'
+		 ORDER BY resource_type, resource_id, timestamp, event_type`, cloud)
+	if err != nil {
+		t.Fatalf("reading the corrections of %s: %v", cloud, err)
+	}
+	defer rows.Close()
+
+	var found []correction
+	for rows.Next() {
+		var (
+			got     correction
+			ts      time.Time
+			payload []byte
+		)
+		if err := rows.Scan(&got.eventType, &got.resourceType, &got.resourceID,
+			&got.projectID, &ts, &payload); err != nil {
+			t.Fatalf("scanning a correction: %v", err)
+		}
+
+		var envelope event.PayloadEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			t.Fatalf("decoding the payload of a correction: %v", err)
+		}
+		if envelope.State != nil {
+			got.state = *envelope.State
+		}
+		got.at, got.size = rfc(ts), envelope.Size
+		found = append(found, got)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the corrections of %s: %v", cloud, err)
+	}
+	return found
+}
+
+// assertCorrections fails the test unless cloud holds exactly want.
+func assertCorrections(t *testing.T, db storetest.DB, cloud string, want []correction) {
+	t.Helper()
+
+	if got := corrections(t, db, cloud); !reflect.DeepEqual(got, want) {
+		t.Errorf("stored corrections = %+v, want %+v", got, want)
+	}
+}
+
+// assertCorrection fails the test unless exactly one correction of eventType is
+// stored for cloud, and it is want. It is what a subtest that seeded its fleet
+// through an earlier run asserts with: the creates of the seeding run are
+// stored as well, and only the event type under test is the subject.
+func assertCorrection(t *testing.T, db storetest.DB, cloud, eventType string, want correction) {
+	t.Helper()
+
+	var found []correction
+	for _, got := range corrections(t, db, cloud) {
+		if got.eventType == eventType {
+			found = append(found, got)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("stored %s corrections = %+v, want exactly one", eventType, found)
+	}
+	if !reflect.DeepEqual(found[0], want) {
+		t.Errorf("stored correction = %+v, want %+v", found[0], want)
+	}
+}
+
+// storedEventIDs is the id of every synthetic event stored for cloud, sorted.
+func storedEventIDs(t *testing.T, db storetest.DB, cloud string) []string {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT event_id FROM events WHERE cloud = $1 AND source = 'reconciliation'
+		 ORDER BY event_id`, cloud)
+	if err != nil {
+		t.Fatalf("reading the event ids of %s: %v", cloud, err)
+	}
+	defer rows.Close()
+
+	var found []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scanning an event id: %v", err)
+		}
+		found = append(found, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the event ids of %s: %v", cloud, err)
+	}
+	return found
+}
+
+// storedItems is every synthetic event of cloud rendered as the batch items a
+// caller re-submitting the run would send.
+func storedItems(t *testing.T, db storetest.DB, cloud string) []json.RawMessage {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT event_id, timestamp, event_type, platform, cloud, resource_type, resource_id,
+		        project_id, payload
+		 FROM events
+		 WHERE cloud = $1 AND source = 'reconciliation'
+		 ORDER BY event_id`, cloud)
+	if err != nil {
+		t.Fatalf("reading the corrections of %s: %v", cloud, err)
+	}
+	defer rows.Close()
+
+	var found []json.RawMessage
+	for rows.Next() {
+		var (
+			e       event.Event
+			payload []byte
+		)
+		if err := rows.Scan(&e.EventID, &e.Timestamp, &e.EventType, &e.Platform, &e.Cloud,
+			&e.ResourceType, &e.ResourceID, &e.ProjectID, &payload); err != nil {
+			t.Fatalf("scanning a correction: %v", err)
+		}
+		if err := json.Unmarshal(payload, &e.Payload); err != nil {
+			t.Fatalf("decoding the payload of correction %s: %v", e.EventID, err)
+		}
+		e.Source = event.SourceReconciliation
+
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshaling correction %s: %v", e.EventID, err)
+		}
+		found = append(found, raw)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the corrections of %s: %v", cloud, err)
+	}
+	return found
+}
+
+// projectionRow is a current_resources row as the assertions compare it. The
+// instants are kept as text, empty for a column holding NULL, so that a whole
+// snapshot compares in one DeepEqual.
+type projectionRow struct {
+	resourceType string
+	resourceID   string
+	projectID    string
+	state        string
+	size         map[string]any
+	createdAt    string
+	deletedAt    string
+}
+
+// rows is the projection of cloud, ordered by resource.
+func rows(t *testing.T, db storetest.DB, cloud string) []projectionRow {
+	t.Helper()
+
+	found, err := db.Store.Pool().Query(t.Context(),
+		`SELECT resource_type, resource_id, project_id, state, size, created_at, deleted_at
+		 FROM current_resources
+		 WHERE cloud = $1
+		 ORDER BY resource_type, resource_id`, cloud)
+	if err != nil {
+		t.Fatalf("reading the projection rows of %s: %v", cloud, err)
+	}
+	defer found.Close()
+
+	var snapshot []projectionRow
+	for found.Next() {
+		var (
+			row                  projectionRow
+			size                 []byte
+			createdAt, deletedAt pgtype.Timestamptz
+		)
+		if err := found.Scan(&row.resourceType, &row.resourceID, &row.projectID, &row.state,
+			&size, &createdAt, &deletedAt); err != nil {
+			t.Fatalf("scanning a projection row: %v", err)
+		}
+		if err := json.Unmarshal(size, &row.size); err != nil {
+			t.Fatalf("decoding the size of %s: %v", row.resourceID, err)
+		}
+		if createdAt.Valid {
+			row.createdAt = rfc(createdAt.Time)
+		}
+		if deletedAt.Valid {
+			row.deletedAt = rfc(deletedAt.Time)
+		}
+		snapshot = append(snapshot, row)
+	}
+	if err := found.Err(); err != nil {
+		t.Fatalf("reading the projection rows of %s: %v", cloud, err)
+	}
+	return snapshot
+}
+
+// assertRows fails the test unless the projection of cloud is exactly want.
+func assertRows(t *testing.T, db storetest.DB, cloud string, want []projectionRow) {
+	t.Helper()
+
+	if got := rows(t, db, cloud); !reflect.DeepEqual(got, want) {
+		t.Errorf("projection rows = %+v, want %+v", got, want)
+	}
+}
+
+// rowOf is the projection row of one resource. A subtest asking for a row it
+// expects to exist gets a failure rather than a zero value when it does not.
+func rowOf(t *testing.T, db storetest.DB, cloud, resourceType, resourceID string) projectionRow {
+	t.Helper()
+
+	for _, row := range rows(t, db, cloud) {
+		if row.resourceType == resourceType && row.resourceID == resourceID {
+			return row
+		}
+	}
+	t.Fatalf("no projection row for %s %s in %s, want one", resourceType, resourceID, cloud)
+	return projectionRow{}
+}
+
+// registerSizeSchema registers raw as the size schema of (platform,
+// resourceType), which is what makes the strict pipeline measure a reported
+// size against it.
+func registerSizeSchema(t *testing.T, db storetest.DB, resourceType, raw string) {
+	t.Helper()
+
+	if _, err := sqlcgen.New(db.Store.Pool()).UpsertResourceType(t.Context(),
+		sqlcgen.UpsertResourceTypeParams{
+			Platform: platform, ResourceType: resourceType, SizeSchema: []byte(raw),
+		}); err != nil {
+		t.Fatalf("registering the size schema of %s: %v", resourceType, err)
+	}
+}
+
+// rfc renders an instant the way the assertions compare instants.
+func rfc(ts time.Time) string {
+	return ts.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/reporting/reconciliation/reconciliation_test.go
+++ b/internal/reporting/reconciliation/reconciliation_test.go
@@ -1,0 +1,47 @@
+package reconciliation_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+)
+
+// errCinderDown stands in for whatever a platform client returns when one of
+// its services is unreachable.
+var errCinderDown = errors.New("connection refused")
+
+func TestEnumerationError(t *testing.T) {
+	err := error(&reconciliation.EnumerationError{
+		ResourceType: "storage.volume",
+		Err:          errCinderDown,
+	})
+
+	t.Run("the message names the type that stayed incomplete", func(t *testing.T) {
+		for _, want := range []string{"storage.volume", "connection refused"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Error() = %q, want it to name %q", err, want)
+			}
+		}
+	})
+
+	t.Run("the platform error stays matchable", func(t *testing.T) {
+		if !errors.Is(err, errCinderDown) {
+			t.Errorf("errors.Is(%v, errCinderDown) = false, want true", err)
+		}
+	})
+
+	// The sync tells this error apart from every other one to decide whether to
+	// skip the type or abort the run, so it has to survive being wrapped by the
+	// layers between the adapter and the diff.
+	t.Run("a wrapped enumeration error is still recognizable", func(t *testing.T) {
+		var enumErr *reconciliation.EnumerationError
+		if !errors.As(errors.Join(errors.New("collecting the inventory"), err), &enumErr) {
+			t.Fatal("errors.As() = false, want true")
+		}
+		if enumErr.ResourceType != "storage.volume" {
+			t.Errorf("ResourceType = %q, want %q", enumErr.ResourceType, "storage.volume")
+		}
+	})
+}

--- a/internal/reporting/reconciliation/sync.go
+++ b/internal/reporting/reconciliation/sync.go
@@ -1,0 +1,648 @@
+package reconciliation
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/ids"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/store"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// The statuses a finished run leaves behind. A row holding neither is a run
+// that never finished, which is what the column's default 'running' says.
+const (
+	statusCompleted = "completed"
+	statusFailed    = "failed"
+)
+
+// stateDeleted is the state the projection row of a deleted resource holds. The
+// diff reads it to tell a resource that is gone from one the platform still has.
+const stateDeleted = "deleted"
+
+// The kinds a correction comes in. Each is the last segment of the event type
+// and the last component of the synthetic event id, so the id of a correction
+// and the effect it has cannot drift apart.
+const (
+	kindCreate = "create"
+	kindUpdate = "update"
+	kindDelete = "delete"
+)
+
+// correctionBatchSize is how many corrections one transaction carries. The
+// ingest pipeline takes a transaction-scoped advisory lock per resource, so a
+// batch is also how many of the shared lock table's slots the run holds at
+// once, and the first sync of a fleet emits one correction per resource it
+// holds. projection.Rebuild bounds its replay at the same size for the same
+// reason.
+const correctionBatchSize = 100
+
+// maxRecordedErrors is how many reasons one run keeps in Stats.Errors. Nothing
+// bounds how many an adapter can produce — one per unreadable observation and
+// one per refused correction — and the slice is marshaled into a jsonb column,
+// answered to the caller, and joined into one error string.
+const maxRecordedErrors = 100
+
+// maxErrorBytes is how much of one reason is kept. Nothing bounds how long one
+// is either: an HTTP client hands the response body back verbatim, so a
+// platform answering a listing with a multi-megabyte error page writes that page
+// into the run's row and its log line. The head of it is what an operator works
+// from, the way the dead letter next door keeps the head of a refused item.
+const maxErrorBytes = 4 << 10
+
+// completionBudget bounds the two writes a run ends with. They run detached
+// from the caller's context, which strips its deadline along with its
+// cancellation: without a bound of their own they would wait on a stalled pool
+// forever, and the run would never reach the unlock behind them, leaving the
+// cloud's advisory lock held for the life of the process.
+const completionBudget = 10 * time.Second
+
+// Stats is what one run did. It is stored as the sync_runs stats column and
+// returned to the caller unchanged, so the row and the answer say the same
+// thing.
+type Stats struct {
+	// Created, Updated, and Deleted count the corrections a batch the database
+	// committed carried, one per synthetic event. A batch that was rolled back is
+	// in none of them: the row would otherwise report corrections that never
+	// happened.
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Deleted int `json:"deleted"`
+	// Errors is what went wrong: a type the adapter could not enumerate, an
+	// observation it reported incompletely, a correction the pipeline refused,
+	// or the error that ended the run. A run with an error here is 'failed'. It
+	// carries the first maxRecordedErrors reasons only, because nothing bounds
+	// how many an adapter can produce.
+	Errors []string `json:"errors"`
+	// ErrorCount is how many reasons the run recorded, the ones past the cap
+	// included. It is what says that Errors is a sample rather than the whole
+	// record.
+	ErrorCount int `json:"error_count"`
+}
+
+// Result is what a sync run reports back.
+type Result struct {
+	// RunID is the id of the sync_runs row. It is also what the run's synthetic
+	// event ids are derived from, which is what makes them stable per run.
+	RunID string
+	// Stats is the tally of the run, the same one the row carries.
+	Stats Stats
+}
+
+// Syncer reconciles the clouds it was configured with. Its zero value is not
+// usable; New builds one. It is safe for concurrent use, and two runs of one
+// cloud are kept apart by an advisory lock rather than by a mutex, so that the
+// guarantee holds across replicas as well.
+type Syncer struct {
+	db       *store.Store
+	pipeline *ingest.Pipeline
+	clouds   map[string]CloudConfig
+	adapters map[string]Adapter
+	now      func() time.Time
+}
+
+// New builds a Syncer over the clouds cfg names and the adapters that observe
+// them, indexing the clouds by name so that a sync resolves its configuration
+// without walking the list.
+//
+// now is where every poll-time timestamp comes from. It is injected rather than
+// read from the clock, so that a test can state which instant a correction the
+// platform gave no timestamp for is dated at.
+func New(db *store.Store, pipeline *ingest.Pipeline, cfg Config, adapters map[string]Adapter,
+	now func() time.Time,
+) *Syncer {
+	clouds := make(map[string]CloudConfig, len(cfg.Clouds))
+	for _, cloud := range cfg.Clouds {
+		clouds[cloud.Cloud] = cloud
+	}
+	return &Syncer{db: db, pipeline: pipeline, clouds: clouds, adapters: adapters, now: now}
+}
+
+// Sync reconciles one cloud: it asks the adapter what the platform holds, diffs
+// that against the projection, and ingests the difference as synthetic events
+// through the ordinary pipeline.
+//
+// A run that recorded anything in Stats.Errors is 'failed' in sync_runs and
+// comes back with a non-nil error, whether that error ended the run or only
+// spoiled part of it. The Result is returned in either case, so that a caller
+// can report the run id and the tally of a run that went badly. What such a run
+// did observe is kept: an enumeration failure is missing information, and the
+// corrections it did not keep the run from are facts either way.
+func (s *Syncer) Sync(ctx context.Context, cloud string) (Result, error) {
+	entry, ok := s.clouds[cloud]
+	if !ok {
+		return Result{}, fmt.Errorf("syncing %s: %w", cloud, ErrUnknownCloud)
+	}
+	adapter, ok := s.adapters[entry.Adapter]
+	if !ok {
+		return Result{}, fmt.Errorf("syncing %s: no adapter named %q is registered", cloud, entry.Adapter)
+	}
+
+	// The lock lives for the session rather than for a transaction, so the run
+	// holds a connection of its own for as long as it works.
+	conn, err := s.db.Pool().Acquire(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("acquiring a connection for the sync of %s: %w", cloud, err)
+	}
+	locked, err := sqlcgen.New(conn).TrySyncLock(ctx, cloud)
+	if err != nil {
+		conn.Release()
+		return Result{}, fmt.Errorf("locking the sync of %s: %w", cloud, err)
+	}
+	if !locked {
+		conn.Release()
+		return Result{}, fmt.Errorf("syncing %s: %w", cloud, ErrAlreadyRunning)
+	}
+	defer release(ctx, conn, cloud)
+
+	q := sqlcgen.New(s.db.Pool())
+	// The run row is written outside a transaction, so that a run in flight can
+	// be seen at 'running' while it works rather than appearing when it ends.
+	id, err := q.InsertSyncRun(ctx, cloud)
+	if err != nil {
+		return Result{}, fmt.Errorf("recording the sync run of %s: %w", cloud, err)
+	}
+	runID := id.String()
+	// The empty slice rather than a nil one: the stored stats say "errors": []
+	// for a clean run, which is a document an operator can read the same way
+	// whatever the run did.
+	stats := Stats{Errors: []string{}}
+
+	// Once the row exists, no path may leave it at 'running'. Every error return
+	// from here on goes through abort, which records the error in the row and
+	// hands the caller the run id and the tally alongside it.
+	abort := func(err error) (Result, error) {
+		recordError(&stats, err.Error())
+		if cerr := s.complete(ctx, id, stats); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+		return Result{RunID: runID, Stats: stats}, err
+	}
+
+	since, err := lastCompleted(ctx, q, cloud)
+	if err != nil {
+		return abort(err)
+	}
+
+	observed, incomplete, err := collect(ctx, adapter, entry.AdapterConfig, since, &stats)
+	if err != nil {
+		return abort(fmt.Errorf("listing the resources of %s: %w", cloud, err))
+	}
+
+	types, err := adapter.ResourceTypes(entry.AdapterConfig)
+	if err != nil {
+		return abort(fmt.Errorf("reading the resource types of %s: %w", cloud, err))
+	}
+	// Only a type the run reached the end of can say that a row it did not name
+	// is gone. The set is the positive one for that reason: a type that holds
+	// nothing is still a type that was enumerated.
+	//
+	// An observation the adapter reported without naming a type is missing
+	// information about the inventory as a whole rather than about one type of
+	// it: there is no type to hold back, so no type may conclude that a row it
+	// did not name is gone. collect records such an item under the empty key,
+	// which screen refuses as a resource type, and the whole pass steps aside.
+	enumerated := make(map[string]bool, len(types))
+	if !incomplete[""] {
+		for _, resourceType := range types {
+			if !incomplete[resourceType] {
+				enumerated[resourceType] = true
+			}
+		}
+	}
+
+	rows, err := q.ListCurrentResourcesByCloud(ctx, cloud)
+	if err != nil {
+		return abort(fmt.Errorf("loading the projection of %s: %w", cloud, err))
+	}
+
+	events, err := s.diff(runID, entry, observed, rows, enumerated)
+	if err != nil {
+		return abort(err)
+	}
+	// The corrections go in one transaction per batch rather than one for the
+	// whole run, the way projection.Rebuild replays in batches and for the same
+	// reason: the pipeline takes an advisory lock per resource that the
+	// transaction holds until it commits, and the first sync of a fleet emits a
+	// correction per resource. A run that fails partway keeps the batches it
+	// committed, so the next one has less to do rather than exactly as much.
+	for batch := range slices.Chunk(events, correctionBatchSize) {
+		items := make([]json.RawMessage, len(batch))
+		for i, e := range batch {
+			raw, err := json.Marshal(e)
+			if err != nil {
+				return abort(fmt.Errorf("marshaling the correction %s: %w", e.EventID, err))
+			}
+			items[i] = raw
+		}
+
+		var outcome ingest.Outcome
+		if err := s.db.WithTx(ctx, func(tx pgx.Tx) error {
+			var err error
+			outcome, err = s.pipeline.Ingest(ctx, tx, items, event.SourceReconciliation, nil)
+			return err
+		}); err != nil {
+			return abort(fmt.Errorf("ingesting the corrections of %s: %w", cloud, err))
+		}
+
+		// Counted once the batch is committed rather than once it is built: a
+		// batch the database rolled back wrote nothing, and a row claiming those
+		// corrections is a record of a fleet that never went through them.
+		for _, e := range batch {
+			switch event.Categorize(e.EventType) {
+			case event.CategoryCreate:
+				stats.Created++
+			case event.CategoryUpdate:
+				stats.Updated++
+			case event.CategoryDelete:
+				stats.Deleted++
+			}
+		}
+		// A refused correction is the run's problem rather than the batch's: it
+		// was dead-lettered, the corrections around it landed, and the reason is
+		// what an operator works from.
+		for _, rejected := range outcome.Rejected {
+			recordError(&stats,
+				fmt.Sprintf("event %s rejected: %s", rejected.EventID, rejected.Reason))
+		}
+	}
+
+	result := Result{RunID: runID, Stats: stats}
+	if err := s.complete(ctx, id, stats); err != nil {
+		return result, err
+	}
+	if stats.ErrorCount > 0 {
+		return result, fmt.Errorf("the sync of %s did not finish clean: %s",
+			cloud, strings.Join(stats.Errors, "; "))
+	}
+	return result, nil
+}
+
+// complete writes the run's final row, deriving the status from the errors the
+// run recorded so that the two cannot disagree.
+//
+// The write runs on a context detached from the caller's. A run ends because
+// its deadline passed as readily as because it finished, and a completion that
+// the expired context refuses would leave the row at 'running' for a run that
+// is over. It gets a deadline of its own, because the detached context has
+// none: this write has to acquire a connection while the run still holds one,
+// and waiting for it without a bound would hold the run's advisory lock forever.
+func (s *Syncer) complete(ctx context.Context, id uuid.UUID, stats Stats) error {
+	status := statusCompleted
+	if stats.ErrorCount > 0 {
+		status = statusFailed
+	}
+	raw, err := json.Marshal(stats)
+	if err != nil {
+		return fmt.Errorf("marshaling the stats of sync run %s: %w", id, err)
+	}
+
+	done, cancel := context.WithTimeout(context.WithoutCancel(ctx), completionBudget)
+	defer cancel()
+	if err := sqlcgen.New(s.db.Pool()).CompleteSyncRun(done,
+		sqlcgen.CompleteSyncRunParams{ID: id, Status: status, Stats: raw},
+	); err != nil {
+		return fmt.Errorf("completing sync run %s: %w", id, err)
+	}
+	return nil
+}
+
+// release gives the run's connection back after unlocking the cloud on it. It
+// covers the successful return, the error return, and a panic alike, because a
+// lock nobody releases keeps every later run of the cloud out.
+//
+// The unlock runs on a detached context for the same reason the completion
+// does: a run whose context expired still holds the lock, and an unlock the
+// dead context refuses would send the session back into the pool holding it. A
+// session that could not be unlocked is therefore closed rather than reused,
+// which is what makes the database drop the session-scoped lock with it. The
+// detached context is bounded, because an unlock that waits forever on a
+// database that stopped answering never reaches that close either.
+func release(ctx context.Context, conn *pgxpool.Conn, cloud string) {
+	detached, cancel := context.WithTimeout(context.WithoutCancel(ctx), completionBudget)
+	defer cancel()
+	if err := sqlcgen.New(conn).UnlockSync(detached, cloud); err != nil {
+		_ = conn.Conn().Close(detached)
+	}
+	conn.Release()
+}
+
+// lastCompleted is where an incremental run starts: the started_at of the last
+// run of this cloud that completed. A cloud that never completed one gets no
+// bound, which is what makes its first run a full one.
+//
+// A failed run does not move the bound. What it could not enumerate is exactly
+// what it may have missed, so the next run walks that window again.
+func lastCompleted(ctx context.Context, q *sqlcgen.Queries, cloud string) (*time.Time, error) {
+	startedAt, err := q.GetLastCompletedSyncStartedAt(ctx, cloud)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading the last completed sync of %s: %w", cloud, err)
+	}
+	since := startedAt.Time
+	return &since, nil
+}
+
+// collect drains the adapter's stream into the observations the diff works on.
+// A later report of a resource replaces an earlier one, so an adapter that
+// lists a resource twice states its final word rather than two facts.
+//
+// The second result is the set of resource types that stayed incomplete, which
+// the missed-delete pass leaves alone. An error the stream yields is either an
+// EnumerationError, which costs its type and nothing else, or an error about
+// the run as a whole, which ends it: a platform that stopped answering says
+// nothing about what it holds, and reading that as an empty inventory would
+// delete a fleet.
+func collect(ctx context.Context, adapter Adapter, cfg map[string]any, since *time.Time,
+	stats *Stats,
+) (map[resourceKey]ObservedResource, map[string]bool, error) {
+	observed := map[resourceKey]ObservedResource{}
+	incomplete := map[string]bool{}
+
+	for obs, err := range adapter.ListResources(ctx, cfg, since) {
+		if err != nil {
+			var enumErr *EnumerationError
+			if !errors.As(err, &enumErr) {
+				return nil, nil, err
+			}
+			incomplete[enumErr.ResourceType] = true
+			recordError(stats, err.Error())
+			continue
+		}
+		if reason := screen(obs); reason != "" {
+			// The type counts as incomplete as well: an item this run could not
+			// read is an item it did not see, and the row it would have matched
+			// must not be deleted for an absence the adapter caused. An item that
+			// names no type is recorded under the empty key, which holds every
+			// type back: it is missing information about the inventory as a whole
+			// rather than about one type of it.
+			recordError(stats, reason)
+			incomplete[obs.ResourceType] = true
+			continue
+		}
+		observed[resourceKey{ResourceType: obs.ResourceType, ResourceID: obs.ResourceID}] = obs
+	}
+	// A stream that stopped because the run's deadline passed enumerated nothing
+	// conclusive. An adapter that returns on a cancelled context without yielding
+	// an error would otherwise hand back a partial inventory that reads as a
+	// complete one, and every resource it did not reach as a missed delete.
+	if err := ctx.Err(); err != nil {
+		return nil, nil, fmt.Errorf("the resource stream ended early: %w", err)
+	}
+	return observed, incomplete, nil
+}
+
+// recordError keeps one reason the run has to report, and counts it either way.
+// Past the cap only the count grows: the entries are stored, answered, and
+// joined into one string, and nothing bounds how many an adapter produces.
+//
+// A platform's error text is bytes this service did not choose — an HTTP client
+// hands the response body back verbatim — so a reason is bounded in length as
+// well as in number. PostgreSQL holds no NUL in a jsonb document either, so an
+// unscreened one would fail the write that records why the run ended and leave
+// the row at 'running' for a run that is over. It is spelled out rather than
+// dropped, so what the platform sent stays legible; the encoder already
+// replaces every other byte that is not UTF-8.
+func recordError(stats *Stats, msg string) {
+	stats.ErrorCount++
+	if len(stats.Errors) >= maxRecordedErrors {
+		return
+	}
+	if len(msg) > maxErrorBytes {
+		// The cut can fall inside a character the platform sent. The encoder
+		// replaces what is left of it, the way it replaces every other byte that is
+		// not UTF-8.
+		msg = msg[:maxErrorBytes] + "… (truncated)"
+	}
+	stats.Errors = append(stats.Errors, strings.ReplaceAll(msg, "\x00", `\x00`))
+}
+
+// screen reports why an observation cannot be diffed, and the empty string for
+// one that can. What it refuses is an adapter bug rather than a fact about the
+// platform: a correction that names no resource, or hands a live resource to no
+// project, is worse than the drift it was meant to fix.
+func screen(obs ObservedResource) string {
+	if obs.ResourceType == "" {
+		return fmt.Sprintf("the adapter reported the resource %q without a resource type", obs.ResourceID)
+	}
+	if obs.ResourceID == "" {
+		return fmt.Sprintf("the adapter reported a %s without a resource id", obs.ResourceType)
+	}
+	// A deleted resource is reported by its key alone: what state it was in and
+	// who owned it is what the projection row already holds.
+	if obs.DeletedAt != nil {
+		return ""
+	}
+	if obs.State == "" {
+		return fmt.Sprintf("the adapter reported the live %s %s without a state",
+			obs.ResourceType, obs.ResourceID)
+	}
+	if obs.ProjectID == "" {
+		return fmt.Sprintf("the adapter reported the live %s %s without a project id",
+			obs.ResourceType, obs.ResourceID)
+	}
+	return ""
+}
+
+// resourceKey identifies one resource within a cloud. Both sides of the diff
+// are keyed by it, which is how an observation and the projection row it
+// belongs to meet.
+type resourceKey struct {
+	ResourceType string
+	ResourceID   string
+}
+
+// diff is the correction the observation implies for the projection: what the
+// platform holds that the projection does not, what it holds differently, and
+// what it no longer holds.
+//
+// enumerated is the set of resource types the run reached the end of. A row of
+// any other type is left alone, however absent it was from the observation.
+func (s *Syncer) diff(runID string, entry CloudConfig, observed map[resourceKey]ObservedResource,
+	rows []sqlcgen.ListCurrentResourcesByCloudRow, enumerated map[string]bool,
+) ([]event.Event, error) {
+	stored := make(map[resourceKey]sqlcgen.ListCurrentResourcesByCloudRow, len(rows))
+	for _, row := range rows {
+		stored[resourceKey{ResourceType: row.ResourceType, ResourceID: row.ResourceID}] = row
+	}
+
+	var events []event.Event
+	// Both passes walk their keys in one order, so that a run over one
+	// observation always emits the same batch in the same sequence.
+	for _, key := range slices.SortedFunc(maps.Keys(observed), compareResourceKey) {
+		obs := observed[key]
+		row, known := stored[key]
+		state := obs.State
+
+		if obs.DeletedAt != nil {
+			// A deletion the projection already holds, or one of a resource it
+			// never held at all, corrects nothing. The owner is the row's: the
+			// resource is gone, so who it belonged to is settled history.
+			if known && row.State != stateDeleted {
+				events = append(events,
+					syntheticEvent(runID, entry, key, kindDelete,
+						correctedAt(*obs.DeletedAt, row), row.ProjectID))
+			}
+			continue
+		}
+
+		if !known || row.State == stateDeleted {
+			// A resource the projection does not hold live starts a life here,
+			// whether the run missed its creation or the resource has come back.
+			// The platform's own instant is used when it exposes one; poll time is
+			// the concept's accepted approximation when it does not.
+			//
+			// Only a resource the projection never held may be dated at that
+			// instant. One whose row already holds a delete cannot be revived by a
+			// create ordered before it: the fold takes the state from the newest
+			// lifecycle event, which is then still that delete, so the correction
+			// would land, count, and change nothing, and every later run would
+			// write another one.
+			ts := s.now().UTC()
+			if obs.CreatedAt != nil && !known {
+				ts = *obs.CreatedAt
+			}
+			if known {
+				ts = correctedAt(ts, row)
+			}
+			// A create reports the size the resource starts with. An adapter that
+			// reported none leaves the resource sizeless rather than the event
+			// invalid, so the correction still lands.
+			size := obs.Size
+			if size == nil {
+				size = map[string]any{}
+			}
+			create := syntheticEvent(runID, entry, key, kindCreate, ts, obs.ProjectID)
+			create.Payload = event.PayloadEnvelope{State: &state, Size: size}
+			events = append(events, create)
+			continue
+		}
+
+		same, err := sameSize(obs.Size, row.Size)
+		if err != nil {
+			return nil, fmt.Errorf("comparing the size of %s %s: %w",
+				key.ResourceType, key.ResourceID, err)
+		}
+		if row.State == obs.State && row.ProjectID == obs.ProjectID && same {
+			continue
+		}
+		// A resource that changed hands drifted like one that changed size, so
+		// the correction names the owner the platform reports.
+		update := syntheticEvent(runID, entry, key, kindUpdate,
+			correctedAt(s.now().UTC(), row), obs.ProjectID)
+		// A size the adapter did not report is a size that did not change, and an
+		// event without one leaves the projection the size it holds.
+		update.Payload = event.PayloadEnvelope{State: &state, Size: obs.Size}
+		events = append(events, update)
+	}
+
+	// What the projection holds live and the observation did not name at all. A
+	// resource the adapter reported as deleted is not one of those: it already
+	// got its correction at the instant the platform gave, and a second one
+	// would carry the same synthetic id at poll time and bury that instant.
+	for _, key := range slices.SortedFunc(maps.Keys(stored), compareResourceKey) {
+		row := stored[key]
+		if row.State == stateDeleted || !enumerated[key.ResourceType] {
+			continue
+		}
+		if _, seen := observed[key]; seen {
+			continue
+		}
+		events = append(events,
+			syntheticEvent(runID, entry, key, kindDelete, correctedAt(s.now().UTC(), row), row.ProjectID))
+	}
+	return events, nil
+}
+
+// correctedAt is when a correction of row is dated. It starts from the instant
+// the platform gave where the platform gave one and from poll time where it did
+// not, and neither is a guarantee of falling past what the row already holds: a
+// platform whose clock runs ahead of this one dates its events in this service's
+// future, and one that reports a deletion of a resource this run only just
+// discovered dates it before the poll the discovery was approximated at.
+//
+// A correction the fold does not order last decides nothing. Both fold paths
+// take a resource's state from its newest event, so a correction slotted
+// underneath one would land, count, and change nothing, and every later run
+// would mint another event id for the same drift. One that would fall there is
+// dated one instant past the row's newest event instead, which is the resolution
+// the column holds.
+func correctedAt(ts time.Time, row sqlcgen.ListCurrentResourcesByCloudRow) time.Time {
+	if ts.Before(row.LastEventAt.Time) {
+		return row.LastEventAt.Time.Add(time.Microsecond).UTC()
+	}
+	return ts
+}
+
+// syntheticEvent is the shell every correction shares: the id the run derives
+// for it, the coordinates of the cloud it belongs to, and the source that marks
+// it as this framework's output rather than a collector's.
+//
+// A delete carries no payload. The core forces the state of a deleted resource
+// itself, and a size is not something a resource that is gone reports.
+func syntheticEvent(runID string, entry CloudConfig, key resourceKey, kind string,
+	ts time.Time, projectID string,
+) event.Event {
+	return event.Event{
+		EventID:      ids.SyntheticEventID(runID, entry.Cloud, key.ResourceType, key.ResourceID, kind),
+		Timestamp:    ts,
+		EventType:    "sync." + kind,
+		Platform:     entry.Platform,
+		Cloud:        entry.Cloud,
+		ResourceType: key.ResourceType,
+		ResourceID:   key.ResourceID,
+		ProjectID:    projectID,
+		Source:       event.SourceReconciliation,
+	}
+}
+
+// sameSize reports whether the observed size says what the projection row
+// already holds. The comparison runs over the decoded documents rather than
+// over their bytes, so a size an adapter built from an int and the JSON number
+// the database returns for it are one size rather than drift.
+//
+// An adapter that reported no size reported no evidence: that reads as
+// unchanged, never as a size that became empty.
+func sameSize(observed map[string]any, stored []byte) (bool, error) {
+	if observed == nil {
+		return true, nil
+	}
+
+	raw, err := json.Marshal(observed)
+	if err != nil {
+		return false, fmt.Errorf("marshaling the observed size: %w", err)
+	}
+	var reported, held any
+	if err := json.Unmarshal(raw, &reported); err != nil {
+		return false, fmt.Errorf("decoding the observed size: %w", err)
+	}
+	if err := json.Unmarshal(stored, &held); err != nil {
+		return false, fmt.Errorf("decoding the stored size: %w", err)
+	}
+	return reflect.DeepEqual(reported, held), nil
+}
+
+// compareResourceKey orders two keys byte-wise over their two fields, which is
+// the order the corrections of one run are emitted in.
+func compareResourceKey(a, b resourceKey) int {
+	return cmp.Or(
+		strings.Compare(a.ResourceType, b.ResourceType),
+		strings.Compare(a.ResourceID, b.ResourceID),
+	)
+}

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -343,3 +343,52 @@ ORDER BY source_id, created_at, id;
 -- cannot each pass the cycle walk and leave a cycle behind.
 -- name: LockAttributingRelations :exec
 SELECT pg_advisory_xact_lock(hashtextextended('project_relations:attributing', 0));
+
+-- The run row is written before the adapter is called, so that a run in flight
+-- can be seen while it works: status defaults to 'running' in the schema, and
+-- the row is left at that value until the run finishes.
+-- name: InsertSyncRun :one
+INSERT INTO sync_runs (cloud)
+VALUES ($1)
+RETURNING id;
+
+-- name: CompleteSyncRun :exec
+UPDATE sync_runs
+SET status = $2, stats = $3, completed_at = now()
+WHERE id = $1;
+
+-- Reads a finished run back, for the tests that compare the stored row against
+-- the response the sync returned.
+-- name: GetSyncRun :one
+SELECT id, cloud, started_at, completed_at, status, stats
+FROM sync_runs
+WHERE id = $1;
+
+-- Where an incremental sync starts. The bound is the previous run's started_at
+-- rather than its completed_at, so that the window overlaps that run and a
+-- change made while it was working cannot fall between the two.
+-- name: GetLastCompletedSyncStartedAt :one
+SELECT started_at
+FROM sync_runs
+WHERE cloud = $1 AND status = 'completed'
+ORDER BY started_at DESC
+LIMIT 1;
+
+-- The stored side of the reconciliation diff, in the six columns the diff
+-- reads. Deleted resources are part of the answer: one the adapter reports
+-- again has come back, and telling that apart from a first sighting needs the
+-- row. last_event_at is what a correction has to be dated past to reach the
+-- row at all: one the fold orders before it replays the history instead.
+-- name: ListCurrentResourcesByCloud :many
+SELECT resource_type, resource_id, project_id, state, size, last_event_at
+FROM current_resources
+WHERE cloud = $1;
+
+-- Keeps two syncs of one cloud from running at once. The lock is held for the
+-- session rather than for the transaction, as LockResource is, because a run
+-- spans several transactions.
+-- name: TrySyncLock :one
+SELECT pg_try_advisory_lock(hashtextextended('sync:' || $1::text, 0));
+
+-- name: UnlockSync :exec
+SELECT pg_advisory_unlock(hashtextextended('sync:' || $1::text, 0));

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -34,6 +34,23 @@ func (q *Queries) CloseProjectRelation(ctx context.Context, arg CloseProjectRela
 	return result.RowsAffected(), nil
 }
 
+const completeSyncRun = `-- name: CompleteSyncRun :exec
+UPDATE sync_runs
+SET status = $2, stats = $3, completed_at = now()
+WHERE id = $1
+`
+
+type CompleteSyncRunParams struct {
+	ID     uuid.UUID
+	Status string
+	Stats  []byte
+}
+
+func (q *Queries) CompleteSyncRun(ctx context.Context, arg CompleteSyncRunParams) error {
+	_, err := q.db.Exec(ctx, completeSyncRun, arg.ID, arg.Status, arg.Stats)
+	return err
+}
+
 const countEventsForResource = `-- name: CountEventsForResource :one
 SELECT count(*)
 FROM (
@@ -288,6 +305,24 @@ func (q *Queries) GetIngestCredentialForUpdate(ctx context.Context, id uuid.UUID
 	return i, err
 }
 
+const getLastCompletedSyncStartedAt = `-- name: GetLastCompletedSyncStartedAt :one
+SELECT started_at
+FROM sync_runs
+WHERE cloud = $1 AND status = 'completed'
+ORDER BY started_at DESC
+LIMIT 1
+`
+
+// Where an incremental sync starts. The bound is the previous run's started_at
+// rather than its completed_at, so that the window overlaps that run and a
+// change made while it was working cannot fall between the two.
+func (q *Queries) GetLastCompletedSyncStartedAt(ctx context.Context, cloud string) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getLastCompletedSyncStartedAt, cloud)
+	var started_at pgtype.Timestamptz
+	err := row.Scan(&started_at)
+	return started_at, err
+}
+
 const getProject = `-- name: GetProject :one
 SELECT id, platform, cloud, external_id, name, metadata, created_at
 FROM projects
@@ -428,6 +463,28 @@ func (q *Queries) GetResourceType(ctx context.Context, arg GetResourceTypeParams
 		&i.ResourceType,
 		&i.SizeSchema,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getSyncRun = `-- name: GetSyncRun :one
+SELECT id, cloud, started_at, completed_at, status, stats
+FROM sync_runs
+WHERE id = $1
+`
+
+// Reads a finished run back, for the tests that compare the stored row against
+// the response the sync returned.
+func (q *Queries) GetSyncRun(ctx context.Context, id uuid.UUID) (SyncRun, error) {
+	row := q.db.QueryRow(ctx, getSyncRun, id)
+	var i SyncRun
+	err := row.Scan(
+		&i.ID,
+		&i.Cloud,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Status,
+		&i.Stats,
 	)
 	return i, err
 }
@@ -585,6 +642,22 @@ func (q *Queries) InsertRejectedEvent(ctx context.Context, arg InsertRejectedEve
 	return err
 }
 
+const insertSyncRun = `-- name: InsertSyncRun :one
+INSERT INTO sync_runs (cloud)
+VALUES ($1)
+RETURNING id
+`
+
+// The run row is written before the adapter is called, so that a run in flight
+// can be seen while it works: status defaults to 'running' in the schema, and
+// the row is left at that value until the run finishes.
+func (q *Queries) InsertSyncRun(ctx context.Context, cloud string) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, insertSyncRun, cloud)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const listActiveAttributingRelations = `-- name: ListActiveAttributingRelations :many
 SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to,
        created_at
@@ -709,6 +782,53 @@ func (q *Queries) ListCurrentResources(ctx context.Context, arg ListCurrentResou
 			&i.LastEventType,
 			&i.LastEventAt,
 			&i.LastPayload,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCurrentResourcesByCloud = `-- name: ListCurrentResourcesByCloud :many
+SELECT resource_type, resource_id, project_id, state, size, last_event_at
+FROM current_resources
+WHERE cloud = $1
+`
+
+type ListCurrentResourcesByCloudRow struct {
+	ResourceType string
+	ResourceID   string
+	ProjectID    string
+	State        string
+	Size         []byte
+	LastEventAt  pgtype.Timestamptz
+}
+
+// The stored side of the reconciliation diff, in the six columns the diff
+// reads. Deleted resources are part of the answer: one the adapter reports
+// again has come back, and telling that apart from a first sighting needs the
+// row. last_event_at is what a correction has to be dated past to reach the
+// row at all: one the fold orders before it replays the history instead.
+func (q *Queries) ListCurrentResourcesByCloud(ctx context.Context, cloud string) ([]ListCurrentResourcesByCloudRow, error) {
+	rows, err := q.db.Query(ctx, listCurrentResourcesByCloud, cloud)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCurrentResourcesByCloudRow
+	for rows.Next() {
+		var i ListCurrentResourcesByCloudRow
+		if err := rows.Scan(
+			&i.ResourceType,
+			&i.ResourceID,
+			&i.ProjectID,
+			&i.State,
+			&i.Size,
+			&i.LastEventAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1208,6 +1328,29 @@ WHERE id = $1 AND revoked_at IS NULL
 
 func (q *Queries) RevokeIngestCredential(ctx context.Context, id uuid.UUID) error {
 	_, err := q.db.Exec(ctx, revokeIngestCredential, id)
+	return err
+}
+
+const trySyncLock = `-- name: TrySyncLock :one
+SELECT pg_try_advisory_lock(hashtextextended('sync:' || $1::text, 0))
+`
+
+// Keeps two syncs of one cloud from running at once. The lock is held for the
+// session rather than for the transaction, as LockResource is, because a run
+// spans several transactions.
+func (q *Queries) TrySyncLock(ctx context.Context, dollar_1 string) (bool, error) {
+	row := q.db.QueryRow(ctx, trySyncLock, dollar_1)
+	var pg_try_advisory_lock bool
+	err := row.Scan(&pg_try_advisory_lock)
+	return pg_try_advisory_lock, err
+}
+
+const unlockSync = `-- name: UnlockSync :exec
+SELECT pg_advisory_unlock(hashtextextended('sync:' || $1::text, 0))
+`
+
+func (q *Queries) UnlockSync(ctx context.Context, dollar_1 string) error {
+	_, err := q.db.Exec(ctx, unlockSync, dollar_1)
 	return err
 }
 


### PR DESCRIPTION
Closes #7

Builds the provider-agnostic half of reconciliation: a new `internal/reporting/reconciliation` package holding the adapter seam, the clouds configuration, and the sync orchestrator, plus `POST /internal/sync/{cloud}` that triggers one run. No provider adapter is part of this branch — the OpenStack one is #10, and the registry `main.go` passes is deliberately empty until it lands.

## The change set, in commit order

**`4f6fd6b` Add the sync-run and advisory-lock queries** — the statements the orchestrator runs: `InsertSyncRun` / `CompleteSyncRun` / `GetSyncRun` for the run-row lifecycle, `GetLastCompletedSyncStartedAt` for the start of the incremental window, `ListCurrentResourcesByCloud` for the stored side of the diff, and `TrySyncLock` / `UnlockSync`. The sync lock is session-scoped rather than transaction-scoped, unlike the existing `LockResource`, because a run spans several transactions and the run row must survive a failed run. No migration: `sync_runs` already exists in `0001_init.sql`.

**`5994aa9` Build the reconciliation clouds config and adapter seam** — `ObservedResource`, `Adapter`, `EnumerationError`, and the sentinels `ErrUnknownCloud` / `ErrAlreadyRunning`; `CloudConfig` / `Config` / `LoadConfig` with the full validation set (non-empty `cloud`/`platform`/`adapter`, unique cloud names, adapter present in the registry, adapter's `Platform()` matching the entry). An empty path yields the zero `Config`, so a deployment without clouds starts normally. `gopkg.in/yaml.v3` moves into the direct require block.

**`78510da` Orchestrate sync runs and diff observations into events** — `Syncer`, `New`, `Sync`, and the diff. A run takes the cloud's advisory lock on a connection of its own, records the run at `running`, streams the adapter's inventory, diffs it against the projection, and ingests the corrections through the ordinary `pipeline.Ingest` path with `event.SourceReconciliation` in one `store.WithTx` transaction. The run row is completed on every exit path, on a context detached from the caller's — a run that ended because its deadline passed is still a run that is over — and a lock the dead context could not release is dropped by closing the session rather than returned to the pool. The missed-delete pass runs only over resource types the adapter enumerated to their end; a failed or incompletely reported type keeps its rows, because a platform that stopped answering says nothing about what it holds. A run that recorded any error is `failed` and returns one, but keeps what it did observe.

**`bc066fb` Cover the reconciliation framework with integration tests** — one configurable fake adapter against a real database: every diff branch, the size comparison across a JSON round trip, the enumeration failure that must not delete a fleet, incompletely reported observations, the correction the size schema refuses, and the run lifecycle (the lock refusing a second sync and being given back after a run that finished, failed, crashed, or ran out of time; the incremental window following the last *completed* run rather than the last one).

**`b4d8051` Declare POST /internal/sync/{cloud} and serve it** — the path in `api/reporting/openapi.yaml` under `internalToken` with the `SyncResult` / `SyncStats` schemas, the regenerated `openapi.gen.go`, the handler in `internal/reporting/httpapi/sync.go` under a 45-second `syncBudget`, the guard entry in `authdispatch.go`, and `Syncer` on `Options` / `server`. Unconfigured cloud → 404, lock held → 409, anything else → 500; the run is synchronous, so the caller learns the outcome from the response rather than by polling.

**`0872099` Cover the sync endpoint through the router** — the cases run through the full router rather than against the handler, because the answer is the product of the validator, the internal-token guard, and the framework together: 401 without the token, 404 unconfigured, 409 that writes no row of its own, 500 whose reason stays in `sync_runs`, 200 whose stats match the row.

**`0ac704e` Load the clouds config at startup and build the Syncer** — `TALLY_REPORTING_CLOUDS_CONFIG` on `Config`, in `EnvNames`, and in `.env.example`; read once at startup so a broken file refuses the process rather than failing every request that reaches the endpoint. Unset stays valid: the `Syncer` is then built over the empty configuration and answers every cloud 404, which is why the router needs no nil check.

## Divergences worth a reviewer's eye

- **The adapter seam takes one method more than the roadmap's WP 1.10 sketch.** `ResourceTypes(cfg) ([]string, error)` and `EnumerationError` are added beyond `Platform()` + `ListResources`. The roadmap's own failure rule is why: a resource type that legitimately returned zero live resources still has to have its stored rows deleted, so the framework needs the positive set of *attempted* types, not only the set of failures — otherwise a stream that yielded nothing for a type is indistinguishable from one whose type was never tried. Issue #7 sanctions this explicitly and #10 already assumes per-type success reporting; surfaced here per `roadmap/00-conventions.md` section 10 item 10.
- **`internal/core/timeline/timeline.go` changed, which is outside the issue's Affected Areas.** A create that follows a delete now clears `Timeline.DeletedAt`. The resurrection case (`sync.create` against a projection row in state `deleted`) exposed that the replay fold was delete-dominant while the projection's incremental fold is not — the two would disagree about a resurrected resource. `TestBuildCreateAfterDeleteStartsASecondLife` pins the new behaviour. Small, but it touches shared core code, so it deserves a look on its own terms.
- **No audit row is written for a sync run.** `sync_runs` is the operational record, and a row per ten-minute CronJob tick would say less than the run row already does. This deviates from the neighbouring rebuild handler, which does audit, and is intentional per the issue.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
