### PR TITLE
Prove the billing chain end-to-end with a golden-numbers vertical slice

### DIFF
--- a/cmd/tally-vertical-slice/.env.example
+++ b/cmd/tally-vertical-slice/.env.example
@@ -1,0 +1,11 @@
+# Vertical slice configuration.
+#
+# The slice takes everything else from flags (--cloud, --project, --month,
+# --reporting-url, --pricing, --ca-file). Only the credential is read from the
+# environment, so the bearer token stays out of the process's argv, where every
+# other user on the host can read it.
+
+# API token the slice authenticates with against the Reporting API. Issue it
+# with the read_all role: the run lists a project's resources and reads each
+# resource's event history. Required; there is no default.
+TALLY_SLICE_TOKEN=

--- a/cmd/tally-vertical-slice/README.md
+++ b/cmd/tally-vertical-slice/README.md
@@ -1,0 +1,366 @@
+# tally-vertical-slice
+
+`tally-vertical-slice` rates one project's instance usage for one calendar
+month and prints it as JSON. It reads the Reporting API, folds each instance's
+event history with [`internal/core/timeline`](../../internal/core/timeline),
+clips the intervals to the month, rates the records against
+[`pricing/prototype.yaml`](../../pricing/prototype.yaml), and checks the
+metering invariants over what it derived.
+
+## A throwaway prototype
+
+The slice is throwaway on purpose. It is the golden-numbers gate of
+[WP 1.15 in the Phase 1 roadmap](../../roadmap/01-phase-1-core-platform-openstack.md),
+and its job is to prove the billing chain end to end, once, on figures a person
+can check by hand.
+
+Phase 3 replaces it wholesale. WP 3.3 of the
+[Phase 3 roadmap](../../roadmap/03-phase-3-metering-rating.md) creates
+`internal/engine/metering`, which meters every resource type against the
+project graph and versioned pricing models. Only the timeline fold carries
+over. Nothing else in this directory does.
+
+That is why the clipping, the rating, and the invariant checks live in this
+command instead of in a package under `internal/`. They are the engine's work,
+and a prototype's version of them in the core would give code that is meant to
+be deleted a home that other packages import. Nothing under `internal/` knows
+about this command.
+
+## The egress delta
+
+The slice rates the golden instance `abc-123` at 124.80 EUR for March 2026. The
+end-to-end example of section 3.4 in the [root README](../../README.md) rates
+the same instance at 128.45 EUR. The whole difference is egress: that example
+bills 18.0 GB in the first active interval at 1.62 EUR and 22.5 GB in the third
+at 2.03 EUR, and 124.80 plus 3.65 is 128.45. The vCPU, RAM, and disk costs of
+the two agree interval for interval, and so do the three intervals themselves.
+
+The slice bills no egress because egress is a counter metric rather than a
+property of a resource's state timeline: it is summed from usage counters over
+the period, which is Phase 3 scope, and WP 1.15 puts it there. The delta is
+recorded here rather than approximated. An estimated egress figure would cost
+the golden numbers the one property this prototype exists for, that a reader
+can recompute them from the events and the price list alone.
+
+## The dev-cluster drill
+
+The drill reproduces the golden numbers against a dev cluster: over TLS through
+the Gateway, against the Reporting API the dev overlay deploys, with
+credentials issued by the admin CLI. Run the steps in order, in one shell, from
+the repository root. The tokens are shell variables the later steps read.
+
+### What the drill needs
+
+Docker and kind on the host, and a dev cluster that is up:
+
+```sh
+make up
+make migrate
+```
+
+`make up` applies the migration chain as its last step. `make migrate` is what
+a cluster that was already running when a migration landed needs.
+
+### Trust the dev CA
+
+The Gateway serves a certificate from the cluster's own CA, which the host does
+not know. Write it next to the repository; curl and the slice both read it from
+there:
+
+```sh
+make -s ca > tally-ca.crt
+```
+
+### Issue the two credentials
+
+The admin CLI works on the reporting database directly and reads its URL from
+`TALLY_REPORTING_DB_URL`. The dev value is the Makefile's `TALLY_DEV_DB_URL`,
+which reaches TimescaleDB through the Gateway's TCP listener. A new token is
+printed once, alone on stdout, so a command substitution captures it:
+
+```sh
+INGEST_TOKEN="$(TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable' \
+  go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud os-prod-eu1)"
+export TALLY_SLICE_TOKEN="$(TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable' \
+  go run ./cmd/tally-reporting-admin create-api-token --role read_all)"
+```
+
+The ingest credential is scoped to the platform and cloud the batch below
+claims, which is what the ingest guard holds the batch against. The query token
+is `read_all` because a `project` token is scoped by project registry ids, and
+the drill would have to create registry rows before it could name one.
+`TALLY_SLICE_TOKEN` is exported because the slice reads its token from the
+environment rather than from a flag, which keeps the credential out of the
+process's argv.
+
+### Ingest the golden history
+
+One call submits all five events as a single JSON array. Two instances share
+the month: `abc-123` is created in February, powered off on 03-11 and on again
+on 03-21, and `def-456` is created on 03-01 and resized on 03-16.
+
+```sh
+curl --cacert tally-ca.crt -X POST \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events' \
+  -H "Authorization: Bearer $INGEST_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '[
+  {
+    "event_id": "vs-abc-123-create",
+    "timestamp": "2026-02-10T08:00:00Z",
+    "event_type": "compute.instance.create.end",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "abc-123",
+    "project_id": "proj-456",
+    "payload": {
+      "state": "active",
+      "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+    }
+  },
+  {
+    "event_id": "vs-abc-123-power-off",
+    "timestamp": "2026-03-11T00:00:00Z",
+    "event_type": "compute.instance.power_off",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "abc-123",
+    "project_id": "proj-456",
+    "payload": {"state": "shutoff"}
+  },
+  {
+    "event_id": "vs-abc-123-power-on",
+    "timestamp": "2026-03-21T00:00:00Z",
+    "event_type": "compute.instance.power_on",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "abc-123",
+    "project_id": "proj-456",
+    "payload": {"state": "active"}
+  },
+  {
+    "event_id": "vs-def-456-create",
+    "timestamp": "2026-03-01T00:00:00Z",
+    "event_type": "compute.instance.create.end",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "def-456",
+    "project_id": "proj-456",
+    "payload": {
+      "state": "active",
+      "size": {"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "flavor": "m1.small"}
+    }
+  },
+  {
+    "event_id": "vs-def-456-resize",
+    "timestamp": "2026-03-16T00:00:00Z",
+    "event_type": "compute.instance.resize.end",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "def-456",
+    "project_id": "proj-456",
+    "payload": {
+      "state": "active",
+      "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+    }
+  }
+]'
+```
+
+The answer is 200 with:
+
+```json
+{"accepted":5,"duplicates":0,"rejected":[]}
+```
+
+Repeating the call is safe. The insert carries `ON CONFLICT (event_id,
+timestamp) DO NOTHING`
+([`queries.sql`](../../internal/reporting/store/queries.sql)), so a second run
+answers `{"accepted":0,"duplicates":5,"rejected":[]}` and books nothing twice.
+
+### Rate the month
+
+```sh
+go run ./cmd/tally-vertical-slice \
+  --cloud os-prod-eu1 --project proj-456 --month 2026-03 \
+  --reporting-url https://api.tally.127-0-0-1.nip.io:8443 \
+  --pricing pricing/prototype.yaml --ca-file tally-ca.crt
+```
+
+The run reads its token from `TALLY_SLICE_TOKEN`, which the credential step
+exported. `--reporting-url` is the API's root without the `/api/v1` suffix, and
+`--ca-file` replaces the system trust store for the run, which is what reaches
+a Gateway whose certificate the host does not verify on its own.
+
+### The document
+
+The run prints this document, and
+[`slice_integration_test.go`](slice_integration_test.go) asserts the same
+numbers in CI:
+
+```json
+{
+  "cloud": "os-prod-eu1",
+  "project_id": "proj-456",
+  "period": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-04-01T00:00:00Z"
+  },
+  "currency": "EUR",
+  "resources": [
+    {
+      "resource_id": "abc-123",
+      "warnings": [],
+      "violations": [],
+      "records": [
+        {
+          "from": "2026-03-01T00:00:00Z",
+          "to": "2026-03-11T00:00:00Z",
+          "state": "active",
+          "seconds": 864000,
+          "minutes": 14400.0000,
+          "dimensions": {
+            "disk_gb": {
+              "quantity": 80,
+              "cost": 19.20
+            },
+            "ram_gb": {
+              "quantity": 8,
+              "cost": 9.60
+            },
+            "vcpus": {
+              "quantity": 4,
+              "cost": 19.20
+            }
+          },
+          "subtotal": 48.00
+        },
+        {
+          "from": "2026-03-11T00:00:00Z",
+          "to": "2026-03-21T00:00:00Z",
+          "state": "shutoff",
+          "seconds": 864000,
+          "minutes": 14400.0000,
+          "dimensions": {
+            "disk_gb": {
+              "quantity": 80,
+              "cost": 9.60
+            },
+            "ram_gb": {
+              "quantity": 8,
+              "cost": 4.80
+            },
+            "vcpus": {
+              "quantity": 4,
+              "cost": 9.60
+            }
+          },
+          "subtotal": 24.00
+        },
+        {
+          "from": "2026-03-21T00:00:00Z",
+          "to": "2026-04-01T00:00:00Z",
+          "state": "active",
+          "seconds": 950400,
+          "minutes": 15840.0000,
+          "dimensions": {
+            "disk_gb": {
+              "quantity": 80,
+              "cost": 21.12
+            },
+            "ram_gb": {
+              "quantity": 8,
+              "cost": 10.56
+            },
+            "vcpus": {
+              "quantity": 4,
+              "cost": 21.12
+            }
+          },
+          "subtotal": 52.80
+        }
+      ],
+      "total": 124.80
+    },
+    {
+      "resource_id": "def-456",
+      "warnings": [],
+      "violations": [],
+      "records": [
+        {
+          "from": "2026-03-01T00:00:00Z",
+          "to": "2026-03-16T00:00:00Z",
+          "state": "active",
+          "seconds": 1296000,
+          "minutes": 21600.0000,
+          "dimensions": {
+            "disk_gb": {
+              "quantity": 40,
+              "cost": 14.40
+            },
+            "ram_gb": {
+              "quantity": 4,
+              "cost": 7.20
+            },
+            "vcpus": {
+              "quantity": 2,
+              "cost": 14.40
+            }
+          },
+          "subtotal": 36.00
+        },
+        {
+          "from": "2026-03-16T00:00:00Z",
+          "to": "2026-04-01T00:00:00Z",
+          "state": "active",
+          "seconds": 1382400,
+          "minutes": 23040.0000,
+          "dimensions": {
+            "disk_gb": {
+              "quantity": 80,
+              "cost": 30.72
+            },
+            "ram_gb": {
+              "quantity": 8,
+              "cost": 15.36
+            },
+            "vcpus": {
+              "quantity": 4,
+              "cost": 30.72
+            }
+          },
+          "subtotal": 76.80
+        }
+      ],
+      "total": 112.80
+    }
+  ],
+  "total": 237.60
+}
+```
+
+Both `warnings` arrays are empty, and so are both `violations` arrays: the
+golden history folds without a gap, and the records tile exactly the part of
+March each instance lived through.
+
+The exit status is 0 for a clean run. A run whose records break a metering
+invariant prints the document first and exits 1, with the breaches in the
+resource's `violations` array: the numbers are what the run is for, so they
+stay readable while the status still reports the failure. Any other error exits
+1 without a document.
+
+### Why the drill runs outside CI
+
+CI runs `go test ./...` on a runner that has Docker and no kind cluster
+([`ci.yaml`](../../.github/workflows/ci.yaml)), so the drill is not part of it.
+`slice_integration_test.go` proves the same numbers there instead: it assembles
+the real router, ingest pipeline, and authenticator over a migrated TimescaleDB
+in a container, submits the same five events, and holds the printed document
+against the concept's figures value by value. The drill adds what that test
+leaves out: the Gateway, TLS against the dev CA, and credentials issued by the
+admin CLI. The two halves together are WP 1.15's verification.

--- a/cmd/tally-vertical-slice/client.go
+++ b/cmd/tally-vertical-slice/client.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+const (
+	// pageLimit is how many resources one page of the resource list carries. It
+	// is the maximum the API serves, which keeps the walk to as few calls as the
+	// contract allows.
+	pageLimit = 1000
+	// pageBudget caps how many pages the resource walk reads. An API that keeps
+	// handing out cursors beyond it is broken or hostile, and either way the run
+	// stops rather than calling forever.
+	pageBudget = 1000
+	// resourceBudget caps what the walk collects. limit= is a request, not a
+	// constraint: a server free to ignore it can serve a bodyLimit-sized page
+	// every time, and pageBudget bounds the number of those pages without
+	// bounding their contents. A million instances is past any project this
+	// prototype rates.
+	resourceBudget = pageBudget * pageLimit
+	// bodyLimit caps one answer. The API's pages are bounded by pageLimit, so a
+	// body past this is not an answer this client should keep reading into
+	// memory.
+	bodyLimit = 64 << 20
+	// requestTimeout bounds one call. A server that accepts the connection and
+	// then never answers would otherwise hold the run until the operator
+	// interrupts it.
+	requestTimeout = 2 * time.Minute
+)
+
+// client reads the Reporting API. It is deliberately minimal: no retries, and
+// one flat timeout rather than a policy, because a prototype run that fails is
+// rerun by the operator watching it.
+type client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// newClient builds the read client. The base URL is the API's root without the
+// /api/v1 suffix, the same form the collector's sender takes.
+//
+// An empty caFile trusts the system store. A named one is trusted instead of
+// it, which is what reaches a dev cluster whose certificates come from a CA the
+// host does not know.
+func newClient(baseURL, token, caFile string) (*client, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("reading the reporting URL %s: %w", baseURL, err)
+	}
+	// The token rides on every call, so a plaintext base URL puts a read_all
+	// credential on the wire in the clear. Loopback is exempt: that is where a
+	// test's server and a port-forwarded cluster listen.
+	if parsed.Scheme != "https" && !isLoopback(parsed.Hostname()) {
+		return nil, fmt.Errorf("the reporting URL %s is not https: the API token would travel in cleartext", baseURL)
+	}
+
+	httpClient := &http.Client{
+		Timeout: requestTimeout,
+		// A redirect is answered rather than followed. The API documents none,
+		// and Go strips the Authorization header only across hosts, so a
+		// same-host redirect to http:// would carry the token over in the clear.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading the CA file %s: %w", caFile, err)
+		}
+		pool := x509.NewCertPool()
+		// A pool that accepted nothing trusts nothing, and every call would fail
+		// with a verification error that says nothing about the file behind it.
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no PEM certificates were found in the CA file %s", caFile)
+		}
+		// The default transport is cloned rather than replaced: a bare literal
+		// would drop the proxy, the dial timeout, and the handshake timeout it
+		// sets, so naming a CA file would silently change how a run fails too.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+		httpClient.Transport = transport
+	}
+
+	return &client{baseURL: baseURL, token: token, http: httpClient}, nil
+}
+
+// isLoopback reports whether a host names the machine the run is on. The name
+// is taken as well as the address, because that is what a port-forward is
+// reached under.
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// listResources walks the projection for one project's instances and returns
+// their ids in the order the API served them. Deleted resources are asked for
+// as well: one that was deleted during the month still billed the part of it it
+// lived through.
+func (c *client) listResources(ctx context.Context, cloud, project string) ([]string, error) {
+	var (
+		ids    []string
+		cursor string
+	)
+
+	for page := 0; ; page++ {
+		if page == pageBudget {
+			return nil, fmt.Errorf("the resource list of %s/%s did not end within %d pages",
+				cloud, project, pageBudget)
+		}
+
+		query := url.Values{
+			"cloud":         {cloud},
+			"project_id":    {project},
+			"resource_type": {"instance"},
+			"status":        {"all"},
+			"limit":         {strconv.Itoa(pageLimit)},
+		}
+		if cursor != "" {
+			query.Set("cursor", cursor)
+		}
+
+		var answer struct {
+			Items []struct {
+				ResourceID string `json:"resource_id"`
+			} `json:"items"`
+			NextCursor *string `json:"next_cursor"`
+		}
+		if err := c.get(ctx, c.baseURL+"/api/v1/resources?"+query.Encode(), &answer); err != nil {
+			return nil, err
+		}
+
+		for _, item := range answer.Items {
+			if len(ids) == resourceBudget {
+				return nil, fmt.Errorf("the resource list of %s/%s served more than %d resources",
+					cloud, project, resourceBudget)
+			}
+			ids = append(ids, item.ResourceID)
+		}
+		if answer.NextCursor == nil {
+			return ids, nil
+		}
+		// A cursor that does not advance would be asked for again forever, with
+		// the same page appended to the result on every turn.
+		if *answer.NextCursor == cursor {
+			return nil, fmt.Errorf("the API repeated the cursor %q, which would page forever", cursor)
+		}
+		cursor = *answer.NextCursor
+	}
+}
+
+// fetchHistory reads one instance's whole event history. The endpoint never
+// pages: it either serves the history in one answer or refuses a history longer
+// than it will serve, which the error names the resource for.
+func (c *client) fetchHistory(ctx context.Context, cloud, resourceID string) ([]event.Stored, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/resources/%s/instance/%s/events",
+		c.baseURL, url.PathEscape(cloud), url.PathEscape(resourceID))
+
+	var page struct {
+		Items []event.Stored `json:"items"`
+	}
+	if err := c.get(ctx, endpoint, &page); err != nil {
+		return nil, fmt.Errorf("fetching the history of %s: %w", resourceID, err)
+	}
+	return page.Items, nil
+}
+
+// get runs one authenticated GET and decodes its answer. The token travels in
+// the header on every call, so nothing the API serves is read unauthenticated.
+func (c *client) get(ctx context.Context, endpoint string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("building the request for %s: %w", endpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return problemError(resp)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, bodyLimit)).Decode(out); err != nil {
+		return fmt.Errorf("decoding the answer of %s: %w", endpoint, err)
+	}
+	return nil
+}
+
+// problemError turns a refused answer into an error carrying the API's own
+// diagnosis. The problem type is what a reader recognizes the case by, so it is
+// in the text next to the title rather than dropped for the status code.
+func problemError(resp *http.Response) error {
+	var problem struct {
+		Type   string `json:"type"`
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, bodyLimit)).Decode(&problem); err != nil {
+		return fmt.Errorf("the API answered %d with an unreadable problem document: %w", resp.StatusCode, err)
+	}
+
+	if problem.Detail != "" {
+		return fmt.Errorf("the API answered %d %s: %s: %s",
+			resp.StatusCode, problem.Type, problem.Title, problem.Detail)
+	}
+	return fmt.Errorf("the API answered %d %s: %s", resp.StatusCode, problem.Type, problem.Title)
+}

--- a/cmd/tally-vertical-slice/client_test.go
+++ b/cmd/tally-vertical-slice/client_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// testToken is the credential every request under test has to carry.
+const testToken = "s3cr3t-token"
+
+// testClient builds a client against a stub server. The stub speaks plain HTTP,
+// so no CA file is involved.
+func testClient(t *testing.T, baseURL string) *client {
+	t.Helper()
+
+	api, err := newClient(baseURL, testToken, "")
+	if err != nil {
+		t.Fatalf("newClient() error = %v, want nil", err)
+	}
+	return api
+}
+
+// TestListResourcesFollowsTheCursor holds the walk to the paging contract: a
+// page that names a next cursor is followed, and the filters travel with every
+// call. A walk that stopped after the first page would bill a project's second
+// page as if it did not exist.
+func TestListResourcesFollowsTheCursor(t *testing.T) {
+	var (
+		queries []url.Values
+		auths   []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		auths = append(auths, r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_, _ = io.WriteString(w, `{"items":[{"resource_id":"abc-123"}],"next_cursor":"abc"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"items":[{"resource_id":"def-456"}],"next_cursor":null}`)
+	}))
+	defer server.Close()
+
+	ids, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+	if err != nil {
+		t.Fatalf("listResources() error = %v, want nil", err)
+	}
+
+	if want := []string{"abc-123", "def-456"}; strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Errorf("listResources() = %v, want %v", ids, want)
+	}
+	if len(queries) != 2 {
+		t.Fatalf("the stub served %d requests, want 2", len(queries))
+	}
+
+	for i, query := range queries {
+		for name, want := range map[string]string{
+			"cloud":         "os-prod-eu1",
+			"project_id":    "proj-456",
+			"resource_type": "instance",
+			"status":        "all",
+			"limit":         "1000",
+		} {
+			if got := query.Get(name); got != want {
+				t.Errorf("request %d asked for %s=%q, want %q", i, name, got, want)
+			}
+		}
+		if want := "Bearer " + testToken; auths[i] != want {
+			t.Errorf("request %d carried Authorization %q, want %q", i, auths[i], want)
+		}
+	}
+	if got := queries[1].Get("cursor"); got != "abc" {
+		t.Errorf("the second request asked for cursor=%q, want %q", got, "abc")
+	}
+	if got := queries[0].Get("cursor"); got != "" {
+		t.Errorf("the first request asked for cursor=%q, want none", got)
+	}
+}
+
+// TestListResourcesRefusesACursorThatDoesNotAdvance stops a walk the API cannot
+// end. A page that names itself as the next one would be asked for forever,
+// with its resources appended to the result on every turn, until the host runs
+// out of memory.
+func TestListResourcesRefusesACursorThatDoesNotAdvance(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[{"resource_id":"abc-123"}],"next_cursor":"stuck"}`)
+	}))
+	defer server.Close()
+
+	_, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+	if err == nil {
+		t.Fatalf("listResources() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "stuck") {
+		t.Errorf("listResources() error = %v, want it to name the repeated cursor", err)
+	}
+	// The first page names the cursor and the second one repeats it, which is
+	// where the walk stops: a third call would already be the loop.
+	if calls != 2 {
+		t.Errorf("the stub served %d requests, want 2", calls)
+	}
+}
+
+// TestListResourcesRefusesMoreResourcesThanTheBudget bounds what the walk keeps
+// in memory. limit= is a request the API is free to ignore, and a server that
+// does serves pages of any size it likes; every one of them advances the
+// cursor, so neither the repeat guard nor the page budget ends the growth. The
+// walk stops on the resource past the budget rather than on the page.
+func TestListResourcesRefusesMoreResourcesThanTheBudget(t *testing.T) {
+	// A page a hundred times the size the walk asked for reaches the budget in
+	// eleven pages rather than in a thousand.
+	items := strings.TrimSuffix(strings.Repeat(`{"resource_id":"r"},`, 100*pageLimit), ",")
+
+	served := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[`)
+		_, _ = io.WriteString(w, items)
+		_, _ = fmt.Fprintf(w, `],"next_cursor":"%d"}`, served)
+	}))
+	defer server.Close()
+
+	ids, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+	if err == nil {
+		t.Fatalf("listResources() = %d ids, want an error", len(ids))
+	}
+	for _, want := range []string{"proj-456", strconv.Itoa(resourceBudget)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("listResources() error = %v, want it to name %s", err, want)
+		}
+	}
+	if ids != nil {
+		t.Errorf("listResources() = %d ids, want none kept", len(ids))
+	}
+	// Ten pages fill the budget and the eleventh is where the walk gives up: a
+	// walk that ran to the page budget would have served a thousand.
+	if want := resourceBudget/(100*pageLimit) + 1; served != want {
+		t.Errorf("the stub served %d pages, want %d", served, want)
+	}
+}
+
+// TestClientMapsProblems keeps the API's own diagnosis in the error. The
+// problem type is the part a reader recognizes the case by, so an unauthorized
+// run and a history the API refuses to serve stay distinguishable from the
+// error text alone.
+func TestClientMapsProblems(t *testing.T) {
+	t.Run("an unauthorized list", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"type":"urn:tally:error:unauthorized","title":"Unauthorized",`+
+				`"status":401,"detail":"the token is unknown"}`)
+		}))
+		defer server.Close()
+
+		_, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+		if err == nil {
+			t.Fatalf("listResources() error = nil, want an error")
+		}
+		for _, want := range []string{"urn:tally:error:unauthorized", "Unauthorized", "the token is unknown"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("listResources() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+
+	t.Run("a history the API refuses to serve", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"type":"urn:tally:error:history_too_long","title":"History too long",`+
+				`"status":422}`)
+		}))
+		defer server.Close()
+
+		_, err := testClient(t, server.URL).fetchHistory(context.Background(), "os-prod-eu1", "abc-123")
+		if err == nil {
+			t.Fatalf("fetchHistory() error = nil, want an error")
+		}
+		for _, want := range []string{"abc-123", "urn:tally:error:history_too_long", "History too long"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("fetchHistory() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+}
+
+// TestClientReportsUnreadableAnswers keeps an answer the client cannot read
+// apart from one the API refused in its own words. A gateway between the run
+// and the API answers in HTML, and a connection cut mid-answer leaves valid
+// JSON that simply stops: neither is a problem document, and the error has to
+// say so rather than report an empty title.
+func TestClientReportsUnreadableAnswers(t *testing.T) {
+	t.Run("a gateway answering in HTML", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = io.WriteString(w, "<html><body>502 Bad Gateway</body></html>")
+		}))
+		defer server.Close()
+
+		_, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+		if err == nil {
+			t.Fatalf("listResources() error = nil, want an error")
+		}
+		for _, want := range []string{"502", "unreadable problem document"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("listResources() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+
+	t.Run("an answer that stops halfway", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"items":[{"resource_id":"abc-`)
+		}))
+		defer server.Close()
+
+		_, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+		if err == nil {
+			t.Fatalf("listResources() error = nil, want an error")
+		}
+		for _, want := range []string{"decoding the answer", "/api/v1/resources"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("listResources() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+}
+
+// TestClientPropagatesTransportErrors keeps a failed call wrapped rather than
+// replaced: an unreachable API is a different problem from one that answered,
+// and only the wrapped error says which host and which URL failed.
+func TestClientPropagatesTransportErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	api := testClient(t, server.URL)
+	server.Close()
+
+	_, err := api.listResources(context.Background(), "os-prod-eu1", "proj-456")
+	if err == nil {
+		t.Fatalf("listResources() error = nil, want an error")
+	}
+
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Errorf("listResources() error = %v, want it to wrap a *url.Error", err)
+	}
+}
+
+// TestNewClientRejectsABadCAFile refuses a trust store that would trust
+// nothing. Without the check every call would fail with a verification error
+// that says nothing about the file behind it.
+func TestNewClientRejectsABadCAFile(t *testing.T) {
+	t.Run("a file that is not there", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "absent.crt")
+
+		_, err := newClient("https://api.example", testToken, path)
+		if err == nil {
+			t.Fatalf("newClient() error = nil, want an error")
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("newClient() error = %v, want it to wrap os.ErrNotExist", err)
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("newClient() error = %v, want it to name the file %s", err, path)
+		}
+	})
+
+	t.Run("a file without certificates", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.crt")
+		if err := os.WriteFile(path, []byte("not a certificate\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		_, err := newClient("https://api.example", testToken, path)
+		if err == nil {
+			t.Fatalf("newClient() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "no PEM certificates") {
+			t.Errorf("newClient() error = %v, want it to report an empty trust store", err)
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("newClient() error = %v, want it to name the file %s", err, path)
+		}
+	})
+}
+
+// TestNewClientRefusesAPlaintextURL keeps the credential off the wire. The
+// token the run authenticates with reads every project's resources and their
+// whole history, and it travels in a header on every call, so a base URL that
+// is not https would hand it to anything on the path.
+func TestNewClientRefusesAPlaintextURL(t *testing.T) {
+	t.Run("a plaintext URL", func(t *testing.T) {
+		_, err := newClient("http://api.example", testToken, "")
+		if err == nil {
+			t.Fatalf("newClient() error = nil, want an error")
+		}
+		for _, want := range []string{"http://api.example", "cleartext"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("newClient() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+
+	// Loopback is the exception: a port-forward to a dev cluster and the test
+	// servers of this package both listen there, and nothing leaves the host.
+	for name, baseURL := range map[string]string{
+		"an https URL":         "https://api.example",
+		"a loopback address":   "http://127.0.0.1:8443",
+		"a loopback name":      "http://localhost:8443",
+		"a loopback IPv6 host": "http://[::1]:8443",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := newClient(baseURL, testToken, ""); err != nil {
+				t.Errorf("newClient(%q) error = %v, want nil", baseURL, err)
+			}
+		})
+	}
+}
+
+// TestClientDoesNotFollowRedirects keeps the token from travelling somewhere
+// the operator did not name. Go strips the Authorization header only across
+// hosts, so a redirect from https to http on the same host would carry the
+// credential over in the clear; the answer is reported instead of followed.
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("the redirect was followed, carrying Authorization %q", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[],"next_cursor":null}`)
+	}))
+	defer target.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, target.URL+"/api/v1/resources", http.StatusFound)
+	}))
+	defer server.Close()
+
+	_, err := testClient(t, server.URL).listResources(context.Background(), "os-prod-eu1", "proj-456")
+	if err == nil {
+		t.Fatalf("listResources() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "302") {
+		t.Errorf("listResources() error = %v, want it to report the redirect's status", err)
+	}
+}
+
+// TestNewClientKeepsTheTransportDefaults holds the CA file to changing the
+// trust anchors alone. A bare transport literal inherits nothing from the
+// default one, so a run that names a CA file would also lose the proxy, the
+// dial timeout, and the handshake timeout: a Gateway that accepts the
+// connection and never completes the handshake would hang the run instead of
+// failing it.
+func TestNewClientKeepsTheTransportDefaults(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	block := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(path, block, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	api, err := newClient("https://api.example", testToken, path)
+	if err != nil {
+		t.Fatalf("newClient() error = %v, want nil", err)
+	}
+
+	transport, ok := api.http.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport = %T, want *http.Transport", api.http.Transport)
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+		t.Errorf("Transport carries no trust store, want the CA file's")
+	}
+	if transport.Proxy == nil {
+		t.Errorf("Transport.Proxy = nil, want the default's, which reads HTTPS_PROXY")
+	}
+	if transport.DialContext == nil {
+		t.Errorf("Transport.DialContext = nil, want the default's, which bounds the dial")
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		t.Errorf("Transport.TLSHandshakeTimeout = 0, want the default's bound")
+	}
+}

--- a/cmd/tally-vertical-slice/compute.go
+++ b/cmd/tally-vertical-slice/compute.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/core/timeline"
+)
+
+const (
+	// minutePlaces is the scale minute quantities are rendered at. It matches
+	// what money.Minutes rounds to, so the output shows the quantity that was
+	// rated rather than a shortened one.
+	minutePlaces = 4
+	// minutesPerHour turns a minute quantity into the hours prices are given in.
+	minutesPerHour = 60
+)
+
+// period is the half-open span [From, To) usage is reported for.
+type period struct {
+	From, To time.Time
+}
+
+// parseMonth reads a calendar month as YYYY-MM and returns the UTC span it
+// covers. The end is the first instant of the next month, so a month is
+// expressed the same way an interval is and the two clip against each other
+// without a special case for the last second of the month.
+func parseMonth(value string) (period, error) {
+	from, err := time.Parse("2006-01", value)
+	if err != nil {
+		return period{}, fmt.Errorf("reading the month %q: %w", value, err)
+	}
+	return period{From: from, To: from.AddDate(0, 1, 0)}, nil
+}
+
+// usageRecord is one interval clipped to the reported period. Seconds is what
+// the clipping produced, and Minutes is the billable quantity derived from it:
+// the duration is kept as integer seconds up to that single conversion.
+type usageRecord struct {
+	From, To time.Time
+	State    string
+	Size     map[string]any
+	Seconds  int64
+	Minutes  decimal.Decimal
+}
+
+// buildRecords clips a resource's intervals to the period. An interval that
+// started before the period is billed from the period's start, and an open one
+// is billed to its end: the month is what is being reported, so nothing outside
+// it may reach the output.
+func buildRecords(tl timeline.Timeline, p period) []usageRecord {
+	records := make([]usageRecord, 0, len(tl.Intervals))
+
+	for _, interval := range tl.Intervals {
+		start := interval.Start
+		if start.Before(p.From) {
+			start = p.From
+		}
+		end := p.To
+		if interval.End != nil && interval.End.Before(p.To) {
+			end = *interval.End
+		}
+		// An interval that lies entirely outside the period clips to nothing,
+		// and an empty span bills nothing, so neither becomes a record.
+		if !end.After(start) {
+			continue
+		}
+
+		seconds := int64(end.Sub(start) / time.Second)
+		records = append(records, usageRecord{
+			From:    start.UTC(),
+			To:      end.UTC(),
+			State:   interval.State,
+			Size:    interval.Size,
+			Seconds: seconds,
+			Minutes: money.Minutes(seconds),
+		})
+	}
+
+	return records
+}
+
+// sizeDecimal reads one metric out of a size object as a decimal. The size
+// arrives as decoded JSON, where a number is a float64, so the value is taken
+// back to its JSON literal and parsed from there: that keeps the float out of
+// the money path, which roadmap/00-conventions.md section 6 forbids it from.
+func sizeDecimal(size map[string]any, metric string) (decimal.Decimal, error) {
+	value, ok := size[metric]
+	if !ok {
+		return decimal.Decimal{}, fmt.Errorf("the size carries no %s", metric)
+	}
+
+	literal, err := json.Marshal(value)
+	if err != nil {
+		return decimal.Decimal{}, fmt.Errorf("encoding the size value of %s: %w", metric, err)
+	}
+	quantity, err := decimal.NewFromString(string(literal))
+	if err != nil {
+		return decimal.Decimal{}, fmt.Errorf("reading the size value of %s as a number: %w", metric, err)
+	}
+	return quantity, nil
+}
+
+// rate prices one record against every configured dimension, and returns its
+// line items keyed by metric together with their subtotal. Each dimension is
+// computed at full precision and rounded once at the end, and the subtotal is
+// the sum of those rounded costs, so the subtotal always equals the line items
+// the output shows.
+//
+// A state the pricing names no modifier for is billed at the full price, which
+// is what an active instance is.
+func rate(rec usageRecord, pr pricing) (map[string]dimensionDoc, decimal.Decimal, error) {
+	modifier := decimal.NewFromInt(1)
+	if factor, ok := pr.StateModifiers[rec.State]; ok {
+		modifier = factor
+	}
+	hours := money.Div(rec.Minutes, decimal.NewFromInt(minutesPerHour))
+
+	dimensions := make(map[string]dimensionDoc, len(pr.Dimensions))
+	subtotal := decimal.Zero
+	for _, dim := range pr.Dimensions {
+		quantity, err := sizeDecimal(rec.Size, dim.Metric)
+		if err != nil {
+			return nil, decimal.Zero, fmt.Errorf("rating the interval starting %s: %w",
+				rec.From.Format(time.RFC3339), err)
+		}
+
+		cost := money.Round2(hours.Mul(quantity).Mul(dim.PricePerUnitHour).Mul(modifier))
+		dimensions[dim.Metric] = dimensionDoc{
+			Quantity: jsonQuantity{Decimal: quantity},
+			Cost:     money.NewAmount(cost),
+		}
+		subtotal = subtotal.Add(cost)
+	}
+
+	return dimensions, subtotal, nil
+}
+
+// checkInvariants holds the derived records against what metering promises:
+// they stay inside the period, each of them bills time, and together they tile
+// the part of the period the resource lived through without a gap or an
+// overlap. It returns one line per breach rather than the first, so a broken
+// run is diagnosed from one output.
+//
+// How many seconds the records bill in total is not among the checks. The only
+// figures an expectation could be derived from are the interval boundaries the
+// clipping already read, so a comparison against it would restate the clipping
+// rather than hold it to anything.
+func checkInvariants(records []usageRecord, tl timeline.Timeline, p period) []string {
+	violations := []string{}
+
+	ordered := slices.Clone(records)
+	slices.SortStableFunc(ordered, func(a, b usageRecord) int { return a.From.Compare(b.From) })
+
+	for i, rec := range ordered {
+		if rec.From.Before(p.From) || rec.To.After(p.To) {
+			violations = append(violations, fmt.Sprintf("the record %s..%s lies outside the period %s..%s",
+				rec.From.Format(time.RFC3339), rec.To.Format(time.RFC3339),
+				p.From.Format(time.RFC3339), p.To.Format(time.RFC3339)))
+		}
+		if !rec.To.After(rec.From) {
+			violations = append(violations, fmt.Sprintf("the record %s..%s bills no time",
+				rec.From.Format(time.RFC3339), rec.To.Format(time.RFC3339)))
+		}
+		// Two records that do not meet have lost or double-billed the time
+		// between them. The two directions are not held to the same test: an
+		// overlap bills a second twice wherever it falls, while a gap is only
+		// wrong over time the resource lived through, because a delete and a
+		// later create leave one the records are not meant to close and
+		// reporting it would fail a run whose numbers are right.
+		if i+1 < len(ordered) {
+			next := ordered[i+1]
+			switch {
+			case rec.To.After(next.From):
+				violations = append(violations, fmt.Sprintf("the record ending %s overlaps the next one starting %s",
+					rec.To.Format(time.RFC3339), next.From.Format(time.RFC3339)))
+			case rec.To.Before(next.From) && existedAt(tl, rec.To):
+				violations = append(violations, fmt.Sprintf("the record ending %s does not meet the next one starting %s",
+					rec.To.Format(time.RFC3339), next.From.Format(time.RFC3339)))
+			}
+		}
+	}
+
+	return violations
+}
+
+// existedAt reports whether the resource was alive at ts, which is whether any
+// interval of its timeline covers that instant. The intervals are half-open, so
+// the instant a life ends at is one the resource no longer existed in.
+//
+// Build emits the intervals in ascending order and never overlapping, so the
+// only one that can cover ts is the last one starting at or before it. It is
+// found by search rather than by a scan: a history whose every record boundary
+// is a lifecycle gap asks this once per record, and scanning would make the
+// invariant check quadratic over a history the API served in one answer.
+func existedAt(tl timeline.Timeline, ts time.Time) bool {
+	i, found := slices.BinarySearchFunc(tl.Intervals, ts,
+		func(interval timeline.Interval, ts time.Time) int { return interval.Start.Compare(ts) })
+	if !found {
+		i--
+	}
+	if i < 0 {
+		return false
+	}
+	interval := tl.Intervals[i]
+	return interval.End == nil || ts.Before(*interval.End)
+}
+
+// jsonMinutes is a minute quantity that serializes at its full scale. A bare
+// decimal renders 14400.0000 as 14400, which hides the scale the quantity was
+// rated at.
+type jsonMinutes struct {
+	decimal.Decimal
+}
+
+// MarshalJSON renders the quantity as a JSON number with four decimal places.
+func (m jsonMinutes) MarshalJSON() ([]byte, error) {
+	return []byte(m.StringFixed(minutePlaces)), nil
+}
+
+// jsonQuantity is a size quantity that serializes as the number it is, without
+// the quotes a decimal marshals itself with.
+type jsonQuantity struct {
+	decimal.Decimal
+}
+
+// MarshalJSON renders the quantity as a JSON number at the scale it carries.
+func (q jsonQuantity) MarshalJSON() ([]byte, error) {
+	return []byte(q.String()), nil
+}
+
+// document is the slice's whole output: one project's rated usage for one
+// month.
+type document struct {
+	Cloud     string        `json:"cloud"`
+	ProjectID string        `json:"project_id"`
+	Period    periodDoc     `json:"period"`
+	Currency  string        `json:"currency"`
+	Resources []resourceDoc `json:"resources"`
+	Total     money.Amount  `json:"total"`
+}
+
+// periodDoc is the reported span, half-open as everywhere else.
+type periodDoc struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+// resourceDoc is one resource's rated usage. Warnings come from the fold and
+// violations from the invariant checks: both are reported next to the numbers
+// they qualify rather than to a log nobody reads next to the output.
+type resourceDoc struct {
+	ResourceID string       `json:"resource_id"`
+	Warnings   []string     `json:"warnings"`
+	Violations []string     `json:"violations"`
+	Records    []recordDoc  `json:"records"`
+	Total      money.Amount `json:"total"`
+}
+
+// recordDoc is one billed interval with its line items.
+type recordDoc struct {
+	From       time.Time               `json:"from"`
+	To         time.Time               `json:"to"`
+	State      string                  `json:"state"`
+	Seconds    int64                   `json:"seconds"`
+	Minutes    jsonMinutes             `json:"minutes"`
+	Dimensions map[string]dimensionDoc `json:"dimensions"`
+	Subtotal   money.Amount            `json:"subtotal"`
+}
+
+// dimensionDoc is what one priced metric contributed to a record.
+type dimensionDoc struct {
+	Quantity jsonQuantity `json:"quantity"`
+	Cost     money.Amount `json:"cost"`
+}
+
+// buildResourceDoc rates one folded history for the period. The second result
+// is false for a resource that bills nothing in it, which the caller leaves out
+// of the document: an empty history and a resource that lived outside the month
+// both produce that.
+func buildResourceDoc(resourceID string, tl timeline.Timeline, p period, pr pricing) (resourceDoc, bool, error) {
+	records := buildRecords(tl, p)
+	if len(records) == 0 {
+		return resourceDoc{}, false, nil
+	}
+
+	// The fold's warnings are copied rather than referenced, so that the
+	// document holds an empty array for a clean resource instead of the null a
+	// nil slice marshals to.
+	warnings := make([]string, 0, len(tl.Warnings))
+	warnings = append(warnings, tl.Warnings...)
+
+	doc := resourceDoc{
+		ResourceID: resourceID,
+		Warnings:   warnings,
+		Violations: checkInvariants(records, tl, p),
+		Records:    make([]recordDoc, 0, len(records)),
+	}
+
+	total := decimal.Zero
+	for _, rec := range records {
+		dimensions, subtotal, err := rate(rec, pr)
+		if err != nil {
+			return resourceDoc{}, false, err
+		}
+
+		doc.Records = append(doc.Records, recordDoc{
+			From:       rec.From,
+			To:         rec.To,
+			State:      rec.State,
+			Seconds:    rec.Seconds,
+			Minutes:    jsonMinutes{Decimal: rec.Minutes},
+			Dimensions: dimensions,
+			Subtotal:   money.NewAmount(subtotal),
+		})
+		total = total.Add(subtotal)
+	}
+	doc.Total = money.NewAmount(total)
+
+	return doc, true, nil
+}

--- a/cmd/tally-vertical-slice/compute_test.go
+++ b/cmd/tally-vertical-slice/compute_test.go
@@ -1,0 +1,679 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/core/timeline"
+)
+
+// instant parses an RFC 3339 timestamp a test states inline.
+func instant(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", value, err)
+	}
+	return parsed
+}
+
+// march is the period every clipping test reports.
+func march(t *testing.T) period {
+	t.Helper()
+
+	p, err := parseMonth("2026-03")
+	if err != nil {
+		t.Fatalf("parseMonth() error = %v, want nil", err)
+	}
+	return p
+}
+
+// goldenSize is the instance the golden numbers are rated for: the concept's
+// section 3.4 example. The values are float64 because that is what a decoded
+// JSON payload carries.
+func goldenSize() map[string]any {
+	return map[string]any{
+		"vcpus":   float64(4),
+		"ram_gb":  float64(8),
+		"disk_gb": float64(80),
+		"flavor":  "m1.large",
+	}
+}
+
+// storedEvent builds one history entry. received_at follows the timestamp,
+// which is what a collector that delivered promptly produces.
+func storedEvent(t *testing.T, eventID, eventType, timestamp, state string, size map[string]any) event.Stored {
+	t.Helper()
+
+	ts := instant(t, timestamp)
+	return event.Stored{
+		Event: event.Event{
+			EventID:      eventID,
+			Timestamp:    ts,
+			EventType:    eventType,
+			Platform:     "openstack",
+			Cloud:        "os-prod-eu1",
+			ResourceType: "instance",
+			ResourceID:   "abc-123",
+			ProjectID:    "proj-456",
+			Source:       event.SourceCollector,
+			Payload:      event.PayloadEnvelope{State: &state, Size: size},
+		},
+		ReceivedAt: ts,
+	}
+}
+
+// goldenTimeline folds the WP 1.15 history: an instance created in February,
+// powered off on 03-11, and powered on again on 03-21. It is folded rather than
+// written out, so the tests rate what the shared fold produces.
+func goldenTimeline(t *testing.T) timeline.Timeline {
+	t.Helper()
+
+	return timeline.Build([]event.Stored{
+		storedEvent(t, "e1", "compute.instance.create.end", "2026-02-10T08:00:00Z", "active", goldenSize()),
+		storedEvent(t, "e2", "compute.instance.power_off", "2026-03-11T00:00:00Z", "shutoff", nil),
+		storedEvent(t, "e3", "compute.instance.power_on", "2026-03-21T00:00:00Z", "active", nil),
+	})
+}
+
+// prototypePricing loads the pricing the golden numbers are rated against.
+func prototypePricing(t *testing.T) pricing {
+	t.Helper()
+
+	pr, err := loadPricing(filepath.Join("..", "..", "pricing", "prototype.yaml"))
+	if err != nil {
+		t.Fatalf("loadPricing() error = %v, want nil", err)
+	}
+	return pr
+}
+
+func TestParseMonth(t *testing.T) {
+	t.Run("a month becomes the half-open span it covers", func(t *testing.T) {
+		p, err := parseMonth("2026-03")
+		if err != nil {
+			t.Fatalf("parseMonth() error = %v, want nil", err)
+		}
+
+		if want := instant(t, "2026-03-01T00:00:00Z"); !p.From.Equal(want) {
+			t.Errorf("From = %s, want %s", p.From.Format(time.RFC3339), want.Format(time.RFC3339))
+		}
+		if want := instant(t, "2026-04-01T00:00:00Z"); !p.To.Equal(want) {
+			t.Errorf("To = %s, want %s", p.To.Format(time.RFC3339), want.Format(time.RFC3339))
+		}
+	})
+
+	// A month that is almost right is the likelier mistake, and rating the wrong
+	// span silently is what the refusal prevents.
+	for name, value := range map[string]string{
+		"a month without its leading zero": "2026-3",
+		"a month that does not exist":      "2026-13",
+		"an empty value":                   "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseMonth(value); err == nil {
+				t.Fatalf("parseMonth(%q) error = nil, want an error", value)
+			}
+		})
+	}
+}
+
+func TestBuildRecordsClipsToThePeriod(t *testing.T) {
+	p := march(t)
+	end := instant(t, "2026-02-20T00:00:00Z")
+	late := instant(t, "2026-05-02T00:00:00Z")
+
+	t.Run("an interval straddling the start is billed from the start", func(t *testing.T) {
+		closed := instant(t, "2026-03-05T00:00:00Z")
+		records := buildRecords(timeline.Timeline{Intervals: []timeline.Interval{
+			{Start: instant(t, "2026-02-10T08:00:00Z"), End: &closed, State: "active"},
+		}}, p)
+
+		if len(records) != 1 {
+			t.Fatalf("buildRecords() = %d records, want 1", len(records))
+		}
+		if !records[0].From.Equal(p.From) {
+			t.Errorf("From = %s, want the period's start %s",
+				records[0].From.Format(time.RFC3339), p.From.Format(time.RFC3339))
+		}
+	})
+
+	t.Run("an open interval is billed to the end of the period", func(t *testing.T) {
+		records := buildRecords(timeline.Timeline{Intervals: []timeline.Interval{
+			{Start: instant(t, "2026-03-20T00:00:00Z"), State: "active"},
+		}}, p)
+
+		if len(records) != 1 {
+			t.Fatalf("buildRecords() = %d records, want 1", len(records))
+		}
+		if !records[0].To.Equal(p.To) {
+			t.Errorf("To = %s, want the period's end %s",
+				records[0].To.Format(time.RFC3339), p.To.Format(time.RFC3339))
+		}
+	})
+
+	t.Run("an interval before the period bills nothing", func(t *testing.T) {
+		records := buildRecords(timeline.Timeline{Intervals: []timeline.Interval{
+			{Start: instant(t, "2026-02-10T08:00:00Z"), End: &end, State: "active"},
+		}}, p)
+
+		if len(records) != 0 {
+			t.Errorf("buildRecords() = %d records, want none", len(records))
+		}
+	})
+
+	t.Run("an interval starting at the period's end bills nothing", func(t *testing.T) {
+		records := buildRecords(timeline.Timeline{Intervals: []timeline.Interval{
+			{Start: p.To, End: &late, State: "active"},
+		}}, p)
+
+		if len(records) != 0 {
+			t.Errorf("buildRecords() = %d records, want none", len(records))
+		}
+	})
+
+	t.Run("an empty history bills nothing", func(t *testing.T) {
+		if records := buildRecords(timeline.Build(nil), p); len(records) != 0 {
+			t.Errorf("buildRecords() = %d records, want none", len(records))
+		}
+	})
+
+	// A delete is how an instance's billing ends, and it ends it where the
+	// delete says rather than at the end of the month.
+	t.Run("a deleted resource is billed to its deletion", func(t *testing.T) {
+		deleted := instant(t, "2026-03-20T00:00:00Z")
+		tl := timeline.Build([]event.Stored{
+			storedEvent(t, "e1", "compute.instance.create.end", "2026-03-05T00:00:00Z", "active", goldenSize()),
+			storedEvent(t, "e2", "compute.instance.delete.end", "2026-03-20T00:00:00Z", "deleted", nil),
+		})
+
+		records := buildRecords(tl, p)
+		if len(records) != 1 {
+			t.Fatalf("buildRecords() = %d records, want 1", len(records))
+		}
+		if !records[0].To.Equal(deleted) {
+			t.Errorf("To = %s, want the deletion %s",
+				records[0].To.Format(time.RFC3339), deleted.Format(time.RFC3339))
+		}
+		if want := int64(15 * 24 * 60 * 60); records[0].Seconds != want {
+			t.Errorf("Seconds = %d, want %d", records[0].Seconds, want)
+		}
+		if violations := checkInvariants(records, tl, p); len(violations) != 0 {
+			t.Errorf("checkInvariants() = %v, want none", violations)
+		}
+	})
+
+	// The golden history, clipped to March: ten days active, ten days off, and
+	// the remaining eleven days active again. These are the seconds the WP 1.15
+	// table's minutes are derived from.
+	t.Run("the golden history yields the golden quantities", func(t *testing.T) {
+		records := buildRecords(goldenTimeline(t), p)
+
+		want := []struct {
+			from, to, state, minutes string
+			seconds                  int64
+		}{
+			{"2026-03-01T00:00:00Z", "2026-03-11T00:00:00Z", "active", "14400", 864000},
+			{"2026-03-11T00:00:00Z", "2026-03-21T00:00:00Z", "shutoff", "14400", 864000},
+			{"2026-03-21T00:00:00Z", "2026-04-01T00:00:00Z", "active", "15840", 950400},
+		}
+		if len(records) != len(want) {
+			t.Fatalf("buildRecords() = %d records, want %d", len(records), len(want))
+		}
+		for i, expected := range want {
+			got := records[i]
+			if !got.From.Equal(instant(t, expected.from)) || !got.To.Equal(instant(t, expected.to)) {
+				t.Errorf("records[%d] = %s..%s, want %s..%s", i,
+					got.From.Format(time.RFC3339), got.To.Format(time.RFC3339), expected.from, expected.to)
+			}
+			if got.State != expected.state {
+				t.Errorf("records[%d].State = %q, want %q", i, got.State, expected.state)
+			}
+			if got.Seconds != expected.seconds {
+				t.Errorf("records[%d].Seconds = %d, want %d", i, got.Seconds, expected.seconds)
+			}
+			if !got.Minutes.Equal(decimal.RequireFromString(expected.minutes)) {
+				t.Errorf("records[%d].Minutes = %s, want %s", i, got.Minutes, expected.minutes)
+			}
+		}
+	})
+}
+
+func TestSizeDecimal(t *testing.T) {
+	t.Run("a decoded JSON number keeps its value", func(t *testing.T) {
+		for metric, want := range map[string]string{"vcpus": "4", "disk_gb": "80"} {
+			got, err := sizeDecimal(goldenSize(), metric)
+			if err != nil {
+				t.Fatalf("sizeDecimal(%q) error = %v, want nil", metric, err)
+			}
+			if !got.Equal(decimal.RequireFromString(want)) {
+				t.Errorf("sizeDecimal(%q) = %s, want %s", metric, got, want)
+			}
+		}
+	})
+
+	// A size assembled in Go rather than decoded carries plain ints, which the
+	// same path has to read.
+	t.Run("an integer value keeps its value", func(t *testing.T) {
+		got, err := sizeDecimal(map[string]any{"vcpus": 4}, "vcpus")
+		if err != nil {
+			t.Fatalf("sizeDecimal() error = %v, want nil", err)
+		}
+		if !got.Equal(decimal.NewFromInt(4)) {
+			t.Errorf("sizeDecimal() = %s, want 4", got)
+		}
+	})
+
+	t.Run("a metric the size does not carry is refused", func(t *testing.T) {
+		_, err := sizeDecimal(map[string]any{"vcpus": float64(4)}, "ram_gb")
+		if err == nil {
+			t.Fatalf("sizeDecimal() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "ram_gb") {
+			t.Errorf("sizeDecimal() error = %v, want it to name ram_gb", err)
+		}
+	})
+
+	t.Run("a metric that is not a number is refused", func(t *testing.T) {
+		_, err := sizeDecimal(goldenSize(), "flavor")
+		if err == nil {
+			t.Fatalf("sizeDecimal() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "flavor") {
+			t.Errorf("sizeDecimal() error = %v, want it to name flavor", err)
+		}
+	})
+}
+
+// TestRateAppliesPricesAndModifiers is the golden-numbers gate on the rating
+// itself: the first row of the WP 1.15 table, and what the modifiers do to it.
+func TestRateAppliesPricesAndModifiers(t *testing.T) {
+	pr := prototypePricing(t)
+	golden := usageRecord{
+		From:    instant(t, "2026-03-01T00:00:00Z"),
+		To:      instant(t, "2026-03-11T00:00:00Z"),
+		State:   "active",
+		Size:    goldenSize(),
+		Seconds: 864000,
+		Minutes: money.Minutes(864000),
+	}
+
+	for name, tc := range map[string]struct {
+		state    string
+		costs    map[string]string
+		subtotal string
+	}{
+		"active is billed in full": {
+			state:    "active",
+			costs:    map[string]string{"vcpus": "19.20", "ram_gb": "9.60", "disk_gb": "19.20"},
+			subtotal: "48.00",
+		},
+		"shutoff is halved": {
+			state:    "shutoff",
+			costs:    map[string]string{"vcpus": "9.60", "ram_gb": "4.80", "disk_gb": "9.60"},
+			subtotal: "24.00",
+		},
+		"shelved is free": {
+			state:    "shelved",
+			costs:    map[string]string{"vcpus": "0.00", "ram_gb": "0.00", "disk_gb": "0.00"},
+			subtotal: "0.00",
+		},
+		"a state with no modifier is billed in full": {
+			state:    "rescued",
+			costs:    map[string]string{"vcpus": "19.20", "ram_gb": "9.60", "disk_gb": "19.20"},
+			subtotal: "48.00",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := golden
+			rec.State = tc.state
+
+			dimensions, subtotal, err := rate(rec, pr)
+			if err != nil {
+				t.Fatalf("rate() error = %v, want nil", err)
+			}
+
+			if len(dimensions) != len(tc.costs) {
+				t.Fatalf("rate() = %d dimensions, want %d", len(dimensions), len(tc.costs))
+			}
+			for metric, dim := range dimensions {
+				want, ok := tc.costs[metric]
+				if !ok {
+					t.Errorf("rate() priced %q, which the case does not expect", metric)
+					continue
+				}
+				if got := dim.Cost.StringFixed(2); got != want {
+					t.Errorf("%s cost = %s, want %s", metric, got, want)
+				}
+			}
+			if got := subtotal.StringFixed(2); got != tc.subtotal {
+				t.Errorf("Subtotal = %s, want %s", got, tc.subtotal)
+			}
+		})
+	}
+
+	t.Run("a priced metric the size does not carry is refused", func(t *testing.T) {
+		rec := golden
+		rec.Size = map[string]any{"vcpus": float64(4), "disk_gb": float64(80)}
+
+		_, _, err := rate(rec, pr)
+		if err == nil {
+			t.Fatalf("rate() error = nil, want an error")
+		}
+		for _, want := range []string{"2026-03-01T00:00:00Z", "ram_gb"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("rate() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+}
+
+func TestCheckInvariantsTripsOnBadRecords(t *testing.T) {
+	p := march(t)
+	tl := goldenTimeline(t)
+
+	// A record is only ever built from an interval, so these are stated by hand:
+	// they are what a broken clipping would produce.
+	record := func(from, to string, seconds int64) usageRecord {
+		return usageRecord{
+			From:    instant(t, from),
+			To:      instant(t, to),
+			State:   "active",
+			Size:    goldenSize(),
+			Seconds: seconds,
+			Minutes: money.Minutes(seconds),
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		records []usageRecord
+		want    []string
+	}{
+		"an overlap between two records": {
+			records: []usageRecord{
+				record("2026-03-01T00:00:00Z", "2026-03-12T00:00:00Z", 950400),
+				record("2026-03-11T00:00:00Z", "2026-04-01T00:00:00Z", 1814400),
+			},
+			want: []string{"2026-03-12T00:00:00Z", "2026-03-11T00:00:00Z"},
+		},
+		"a gap between two records": {
+			records: []usageRecord{
+				record("2026-03-01T00:00:00Z", "2026-03-05T00:00:00Z", 345600),
+				record("2026-03-06T00:00:00Z", "2026-04-01T00:00:00Z", 2246400),
+			},
+			want: []string{"2026-03-05T00:00:00Z", "2026-03-06T00:00:00Z"},
+		},
+		"a record outside the period": {
+			records: []usageRecord{
+				record("2026-02-25T00:00:00Z", "2026-04-01T00:00:00Z", 2678400),
+			},
+			want: []string{"2026-02-25T00:00:00Z", "2026-03-01T00:00:00Z"},
+		},
+		"a record that bills no time": {
+			records: []usageRecord{
+				record("2026-03-05T00:00:00Z", "2026-03-05T00:00:00Z", 0),
+			},
+			want: []string{"bills no time"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			violations := checkInvariants(tc.records, tl, p)
+			if len(violations) == 0 {
+				t.Fatalf("checkInvariants() = no violations, want one naming %v", tc.want)
+			}
+
+			joined := strings.Join(violations, "\n")
+			for _, want := range tc.want {
+				if !strings.Contains(joined, want) {
+					t.Errorf("checkInvariants() = %v, want a violation naming %s", violations, want)
+				}
+			}
+		})
+	}
+
+	t.Run("the golden records are clean", func(t *testing.T) {
+		if violations := checkInvariants(buildRecords(tl, p), tl, p); len(violations) != 0 {
+			t.Errorf("checkInvariants() = %v, want none", violations)
+		}
+	})
+
+	t.Run("an empty history breaks nothing", func(t *testing.T) {
+		if violations := checkInvariants(nil, timeline.Build(nil), p); len(violations) != 0 {
+			t.Errorf("checkInvariants() = %v, want none", violations)
+		}
+	})
+
+	// An OpenStack notification carries microseconds, so a transition inside the
+	// month lands between two seconds. The two records still meet there: a
+	// boundary is carried over as it stands, and only the durations derived from
+	// it are truncated.
+	t.Run("a history with sub-second timestamps breaks nothing", func(t *testing.T) {
+		tl := timeline.Build([]event.Stored{
+			storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T12:00:00.5Z", "active", goldenSize()),
+			storedEvent(t, "e2", "compute.instance.power_off", "2026-03-11T00:00:00.1Z", "shutoff", nil),
+		})
+
+		records := buildRecords(tl, p)
+		if len(records) != 2 {
+			t.Fatalf("buildRecords() = %d records, want 2", len(records))
+		}
+		if violations := checkInvariants(records, tl, p); len(violations) != 0 {
+			t.Errorf("checkInvariants() = %v, want none", violations)
+		}
+	})
+
+	// A create after a delete is the resource coming back: two lives with three
+	// days between them the resource did not exist for.
+	recreated := timeline.Build([]event.Stored{
+		storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T00:00:00Z", "active", goldenSize()),
+		storedEvent(t, "e2", "compute.instance.delete.end", "2026-03-02T00:00:00Z", "deleted", nil),
+		storedEvent(t, "e3", "compute.instance.create.end", "2026-03-05T00:00:00Z", "active", goldenSize()),
+	})
+
+	// The days between the two lives are not time the resource lived, so the
+	// records on either side of them are not meant to meet: reporting that as a
+	// gap would fail the run on numbers that are all right.
+	t.Run("a resource that was deleted and created again breaks nothing", func(t *testing.T) {
+		records := buildRecords(recreated, p)
+		if len(records) != 2 {
+			t.Fatalf("buildRecords() = %d records, want 2", len(records))
+		}
+		if violations := checkInvariants(records, recreated, p); len(violations) != 0 {
+			t.Errorf("checkInvariants() = %v, want none", violations)
+		}
+	})
+
+	// An overlap is wrong wherever it falls, including at the instant a life
+	// ends. Only a gap is forgiven over time the resource did not exist for, and
+	// a second the records bill twice is not that: the resource lived through it
+	// once, whether or not it lived through the instant the overlap ends at.
+	t.Run("an overlap at the end of a life is still reported", func(t *testing.T) {
+		deleted := timeline.Build([]event.Stored{
+			storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T00:00:00Z", "active", goldenSize()),
+			storedEvent(t, "e2", "compute.instance.delete.end", "2026-03-10T00:00:00Z", "deleted", nil),
+		})
+
+		// The one life billed twice: the record ends where the resource does, so
+		// the resource no longer existed at the instant the overlap closes at.
+		violations := checkInvariants([]usageRecord{
+			record("2026-03-01T00:00:00Z", "2026-03-10T00:00:00Z", 777600),
+			record("2026-03-01T00:00:00Z", "2026-03-10T00:00:00Z", 777600),
+		}, deleted, p)
+
+		if len(violations) != 1 || !strings.Contains(violations[0], "overlaps") {
+			t.Errorf("checkInvariants() = %v, want the double-billed life reported", violations)
+		}
+	})
+
+	// Only the gap between two lives is forgiven. One inside a life is time the
+	// clipping lost, and it is reported even when the same history carries a
+	// legitimate gap next to it.
+	t.Run("a gap inside a life is still reported", func(t *testing.T) {
+		violations := checkInvariants([]usageRecord{
+			record("2026-03-01T00:00:00Z", "2026-03-02T00:00:00Z", 86400),
+			record("2026-03-05T00:00:00Z", "2026-03-06T00:00:00Z", 86400),
+			record("2026-03-07T00:00:00Z", "2026-04-01T00:00:00Z", 2160000),
+		}, recreated, p)
+
+		if len(violations) != 1 || !strings.Contains(violations[0], "2026-03-06T00:00:00Z") {
+			t.Errorf("checkInvariants() = %v, want the gap inside the second life alone", violations)
+		}
+	})
+}
+
+// TestWarningsPassThrough keeps what the fold could not establish visible in
+// the output: a history that starts mid-life bills from an unknown start, and
+// the reader of the numbers has to be told so.
+func TestWarningsPassThrough(t *testing.T) {
+	tl := timeline.Build([]event.Stored{
+		storedEvent(t, "e1", "compute.instance.power_on", "2026-03-01T00:00:00Z", "active", goldenSize()),
+	})
+	if !slices.Contains(tl.Warnings, timeline.WarningHistoryStartsWithoutCreate) {
+		t.Fatalf("Warnings = %v, want %q", tl.Warnings, timeline.WarningHistoryStartsWithoutCreate)
+	}
+
+	doc, billed, err := buildResourceDoc("abc-123", tl, march(t), prototypePricing(t))
+	if err != nil {
+		t.Fatalf("buildResourceDoc() error = %v, want nil", err)
+	}
+	if !billed {
+		t.Fatalf("buildResourceDoc() billed = false, want the resource in the document")
+	}
+	if !slices.Contains(doc.Warnings, timeline.WarningHistoryStartsWithoutCreate) {
+		t.Errorf("Warnings = %v, want %q", doc.Warnings, timeline.WarningHistoryStartsWithoutCreate)
+	}
+}
+
+// TestBuildResourceDocDropsAResourceThatBillsNothing keeps a resource that
+// lived outside the month out of the document: it is not an empty entry with a
+// zero total, which a reader would take for an instance that ran for free.
+func TestBuildResourceDocDropsAResourceThatBillsNothing(t *testing.T) {
+	tl := timeline.Build([]event.Stored{
+		storedEvent(t, "e1", "compute.instance.create.end", "2026-01-10T00:00:00Z", "active", goldenSize()),
+		storedEvent(t, "e2", "compute.instance.delete.end", "2026-02-05T00:00:00Z", "deleted", nil),
+	})
+
+	doc, billed, err := buildResourceDoc("abc-123", tl, march(t), prototypePricing(t))
+	if err != nil {
+		t.Fatalf("buildResourceDoc() error = %v, want nil", err)
+	}
+	if billed {
+		t.Errorf("buildResourceDoc() billed = true with %+v, want the resource left out", doc)
+	}
+}
+
+// TestDocumentSerializationKeepsPrecision reads the encoded bytes rather than
+// the values behind them: what a customer reconciles against an invoice is the
+// output, and a subtotal rendered as 48 rather than 48.00 is already wrong
+// there.
+func TestDocumentSerializationKeepsPrecision(t *testing.T) {
+	t.Run("a rated record keeps its scale", func(t *testing.T) {
+		doc := document{
+			Cloud:     "os-prod-eu1",
+			ProjectID: "proj-456",
+			Period:    periodDoc{From: instant(t, "2026-03-01T00:00:00Z"), To: instant(t, "2026-04-01T00:00:00Z")},
+			Currency:  "EUR",
+			Resources: []resourceDoc{{
+				ResourceID: "abc-123",
+				Warnings:   []string{},
+				Violations: []string{},
+				Records: []recordDoc{{
+					From:    instant(t, "2026-03-01T00:00:00Z"),
+					To:      instant(t, "2026-03-11T00:00:00Z"),
+					State:   "active",
+					Seconds: 864000,
+					Minutes: jsonMinutes{Decimal: money.Minutes(864000)},
+					Dimensions: map[string]dimensionDoc{"vcpus": {
+						Quantity: jsonQuantity{Decimal: decimal.NewFromInt(4)},
+						Cost:     money.NewAmount(decimal.RequireFromString("19.2")),
+					}},
+					Subtotal: money.NewAmount(decimal.RequireFromString("48")),
+				}},
+				Total: money.NewAmount(decimal.RequireFromString("48")),
+			}},
+			Total: money.NewAmount(decimal.RequireFromString("48")),
+		}
+
+		encoded, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+
+		for _, want := range []string{
+			`"minutes":14400.0000`,
+			`"quantity":4`,
+			`"cost":19.20`,
+			`"subtotal":48.00`,
+			`"total":48.00`,
+			`"warnings":[]`,
+			`"violations":[]`,
+			`"from":"2026-03-01T00:00:00Z"`,
+		} {
+			if !strings.Contains(string(encoded), want) {
+				t.Errorf("the document does not carry %s:\n%s", want, encoded)
+			}
+		}
+	})
+
+	t.Run("a project without resources renders empty lists", func(t *testing.T) {
+		encoded, err := json.Marshal(document{Resources: []resourceDoc{}, Total: money.NewAmount(decimal.Zero)})
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+
+		for _, want := range []string{`"resources":[]`, `"total":0.00`} {
+			if !strings.Contains(string(encoded), want) {
+				t.Errorf("the document does not carry %s:\n%s", want, encoded)
+			}
+		}
+	})
+}
+
+// TestExistedAt pins the lookup the gap check forgives a gap by. It answers
+// from the ordering timeline.Build guarantees rather than from a scan, so the
+// boundaries of a life, and an instant before every life, are what the search
+// has to get right.
+func TestExistedAt(t *testing.T) {
+	// Two lives with three days between them, the second one still open.
+	tl := timeline.Build([]event.Stored{
+		storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T00:00:00Z", "active", goldenSize()),
+		storedEvent(t, "e2", "compute.instance.delete.end", "2026-03-02T00:00:00Z", "deleted", nil),
+		storedEvent(t, "e3", "compute.instance.create.end", "2026-03-05T00:00:00Z", "active", goldenSize()),
+	})
+
+	for name, tc := range map[string]struct {
+		ts   string
+		want bool
+	}{
+		"before the first life":              {ts: "2026-02-28T00:00:00Z", want: false},
+		"the instant the first life starts":  {ts: "2026-03-01T00:00:00Z", want: true},
+		"inside the first life":              {ts: "2026-03-01T12:00:00Z", want: true},
+		"the instant the first life ends":    {ts: "2026-03-02T00:00:00Z", want: false},
+		"between the two lives":              {ts: "2026-03-03T00:00:00Z", want: false},
+		"the instant the second life starts": {ts: "2026-03-05T00:00:00Z", want: true},
+		"long after the open life started":   {ts: "2027-01-01T00:00:00Z", want: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := existedAt(tl, instant(t, tc.ts)); got != tc.want {
+				t.Errorf("existedAt(%s) = %t, want %t", tc.ts, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExistedAtOnAnEmptyTimeline holds the lookup to answering rather than
+// panicking for a history that folded to nothing: a resource the API served no
+// events for reaches the invariant check the same way any other does.
+func TestExistedAtOnAnEmptyTimeline(t *testing.T) {
+	if existedAt(timeline.Build(nil), instant(t, "2026-03-01T00:00:00Z")) {
+		t.Error("existedAt() = true on an empty timeline, want false")
+	}
+}

--- a/cmd/tally-vertical-slice/main.go
+++ b/cmd/tally-vertical-slice/main.go
@@ -1,0 +1,214 @@
+// Command tally-vertical-slice rates one project's instance usage for one
+// calendar month and prints it as JSON.
+//
+// It is a throwaway prototype (roadmap/01-phase-1-core-platform-openstack.md,
+// WP 1.15). It exists to prove the billing chain end to end on numbers that can
+// be checked by hand: it reads the Reporting API, folds each instance's history
+// with internal/core/timeline, clips the intervals to the month, derives usage
+// records, rates them against a pricing file, and checks the metering
+// invariants over what it derived. Nothing under internal/ knows about it, and
+// Phase 3 replaces it with the metering engine; only the timeline fold carries
+// over.
+//
+// The clipping, the rating, and the invariant checks therefore live here rather
+// than in a package: they are the engine's work, and putting a prototype's
+// version of them in the core would be the wrong home for code that is meant to
+// be deleted.
+//
+// The document goes to stdout even when an invariant is broken, and the process
+// then exits 1: the numbers are what the run is for, so they stay inspectable
+// while the exit status still reports the failure.
+//
+//	TALLY_SLICE_TOKEN=<api-token> go run ./cmd/tally-vertical-slice \
+//	  --cloud os-prod-eu1 --project proj-456 --month 2026-03 \
+//	  --reporting-url https://api.tally.127-0-0-1.nip.io:8443 \
+//	  --pricing pricing/prototype.yaml --ca-file tally-ca.crt
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/core/timeline"
+)
+
+const (
+	// tokenEnv names the variable the API token is read from. It stays out of
+	// the flags so that the credential never appears in the process's argv.
+	tokenEnv = "TALLY_SLICE_TOKEN"
+	// violationLimit caps what one failure may add to the document. The text is
+	// the API's to choose, and one line of it is held per resource until the run
+	// encodes the document at the end, so an unbounded one would let a project's
+	// worth of oversized problem documents grow the run out of memory before it
+	// prints anything at all.
+	violationLimit = 4 << 10
+)
+
+// config is one run's input. It is a value rather than a set of globals, so a
+// test drives run against an httptest server and a buffer.
+type config struct {
+	cloud        string
+	project      string
+	month        string
+	reportingURL string
+	pricingPath  string
+	caFile       string
+	token        string
+}
+
+func main() {
+	var cfg config
+	flag.StringVar(&cfg.cloud, "cloud", "", "the cloud the instances live in, os-prod-eu1 for example")
+	flag.StringVar(&cfg.project, "project", "", "the project to rate, named the way its cloud names it")
+	flag.StringVar(&cfg.month, "month", "", "the calendar month to rate, as YYYY-MM")
+	flag.StringVar(&cfg.reportingURL, "reporting-url", "",
+		"https base URL of the Reporting API, without the /api/v1 suffix")
+	flag.StringVar(&cfg.pricingPath, "pricing", "", "path to the pricing file, pricing/prototype.yaml for example")
+	flag.StringVar(&cfg.caFile, "ca-file", "",
+		"PEM bundle to trust instead of the system store, for a dev cluster's own CA")
+	flag.Parse()
+
+	cfg.token = os.Getenv(tokenEnv)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, cfg, os.Stdout); err != nil {
+		slog.Error("tally-vertical-slice stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+// run rates the configured month and writes the document to out. It returns an
+// error for a run that could not produce a document, and for one whose numbers
+// broke an invariant: the second kind has already written its output by then.
+func run(ctx context.Context, cfg config, out io.Writer) error {
+	for _, required := range []struct{ name, value string }{
+		{"--cloud", cfg.cloud},
+		{"--project", cfg.project},
+		{"--month", cfg.month},
+		{"--reporting-url", cfg.reportingURL},
+		{"--pricing", cfg.pricingPath},
+	} {
+		if required.value == "" {
+			return fmt.Errorf("%s is required", required.name)
+		}
+	}
+	if cfg.token == "" {
+		return fmt.Errorf("%s is required", tokenEnv)
+	}
+
+	p, err := parseMonth(cfg.month)
+	if err != nil {
+		return err
+	}
+	pr, err := loadPricing(cfg.pricingPath)
+	if err != nil {
+		return err
+	}
+	api, err := newClient(cfg.reportingURL, cfg.token, cfg.caFile)
+	if err != nil {
+		return err
+	}
+
+	resourceIDs, err := api.listResources(ctx, cfg.cloud, cfg.project)
+	if err != nil {
+		return fmt.Errorf("listing resources for %s/%s: %w", cfg.cloud, cfg.project, err)
+	}
+
+	doc := document{
+		Cloud:     cfg.cloud,
+		ProjectID: cfg.project,
+		Period:    periodDoc(p),
+		Currency:  pr.Currency,
+		Resources: make([]resourceDoc, 0, len(resourceIDs)),
+	}
+	total := decimal.Zero
+	violations := 0
+
+	for _, resourceID := range resourceIDs {
+		resource, billed, err := rateResource(ctx, api, cfg.cloud, resourceID, p, pr)
+		if err != nil {
+			return err
+		}
+		if !billed {
+			continue
+		}
+
+		violations += len(resource.Violations)
+		total = total.Add(resource.Total.Decimal)
+		doc.Resources = append(doc.Resources, resource)
+	}
+	doc.Total = money.NewAmount(total)
+
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(doc); err != nil {
+		return fmt.Errorf("writing the document: %w", err)
+	}
+
+	// The document is out before this returns, which is the point of checking
+	// here: a broken run is one whose numbers are read, not one that printed
+	// nothing.
+	if violations > 0 {
+		return fmt.Errorf("the document reports %d broken metering invariants", violations)
+	}
+	return nil
+}
+
+// rateResource reads one instance's history and rates it for the period. A
+// history the API will not serve and a history the rating refuses both become a
+// resource carrying the failure as a violation rather than an error: one
+// instance the API lost between the listing and the walk, or one whose history
+// carries no size, is not a reason to withhold the numbers of every other
+// instance of the project. The document already has the slot that says these
+// are not to be trusted.
+//
+// The error return is what stops the run, and a cancelled one is what it is
+// for: every remaining fetch would fail the same way, so the run would print a
+// document that reports the operator's own interrupt once per resource.
+func rateResource(ctx context.Context, api *client, cloud, resourceID string, p period, pr pricing) (resourceDoc, bool, error) {
+	events, err := api.fetchHistory(ctx, cloud, resourceID)
+	if err != nil {
+		if ctx.Err() != nil {
+			return resourceDoc{}, false, err
+		}
+		return brokenResource(resourceID, fmt.Sprintf("the history could not be read: %v", err)), true, nil
+	}
+
+	resource, billed, err := buildResourceDoc(resourceID, timeline.Build(events), p, pr)
+	if err != nil {
+		return brokenResource(resourceID, fmt.Sprintf("the resource could not be rated: %v", err)), true, nil
+	}
+	return resource, billed, nil
+}
+
+// brokenResource is a resource the run could not put numbers on, reported with
+// what went wrong in the slot the document keeps for numbers that are not to be
+// trusted.
+func brokenResource(resourceID, violation string) resourceDoc {
+	if len(violation) > violationLimit {
+		// The cut lands on a byte, so what it leaves of a multi-byte character
+		// is dropped rather than encoded as the U+FFFD the encoder would put
+		// there.
+		violation = strings.ToValidUTF8(violation[:violationLimit], "") + "…"
+	}
+	return resourceDoc{
+		ResourceID: resourceID,
+		Warnings:   []string{},
+		Violations: []string{violation},
+		Records:    []recordDoc{},
+		Total:      money.NewAmount(decimal.Zero),
+	}
+}

--- a/cmd/tally-vertical-slice/main_test.go
+++ b/cmd/tally-vertical-slice/main_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+// completeConfig is a run's input with nothing missing. Every case below is
+// refused before the first request, so the URL is never dialled and the pricing
+// file is never read: both only have to be non-empty.
+func completeConfig() config {
+	return config{
+		cloud:        "os-prod-eu1",
+		project:      "proj-456",
+		month:        "2026-03",
+		reportingURL: "https://api.example",
+		pricingPath:  "absent.yaml",
+		token:        testToken,
+	}
+}
+
+// TestRunRejectsMissingConfiguration holds run to what it refuses before it
+// calls the API. Started on an incomplete configuration, a run would report a
+// connection or a pricing problem for a flag nobody passed, and an unset
+// TALLY_SLICE_TOKEN would reach the reader as an unauthorized request rather
+// than as the name of the variable to set.
+func TestRunRejectsMissingConfiguration(t *testing.T) {
+	for name, tc := range map[string]struct {
+		change func(*config)
+		want   string
+	}{
+		"a missing cloud":         {change: func(c *config) { c.cloud = "" }, want: "--cloud"},
+		"a missing project":       {change: func(c *config) { c.project = "" }, want: "--project"},
+		"a missing month":         {change: func(c *config) { c.month = "" }, want: "--month"},
+		"a missing reporting URL": {change: func(c *config) { c.reportingURL = "" }, want: "--reporting-url"},
+		"a missing pricing file":  {change: func(c *config) { c.pricingPath = "" }, want: "--pricing"},
+		// The variable's name is stated rather than read from tokenEnv: renaming
+		// it would break every documented run, so the test has to notice.
+		"a missing token": {change: func(c *config) { c.token = "" }, want: "TALLY_SLICE_TOKEN"},
+		// The month is checked before the pricing file is opened, so these two
+		// fail on the month rather than on the path that is not there.
+		"a month without its leading zero": {change: func(c *config) { c.month = "2026-3" }, want: `"2026-3"`},
+		"a month that does not exist":      {change: func(c *config) { c.month = "2026-13" }, want: `"2026-13"`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := completeConfig()
+			tc.change(&cfg)
+
+			var out bytes.Buffer
+			err := run(t.Context(), cfg, &out)
+			if err == nil {
+				t.Fatalf("run() error = nil, want an error naming %s", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("run() error = %v, want it to name %s", err, tc.want)
+			}
+			if out.Len() != 0 {
+				t.Errorf("run() wrote %q, want nothing written before the configuration is checked", out.String())
+			}
+		})
+	}
+}
+
+// TestRunPrintsTheDocumentAndThenFails is the command's stated contract: a run
+// whose numbers broke an invariant still writes them, and only then reports the
+// failure. An instance whose history carries no size cannot be rated, and the
+// numbers of every other instance of the project are what the run is for, so
+// the unrateable one becomes a violation next to them rather than a run that
+// printed nothing.
+func TestRunPrintsTheDocumentAndThenFails(t *testing.T) {
+	histories := map[string][]event.Stored{
+		"abc-123": {
+			storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T00:00:00Z", "active", goldenSize()),
+		},
+		// A history the collector joined mid-life: it starts without a create, so
+		// no event ever carried a size, and the fold has none to rate.
+		"def-456": {
+			storedEvent(t, "e1", "compute.instance.power_on", "2026-03-01T00:00:00Z", "active", nil),
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/resources" {
+			_, _ = fmt.Fprint(w, `{"items":[{"resource_id":"abc-123"},{"resource_id":"def-456"}],"next_cursor":null}`)
+			return
+		}
+		for resourceID, history := range histories {
+			if strings.Contains(r.URL.Path, resourceID) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": history})
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := run(t.Context(), config{
+		cloud:        "os-prod-eu1",
+		project:      "proj-456",
+		month:        "2026-03",
+		reportingURL: server.URL,
+		pricingPath:  filepath.Join("..", "..", "pricing", "prototype.yaml"),
+		token:        testToken,
+	}, &out)
+
+	if err == nil {
+		t.Fatalf("run() error = nil, want the broken invariants reported")
+	}
+	if !strings.Contains(err.Error(), "1 broken metering invariants") {
+		t.Errorf("run() error = %v, want it to count the broken invariants", err)
+	}
+
+	doc := decodeSliceDocument(t, out.String())
+	if len(doc.Resources) != 2 {
+		t.Fatalf("the document rates %d resources, want both:\n%s", len(doc.Resources), out.String())
+	}
+
+	rated, refused := doc.Resources[0], doc.Resources[1]
+	if len(rated.Violations) != 0 {
+		t.Errorf("abc-123 violations = %v, want none", rated.Violations)
+	}
+	assertNumber(t, "abc-123.total", rated.Total, "148.80")
+
+	if len(refused.Violations) != 1 || !strings.Contains(refused.Violations[0], "could not be rated") {
+		t.Errorf("def-456 violations = %v, want the rating's refusal", refused.Violations)
+	}
+	if len(refused.Records) != 0 {
+		t.Errorf("def-456 carries %d records, want none", len(refused.Records))
+	}
+	assertNumber(t, "def-456.total", refused.Total, "0.00")
+}
+
+// TestRunReportsAHistoryItCouldNotRead keeps one instance the API will not
+// serve from withholding the project's numbers. A resource a retention job
+// purges between the listing and the walk answers 404, and so does a gateway
+// having a bad minute: a run that stopped there would print nothing at all, not
+// even the instances it had already rated.
+func TestRunReportsAHistoryItCouldNotRead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/resources":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"items":[{"resource_id":"abc-123"},{"resource_id":"gone-789"}],"next_cursor":null}`)
+		case strings.Contains(r.URL.Path, "abc-123"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []event.Stored{
+				storedEvent(t, "e1", "compute.instance.create.end", "2026-03-01T00:00:00Z", "active", goldenSize()),
+			}})
+		default:
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"type":"urn:tally:error:not_found","title":"Not Found","status":404}`)
+		}
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := run(t.Context(), config{
+		cloud:        "os-prod-eu1",
+		project:      "proj-456",
+		month:        "2026-03",
+		reportingURL: server.URL,
+		pricingPath:  filepath.Join("..", "..", "pricing", "prototype.yaml"),
+		token:        testToken,
+	}, &out)
+
+	if err == nil {
+		t.Fatalf("run() error = nil, want the unread history reported")
+	}
+	if !strings.Contains(err.Error(), "1 broken metering invariants") {
+		t.Errorf("run() error = %v, want it to count the broken invariants", err)
+	}
+
+	doc := decodeSliceDocument(t, out.String())
+	if len(doc.Resources) != 2 {
+		t.Fatalf("the document rates %d resources, want both:\n%s", len(doc.Resources), out.String())
+	}
+
+	rated, unread := doc.Resources[0], doc.Resources[1]
+	if len(rated.Violations) != 0 {
+		t.Errorf("abc-123 violations = %v, want none", rated.Violations)
+	}
+	assertNumber(t, "abc-123.total", rated.Total, "148.80")
+
+	// The failure is named rather than summarized: the reader has to be able to
+	// tell a purged resource from a gateway that answered for one call.
+	if len(unread.Violations) != 1 {
+		t.Fatalf("gone-789 violations = %v, want the fetch's refusal", unread.Violations)
+	}
+	for _, want := range []string{"could not be read", "urn:tally:error:not_found"} {
+		if !strings.Contains(unread.Violations[0], want) {
+			t.Errorf("gone-789 violation = %q, want it to name %s", unread.Violations[0], want)
+		}
+	}
+	assertNumber(t, "gone-789.total", unread.Total, "0.00")
+}
+
+// TestBrokenResourceBoundsTheViolation keeps one refused answer from growing
+// the document without a bound. The text is the API's own diagnosis, and one
+// line of it is held per resource until the run encodes the document, so a
+// gateway answering every call with an oversized problem detail would otherwise
+// take the run out of memory before it printed anything.
+func TestBrokenResourceBoundsTheViolation(t *testing.T) {
+	t.Run("an oversized violation is cut to the limit", func(t *testing.T) {
+		resource := brokenResource("abc-123", strings.Repeat("a", 4*violationLimit))
+
+		if len(resource.Violations) != 1 {
+			t.Fatalf("Violations = %v, want one", resource.Violations)
+		}
+		// The ellipsis is what is left over the limit: it tells the reader they
+		// are not looking at the whole of what the API answered.
+		if got, want := len(resource.Violations[0]), violationLimit+len("…"); got > want {
+			t.Errorf("the violation is %d bytes, want at most %d", got, want)
+		}
+		if !strings.HasSuffix(resource.Violations[0], "…") {
+			t.Error("the violation does not end in the ellipsis that marks the cut")
+		}
+	})
+
+	// The cut lands on a byte whose position the API chose, so a multi-byte
+	// character straddling it must not reach the document half-encoded.
+	t.Run("the cut leaves valid UTF-8", func(t *testing.T) {
+		resource := brokenResource("abc-123", strings.Repeat("ä", violationLimit))
+
+		if !utf8.ValidString(resource.Violations[0]) {
+			t.Errorf("the violation is not valid UTF-8: %q", resource.Violations[0])
+		}
+	})
+
+	// A violation that fits is the ordinary case, and it is carried over whole.
+	t.Run("a violation that fits is left alone", func(t *testing.T) {
+		violation := "the history could not be read: the API answered 404"
+
+		resource := brokenResource("abc-123", violation)
+
+		if len(resource.Violations) != 1 || resource.Violations[0] != violation {
+			t.Errorf("Violations = %v, want [%q]", resource.Violations, violation)
+		}
+	})
+}

--- a/cmd/tally-vertical-slice/pricing.go
+++ b/cmd/tally-vertical-slice/pricing.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shopspring/decimal"
+	"gopkg.in/yaml.v3"
+)
+
+// pricingFile is the pricing document as it is written. Prices are strings
+// there, so every one of them reaches decimal.NewFromString exactly as it was
+// typed: a YAML float would already have lost precision by the time this
+// process saw it.
+type pricingFile struct {
+	Currency   string `yaml:"currency"`
+	Dimensions []struct {
+		Metric           string `yaml:"metric"`
+		PricePerUnitHour string `yaml:"price_per_unit_hour"`
+	} `yaml:"dimensions"`
+	StateModifiers map[string]string `yaml:"state_modifiers"`
+}
+
+// dimension is one priced size metric: what the size object calls it, and what
+// one unit of it costs per hour.
+type dimension struct {
+	Metric           string
+	PricePerUnitHour decimal.Decimal
+}
+
+// pricing is the parsed pricing document. A state that names no modifier is
+// billed at the full price, so the map holds the exceptions alone.
+type pricing struct {
+	Currency       string
+	Dimensions     []dimension
+	StateModifiers map[string]decimal.Decimal
+}
+
+// loadPricing reads and checks the pricing file at path. Every price is parsed
+// here rather than while rating, so a typo in the file stops the run before the
+// first request instead of surfacing as a resource that failed halfway through
+// the output.
+func loadPricing(path string) (pricing, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pricing{}, fmt.Errorf("reading the pricing file %s: %w", path, err)
+	}
+
+	var file pricingFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return pricing{}, fmt.Errorf("parsing the pricing file %s: %w", path, err)
+	}
+
+	if len(file.Dimensions) == 0 {
+		return pricing{}, fmt.Errorf("the pricing file %s lists no dimensions", path)
+	}
+	// The currency is what the document's amounts are denominated in, and it is
+	// carried straight into the output: an absent one ships a total with no unit
+	// on it, which is not a figure anybody can reconcile against an invoice.
+	if file.Currency == "" {
+		return pricing{}, fmt.Errorf("the pricing file %s names no currency", path)
+	}
+
+	parsed := pricing{
+		Currency:       file.Currency,
+		Dimensions:     make([]dimension, 0, len(file.Dimensions)),
+		StateModifiers: make(map[string]decimal.Decimal, len(file.StateModifiers)),
+	}
+
+	seen := make(map[string]bool, len(file.Dimensions))
+	for _, dim := range file.Dimensions {
+		// Two entries for one metric would both be rated, so the metric would be
+		// billed twice without anything in the output saying so.
+		if seen[dim.Metric] {
+			return pricing{}, fmt.Errorf("the pricing file %s prices the metric %q twice", path, dim.Metric)
+		}
+		seen[dim.Metric] = true
+
+		price, err := decimal.NewFromString(dim.PricePerUnitHour)
+		if err != nil {
+			return pricing{}, fmt.Errorf("reading the price of the metric %q in %s: %w", dim.Metric, path, err)
+		}
+		// A stray minus parses cleanly and would credit the customer for usage.
+		if price.IsNegative() {
+			return pricing{}, fmt.Errorf("the price of the metric %q in %s is negative: %s", dim.Metric, path, price)
+		}
+		parsed.Dimensions = append(parsed.Dimensions, dimension{Metric: dim.Metric, PricePerUnitHour: price})
+	}
+
+	for state, modifier := range file.StateModifiers {
+		factor, err := decimal.NewFromString(modifier)
+		if err != nil {
+			return pricing{}, fmt.Errorf("reading the modifier of the state %q in %s: %w", state, path, err)
+		}
+		if factor.IsNegative() {
+			return pricing{}, fmt.Errorf("the modifier of the state %q in %s is negative: %s", state, path, factor)
+		}
+		parsed.StateModifiers[state] = factor
+	}
+
+	return parsed, nil
+}

--- a/cmd/tally-vertical-slice/pricing_test.go
+++ b/cmd/tally-vertical-slice/pricing_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// writePricing writes a pricing document and returns its path.
+func writePricing(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "pricing.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+// TestLoadPricingReadsThePrototype holds the loader to the file the slice is
+// run with. The prices are the concept's section 3.4 numbers, and the golden
+// output is derived from exactly these, so a changed file has to fail here
+// rather than shift the rated total.
+func TestLoadPricingReadsThePrototype(t *testing.T) {
+	pr, err := loadPricing(filepath.Join("..", "..", "pricing", "prototype.yaml"))
+	if err != nil {
+		t.Fatalf("loadPricing() error = %v, want nil", err)
+	}
+
+	if pr.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", pr.Currency, "EUR")
+	}
+
+	wantPrices := []struct{ metric, price string }{
+		{"vcpus", "0.02"},
+		{"ram_gb", "0.005"},
+		{"disk_gb", "0.001"},
+	}
+	if len(pr.Dimensions) != len(wantPrices) {
+		t.Fatalf("Dimensions = %d entries, want %d", len(pr.Dimensions), len(wantPrices))
+	}
+	for i, want := range wantPrices {
+		got := pr.Dimensions[i]
+		if got.Metric != want.metric {
+			t.Errorf("Dimensions[%d].Metric = %q, want %q", i, got.Metric, want.metric)
+		}
+		if !got.PricePerUnitHour.Equal(decimal.RequireFromString(want.price)) {
+			t.Errorf("Dimensions[%d].PricePerUnitHour = %s, want %s", i, got.PricePerUnitHour, want.price)
+		}
+	}
+
+	wantModifiers := map[string]string{"shelved": "0.0", "shutoff": "0.5"}
+	if len(pr.StateModifiers) != len(wantModifiers) {
+		t.Fatalf("StateModifiers = %v, want %d entries", pr.StateModifiers, len(wantModifiers))
+	}
+	for state, want := range wantModifiers {
+		got, ok := pr.StateModifiers[state]
+		if !ok {
+			t.Errorf("StateModifiers has no %q", state)
+			continue
+		}
+		if !got.Equal(decimal.RequireFromString(want)) {
+			t.Errorf("StateModifiers[%q] = %s, want %s", state, got, want)
+		}
+	}
+}
+
+// TestLoadPricingRefusesABrokenFile checks that every way the file can be wrong
+// stops the run before the first request, and names what is wrong with it. A
+// price the loader let through would be discovered as a wrong invoice.
+func TestLoadPricingRefusesABrokenFile(t *testing.T) {
+	for name, tc := range map[string]struct {
+		content string
+		want    string
+	}{
+		"no dimensions": {
+			content: "currency: EUR\ndimensions: []\n",
+			want:    "lists no dimensions",
+		},
+		"a metric priced twice": {
+			content: `currency: EUR
+dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "0.02"
+  - metric: vcpus
+    price_per_unit_hour: "0.03"
+`,
+			want: `"vcpus"`,
+		},
+		"a price that is not a number": {
+			content: `currency: EUR
+dimensions:
+  - metric: ram_gb
+    price_per_unit_hour: "abc"
+`,
+			want: `"ram_gb"`,
+		},
+		"a modifier that is not a number": {
+			content: `currency: EUR
+dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "0.02"
+state_modifiers:
+  shutoff: "half"
+`,
+			want: `"shutoff"`,
+		},
+		"no currency": {
+			content: `dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "0.02"
+`,
+			want: "names no currency",
+		},
+		"a negative price": {
+			content: `currency: EUR
+dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "-0.02"
+`,
+			want: "is negative",
+		},
+		"a negative modifier": {
+			content: `currency: EUR
+dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "0.02"
+state_modifiers:
+  shutoff: "-0.5"
+`,
+			want: "is negative",
+		},
+		"a document that is not YAML": {
+			content: "currency: EUR\ndimensions: [\n",
+			want:    "parsing the pricing file",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := writePricing(t, tc.content)
+
+			_, err := loadPricing(path)
+			if err == nil {
+				t.Fatalf("loadPricing() error = nil, want an error naming %s", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("loadPricing() error = %v, want it to name %s", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("loadPricing() error = %v, want it to name the file %s", err, path)
+			}
+		})
+	}
+}
+
+// TestLoadPricingReportsAMissingFile keeps the read error wrapped rather than
+// replaced, so a caller can still tell a missing file from an unreadable one.
+func TestLoadPricingReportsAMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.yaml")
+
+	_, err := loadPricing(path)
+	if err == nil {
+		t.Fatalf("loadPricing() error = nil, want an error")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("loadPricing() error = %v, want it to wrap fs.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("loadPricing() error = %v, want it to name the file %s", err, path)
+	}
+}

--- a/cmd/tally-vertical-slice/slice_integration_test.go
+++ b/cmd/tally-vertical-slice/slice_integration_test.go
@@ -1,0 +1,548 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// The fixture the golden numbers are rated for: one project of one cloud, whose
+// instances carry the history of the concept's section 3.4 example.
+const (
+	slicePlatform    = "openstack"
+	sliceCloud       = "os-prod-eu1"
+	sliceProject     = "proj-456"
+	sliceMonth       = "2026-03"
+	slicePricingPath = "../../pricing/prototype.yaml"
+)
+
+// sliceInternalToken is the shared secret the /internal routes of the test
+// router are guarded with. The slice never calls one; the router requires the
+// secret either way.
+const sliceInternalToken = "internal-token-of-the-slice-test"
+
+// sliceAPI is the Reporting API one test runs the slice against: where the
+// server listens, and the query token the slice reads it with.
+type sliceAPI struct {
+	url   string
+	token string
+}
+
+// newSliceAPI assembles the real API over a migrated database, seeds the two
+// credentials it takes, and ingests the golden events through it. What the
+// slice then reads has passed the contract validator, the ingest guard, the
+// size schema, and the projection, which is what makes the numbers below a
+// statement about the chain rather than about a fixture.
+func newSliceAPI(t *testing.T) sliceAPI {
+	t.Helper()
+
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	handler, err := httpapi.NewRouter(httpapi.Options{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                       db.Store,
+		UnhealthyThreshold:       time.Minute,
+		Queries:                  q,
+		Store:                    db.Store,
+		AuthMode:                 auth.ModeEnforced,
+		InternalToken:            sliceInternalToken,
+		Authenticator:            auth.NewStaticTokenAuthenticator(q),
+		Pipeline:                 ingest.New(registry.New(), false, nil, nil),
+		AttributingRelationTypes: []string{"infrastructure_tenant"},
+		Syncer: reconciliation.New(db.Store, ingest.New(registry.New(), false, nil, nil),
+			reconciliation.Config{}, map[string]reconciliation.Adapter{}, time.Now, nil),
+	})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v, want nil", err)
+	}
+
+	// Plain HTTP: the slice's TLS handling is the client's own test, and a
+	// server whose certificate the run has to trust would only add a CA file to
+	// this one.
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	ingestGoldenEvents(t, server.URL, seedIngestToken(t, q))
+
+	return sliceAPI{url: server.URL, token: seedReadAllToken(t, q)}
+}
+
+// seedIngestToken issues the credential the golden batch is submitted with and
+// stores its hash. It is scoped to the fixture's platform and cloud, which is
+// what the ingest guard holds the batch against.
+func seedIngestToken(t *testing.T, q *sqlcgen.Queries) string {
+	t.Helper()
+
+	token, err := auth.GenerateIngestToken()
+	if err != nil {
+		t.Fatalf("generating the ingest token: %v", err)
+	}
+	if _, err := q.CreateIngestCredential(t.Context(), sqlcgen.CreateIngestCredentialParams{
+		Platform:    slicePlatform,
+		Cloud:       sliceCloud,
+		TokenHash:   auth.HashToken(token),
+		Description: pgtype.Text{String: "vertical slice integration test", Valid: true},
+	}); err != nil {
+		t.Fatalf("CreateIngestCredential() error = %v, want nil", err)
+	}
+	return token
+}
+
+// seedReadAllToken issues the query token the slice reads with and stores its
+// hash.
+func seedReadAllToken(t *testing.T, q *sqlcgen.Queries) string {
+	t.Helper()
+
+	token, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("generating the api token: %v", err)
+	}
+	// project_ids is NOT NULL, so a token that names no project carries an empty
+	// array rather than a nil slice, which pgx would send as NULL.
+	if _, err := q.CreateAPIToken(t.Context(), sqlcgen.CreateAPITokenParams{
+		TokenHash:   auth.HashToken(token),
+		Role:        string(auth.RoleReadAll),
+		ProjectIds:  []uuid.UUID{},
+		Description: pgtype.Text{String: "vertical slice integration test", Valid: true},
+	}); err != nil {
+		t.Fatalf("CreateAPIToken() error = %v, want nil", err)
+	}
+	return token
+}
+
+// goldenEvent builds one event of the golden history. A nil size reports that
+// the size did not change, which is what a power transition carries.
+func goldenEvent(eventID, eventType, resourceID string, ts time.Time, state string, size map[string]any) event.Event {
+	return event.Event{
+		EventID:      eventID,
+		Timestamp:    ts,
+		EventType:    eventType,
+		Platform:     slicePlatform,
+		Cloud:        sliceCloud,
+		ResourceType: "instance",
+		ResourceID:   resourceID,
+		ProjectID:    sliceProject,
+		Source:       event.SourceCollector,
+		Payload:      event.PayloadEnvelope{State: &state, Size: size},
+	}
+}
+
+// goldenEvents is the history the concept's example rates: an instance created
+// in February, powered off on 03-11 and on again on 03-21, next to one created
+// on 03-01 and resized on 03-16. Two more carry the ends of a life: one deleted
+// inside the month, which is how an instance's billing usually stops, and one
+// that lived and died before it. Every size meets the (openstack, instance)
+// schema the migration chain seeds.
+func goldenEvents() []event.Event {
+	large := map[string]any{"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+	small := map[string]any{"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "flavor": "m1.small"}
+
+	return []event.Event{
+		goldenEvent("vs-abc-123-create", "compute.instance.create.end", "abc-123",
+			time.Date(2026, 2, 10, 8, 0, 0, 0, time.UTC), "active", large),
+		goldenEvent("vs-abc-123-power-off", "compute.instance.power_off", "abc-123",
+			time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC), "shutoff", nil),
+		goldenEvent("vs-abc-123-power-on", "compute.instance.power_on", "abc-123",
+			time.Date(2026, 3, 21, 0, 0, 0, 0, time.UTC), "active", nil),
+		goldenEvent("vs-def-456-create", "compute.instance.create.end", "def-456",
+			time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), "active", small),
+		goldenEvent("vs-def-456-resize", "compute.instance.resize.end", "def-456",
+			time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC), "active", large),
+		goldenEvent("vs-ghi-789-create", "compute.instance.create.end", "ghi-789",
+			time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC), "active", small),
+		goldenEvent("vs-ghi-789-delete", "compute.instance.delete.end", "ghi-789",
+			time.Date(2026, 3, 20, 0, 0, 0, 0, time.UTC), "deleted", nil),
+		goldenEvent("vs-jkl-012-create", "compute.instance.create.end", "jkl-012",
+			time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC), "active", small),
+		goldenEvent("vs-jkl-012-delete", "compute.instance.delete.end", "jkl-012",
+			time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC), "deleted", nil),
+	}
+}
+
+// ingestGoldenEvents submits the whole history as one batch. A refused item is
+// reported with the answer in full: the numbers the tests below assert only
+// exist because the ingest took every event, so an ingest that took fewer has
+// to be diagnosable from this failure alone.
+func ingestGoldenEvents(t *testing.T, baseURL, token string) {
+	t.Helper()
+
+	events := goldenEvents()
+	body, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshaling the golden batch: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, baseURL+"/api/v1/events", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the ingest request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("submitting the golden batch: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	answer, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the ingest answer: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ingest status = %d, want %d (body %s)", resp.StatusCode, http.StatusOK, answer)
+	}
+
+	var result httpapi.IngestResult
+	if err := json.Unmarshal(answer, &result); err != nil {
+		t.Fatalf("decoding the ingest answer %s: %v", answer, err)
+	}
+	if result.Accepted != len(events) || len(result.Rejected) != 0 {
+		t.Fatalf("ingest result = %+v, want %d accepted and nothing rejected (body %s)",
+			result, len(events), answer)
+	}
+}
+
+// The document as a test reads it back. Every number is a json.Number, so an
+// assertion compares the digits the slice wrote rather than a value they were
+// parsed into: what a customer reconciles against an invoice is the rendering,
+// and 19.2 is not 19.20 there.
+type sliceDocument struct {
+	Cloud     string `json:"cloud"`
+	ProjectID string `json:"project_id"`
+	Period    struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"period"`
+	Currency  string          `json:"currency"`
+	Resources []sliceResource `json:"resources"`
+	Total     json.Number     `json:"total"`
+}
+
+// sliceResource is one rated resource of the document.
+type sliceResource struct {
+	ResourceID string        `json:"resource_id"`
+	Warnings   []string      `json:"warnings"`
+	Violations []string      `json:"violations"`
+	Records    []sliceRecord `json:"records"`
+	Total      json.Number   `json:"total"`
+}
+
+// sliceRecord is one billed interval with its line items.
+type sliceRecord struct {
+	From       string                    `json:"from"`
+	To         string                    `json:"to"`
+	State      string                    `json:"state"`
+	Seconds    int64                     `json:"seconds"`
+	Minutes    json.Number               `json:"minutes"`
+	Dimensions map[string]sliceDimension `json:"dimensions"`
+	Subtotal   json.Number               `json:"subtotal"`
+}
+
+// sliceDimension is what one priced metric contributed to a record.
+type sliceDimension struct {
+	Quantity json.Number `json:"quantity"`
+	Cost     json.Number `json:"cost"`
+}
+
+// wantResource is the golden rating of one resource. Every figure is pinned:
+// the quantities come from the concept's example and the prices from the
+// prototype file, which TestLoadPricingReadsThePrototype holds to its own
+// numbers, so each cost below is determined by the two together.
+type wantResource struct {
+	resourceID string
+	records    []wantRecord
+	total      string
+}
+
+// wantRecord is one golden billed interval.
+type wantRecord struct {
+	from       string
+	to         string
+	state      string
+	seconds    int64
+	minutes    string
+	dimensions map[string]wantDimension
+	subtotal   string
+}
+
+// wantDimension is the golden quantity and cost of one priced metric.
+type wantDimension struct {
+	quantity string
+	cost     string
+}
+
+// goldenResources is what the concept's section 3.4 example rates the March of
+// the fixture at: abc-123 with its three intervals in EUR, def-456 with the two
+// the resize splits its month into, and ghi-789 with the one its deletion ends.
+// jkl-012 is not among them: it was gone before the month began, so the
+// document leaves it out rather than rating it at zero.
+func goldenResources() []wantResource {
+	return []wantResource{
+		{
+			resourceID: "abc-123",
+			records: []wantRecord{
+				{
+					from: "2026-03-01T00:00:00Z", to: "2026-03-11T00:00:00Z", state: "active",
+					seconds: 864000, minutes: "14400.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "4", cost: "19.20"},
+						"ram_gb":  {quantity: "8", cost: "9.60"},
+						"disk_gb": {quantity: "80", cost: "19.20"},
+					},
+					subtotal: "48.00",
+				},
+				{
+					from: "2026-03-11T00:00:00Z", to: "2026-03-21T00:00:00Z", state: "shutoff",
+					seconds: 864000, minutes: "14400.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "4", cost: "9.60"},
+						"ram_gb":  {quantity: "8", cost: "4.80"},
+						"disk_gb": {quantity: "80", cost: "9.60"},
+					},
+					subtotal: "24.00",
+				},
+				{
+					from: "2026-03-21T00:00:00Z", to: "2026-04-01T00:00:00Z", state: "active",
+					seconds: 950400, minutes: "15840.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "4", cost: "21.12"},
+						"ram_gb":  {quantity: "8", cost: "10.56"},
+						"disk_gb": {quantity: "80", cost: "21.12"},
+					},
+					subtotal: "52.80",
+				},
+			},
+			total: "124.80",
+		},
+		{
+			resourceID: "def-456",
+			records: []wantRecord{
+				{
+					from: "2026-03-01T00:00:00Z", to: "2026-03-16T00:00:00Z", state: "active",
+					seconds: 1296000, minutes: "21600.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "2", cost: "14.40"},
+						"ram_gb":  {quantity: "4", cost: "7.20"},
+						"disk_gb": {quantity: "40", cost: "14.40"},
+					},
+					subtotal: "36.00",
+				},
+				{
+					from: "2026-03-16T00:00:00Z", to: "2026-04-01T00:00:00Z", state: "active",
+					seconds: 1382400, minutes: "23040.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "4", cost: "30.72"},
+						"ram_gb":  {quantity: "8", cost: "15.36"},
+						"disk_gb": {quantity: "80", cost: "30.72"},
+					},
+					subtotal: "76.80",
+				},
+			},
+			total: "112.80",
+		},
+		{
+			resourceID: "ghi-789",
+			records: []wantRecord{
+				{
+					from: "2026-03-05T00:00:00Z", to: "2026-03-20T00:00:00Z", state: "active",
+					seconds: 1296000, minutes: "21600.0000",
+					dimensions: map[string]wantDimension{
+						"vcpus":   {quantity: "2", cost: "14.40"},
+						"ram_gb":  {quantity: "4", cost: "7.20"},
+						"disk_gb": {quantity: "40", cost: "14.40"},
+					},
+					subtotal: "36.00",
+				},
+			},
+			total: "36.00",
+		},
+	}
+}
+
+// TestSliceReproducesTheGoldenNumbers is the CI-run half of the WP 1.15
+// verification: the golden events go through the real ingest, auth, and query
+// stack, and the document the slice prints is held against the concept's
+// numbers value by value, the encoded precision included.
+func TestSliceReproducesTheGoldenNumbers(t *testing.T) {
+	api := newSliceAPI(t)
+
+	var buf bytes.Buffer
+	if err := run(t.Context(), config{
+		cloud:        sliceCloud,
+		project:      sliceProject,
+		month:        sliceMonth,
+		reportingURL: api.url,
+		pricingPath:  slicePricingPath,
+		token:        api.token,
+	}, &buf); err != nil {
+		t.Fatalf("run() error = %v, want nil", err)
+	}
+
+	output := buf.String()
+	doc := decodeSliceDocument(t, output)
+
+	for _, field := range []struct{ name, got, want string }{
+		{"cloud", doc.Cloud, sliceCloud},
+		{"project_id", doc.ProjectID, sliceProject},
+		{"currency", doc.Currency, "EUR"},
+		{"period.from", doc.Period.From, "2026-03-01T00:00:00Z"},
+		{"period.to", doc.Period.To, "2026-04-01T00:00:00Z"},
+	} {
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+
+	want := goldenResources()
+	if len(doc.Resources) != len(want) {
+		t.Fatalf("the document rates %d resources, want %d:\n%s", len(doc.Resources), len(want), output)
+	}
+	for i, resource := range want {
+		t.Run(resource.resourceID, func(t *testing.T) {
+			assertResource(t, doc.Resources[i], resource)
+		})
+	}
+
+	// The document's total is pinned rather than compared against the sum of the
+	// resource totals it was built from: that comparison would hold the
+	// implementation against itself and pass on any rating.
+	assertNumber(t, "total", doc.Total, "273.60")
+}
+
+// TestSliceServesTheEmptyDocument rates a project the cloud has nothing under.
+// The run is a success rather than a failure, and the document it prints is
+// readable without a special case: a client iterates the resources of an empty
+// month the way it iterates a busy one.
+func TestSliceServesTheEmptyDocument(t *testing.T) {
+	api := newSliceAPI(t)
+
+	var buf bytes.Buffer
+	if err := run(t.Context(), config{
+		cloud:        sliceCloud,
+		project:      "proj-none",
+		month:        sliceMonth,
+		reportingURL: api.url,
+		pricingPath:  slicePricingPath,
+		token:        api.token,
+	}, &buf); err != nil {
+		t.Fatalf("run() error = %v, want nil", err)
+	}
+
+	output := buf.String()
+	// The rendering is asserted on the bytes: a nil slice marshals to null, and
+	// a client that iterates the member without checking would fail on it.
+	if !strings.Contains(output, `"resources": []`) {
+		t.Errorf("the document does not carry resources as an empty array:\n%s", output)
+	}
+
+	doc := decodeSliceDocument(t, output)
+	if len(doc.Resources) != 0 {
+		t.Errorf("the document rates %d resources, want none:\n%s", len(doc.Resources), output)
+	}
+	assertNumber(t, "total", doc.Total, "0.00")
+}
+
+// decodeSliceDocument reads the printed document back, keeping every number as
+// the digits the slice wrote.
+func decodeSliceDocument(t *testing.T, output string) sliceDocument {
+	t.Helper()
+
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.UseNumber()
+
+	var doc sliceDocument
+	if err := decoder.Decode(&doc); err != nil {
+		t.Fatalf("decoding the document:\n%s\nerror = %v", output, err)
+	}
+	return doc
+}
+
+// assertResource holds one rated resource against its golden form.
+func assertResource(t *testing.T, got sliceResource, want wantResource) {
+	t.Helper()
+
+	if got.ResourceID != want.resourceID {
+		t.Errorf("resource_id = %q, want %q", got.ResourceID, want.resourceID)
+	}
+	// A warning or a violation qualifies the numbers next to it, so a clean
+	// resource has neither: the golden history folds without a gap and bills
+	// exactly the part of the month it lived through.
+	if len(got.Warnings) != 0 {
+		t.Errorf("%s warnings = %v, want none", want.resourceID, got.Warnings)
+	}
+	if len(got.Violations) != 0 {
+		t.Errorf("%s violations = %v, want none", want.resourceID, got.Violations)
+	}
+
+	if len(got.Records) != len(want.records) {
+		t.Fatalf("%s carries %d records, want %d", want.resourceID, len(got.Records), len(want.records))
+	}
+	for i, record := range want.records {
+		assertRecord(t, fmt.Sprintf("%s.records[%d]", want.resourceID, i), got.Records[i], record)
+	}
+	assertNumber(t, want.resourceID+".total", got.Total, want.total)
+}
+
+// assertRecord holds one billed interval against its golden form, naming the
+// resource, the record, and the field of every mismatch.
+func assertRecord(t *testing.T, where string, got sliceRecord, want wantRecord) {
+	t.Helper()
+
+	for _, field := range []struct{ name, got, want string }{
+		{"from", got.From, want.from},
+		{"to", got.To, want.to},
+		{"state", got.State, want.state},
+	} {
+		if field.got != field.want {
+			t.Errorf("%s.%s = %q, want %q", where, field.name, field.got, field.want)
+		}
+	}
+	if got.Seconds != want.seconds {
+		t.Errorf("%s.seconds = %d, want %d", where, got.Seconds, want.seconds)
+	}
+	assertNumber(t, where+".minutes", got.Minutes, want.minutes)
+	assertNumber(t, where+".subtotal", got.Subtotal, want.subtotal)
+
+	if len(got.Dimensions) != len(want.dimensions) {
+		t.Fatalf("%s rates %d dimensions, want %d", where, len(got.Dimensions), len(want.dimensions))
+	}
+	for metric, dimension := range want.dimensions {
+		rated, ok := got.Dimensions[metric]
+		if !ok {
+			t.Errorf("%s rates no %s", where, metric)
+			continue
+		}
+		assertNumber(t, fmt.Sprintf("%s.dimensions[%s].quantity", where, metric), rated.Quantity, dimension.quantity)
+		assertNumber(t, fmt.Sprintf("%s.dimensions[%s].cost", where, metric), rated.Cost, dimension.cost)
+	}
+}
+
+// assertNumber compares one rendered number against its golden form.
+func assertNumber(t *testing.T, where string, got json.Number, want string) {
+	t.Helper()
+
+	if string(got) != want {
+		t.Errorf("%s = %s, want %s", where, got, want)
+	}
+}

--- a/pricing/prototype.yaml
+++ b/pricing/prototype.yaml
@@ -1,0 +1,14 @@
+# Prototype pricing for WP 1.15. Phase 3 replaces this file with versioned
+# pricing models in this directory. Prices are strings: they are parsed with
+# decimal.NewFromString, and floats are banned from money paths.
+currency: EUR
+dimensions:
+  - metric: vcpus
+    price_per_unit_hour: "0.02"
+  - metric: ram_gb
+    price_per_unit_hour: "0.005"
+  - metric: disk_gb
+    price_per_unit_hour: "0.001"
+state_modifiers:
+  shelved: "0.0"
+  shutoff: "0.5"


### PR DESCRIPTION
Closes #12

WP 1.15's golden gate: a deliberately throwaway CLI that chains the whole Phase 1 billing path — Reporting API read, timeline fold, month clip, usage records, rating, one JSON document — and reproduces the concept's §3.4 numbers exactly. Nothing under `internal/` changes; the five commits only add files.

## The change set, in commit order

**`11917d5` Add the §3.4 prototype pricing file** — `pricing/prototype.yaml`, verbatim from the issue: the three `time_gauge` dimensions (`vcpus` 0.02, `ram_gb` 0.005, `disk_gb` 0.001 per unit-hour) and the `shelved` / `shutoff` state modifiers. Every price is a quoted string so it reaches `decimal.NewFromString` and no float ever touches a money path.

**`cc3654c` Add the tally-vertical-slice CLI with its unit tests** — the command itself, all in `package main`:

- `main.go` — stdlib `flag` parsing, the `config` value, `TALLY_SLICE_TOKEN` lookup, and a thin `main` delegating to `run(ctx, cfg, out) error` so the tests can drive it with an `httptest` URL and a buffer. `run` writes the document *before* it reports broken invariants, so a failing run still exits 1 with inspectable numbers.
- `client.go` — the hand-rolled read client: CA-pool setup, the `next_cursor` pagination loop over `GET /api/v1/resources`, `fetchHistory` decoding `items` straight into `[]event.Stored`, and problem+json mapping.
- `compute.go` — `parseMonth`, `buildRecords` (clip to the UTC calendar month, integer seconds, `money.Minutes`), `sizeDecimal` (re-marshal the `map[string]any` value and parse the literal, since `decimal.NewFromFloat` is banned), `rate` (one final `money.Round2` per dimension), `checkInvariants` (adjacency, bounds, coverage), the document types, and the `jsonMinutes` / `jsonQuantity` marshallers.
- `pricing.go` — `loadPricing` following the reconciliation loader's conventions: read, unmarshal, then semantic validation naming the offending metric, state, or path.
- Unit tests for all four, needing no Docker: rating goldens against the committed pricing file, encoded-bytes assertions on the document's scales, and the client driven against `httptest` stubs.

**`d7a11a4` Prove the golden numbers against an in-process Reporting API** — `slice_integration_test.go`, the CI-run half of the two-fold verification. It assembles the real stack in-process (`storetest.NewDB`, `httpapi.NewRouter` with auth enforced, seeded ingest credential and `read_all` API token), submits the five golden events as one batch through a real `POST /api/v1/events` so they pass the contract validator, the ingest guard, the size schema, and the projection, then calls `run` against the server and asserts the document value by value: `abc-123`'s three intervals (14400 / 14400 / 15840 minutes, subtotals 48.00 / 24.00 / 52.80, total 124.80) and the two records the resize splits `def-456` into. Comparisons are made on the digits the encoder wrote, so `19.20` rendered as `19.2` fails. A second test rates a project the cloud has nothing under: `resources` renders as `[]` rather than `null` and the total as `0.00`.

**`4434359` Document the throwaway charter and the dev-cluster drill** — `README.md` and `.env.example`. The README records what the prototype is for and that Phase 3 replaces it wholesale with only `internal/core/timeline` carrying over, the egress delta (124.80 EUR here versus the concept's 128.45 EUR, egress counters being Phase 3 scope), and the drill that reproduces the golden numbers against a dev cluster with exact commands — the second half of WP 1.15's two-fold verification.

**`afb71d4` Pin run's contract in unit tests** — `main_test.go`. The required-flag, token, and month checks run before the first request, so they are pinned by driving `run` with an incomplete config and asserting nothing was written. The document-then-fail contract is pinned the same way, against an `httptest` stub.

## Divergences from the issue

Three, all additive; the issue's stated behaviour is unchanged everywhere else.

1. **Rating and history failures become violations, not an aborted run.** The issue says a rating failure makes `run` return an error naming the resource, interval, and metric. It does name them — but as the resource's `violations` entry rather than as a return that stops the walk (`main.go:181` `rateResource`). One instance the API lost between the listing and the walk, or one whose history carries no size, would otherwise withhold every other instance's numbers. The exit code is unchanged: violations still make `run` return an error after the document is written, so the process exits 1. A cancelled context is still a hard error, since every remaining fetch would fail identically. `violationLimit` (4 KiB) caps what one failure may add, so an oversized problem document cannot grow the run out of memory before it prints.
2. **The client refuses a plaintext `--reporting-url`** unless the host is loopback (`client.go:60`). The `read_all` token rides on every call, and the issue's flags do not otherwise stop it travelling in the clear; loopback is exempt because that is where the tests' server and a port-forwarded cluster listen. Redirects are answered rather than followed for the same reason — Go strips `Authorization` only across hosts.
3. **The resource walk is bounded** by `pageBudget`, `resourceBudget`, and a `bodyLimit`, and refuses a cursor that does not advance (`client.go:20`). `limit=` is a request, not a constraint, so nothing in the contract stops a broken server from cursoring forever.

Consequently the file list carries one file the issue does not name — `main_test.go`, the fifth commit — and `client_test.go` covers the two hardening paths above alongside the pagination and problem-mapping cases the issue asks for.

## Verification

`go test ./cmd/tally-vertical-slice` runs the golden integration test under plain `go test ./...`, which is what CI executes; it needs Docker for the TimescaleDB testcontainer. The unit tests need none. The dev-cluster drill stays a documented procedure — CI never runs kind.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
