### PR TITLE
Expose aggregation and stats endpoints on the Reporting API

### DIFF
--- a/api/reporting/openapi.yaml
+++ b/api/reporting/openapi.yaml
@@ -18,8 +18,9 @@ info:
   description: >-
     Event ingestion, resource inventory, and usage reporting for Tally.
     This document covers the health probes, event ingestion, the queries over
-    events, resources, and lifecycles, the resource-type registry, the project
-    registry, dead-letter review, and the projection rebuild.
+    events, resources, and lifecycles, the statistics derived from them, the
+    resource-type registry, the project registry, dead-letter review, and the
+    projection rebuild.
 
 paths:
   /healthz:
@@ -466,6 +467,200 @@ paths:
         "401":
           $ref: "#/components/responses/Problem"
         "404":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/stats/resources:
+    get:
+      operationId: getResourceStats
+      summary: Count the current resources per group
+      description: >-
+        Returns the projection counted along the dimensions `group_by` names,
+        one item per combination of values that carries at least one resource. A
+        combination no resource carries is left out rather than served as a zero.
+        The order is `(cloud, resource_type, state, platform, project_id)`
+        ascending, where a dimension outside the grouping compares as the empty
+        string.
+
+        The answer is never paginated: one item stands for however many
+        resources the group holds, so the answer grows with the number of
+        combinations the fleet shows rather than with the fleet. Four of the
+        five dimensions carry a handful of values each; `project_id` carries one
+        per tenant, so a fleet showing more combinations than one answer holds
+        is refused 422 (`urn:tally:error:result_too_large`) rather than served
+        truncated. The counts are taken along all five dimensions whatever
+        `group_by` names, so a coarser grouping does not lower that bound; the
+        part of the fleet `status` selects is what does.
+
+        A project token counts the resources whose (cloud, project_id) pair one
+        of its projects names, which is the pair the resource list narrows its
+        rows by.
+      security:
+        - apiToken: []
+      parameters:
+        - name: group_by
+          in: query
+          required: true
+          description: >-
+            Which dimensions the counts are grouped by, as a comma-separated
+            list. `cloud` and `resource_type` have to be among them, because
+            they are what an item is read by; a grouping that leaves either out
+            is answered 400. The rule spans the members of one list, which this
+            schema cannot express, so the handler is what enforces it.
+          style: form
+          explode: false
+          schema:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              enum: [cloud, resource_type, state, platform, project_id]
+        - name: status
+          in: query
+          description: >-
+            Which part of the fleet to count. `active` counts the rows whose
+            state is not deleted, `deleted` counts those alone, and `all` counts
+            both.
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+        - name: at
+          in: query
+          description: >-
+            The instant the counts describe. Leaving it out asks for the current
+            counts, which is what the projection holds.
+
+            Any value at all is answered 501
+            (`urn:tally:error:not_implemented`): counting a past instant means
+            replaying the histories, and the Phase 3 usage records are what
+            answer that. A value meaning "now" cannot be told from a historic
+            one, because the two differ by however long the request took, so
+            omitting the parameter rather than sending a timestamp is how the
+            current counts are asked for.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: The counts, one item per group.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceStatsList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+        "501":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/stats/events:
+    get:
+      operationId: getEventStats
+      summary: Count the stored events per time bucket
+      description: >-
+        Returns the stored events of the window counted per time bucket and per
+        combination of the dimensions `group_by` names. `from` and `to` select
+        the half-open window `[from, to)` on the event timestamp: an event at
+        exactly `from` is counted, one at exactly `to` is not, and a `from` at or
+        past `to` holds nothing. The buckets are aligned on UTC hours and days
+        rather than on `from`, so the first one can start before the window;
+        every bucket counts the events inside the window alone.
+
+        The order is `(bucket, cloud, event_type, source)` ascending, and a
+        bucket no event falls into is left out rather than served as a zero. The
+        answer is never paginated: a request that groups into more rows than one
+        answer carries is refused 422
+        (`urn:tally:error:result_too_large`) rather than answered with a
+        truncated count. The bound counts the finest grouping there is, which is
+        what the read returns, so a narrower window or a coarser interval is
+        what gets such a request through; leaving `source` out of `group_by`
+        does not lower it.
+
+        A second bound is read on the window itself, `to - from`, and it is
+        decided before anything is counted: the aggregate behind the count
+        walks every event of the window before its row limit discards
+        anything, so what a request costs is set by the events the window
+        holds rather than by the buckets it names. A window wider than a year
+        and a month is refused 422 whatever the interval, rather than
+        aggregated across the archive and then thrown away.
+
+        The counts are event-scoped the way the event list is: a project token
+        counts every event whose `project_id` names one of its projects,
+        including the events a resource carried before it was transferred away.
+      security:
+        - apiToken: []
+      parameters:
+        - name: group_by
+          in: query
+          required: true
+          description: >-
+            Which dimensions the counts are grouped by, as a comma-separated
+            list. `cloud` and `event_type` have to be among them, because they
+            are what an item is read by; a grouping that leaves either out is
+            answered 400. The rule spans the members of one list, which this
+            schema cannot express, so the handler is what enforces it.
+          style: form
+          explode: false
+          schema:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              enum: [cloud, event_type, source]
+        - name: from
+          in: query
+          required: true
+          description: >-
+            Count only the events at or after this instant, the inclusive bound
+            of the window.
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          description: >-
+            Count only the events before this instant, the exclusive bound of
+            the window.
+          schema:
+            type: string
+            format: date-time
+        - name: interval
+          in: query
+          required: true
+          description: How wide one bucket is.
+          schema:
+            type: string
+            enum: [1h, 1d]
+      responses:
+        "200":
+          description: The counts, one item per bucket and group.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventStatsList"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
           $ref: "#/components/responses/Problem"
         "422":
           $ref: "#/components/responses/Problem"
@@ -1024,6 +1219,91 @@ paths:
         "403":
           $ref: "#/components/responses/Problem"
         "404":
+          $ref: "#/components/responses/Problem"
+        "500":
+          $ref: "#/components/responses/Problem"
+
+  /api/v1/projects/{id}/summary:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The project the summary is about.
+        schema:
+          $ref: "#/components/schemas/Uuid"
+    get:
+      operationId: getProjectSummary
+      summary: Summarize what one project ran inside a window
+      description: >-
+        Returns the project together with what each of its resource types did
+        inside the half-open window `[from, to)`: how many resources of the type
+        began or ended their life in it, how many minutes they ran within it,
+        and how many of the type the project holds right now.
+
+        The three window numbers come from folding the histories of the
+        project's resources with the fold every other read of a history runs,
+        clipped to the window, and an interval still open is counted up to the
+        instant of the request. A resource that changed hands counts here over
+        the part of the window this project held it: the transfer ends its
+        minutes here and begins the new owner's, so a resource is billed to one
+        project at a time. `created` and `deleted` are read off the project's
+        own events, so a transfer moves neither.
+        `active_now` is counted off the projection instead, so it describes the
+        present whatever the window covers. A `from` at or past `to` is an empty
+        window: created, deleted, and the minutes come out zero, while
+        `active_now` stays what it is.
+
+        A project this registry does not hold and a project outside the token's
+        scope are answered the same 404, body for body, so a caller cannot tell
+        the projects another token holds from ids that name nothing.
+
+        The embedded `project` names the project and nothing more. This route is
+        reachable with a `project` token, and the registry row it hangs off is
+        not: the name and the operator-set metadata are served by `getProject`,
+        which takes `read_all`.
+
+        A project whose history is longer than one summary folds at once is
+        answered 422 (`urn:tally:error:history_too_long`) rather than a summary
+        folded from part of it. The Phase 3 usage records are what answer a
+        history that long.
+      security:
+        - apiToken: []
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: >-
+            When the window starts, the inclusive bound.
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          description: >-
+            When the window ends, the exclusive bound.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: The project and what its resource types did in the window.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/RequestID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectSummary"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+        "422":
           $ref: "#/components/responses/Problem"
         "500":
           $ref: "#/components/responses/Problem"
@@ -1595,6 +1875,97 @@ components:
           items:
             type: string
 
+    ResourceStatsItem:
+      type: object
+      description: >-
+        One group of the resource counts: the values its dimensions carry, and
+        how many resources carry all of them.
+      required: [cloud, resource_type, count]
+      properties:
+        cloud:
+          type: string
+          description: The installation the counted resources live in.
+        resource_type:
+          type: string
+          description: The kind of resource that was counted.
+        state:
+          type: string
+          description: >-
+            The state the counted resources are in. The member is there exactly
+            when `group_by` names `state`.
+        platform:
+          type: string
+          description: >-
+            The platform the counted resources live on. The member is there
+            exactly when `group_by` names `platform`.
+        project_id:
+          type: string
+          description: >-
+            The project owning the counted resources, named the way its cloud
+            names it. The member is there exactly when `group_by` names
+            `project_id`.
+        count:
+          type: integer
+          format: int64
+          description: How many resources the group holds.
+
+    ResourceStatsList:
+      type: object
+      description: The resource counts of one grouping.
+      required: [items]
+      properties:
+        items:
+          type: array
+          description: >-
+            The groups, ordered by cloud, resource type, state, platform, and
+            project id. It is the empty array when the grouping counts no
+            resource at all.
+          items:
+            $ref: "#/components/schemas/ResourceStatsItem"
+
+    EventStatsItem:
+      type: object
+      description: >-
+        One group of the event counts: the bucket it falls in, the values its
+        dimensions carry, and how many events carry all of them.
+      required: [bucket, cloud, event_type, count]
+      properties:
+        bucket:
+          type: string
+          format: date-time
+          description: >-
+            When the bucket starts, in UTC. A bucket covers `interval` from
+            there on, the start inclusive and the end exclusive.
+        cloud:
+          type: string
+          description: The installation the counted events came from.
+        event_type:
+          type: string
+          description: The type the counted events carry.
+        source:
+          type: string
+          description: >-
+            Which pipeline produced the counted events, collector or
+            reconciliation. The member is there exactly when `group_by` names
+            `source`.
+        count:
+          type: integer
+          format: int64
+          description: How many events the group holds.
+
+    EventStatsList:
+      type: object
+      description: The event counts of one window.
+      required: [items]
+      properties:
+        items:
+          type: array
+          description: >-
+            The groups, ordered by bucket, cloud, event type, and source. It is
+            the empty array when the window holds no event.
+          items:
+            $ref: "#/components/schemas/EventStatsItem"
+
     ResourceType:
       type: object
       description: >-
@@ -1705,6 +2076,78 @@ components:
           description: >-
             Where the next page starts, passed back as `cursor`. It is null on
             the last page.
+
+    ProjectActivity:
+      type: object
+      description: >-
+        What one resource type of a project did inside the window of a summary.
+      required: [resource_type, active_now, created, deleted, total_minutes]
+      properties:
+        resource_type:
+          type: string
+          description: The kind of resource this row is about.
+        active_now:
+          type: integer
+          description: >-
+            How many resources of the type the project holds right now, counted
+            off the projection rows that are not deleted. It describes the
+            present rather than the window, so a type the window saw nothing of
+            still reports what the project runs of it today.
+        created:
+          type: integer
+          description: >-
+            How many resources of the type began their life inside the window.
+        deleted:
+          type: integer
+          description: >-
+            How many resources of the type ended their life inside the window.
+        total_minutes:
+          type: integer
+          format: int64
+          description: >-
+            How long the resources of the type ran inside the window, in whole
+            minutes, truncated. An interval still open is counted up to the
+            instant of the request, so a window reaching into the future carries
+            no time that has not been served yet.
+
+    ProjectRef:
+      type: object
+      description: >-
+        Which project an answer is about, as much of it as a project-scoped read
+        carries. The registry row itself — the name, the operator-set metadata,
+        the platform, and when it was registered — is what `getProject` serves,
+        and reading that takes `read_all`.
+      required: [id, cloud, external_id]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The project, as this API names it.
+        cloud:
+          type: string
+          description: >-
+            The installation the project lives in, os-prod-eu1 for example.
+        external_id:
+          type: string
+          description: >-
+            The project as its cloud names it, which is the id an event carries.
+
+    ProjectSummary:
+      type: object
+      description: >-
+        One project and what its resource types did inside one window.
+      required: [project, resource_types]
+      properties:
+        project:
+          $ref: "#/components/schemas/ProjectRef"
+        resource_types:
+          type: array
+          description: >-
+            One row per resource type the project has events or resources of,
+            ordered by resource type. It is the empty array for a project with
+            neither.
+          items:
+            $ref: "#/components/schemas/ProjectActivity"
 
     CreateProject:
       type: object

--- a/internal/core/event/event.go
+++ b/internal/core/event/event.go
@@ -60,9 +60,9 @@ const identifierMaxLen = 512
 
 // stateMaxLen bounds payload.state for the same reason. The projection writes it
 // to current_resources.state, which idx_current_resources_type indexes next to
-// resource_type and idx_current_resources_fleet next to platform, cloud and
-// resource_type. Those three are bounded above, so a state within this bound
-// keeps the widest of the tuples under the btree limit.
+// resource_type and idx_current_resources_stats next to platform, cloud,
+// resource_type and project_id. Those four are bounded above, so a state within
+// this bound keeps the widest of the tuples under the btree limit.
 const stateMaxLen = 512
 
 var eventTypePattern = regexp.MustCompile(`^[a-z0-9_]+(\.[a-z0-9_]+)+$`)

--- a/internal/reporting/httpapi/authdispatch.go
+++ b/internal/reporting/httpapi/authdispatch.go
@@ -24,6 +24,11 @@ const resourceRoute = "/api/v1/resources/{cloud}/{resource_type}/{resource_id}"
 // be the pattern the generated wiring registers, letter for letter.
 const projectRoute = "/api/v1/projects/{id}"
 
+// projectSummaryRoute is the chi pattern the per-project summary is mounted
+// under. It is built from projectRoute because it hangs off it, and it has to be
+// the pattern the generated wiring registers, letter for letter.
+const projectSummaryRoute = projectRoute + "/summary"
+
 // The chi patterns the relation operations of one project are mounted under.
 // They are built from projectRoute because they hang off it, and each of them
 // has to be the pattern the generated wiring registers, letter for letter.
@@ -74,6 +79,17 @@ func newAuthDispatch(opts Options) MiddlewareFunc {
 		http.MethodPost + " " + projectRelationsRoute:  auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
 		http.MethodPatch + " " + projectRelationRoute:  auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
 		http.MethodDelete + " " + projectRelationRoute: auth.Query(opts.Authenticator, auth.RoleAdmin, opts.AuthMode, Logger),
+
+		// The statistics are the query endpoints seen in aggregate, so they are
+		// guarded the way those are. The summary hangs off a registry route whose
+		// read takes read_all, and it is guarded lower on purpose: it reports what
+		// a project ran rather than what the registry holds, so a project token
+		// reaches its own projects here, and the handler answers a foreign one the
+		// 404 an unknown id gets. Its answer names the project rather than
+		// carrying the registry row, which is what keeps the rule above intact.
+		http.MethodGet + " /api/v1/stats/resources": auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
+		http.MethodGet + " /api/v1/stats/events":    auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
+		http.MethodGet + " " + projectSummaryRoute:  auth.Query(opts.Authenticator, auth.RoleProject, opts.AuthMode, Logger),
 
 		// The dead-letter list is admin-only like the two writes above and the
 		// registration below: a refused item carries whatever a collector sent,

--- a/internal/reporting/httpapi/authdispatch_test.go
+++ b/internal/reporting/httpapi/authdispatch_test.go
@@ -143,6 +143,33 @@ func TestAuthDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("puts the stats routes behind a credential", func(t *testing.T) {
+		// The three of them are the aggregate reads, and the summary is keyed on
+		// the pattern rather than on a path. What says the table names all of them
+		// is every one meeting a guard rather than being refused as a route no rule
+		// covers. Which role each demands is the integration test's business.
+		for _, tc := range []struct{ pattern, path string }{
+			{pattern: "/api/v1/stats/resources", path: "/api/v1/stats/resources"},
+			{pattern: "/api/v1/stats/events", path: "/api/v1/stats/events"},
+			{
+				pattern: projectSummaryRoute,
+				path:    "/api/v1/projects/00000000-0000-0000-0000-000000000000/summary",
+			},
+		} {
+			t.Run(tc.pattern, func(t *testing.T) {
+				ran := false
+				handler := dispatchOn(t, http.MethodGet, tc.pattern, &ran)
+
+				rec := serve(handler, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+				assertChallenged(t, rec)
+				if ran {
+					t.Error("the handler ran for a request carrying no credential")
+				}
+			})
+		}
+	})
+
 	t.Run("puts the resource reads behind a credential", func(t *testing.T) {
 		// The two per-resource routes are keyed on the pattern rather than on a
 		// path, so what says the table names them is a request whose path

--- a/internal/reporting/httpapi/openapi.gen.go
+++ b/internal/reporting/httpapi/openapi.gen.go
@@ -63,19 +63,106 @@ func (e ListProjectRelationsParamsDirection) Valid() bool {
 
 // Defines values for ListResourcesParamsStatus.
 const (
-	Active  ListResourcesParamsStatus = "active"
-	All     ListResourcesParamsStatus = "all"
-	Deleted ListResourcesParamsStatus = "deleted"
+	ListResourcesParamsStatusActive  ListResourcesParamsStatus = "active"
+	ListResourcesParamsStatusAll     ListResourcesParamsStatus = "all"
+	ListResourcesParamsStatusDeleted ListResourcesParamsStatus = "deleted"
 )
 
 // Valid indicates whether the value is a known member of the ListResourcesParamsStatus enum.
 func (e ListResourcesParamsStatus) Valid() bool {
 	switch e {
-	case Active:
+	case ListResourcesParamsStatusActive:
 		return true
-	case All:
+	case ListResourcesParamsStatusAll:
 		return true
-	case Deleted:
+	case ListResourcesParamsStatusDeleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetEventStatsParamsGroupBy.
+const (
+	GetEventStatsParamsGroupByCloud     GetEventStatsParamsGroupBy = "cloud"
+	GetEventStatsParamsGroupByEventType GetEventStatsParamsGroupBy = "event_type"
+	GetEventStatsParamsGroupBySource    GetEventStatsParamsGroupBy = "source"
+)
+
+// Valid indicates whether the value is a known member of the GetEventStatsParamsGroupBy enum.
+func (e GetEventStatsParamsGroupBy) Valid() bool {
+	switch e {
+	case GetEventStatsParamsGroupByCloud:
+		return true
+	case GetEventStatsParamsGroupByEventType:
+		return true
+	case GetEventStatsParamsGroupBySource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetEventStatsParamsInterval.
+const (
+	N1d GetEventStatsParamsInterval = "1d"
+	N1h GetEventStatsParamsInterval = "1h"
+)
+
+// Valid indicates whether the value is a known member of the GetEventStatsParamsInterval enum.
+func (e GetEventStatsParamsInterval) Valid() bool {
+	switch e {
+	case N1d:
+		return true
+	case N1h:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetResourceStatsParamsGroupBy.
+const (
+	GetResourceStatsParamsGroupByCloud        GetResourceStatsParamsGroupBy = "cloud"
+	GetResourceStatsParamsGroupByPlatform     GetResourceStatsParamsGroupBy = "platform"
+	GetResourceStatsParamsGroupByProjectId    GetResourceStatsParamsGroupBy = "project_id"
+	GetResourceStatsParamsGroupByResourceType GetResourceStatsParamsGroupBy = "resource_type"
+	GetResourceStatsParamsGroupByState        GetResourceStatsParamsGroupBy = "state"
+)
+
+// Valid indicates whether the value is a known member of the GetResourceStatsParamsGroupBy enum.
+func (e GetResourceStatsParamsGroupBy) Valid() bool {
+	switch e {
+	case GetResourceStatsParamsGroupByCloud:
+		return true
+	case GetResourceStatsParamsGroupByPlatform:
+		return true
+	case GetResourceStatsParamsGroupByProjectId:
+		return true
+	case GetResourceStatsParamsGroupByResourceType:
+		return true
+	case GetResourceStatsParamsGroupByState:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetResourceStatsParamsStatus.
+const (
+	GetResourceStatsParamsStatusActive  GetResourceStatsParamsStatus = "active"
+	GetResourceStatsParamsStatusAll     GetResourceStatsParamsStatus = "all"
+	GetResourceStatsParamsStatusDeleted GetResourceStatsParamsStatus = "deleted"
+)
+
+// Valid indicates whether the value is a known member of the GetResourceStatsParamsStatus enum.
+func (e GetResourceStatsParamsStatus) Valid() bool {
+	switch e {
+	case GetResourceStatsParamsStatusActive:
+		return true
+	case GetResourceStatsParamsStatusAll:
+		return true
+	case GetResourceStatsParamsStatusDeleted:
 		return true
 	default:
 		return false
@@ -182,6 +269,30 @@ type EventList struct {
 	NextCursor *string `json:"next_cursor"`
 }
 
+// EventStatsItem One group of the event counts: the bucket it falls in, the values its dimensions carry, and how many events carry all of them.
+type EventStatsItem struct {
+	// Bucket When the bucket starts, in UTC. A bucket covers `interval` from there on, the start inclusive and the end exclusive.
+	Bucket time.Time `json:"bucket"`
+
+	// Cloud The installation the counted events came from.
+	Cloud string `json:"cloud"`
+
+	// Count How many events the group holds.
+	Count int64 `json:"count"`
+
+	// EventType The type the counted events carry.
+	EventType string `json:"event_type"`
+
+	// Source Which pipeline produced the counted events, collector or reconciliation. The member is there exactly when `group_by` names `source`.
+	Source *string `json:"source,omitempty"`
+}
+
+// EventStatsList The event counts of one window.
+type EventStatsList struct {
+	// Items The groups, ordered by bucket, cloud, event type, and source. It is the empty array when the window holds no event.
+	Items []EventStatsItem `json:"items"`
+}
+
 // IngestResult What one ingest call did with the batch it was given.
 type IngestResult struct {
 	// Accepted How many events the call stored.
@@ -283,6 +394,24 @@ type Project struct {
 	Platform string `json:"platform"`
 }
 
+// ProjectActivity What one resource type of a project did inside the window of a summary.
+type ProjectActivity struct {
+	// ActiveNow How many resources of the type the project holds right now, counted off the projection rows that are not deleted. It describes the present rather than the window, so a type the window saw nothing of still reports what the project runs of it today.
+	ActiveNow int `json:"active_now"`
+
+	// Created How many resources of the type began their life inside the window.
+	Created int `json:"created"`
+
+	// Deleted How many resources of the type ended their life inside the window.
+	Deleted int `json:"deleted"`
+
+	// ResourceType The kind of resource this row is about.
+	ResourceType string `json:"resource_type"`
+
+	// TotalMinutes How long the resources of the type ran inside the window, in whole minutes, truncated. An interval still open is counted up to the instant of the request, so a window reaching into the future carries no time that has not been served yet.
+	TotalMinutes int64 `json:"total_minutes"`
+}
+
 // ProjectList One page of registered projects.
 type ProjectList struct {
 	// Items The projects of this page, ordered by cloud and external id.
@@ -290,6 +419,27 @@ type ProjectList struct {
 
 	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
 	NextCursor *string `json:"next_cursor"`
+}
+
+// ProjectRef Which project an answer is about, as much of it as a project-scoped read carries. The registry row itself — the name, the operator-set metadata, the platform, and when it was registered — is what `getProject` serves, and reading that takes `read_all`.
+type ProjectRef struct {
+	// Cloud The installation the project lives in, os-prod-eu1 for example.
+	Cloud string `json:"cloud"`
+
+	// ExternalId The project as its cloud names it, which is the id an event carries.
+	ExternalId string `json:"external_id"`
+
+	// Id The project, as this API names it.
+	Id openapi_types.UUID `json:"id"`
+}
+
+// ProjectSummary One project and what its resource types did inside one window.
+type ProjectSummary struct {
+	// Project Which project an answer is about, as much of it as a project-scoped read carries. The registry row itself — the name, the operator-set metadata, the platform, and when it was registered — is what `getProject` serves, and reading that takes `read_all`.
+	Project ProjectRef `json:"project"`
+
+	// ResourceTypes One row per resource type the project has events or resources of, ordered by resource type. It is the empty array for a project with neither.
+	ResourceTypes []ProjectActivity `json:"resource_types"`
 }
 
 // RebuildRequest Which resources to replay. A member left out filters nothing, so an empty object rebuilds every resource the events table knows.
@@ -425,6 +575,33 @@ type ResourceList struct {
 
 	// NextCursor Where the next page starts, passed back as `cursor`. It is null on the last page.
 	NextCursor *string `json:"next_cursor"`
+}
+
+// ResourceStatsItem One group of the resource counts: the values its dimensions carry, and how many resources carry all of them.
+type ResourceStatsItem struct {
+	// Cloud The installation the counted resources live in.
+	Cloud string `json:"cloud"`
+
+	// Count How many resources the group holds.
+	Count int64 `json:"count"`
+
+	// Platform The platform the counted resources live on. The member is there exactly when `group_by` names `platform`.
+	Platform *string `json:"platform,omitempty"`
+
+	// ProjectId The project owning the counted resources, named the way its cloud names it. The member is there exactly when `group_by` names `project_id`.
+	ProjectId *string `json:"project_id,omitempty"`
+
+	// ResourceType The kind of resource that was counted.
+	ResourceType string `json:"resource_type"`
+
+	// State The state the counted resources are in. The member is there exactly when `group_by` names `state`.
+	State *string `json:"state,omitempty"`
+}
+
+// ResourceStatsList The resource counts of one grouping.
+type ResourceStatsList struct {
+	// Items The groups, ordered by cloud, resource type, state, platform, and project id. It is the empty array when the grouping counts no resource at all.
+	Items []ResourceStatsItem `json:"items"`
 }
 
 // ResourceType One registered resource type and the size schema the sizes reported for it are validated against.
@@ -621,6 +798,15 @@ type ListProjectRelationsParams struct {
 // ListProjectRelationsParamsDirection defines parameters for ListProjectRelations.
 type ListProjectRelationsParamsDirection string
 
+// GetProjectSummaryParams defines parameters for GetProjectSummary.
+type GetProjectSummaryParams struct {
+	// From When the window starts, the inclusive bound.
+	From time.Time `form:"from" json:"from"`
+
+	// To When the window ends, the exclusive bound.
+	To time.Time `form:"to" json:"to"`
+}
+
 // ListRejectedEventsParams defines parameters for ListRejectedEvents.
 type ListRejectedEventsParams struct {
 	// From Serve only the items refused at or after this instant, the inclusive bound of the window.
@@ -665,6 +851,46 @@ type ListResourcesParams struct {
 
 // ListResourcesParamsStatus defines parameters for ListResources.
 type ListResourcesParamsStatus string
+
+// GetEventStatsParams defines parameters for GetEventStats.
+type GetEventStatsParams struct {
+	// GroupBy Which dimensions the counts are grouped by, as a comma-separated list. `cloud` and `event_type` have to be among them, because they are what an item is read by; a grouping that leaves either out is answered 400. The rule spans the members of one list, which this schema cannot express, so the handler is what enforces it.
+	GroupBy []GetEventStatsParamsGroupBy `form:"group_by" json:"group_by"`
+
+	// From Count only the events at or after this instant, the inclusive bound of the window.
+	From time.Time `form:"from" json:"from"`
+
+	// To Count only the events before this instant, the exclusive bound of the window.
+	To time.Time `form:"to" json:"to"`
+
+	// Interval How wide one bucket is.
+	Interval GetEventStatsParamsInterval `form:"interval" json:"interval"`
+}
+
+// GetEventStatsParamsGroupBy defines parameters for GetEventStats.
+type GetEventStatsParamsGroupBy string
+
+// GetEventStatsParamsInterval defines parameters for GetEventStats.
+type GetEventStatsParamsInterval string
+
+// GetResourceStatsParams defines parameters for GetResourceStats.
+type GetResourceStatsParams struct {
+	// GroupBy Which dimensions the counts are grouped by, as a comma-separated list. `cloud` and `resource_type` have to be among them, because they are what an item is read by; a grouping that leaves either out is answered 400. The rule spans the members of one list, which this schema cannot express, so the handler is what enforces it.
+	GroupBy []GetResourceStatsParamsGroupBy `form:"group_by" json:"group_by"`
+
+	// Status Which part of the fleet to count. `active` counts the rows whose state is not deleted, `deleted` counts those alone, and `all` counts both.
+	Status *GetResourceStatsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// At The instant the counts describe. Leaving it out asks for the current counts, which is what the projection holds.
+	// Any value at all is answered 501 (`urn:tally:error:not_implemented`): counting a past instant means replaying the histories, and the Phase 3 usage records are what answer that. A value meaning "now" cannot be told from a historic one, because the two differ by however long the request took, so omitting the parameter rather than sending a timestamp is how the current counts are asked for.
+	At *time.Time `form:"at,omitempty" json:"at,omitempty"`
+}
+
+// GetResourceStatsParamsGroupBy defines parameters for GetResourceStats.
+type GetResourceStatsParamsGroupBy string
+
+// GetResourceStatsParamsStatus defines parameters for GetResourceStats.
+type GetResourceStatsParamsStatus string
 
 // IngestEventsJSONRequestBody defines body for IngestEvents for application/json ContentType.
 type IngestEventsJSONRequestBody IngestEventsJSONBody
@@ -967,6 +1193,9 @@ type ServerInterface interface {
 	// UpdateProjectRelation Update one relation
 	// (PATCH /api/v1/projects/{id}/relations/{relation_id})
 	UpdateProjectRelation(w http.ResponseWriter, r *http.Request, id Uuid, relationId Uuid)
+	// GetProjectSummary Summarize what one project ran inside a window
+	// (GET /api/v1/projects/{id}/summary)
+	GetProjectSummary(w http.ResponseWriter, r *http.Request, id Uuid, params GetProjectSummaryParams)
 	// ListRejectedEvents List the dead-lettered events
 	// (GET /api/v1/rejected-events)
 	ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams)
@@ -988,6 +1217,12 @@ type ServerInterface interface {
 	// GetResourceLifecycle Read the folded lifecycle of one resource
 	// (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle)
 	GetResourceLifecycle(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string)
+	// GetEventStats Count the stored events per time bucket
+	// (GET /api/v1/stats/events)
+	GetEventStats(w http.ResponseWriter, r *http.Request, params GetEventStatsParams)
+	// GetResourceStats Count the current resources per group
+	// (GET /api/v1/stats/resources)
+	GetResourceStats(w http.ResponseWriter, r *http.Request, params GetResourceStatsParams)
 	// Healthz Liveness probe
 	// (GET /healthz)
 	Healthz(w http.ResponseWriter, r *http.Request)
@@ -1075,6 +1310,12 @@ func (_ Unimplemented) UpdateProjectRelation(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// GetProjectSummary Summarize what one project ran inside a window
+// (GET /api/v1/projects/{id}/summary)
+func (_ Unimplemented) GetProjectSummary(w http.ResponseWriter, r *http.Request, id Uuid, params GetProjectSummaryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // ListRejectedEvents List the dead-lettered events
 // (GET /api/v1/rejected-events)
 func (_ Unimplemented) ListRejectedEvents(w http.ResponseWriter, r *http.Request, params ListRejectedEventsParams) {
@@ -1114,6 +1355,18 @@ func (_ Unimplemented) ListResourceEvents(w http.ResponseWriter, r *http.Request
 // GetResourceLifecycle Read the folded lifecycle of one resource
 // (GET /api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle)
 func (_ Unimplemented) GetResourceLifecycle(w http.ResponseWriter, r *http.Request, cloud string, resourceType string, resourceId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// GetEventStats Count the stored events per time bucket
+// (GET /api/v1/stats/events)
+func (_ Unimplemented) GetEventStats(w http.ResponseWriter, r *http.Request, params GetEventStatsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// GetResourceStats Count the current resources per group
+// (GET /api/v1/stats/resources)
+func (_ Unimplemented) GetResourceStats(w http.ResponseWriter, r *http.Request, params GetResourceStatsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1703,6 +1956,61 @@ func (siw *ServerInterfaceWrapper) UpdateProjectRelation(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
+// GetProjectSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectSummary(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid", ValueIsUnescaped: r.URL.RawPath == ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetProjectSummaryParams
+
+	// ------------- Required query parameter "from" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "from", r.URL.Query(), &params.From, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "from"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "from", Err: err})
+		}
+		return
+	}
+
+	// ------------- Required query parameter "to" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "to", r.URL.Query(), &params.To, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "to"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "to", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectSummary(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRejectedEvents operation middleware
 func (siw *ServerInterfaceWrapper) ListRejectedEvents(w http.ResponseWriter, r *http.Request) {
 
@@ -2071,6 +2379,137 @@ func (siw *ServerInterfaceWrapper) GetResourceLifecycle(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// GetEventStats operation middleware
+func (siw *ServerInterfaceWrapper) GetEventStats(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetEventStatsParams
+
+	// ------------- Required query parameter "group_by" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", false, true, "group_by", r.URL.Query(), &params.GroupBy, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "group_by"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "group_by", Err: err})
+		}
+		return
+	}
+
+	// ------------- Required query parameter "from" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "from", r.URL.Query(), &params.From, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "from"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "from", Err: err})
+		}
+		return
+	}
+
+	// ------------- Required query parameter "to" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "to", r.URL.Query(), &params.To, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "to"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "to", Err: err})
+		}
+		return
+	}
+
+	// ------------- Required query parameter "interval" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "interval", r.URL.Query(), &params.Interval, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "interval"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "interval", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEventStats(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetResourceStats operation middleware
+func (siw *ServerInterfaceWrapper) GetResourceStats(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetResourceStatsParams
+
+	// ------------- Required query parameter "group_by" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", false, true, "group_by", r.URL.Query(), &params.GroupBy, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "group_by"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "group_by", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "status", r.URL.Query(), &params.Status, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "status"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "at" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "at", r.URL.Query(), &params.At, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "at"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "at", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetResourceStats(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // Healthz operation middleware
 func (siw *ServerInterfaceWrapper) Healthz(w http.ResponseWriter, r *http.Request) {
 
@@ -2291,6 +2730,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/resources/{cloud}/{resource_type}/{resource_id}/lifecycle", wrapper.GetResourceLifecycle)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/stats/resources", wrapper.GetResourceStats)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/stats/events", wrapper.GetEventStats)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/resource-types", wrapper.ListResourceTypes)
 	})
 	r.Group(func(r chi.Router) {
@@ -2327,6 +2772,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/projects/{id}/related", wrapper.ListRelatedProjects)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/projects/{id}/summary", wrapper.GetProjectSummary)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/rejected-events", wrapper.ListRejectedEvents)
 	})
 	r.Group(func(r chi.Router) {
@@ -2344,189 +2792,236 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H3rkhs3suarILgnQuPYanZLluecoWN+aGY8M9rQ2gpJs7MRllcEq0AS00WgDKCaoh0dsQ+xT7hPcgKZ",
-	"CRRQrOJF3S3LPvonNasKt0Rev8z8eVLqTaOVUM5OZj9P1oJXwsA/X4kfW2Hd87/4/1TClkY2Tmo1mU3+",
-	"rI0RNff/Y7JiesncWlpm8I0pe7MWzApzIwzjlW6cZW4tmFaCcVbyuhaGWaEqy7iq2EooYbgTFh7Qbi3M",
-	"VlrxNZOO8aYR3PhfmLgRZsdqvWK19M8t4Zs0ZMGsZj+22km18u9JxTizbdNo48IzTFq2XXPHnBQ4IbfV",
-	"zOmV8ENOJ8XElmux4X65bteIyWxinZFqNbm9vS0mDTd8Ixxtzp9bY7XZ3xm/8rkS7927Ep6Yh4k2fCXY",
-	"Qiy1EbhZWokpew6z0g3/sRUzvzm1FMqxhlsrrF/IgpfXjMM/jSiFvBEV7IuqmBG8skxpt/aL1q3zQ0nn",
-	"FyL9VH5shdlNioniG78WnM+xVRphG62sgEW+NHpRi43/Z6mVE8r5f/KmqWUJh3/Z4BP//V/Wr/7n5Nv/",
-	"ZsRyMpv8t8uOvi7xV3sZvgsj7u9fOK8ll7WokJoWutoxy3eWrfXWLzEh1P99QaR6gbQ6NDQ9ftkR9S2M",
-	"TlOCIzWCO/HS6H+J0g2fbIM/MqeZEStpnTD+DC2b/66sdVsVTLx3wihev5PVF3PWcGnYmlv/wgIvABKt",
-	"f9fsWKUFnCBb67piOwGH1xjdCOOJFDbef3d4NlJZx2u6hi6ZXi1vPPWogml70RhdXYj2MVtqw8R7vmlq",
-	"4YfZSPVCqJVbT2aPiz4pFJNkIYf3AojTMpgn87RmiQiPDLARjlfc8f2v/3PNnb/tTNRWwK3Vxq3ZtRCN",
-	"p3S+8LSerHfKnoUtDXvBHasFv8E75B+3Thu69WLTuB3TC3h1EmeGf/AzwwszNKtsl6VFXladsNim5m6p",
-	"zWZkK+nXgUPU/hAb4U+6vD7rCOEy/9hKI6rJ7PtuBgWRVH7EPwzsA16IV8Toh6cexYDTrITnganR5qfr",
-	"QSbo1kgjwLC1qncoGTwHZkJVflNX8kYothZG7N+GeyCaMGNPNTDje6CY8M13+Mso6cTd2giubMGkWhpu",
-	"nWlL1xrxzgnFlTvzojpuVsIdvabZ8Ebwci0sHFXHngJLE1UBAkY6VnLl2dNC7B1l/Bbump+oJy/uJrNJ",
-	"20pPXw13nsAms8n/+f7q4g/8Yvns4q8//Pwftxfpf5+e89/HT27/bTKwCTe8ltW7pdGbod0XKp+yddw4",
-	"yxbCUwa8CjtRiSVvawfb4QJ/Vb3lesoy0jmhsiVX3IkLJzdicuwidufVp5uhO/gXwasXwu/jC2kHpNJ3",
-	"ilQLvWSV4NVFDQ+LyutLytn9KySd2Nixy7xsLSgYYmOjVuc/XzBtKvjsYhcVkXccFREJHDB+95Dk75Yj",
-	"qm/8BIGCcdHcGL4D/tupT4OnaZAa/WO4djzPAtWmKupMc1LBgpql2rpmJCprbvFlP3X/A1/UYjJzphXH",
-	"DhAXmk/z8NGFtQ6enlQrUE6d2OB+P3v5PJxE4Zfhp5scLXN+qqAxBEnbO+ARTpB+w+gtSs3uwIERKI10",
-	"47X6OJmSK+ZMS1o23Aa9fWSZ3oL2H9TqVPb3WcHehTV8O6LU+Kmgwrvlltl2sfG3rSrYVro1+/YfL1i5",
-	"5oaXXhNntjTtYiEqxh1t5JR9Sxqxl89aeaVAKlGBQJnhTDkrdV2L0mmwQxxTQlSMGB1n/+P1d98St0dG",
-	"CDuxEZuFMKzkxnj7YRvkDU50imKA2yFB+c/1jmaHzBc33dFqC2+qwP1gN1ITm0lkQMEaI5byPb2y5Tvi",
-	"TkA3QWFnRnhjJxzA/oZ3l3aURebEFyf4gYyOOFw3bNwgPP6hOwP35LlqWrQ0qkr6GfL6ZULheEf3L1LJ",
-	"lVay5DWSMNoNeGqe19d6y7jx18C/6GnGcFA73JqrlFK+Ru4CC5Y3IpyNt281rza8uby6uii18oNIrex0",
-	"UzErSji2p3dT4I2wujWlOEWD9zq6n8Kg5P9brRe8rnesVfLHVjBZiU2jnVDljl2Lneftj72Ye/LV75Pr",
-	"NGXPVHf/jYiXD++en6HlG8H88VvHNw0rdauc9feVs6pFuzCd2wF9aO1tewUXG+VpXP2U42bCoFwx3SAR",
-	"sGbNrSjSbWBexrROTFFWl2JKSqhQFUyj4bta85H9hzOu5U+iYvQcE+pG1LoRM1yt40543qIN40tgvl4d",
-	"9Esr4J9LL1KMaGpeio3fNyt/Emzrr5PXntZcrYI2FVdh+NZrUjeyEoZ5ZXZ6poXQo5IDJsItEKO/XEf1",
-	"Q71Vnmlm388XLi1dLGQn+Mzod+NHuhf9FQI9PP/CMI34b1xLBc6l8GjBwjH7ed3out2IvQXjo4cUB5xM",
-	"6SnZa4zkrvLqPmlNjNdbvrORpYLuKxsBjicwFZD5guQEoZhKFNKZN9xcg2WMipi/I0aUWpWylnjjdeua",
-	"NuNTbMN3XgbVYglGyNeMe/20Ff4/VlaCzeM4c6Cqef7NOTFvmzBvr2GFC3tAO8aVd7fy+evv2H/8/uox",
-	"XUO49D9p5Tf5doxzH9dR020+TzmlbRzVSjum5PclcLGTNdPXMLHfuk76HOj2lbBt7Ub4su500pLXNatk",
-	"wv4X3JXroJuBob5/hrwsRePEAF/4u96yDVe7cJb+izAGUkWit0jlxEoYP+UoVuyBD6LFApoyd3zBrWC8",
-	"NoJXO7YW9ciXjfDbIqpxRTSZYtTI/f4I5cyOeSP6ZPp6RYONUFjvPOMeZutPpjx0uC/kUpS7shbDVzDh",
-	"ooErsbX0W78Laq5gC4lkx/w+mRteW2R49CBbotmhnJ563oNfnANnR57pUM/mPQHg9Uo0WZQOMgeUYb0F",
-	"Du4/oOwWLvPTq6eZbhb0AHTD1GGV07fqrXpDbvw1r70sRAXPgJvc83b4rZLLpTB+ubhoK5ydsjkSIbHR",
-	"uNw5aPioYodFwwqcvhYKGLSnq4Jt17IWvT1InCS0uAJ2LMwGYxg4i0zSeturVV4hUJrZUjdiyr5T+S7y",
-	"qFCEMWwwxnDXIbYQZBZnc1SFvOo9x+Fj+EHAGoTxUp+EWCCApTTeGqXtCK4S8l85w5VdYrAkv/S4mcM3",
-	"CZSkbi8FbAkzXrNTGQuf/y4y8SL1MhQsaLpfzO+LoccDH57z4D3oKEJumloKWzB/uNbhrk3Zm63u3sTD",
-	"insHmnNwKYHTzJ913OiFcFuBonhDKkU8ezpIOKNK1MKhwYucGj+IxrsCnY3X9cm7FHnGc5rI0F6FiRzn",
-	"cfTcbTHZcuMVSnvAGwpkUOq2RtubXAw9/sqexU3frrUNBBoVSv8mpx2Kxjm98Q6p951nILp178g2SPdm",
-	"3516iC3HjSgCwaeElCz6IHuOWz3Ipte8Xl54fZ7Zhis2/95f3YI5/cWc6RthPOMp1zHuF8kNPdwp1SCz",
-	"2L+rR9ykvbtf0B/LurXeHF7oVlWnugTuZn/ActMpDXo2vMk1/G0wxnp8tjr41e60wPQb+SxYhdl3vTok",
-	"1YkTdvqU3Reqor0X7/O9T1VHlELZixBQFqogQomaZXxALxn3tqPf77gCaUfP9DxVFKgLFhk2kY4oo4Wh",
-	"C5KEm/PNefXXP7M/PP3q3xmFm1klHJf1lH2D8tQYbTpHmExcWWQKScvsmjeiQFRCBQ6LkTD2/n3B0Qa0",
-	"z3bD1YWXpHABxfum5ooiDI0o5VKWGErwJ1KWrTFClWKQJGAJA7zypTAXSynqipZs/QocOhhI2YAN8eoT",
-	"RjLIfchl3Zqc1eWLqnW5P9wLXZJpiqAFvVwKVVGUpBUFE9PVFGLx08QBMLiijV2NsH6IoGi16qwKNHFB",
-	"KnDHaprE9KiH0a8BRxoip74U88TYjoj7v79585LhA6zUlUggLUhVU4iXgpdhMnt6dTVkTzjphnTv12tt",
-	"HFvnxGLbzYabXUSH0Dn6j2ZDTf5Xfqhi0Js+7EL5xyvw5QogOyYroZxc7gKXHR+yNWrmeF3vZkCWs46u",
-	"jge3/K9hJ+KWj1z2YZwFmiohEtnF+N+kwAlp2bXYBa1xCHtRkF5fzTvcT4w0+4sAC7KMV5URNg9VL3Yf",
-	"EYexd5id2n5ATIQhtuBWCrt1uli+G7wjyBYyeWQF5hm51UAFG1zZkbEo2kWs+6xw0qm4AAgpoQtqAEaC",
-	"crUf8YcD43FDEtokvZJxtbsXIEmBMv34eLA5J3iJHgp4ckLg5wjehDYnObmM8A9wjOM+xn3ucZ6nMVrX",
-	"o75GvA3gZ6Q1neNqDKzvt+tmfCUWrawrAtsNrcRzj6BCWMTTNTXfeXOPXOHBB86WsoZYL1k8aByr/Ioa",
-	"HNCShyXxmkTHMYbNr5Xe2pO5+yuYVIdT6mYcSANeHAm4HoxvHP90EMz7RzK+30f8urRNtNlDtiE+4Q64",
-	"WruJbgX6m+Kn+irRnvWM3x6mGLyzwYXwZjQoBEYdxWQTHCZxze7kaffy5fmX33Ug1fzrzzDy/xq/XRm+",
-	"dOzJ1ZOri8dPWKXLdgNRZbxQ/lp7bSz41CT8FUVLhEmEl2BeCT4RvbvWvyHe89IFFFz0vPuHSq7ARtmx",
-	"mjt0ufV2rbe96dqGtzj1QI/oXQkeJHgEMWgfnP70yIgHcFSdSFAlhPFARaHal7pI6HieKuBieNAsKnBz",
-	"JQrIdh3wEJV4H3U90nZlFgkbUkn8W+MBgEeWNdpKRH4h++yC4hAMKTAGHjy8Pwmjx6IN4+CQuCnJDudx",
-	"7rfp8c7Yo5uyae0jtPsCETA6kN3byQlCGhaeYAjiDIdpxxNhdVBpjxojc4bfCGN5TUDDasimbtz6IJep",
-	"SUGvpUidoxkIccvraxSBYf8jXAcilUPn0PChgTMsq6wsRQ/WJGGjHR91NoWDg1IAF146CnDMYW0B+L/J",
-	"1IKjimxfIWi6HT9RpTiCRYWAya5JEigSwwWW5K/ZjajYKRZ4mF5/2IIOmLb7OEkNa3W5NqbEKZR1imIX",
-	"10pfKcLlhuP0R3kjrXSIgdqcEePLbskxbzJ+c3RvBjHXyKXpyOK12OpO0yV+CkY7447N3ZzJ5ZLNO4ws",
-	"e9teXX1Z/pE59uzbv7Df4S9Os+ev2bf/ePGCffeKxb/Bs4K5YFKjpCtrbXsQKopMxOAFh+G9psZNLf22",
-	"UqzCOumtHKlGAIwnGcBxEzzLPBORO26Jhq/+UqZoB04/aIvGxYfI0DFL9EEB6vse+cPQoDNh5PeKeD/l",
-	"+3cFk98xYhJu3mmD62Zg7NMiBimm3Zv69xQAgE3tSKA4gHjPzP9k25NNOOoWCLxyXIJ0uoReghSJmkoW",
-	"Qz0TKh++GRktAcPgW7m3IC7gXLh8lAN3ESVjgLgUExJw5gl4IQDMCTO9hxnBbDyUBkau1o4pzMy7R/jr",
-	"h/tHs8gcvVEMrJLQGdJ1Cl949ZE3JXQdg/7ZLUI+3IEauGMKeLtd661n6TEb6k0+IIWsAeNRhUwTLyzB",
-	"L6+vhaLUqFPAH9IGIUEB8C6cgFpqAnME2muMqCDVtsOAIJBfGLuWTcTHJ67Jhay9nUsgHXAghUD2I5sC",
-	"ZwragQx30nAZPJdeMQYNwf/wobzGK5bhI6cef1RMEv4nyc/54fOouXXv0Ho6MBXuesDK0+VAMsBpqrwS",
-	"WxGhEYGwVbBcIOUDKZizud2pkrDS84L+2zYV/lcb+gvu3LyLN9IQCD1wKYy7I+Vk5zkrtTFE+Yvg6MpA",
-	"sEvDN2KrzXWmS3LCMfmXEmztdHSfDuK8++Bu3LBwNEXwOHoSp38mCSjk0vG3J7n5CLriLoLa1CF3aseO",
-	"7wLznt43voIY9rjr8ii4Wzor6mUxngR8rlt0CPZ9D6gPf0Lb0YOOGG0kOpAHRzTwjPPH15SG0e8BUCIB",
-	"T6IwTStgvjpoD+GcImfroB5UdsEKSAXyp5NdrCBppGN6uaTcMv+RgO0/pt2FYE4S38mPNCefjED3ACGJ",
-	"KM8Y+z7z6/Pb3rU/pPkcDxghNMN1ru0zVcG+5344XlTkzumCijiEAz9HK+xgdr/ZANKhMEAPIpBta3Rb",
-	"Z3EC+n9yw0GfcQAYJnyD19pW3Cul+8f/IWwbZrMQtVYry5z+UG6Yf88rUpIUizDsKH8cjXR0WArYwBPC",
-	"HkMcDfWFI5oYnYAXpUA3d0uePsB10gVncztGX4cMx2Ea+zD+gK9mfCESTsYKQujqLGYAN+X+GEJUFRHV",
-	"D9ff6YrvZnkFE1R/ILaot6wRps/krI4x2SQCtvRCF3RTwCwD8r8H8amldX4yO69GWqlWtSDG2nkwoMQN",
-	"PIlMF+0MXK19OO6UQssHmRNlkdn9+HPPqu6lODd1a3ulB8gFSZ5C6T6GhX04lNfPJe2Sx7LVYD7Dge//",
-	"ormhRGsjpogflYxk65+p2JJvZL0rjhhOADlLLadZbgKFBEivKHrC98qaLEWIH6HiDLYEm/fSSkhfdZot",
-	"DFfl2gvjVLFDs18s5Xv2///v/yO/zF52IG0PhZy1FUkm3r5p8YG5s6cYVPvOlAAgI0oPHu0k2MszVZVy",
-	"JfM0by/OlXYDif/++8H8uxaisZTtIvx95F1CLtQDWIidJjVCK9GPBPz6DL2xRN671Qmgk4r3/3TXxjnZ",
-	"w2Ivefh+rMpTPz2eT+xpMqYFN0ZXbZluR5HkBAM+Pb2Kgf4jMJXsNv+UqXqRte4hYq6GlTWXGzGMPDo/",
-	"2/cDtbEEO9CNmbH3QRzgOfZiSLcJvCgn0EHhvFPlUSCU59HMtIpVciCE7K3U4/llO1W+hgc9kexU+c60",
-	"6oDQDF66eXjWzsmLJC1MZWu0ExldgHwThjsgH16R27ZVaKYtKG+zI4+dcmvhZBnhNjaG+Vu1lxx53NhP",
-	"l1XQtozt+euwaQNOSihFQcGXsPUJhEeHtPqlVNKuRcXKWnA1Ghk+CZ0WVh0tPnJQJr54bpkS2yJMK9u7",
-	"kNw7kJCMfoqD2cjdqNyy1SgWhayUw58i/YFYC3hQCrBmwVELvnumlyfg78LudeN2ixk61X/AU6OYHwwa",
-	"a4pLxPyzpChf0FmSmo5UYw0LrIFuTzEkhA3AAxbvKOFnkgJljRGW5MxGqrQmzOPTC8WhuoC/ZsGS4FSD",
-	"YInSW0Zcmsp7kDqIMo98gRAfsrwWGbvGcOxGmFVwwMcqEWEbIMeY/HBhXDSTkj0LEwN15V4A5tnaTigg",
-	"OEIS4/CUEZpIa+79OoiiQ1h8alQRZzZOFndCEPSKAqLSmICH5lnBEgpnBnV4RjJLZeACAguBs8ELLB7+",
-	"4k90RZ5q/Fu0fCPXC/a+Ef67UMsxoo+SMSCoigV/z9Jn9km8RRn+i1Uz9OqEKFsj3Q58clRVo5Fv9LUY",
-	"uHPPFGjjWJ+A3Ljcsvmz1q21kT/BFs3YnwQ3whD0Cx5GZNd8yr7h3p4MOVFkhmJpAQyVKiEq+zXjNAgW",
-	"00ITM6na8GWsoeyXs4DxuuWtnWsQcbsS1o2vJdQeMQIgvLwumLS29XamMOx3QZ8s0Kn+BYa1P2TVzx1V",
-	"c4BAI3lpvCmKzlUuDeM1ie4TVoV5ICPrgijPmvt9sqI0Ik1GewPaUadhYr2RmNILJaN064QFm7j44MXS",
-	"JaHNdJo17aKWJRXktics8xYWuhzgK9+gvhnA60moQ0KdtFhjpLV8FYpUBJQ3bIDnKtJ2kPlS33iDHoou",
-	"CF67NSQsClsE3bYbK3gCPbuEDGw8y24SFseOuAXKqw4/X4BnPTgei0x0dn/NyieKG+kVxxBrSGt+YIrF",
-	"NGZBziZ4wK/imp+9fD4pJn55uHlX08fTK09EnsHxRk5mky+nV9MvCT0L1/+SN/Ly5vFlV2djJdxQVolr",
-	"jQpSIy22VDDFjQFsymKHqjegNUJ2TSqPQw4fMHqCxNq8OkdXkINxW2KS8JTNQUCgG8zpObOiDki8rqzB",
-	"VqpKb3uFDVKrNA4z67xC3EW/FQ0iLSVzo/6ePuCHRmqfvlVYGrCuiVOhtQHRKzYHh+88ytrOW0uuvKyQ",
-	"e2qtg7scvkql2pOQmeeT4Nbaex2+r6IluOX1Ne4xPkPOYd6lHADogAo9iNqio5AUHtITQv169IgiRwln",
-	"6mcs6ppVYimVqGbk8sIfAwYC9wYSTQgC5blfmIFWW24qO32r4HqCUz74jy4IxJTHl+lO4W9e4euKpl8L",
-	"RXZsWggHy3rMO7t/ThKI9D2vGwTMU4Gwyip4uEJttX5oPM3L2XpdhgrXANp2y3cEyxLmIr6IE4Np79Xp",
-	"gdotW74jfS18jW30TcRSBa+Shgkrse1ydMmVueaqiriZFKWa1sbZWwiWBQJxUVchrSEK6+fVZDZ5Ia37",
-	"JtQjSfsUfL+Xi+5vTJd01qupFpPZBvsHkPdmvH1Acd5oafhyaMDEc3R/Y4ZMYz9GV091ALvCnhHBcnsd",
-	"05E6JyuV4/MvIskMqEKDi8q8W3ddFtpX46mDQzPYi5ve195ivA+rMlKEpI8UH5pP5i2882SAOcPZ7nlm",
-	"xyYQfYzd4EK1G/CYBAcu+h0T/23iMDn70PrO+IgZHoCNR1kBQnNsCQSa7hZwmvFz2nzTpiXZVHso89Om",
-	"inVh7jjRfiHBINKjJOeObbQd7YVSy4102Tyo9vtk9vjqqphs+Hu58STw+Ar+KxX9d8jHNuwm7tjwJfWK",
-	"uf2h117lydXVgdYq57VU6cpvDjRVOViA8z4aqRSTp7iWoTfimru+L/75x2c+/+VZz3911nwSkxuEZmds",
-	"f/+DPzaq1kKiNt9DiM3pIQjJa+wgwalqpl72S1TbpLeNV6okFieJAAIMiwKUA4o2IVEzT5QxuxBLIKLo",
-	"8R95cnUFcF1x03OyERgQYLlkNlJJuVCUpuiKmlNCrbyRVctrqoVZyWqWpORm1cItlmRpHAWyLkA8xgo/",
-	"gznENHiAXCo2D+Ut59CcI0bPNljynCocVkY3yGgAnY+bC6qrl8aLdrmETaQIHxXvBLMItfpNax1YwkY4",
-	"swPdEUeNWcK5doU1U6N+Rfv5J13tzrq9WonvlkBdR+8xFkD3nOUkCFD2Tg8A9MNtHgVwphW3D8iHsgKz",
-	"I/2d8MQ8ITRGl8La/SZP2z60HIEvvxJe9fhj8qrMn9ZnV3gckVPdFtGRECyqo64Etx6qx2Tvw58w2DOr",
-	"cyecbbt3c/tsvWfW+6DF+DJQwHk24351nI9hx+2N+sC2apoqLk1mHMLw4EN4nlQgha4KCkSQ3mIOl9tq",
-	"fNGy1gaPBbgSkqpBEJVfaLcOpQlbVQvr6dG/OadbhtRHOMkxQyorr3TG0qM2naXa/9fWp9OyBEc06pFy",
-	"U5/16rP16hFRM65hh6pBNk3rPbtU4MwzbS4xHyBUjUecbubU+UPP0wkB4K7eQYOp+BnOGdVwfSMMQUr3",
-	"cD1C4WLRyiZ1HsoWdjc+XkMJ7S9PLmSI/VxSXlP7fQpdJwu2ECVvrUg5lde1/a1OqqZnZTOCK3RfpuT9",
-	"Mz9cUT50LfMxTtJtH983TxhTa7OKiSgYtr3ajAlPCKVWh2OF/3j1IugZocRDONPDvP23xGueXv3hk+BN",
-	"gct0/t9BTfryZ1ndJup0fjv+Jlx6NR5WbI131t2rq/qblVRPr55+ItTDKyq+19/8ye0R1fuk4qigkEGZ",
-	"paiPUamNlDEWJ1IQwF9u/RIab6YP9P6mtgbB0860oQQFgk/lRTbOh3yB7Ra+BpZXELUjyCrEVN0dYfdW",
-	"fUsuOJdC9BUtcMRe9Yo/NQXFDB9hMClhB6r9tiuts6+QFASH6oKBoGjfYElMrlDIo/EBeft7QnlfDOeo",
-	"zYcRw/kYH9nFdJYY9jLYOq4q+5nTPTSnQ6oY5XVjIvPSYNm0UU/UP3l9jfxGt26lsW1BKL8DVyZm8ULB",
-	"M+7mBWsbf4VCLb6kBFDrQuZ1CpXZqyoYWyQ/y2CGD1JWjcqFdk584D9aKnchFQTF2I0U26ARrgxv1rCG",
-	"2I7GYr21xQ48WgiSbLjFzSCjApYlLVv4R936Ahup+M9AsTubhrdVGbOunDAbqaBoDGcAn4J3uhyq+NKy",
-	"6/ENmVvL1GnBup5apd6IvOCe89wSyslS3T2SAv5b8xSPmBw7LchpfY11YHm5BtT+aGgEjbGGr2A5OTYF",
-	"a/0PtuXvtaYadqblpf+O+tQG6lyGEnCwqpXGNLMhZ0uorDjkbMlcLccdLfv3LC1InFTNOgFVkNf1OsP9",
-	"9KbXapsOLPRptXu9udV4dJm786PLD+lGGihyeVhs7dem/Cy3PprvKfd/RgQoCIJzdPXQK41KlVKFwJBy",
-	"9TD6+mHp6u/xiZGe7NaLXDUdkLNZ+7aunkvBoFnbJyg9lZCr9UKbtdbV+UL0vqVJVsjaWwqirm1X3j6b",
-	"LFVxY626Vnqrxk2AJLrzKp7+EfINJfmjgNUYkJixedC65l1CtDffkkYyaKDOpSr1Jn8Qbg+aYQWbL7SX",
-	"52hkjYo3SdnywyJu4r8xKSJEK0wOvobDTwp86AMgWp+F3n0JvVCRc9QTdbB+5meh9xEDLsPVUc8WeN2H",
-	"vJigcERaB+TBHFWDsSEMFVBtmrTKcI9vdUYLFnf4GCILjJskpS676a7HGtLZhOpJCI1wRjY1ovqosy+W",
-	"2g2dwRPu1AElYjGdPE0Pyn56ZgHIZ/ywo3ZtISjGSydv+lDnP3zdxYXoPcS28pDRZ7sGpisu/eSf0YQ/",
-	"yP7y88NlSpc/Gtxp9HOYPkyvV6/QiOSjT57AnOJe0EUIARitlnLVQuqAc0YuWkBvQDUnMoPj36Fs61Ib",
-	"YaGAIK0cy5QHJwbtYvqt3ArUSzaPNZPn2PA0LC0p18+jbpquELY437MnT9jv5v2mbpE6wKSffxGzFDAV",
-	"NBCa32woMUqAd+zQR1kg/erjERZzODYY04cfMkbYlU7+uEHCfNwDTSayMGHXAP0uIcKYZv1fKUb49EFj",
-	"ik+fPPlEokh18K12+VQhQnDMt+o5y+XP8cZTmBJLPwwITs+1c2vQ20RWOOBV8yDR5kEtRbyF3nZW0dFW",
-	"EN6iyvpAZM0PMmbcF0KU+51yuCdXT/112oq67nIyCaSdTDfKio32dg3cnCznnOddJVbyRqggQKBQfIgU",
-	"sWx+FJMbEEWxsEn8DRt/j7hN+3JpyNn4F9jaIU6aMbSnx1rchKz8z5r2Q19duE+ZGvrBqnXSJeNBlOni",
-	"MM10xZ5PDUQnPOfjRKS7KLRJAbvp7n+0iPT0rUq4z6GSGokXyGtrwNS30oquCqfVbIv1M/aKXxwroPF1",
-	"Wj+wV68DOPRZlTV6vJlMp8jf/LkP66rnsEDAwx7mg1kI+oE1yl7Vm48c7z5To/wc8f50tbgsQh5PtdPd",
-	"QibSxVllHqhiylBaVpWmYxWn5GPBr3yLuThJ1c5Q1nUviSOpx4dO//sqCDFPvjzP/ORUw6jfMbFXM1Go",
-	"pGkN1EsEBrz23CekFnX5bGGw45UmBp+8S8kJ+NPnnJWBihMiqUrkxWC1kepCq3o3C1VrqBYR+FX8r1iy",
-	"qKdGfzll38YOeZSvD/xY2AQDTYQPxdD1EuRX0g01HJjy8rKWAPXq+khF988YOiBpvXpuwg2CJuId/bVk",
-	"j+fT/pSTyHGmn3Ne/iJ49QIKHJ2S9pLUQ/qcT373MMzQdvZ0g6Ra1amqQYLDSyqnZSVAvsDcl5yr9xto",
-	"JD1yPG8t16K8zvtlDDG9rjOBnTyogtxr5nAc/b7fzuG+yPbxJ5tOla/5AG1d/hxI5fby54xWDqY3ZJ0o",
-	"PtJxn3vUv9xJf8rpCNkWneacOqXjTQEhRut4eT1YCCh3FWWtXcb8RCfhKo53zClY6AlxwsT2y5WfOrsf",
-	"iknTHkxb7PNZclUd5tUFlpNP68/i28FFnhwttjlCnT/WVpSAwW1kndVJk12zO3Dbx95JqfOG3kMfWGc1",
-	"BpMB6/4OJJy/bPf5w/07asLG7rOIj+muOYU9ZR2rTkoY/C25bx5/+akl9vVY4IBsPA0/mVYC1VuLHoO0",
-	"LdI91s3IWEPy37uW0cCJf3ZH9NwRA30YEf3hlWOjt+Rem0OF/nl8GPYx6XzLrHBT9kpvqVuNwLYfG32T",
-	"BEzTvr8SOwhQVCIUa+qqabu10e1qDdMIrYr9bIfqbobjpaKbgZK6qoRkDQyU3gzwKGyoKk0kh0qUshJU",
-	"q72rOV/18tegSJQXR1ZvRHeitKz9hJGDNsW5PpT9EokPXD9koCnkxyiTMjDsb6Ti5S9V5LIbF69M6BWK",
-	"PVulTdppQb+Cdev0cnlK4cvYC/X0uVHPIW7iZVnWQrgI1p6yOaLL5vj/vQsfZ+11uYjSCOwpecs/DNUi",
-	"SBDwuo6/LrRbTyOfw55njrvWzoGjSVWJRqgKulAjryXe4PUrwytZAt4emIhtyzXIDvjaH3H2b9urqye/",
-	"x2/+Mc5th726uoa8oQXp2Oa2dgRCjqMkIPL4h9AOpZjwuj4JQD7QeeazJzFrvXvEjzjYfPezE/GDvD17",
-	"ezmsyV7+DKx/z7uT/F9Wt6fWmk8rWEeoRVB2s/SgpH58FjXsismjejGaZDODr4PCluf0d6W6g+684Ttm",
-	"hRjRY5O2pgjmCk3rvQa3wUgFV1Bp8yov93kCtJY2453T+l2t1Wr+Ra+3vTOtKgGxSY9+zeZ/++YNy4v8",
-	"z+GKWGKRiWqHFiQHDNwKPhOgGBlkCJf0yPZskpBOqyu+2y/PTmICBHwOwwZddFRhTHfFD//06mmaqhQ3",
-	"eCWc7Wu5HbY4jFxy5cddCOb80KCW72PpxHtp3ZR9g70OsHpabOhHtekHqrcniX0kTlKBGrPBsJBbp/6G",
-	"euxokgCRzCLSPVaED3XaY7AR2uuErut5V3phRAdXVGJLVyfMiuiNqM/KUNE0jtVv/4n1UAOdDJMUxs+p",
-	"6W86UTRl0okGeg92aHVYJU8KpP4SNY6jidzdqtj7LnIjNNAyZgAs4FfjFf504Mi8SvtIDrP/k1zJx3sU",
-	"F0zbi8bo6kK0j09w2HZ9Ju/kRu43DE2cxtpQnfsHdR8fdm4naMwBY+7IXOR5+/PDHbSI2HXnxPzjKLYC",
-	"US11XYWWaTlwaCERxYiNkm54Dcah0bza8Oby6uqi1NB9SGplpxtovQRU9lWB/qv9jpBePgaOnHQU8FNg",
-	"hivWNW6Nf97r/9PUfMdMq2xMTe6mh06bwH5V1F9CW04/fqk31G9u+lbNt9woqVY2lMGIHjgYvNRtDR4y",
-	"r1NAllDSTIS7kHoeEnQ4G+jLMKRQ+D1IJOiWU1XUtGFKlzc9y31WhEBDZ57S/f3Fbs/VmAYAesij4GTI",
-	"kDxRmEPidNb/JddiluhHNGJPjD/KGvzwB9f8puyvuq4QW0sbmuSbw2F2lVQ6OhnSUmzDVYgUeMrH6M4s",
-	"0T6yWJ604eaQVzPRHMipGUB1CZFhOXZw555GSkQ+YrMQlR9sHiYQHb4D1yugimFDqPu5ZfOufMDcq4Cs",
-	"MQLwkoRYrIR5ZLHhqV3LhvoC5hsHs2TcZeudsj9Bponfh3l8dr6vzyRR7BeRbT2gRtMNciRQVKTe3U5p",
-	"7NYtHRG9Z5Of9ZkP1mfoykSh9Vml+S2rNNhZ8KcDmglyw+1adHUBsWcBs2uQvZ57e2mvAO/83LEll14P",
-	"UfUuojSxu7v0MpNbthDCG8Y49g6228uK1JJLUo7d2giLGWWgTWCetmds0mveFXd8wS2IUOysSHyaomb7",
-	"PO7vtOajbM2J9+6yqbnsMTSijclsoq8HcJaDfCysH1wv8uYecThfnenj++osn91t7ma7EcofPXSiRNda",
-	"aNF52Um5S2oB6YcZK1vtdUQ7bEAF4F5Up0LEksDzttOE01bmXpuJ0d0yADoqrUSqsUZS4DVbtdxw5YRg",
-	"C7GWJFESRdTOun4wvC/FQbkreh6TRHUl+Q2dt6CuNmT+7xHjK9yql/HjDwYMgXGIdj4+JIRGP9QVhagm",
-	"9sD/3O9krN9J1ml3X5LjNub3o3dZ7U6VwXyFa3qeRNcsNIMTDy/IRwucvGoVxpr8amIpAAhrs2f4R26p",
-	"5kQILj+yjFe88dwkGpIoZil0UO/C1a7kcknlNfXC829KMkPIb29/USVdCkG2SqhTWwq24OW1l+h2p9xa",
-	"OFl2hjXiFqgMpFS8y2XCVMDcTcy9mO3SGplQlWVtkwCWvWkYVJzAlbjtPMdbHiIKGwldh8j0bSG7xO/Y",
-	"2milWzsbKr6PSeXcxdJo/j347r9am3Qryn39a66qGtqCNhqDDbjfqZjHnc1yKPfrhMXG6W2HrKCZr8nE",
-	"7BVmyev7++XFGj/4mS1oMP6suv3rAZi6895q6GNQ86bxYyU0MQD3e71T5Z8jqT8QW/WDHOapcAn8Jj0E",
-	"U338SRWqeGCmSuyuIx7kqBvhjCzHY4SvOxSCpyID+NMOwhHVQlR7XxqABonWMvE+IrAwuwevpJJKsDm4",
-	"XN4BHiH2/MYhPPMo9vhS3roTmIvXXfYyHv6mPbFAxUDoKk+afmxEF5LSoB17mhGWNqvP6/kdd0b+O3Lp",
-	"qPnRnnRG/t+4E1u+w3btdi0sm5Mvdh4gGuBA6QBi5Rq8otgTT0XPWlm3gHb0tolnRJVoar3bdD2Yc37U",
-	"OWW7owv1kZZ9/oRlz/f4wP8k+rgHYwMPHWXHOzxpUb1z2vGaXZ1qh4QA+Q2vW7FHh49sSqX3ySseGvsf",
-	"b+prulHhYsItBVT4eVZuuJlejYfQqrc5l0tZJjZu53+LVqi0rFWRAmMJaX4dOrTpKkD9jCZqCh5FMl0R",
-	"1jlkKsAifimzFZH1AWgVd+PXaMe+giBvasje3v5nAAAA//8=",
+	"7L1tkxs3kif+VRD8b4TG8WdTLVkzu9OOfaH1eGZ04bMVknx7ESNfE6wCSWwXgTKAaop2KOI+xH3C+yQX",
+	"yEw8Fav40OqWZY/eSc2qApAA8jl/+cuk0ptWK6GcnVz9MlkLXgsD/3wlfuqEdS/+4v9TC1sZ2Tqp1eRq",
+	"8rU2RjTc/4/Jmuklc2tpmcE3ZuzNWjArzK0wjNe6dZa5tWBaCcZZxZtGGGaFqi3jqmYroYThTlh4QLu1",
+	"MFtpxVdMOsbbVnDjf2HiVpgda/SKNdI/t4Rv0pBTZjX7qdNOqpV/TyrGme3aVhsXnmHSsu2aO+akwAm5",
+	"rWZOr4QfcjaZTmy1Fhvul+t2rZhcTawzUq0m79+/n05abvhGOCLO152x2uxTxq98rsQ7d13BE/Mw0Zav",
+	"BFuIpTYCiaWVmLEXMCvd8p86ceWJ00ihHGu5tcL6hSx4dcM4/NOISshbUQNdVM2M4LVlSru1X7TunB9K",
+	"Or8Q6afyUyfMbjKdKL7xa8H5HFulEbbVygpY5EujF43Y+H9WWjmhnP8nb9tGVrD5j1t84v//L+tX/0v2",
+	"7X8xYjm5mvx/j9P5eoy/2sfhuzDiPv3Cfi25bESNp2mh6x2zfGfZWm/9ErOD+j8v6Khe4FkdGpoef5wO",
+	"9XsYnaYEW2oEd+Kl0f8lKje8sy3+yJxmRqykdcL4PbRs/oeq0V09ZeKdE0bx5lrWX8xZy6Vha279Cwu8",
+	"AHho/btmx2otYAfZWjc12wnYvNboVhh/SIHw/rvDs5HKOt7QNXTZ9Bp560+PmjJtL1qj6wvRPWFLbZh4",
+	"xzdtI/wwG6m+FWrl1pOrJ9P+UZhOsoUcpgUcTstgnsyfNUuH8MgAG+F4zR3f//p/rrnzt52Jxgq4tdq4",
+	"NbsRovUnnS/8Wc/WO2PPA0kDLbhjjeC3eIf849ZpQ7debFq3Y3oBr07izPAPfmZ4YYZmVVBZWuRl9QmL",
+	"bRvultpsRkhJvw5sovab2Aq/09XNWVsIl/mnThpRT67+kWYwpSNVbvGPA3TAC/GKGP3w1KMYcJpV8Dww",
+	"NSJ+vh5kgm6NZwQYtlbNDiWD58BMqNoTdSVvhWJrYcT+bbiHQxNm7E8NzPgeTkz45jX+Mnp0IrU2gis7",
+	"ZVItDbfOdJXrjLh2QnHlzryojpuVcEevaTG8EbxaCwtbldhTYGminoKAkY5VXHn2tBB7Wxm/hVTzE/XH",
+	"i7vJ1aTrpD9fLXf+gE2uJv/rH5cXf+YXy+cXf/3xl397f5H/99k5/33y9P2/TAaIcMsbWV8vjd4MUV+o",
+	"csrWceMsWwh/MuBVoEQtlrxrHJDDBf6qesv1J8tI54QqllxzJy6c3IjJsYuY9qt/bobu4F8Er78Vno7f",
+	"Sjsglb5XpFroJasFry8aeFjUXl9Szu5fIenExo5d5mVnQcEQGxu1Ov/5KdOmhs8udlERueaoiEjggPG7",
+	"hyR/Wo6ov/EThBOMi+bG8B3w36Q+De6mwdPoH8O1435OUW2qo840JxUsqFmqaxpGorLhFl/2U/c/8EUj",
+	"JlfOdOLYBuJCy2ke3rqw1sHdk2oFyqkTG6T385cvwk5M/TL8dLOtZc5PFTSGIGl7GzzCCfJvGL1FqZk2",
+	"HBiB0nhuvFYfJ1NxxZzpSMuG26C3jyzTW9D+g1qdy/4+K9i7sIZvR5QaPxVUeLfcMtstNv621VO2lW7N",
+	"vvvhW1atueGV18SZrUy3WIiacUeEnLHvSCP28lkrrxRIJWoQKFc4U84q3TSichrsEMeUEDUjRsfZf3v9",
+	"/XfE7ZERAiU2YrMQhlXcGG8/bIO8wYnOUAxwOyQo/3O9o9kh80WiO1rt1JsqcD/YrdTEZjIZMGWtEUv5",
+	"jl7Z8h1xJzg3QWFnRnhjJ2zAPsHTpR1lkeXhixO8I6MjDpeGjQTC7R+6M3BPXqi2Q0ujrqWfIW9eZicc",
+	"7+j+Raq40kpWvMEjjHYD7prn9Y3eMm78NfAv+jNjOKgdbs1VflK+Qu4CC5a3IuyNt281rze8fXx5eVFp",
+	"5QeRWtnZpmZWVLBtzz5MgTfC6s5U4hQN3uvofgqDkv9vjV7wptmxTsmfOsFkLTatdkJVO3Yjdp63P/Fi",
+	"7ukf/5Rdpxl7rtL9NyJePrx7foaWbwTz228d37Ss0p1y1t9XzuoO7cJ8bgf0obW37RVcbJSncfUzjsSE",
+	"QbliusVDwNo1t2Kak4F5GdM5MUNZXYkZKaFC1TCNlu8azUfoD3vcyJ9Fzeg5JtStaHQrrnC1jjvheYs2",
+	"jC+B+Xp10C9tCv9cepFiRNvwSmw83az8WbCtv05ee1pztQraVFyF4VuvSd3KWhjmldnZmRZC75QcMBHe",
+	"w2H0l+uofqi3yjPN4vvlwqWli4XsBJ8Z/W78SHrRXyHQw8svDJ8R/40bqcC5FB6dsrDNfl63uuk2Ym/B",
+	"+OghxQEnU/mT7DVGcld5dZ+0JsabLd/ZyFJB95WtAMcTmArIfEFyglDMJQrpzBtubsAyRkXM3xEjKq0q",
+	"2Ui88bpzbVfwKbbhOy+DGrEEI+Qrxr1+2gn/HytrweZxnDmcqnn5zTkxb5sxb69hhQt7QDvGladb+eL1",
+	"9+zf/nT5hK4hXPqftfJEfj/GuY/rqDmZz1NOiYyjWmliSp4ugYudrJm+hon93nVSWN9rx5194cRmeKtW",
+	"RndtcFvSXQE2jzxx0VU3wuurbMmbBoWU/zucU/QF1XIjlPWyEdSlHTLAtd6yDVe7sJPwE+N+/TDWZv84",
+	"4FgHDi1NJhBbKvbDm6+9Zks/VPrWS/+5VE6YW97M4cb7V40Axklc3vgrXTWd9QIfVT4B/gjxjv56qhI0",
+	"PUvgA2Hjfch40uCH/cP7H/57j67+u7iHYCMUE5fK/elZ+rYny0qYY/LaT93/MjxlY3aD0x1nxLJaJ37q",
+	"tZuuInWz/Pg046ra9NhnwTelpT0V73jlmh2K4DmQ4Xqxm5NxMsc5zWdHlVc6eZmzLNEn7MThCzbMC9/0",
+	"7pQ/+1oJtpWqRsf2yQwRFmcLHoiznrLgjIaB/BzxBpJ6RawnebaAyyHJwMKAuZCFGSzCkxlpj8Xs8dJB",
+	"zjVEyhcgY18J2zVuRIfUyX6uPCOpZaaqLrir1sGOBKfiPnl5VYnWifq0WwVjoASbDV6iqALbAx9E7wpY",
+	"9dzxBbeC8cYIXu/YWjQjXzbCk0XU40ZzNsXoPfD0EcqZHRO8Wp+8ha9osBFp2NvBSMNi/dmUhzb3W7kU",
+	"1a5qxLAMyjS+oEGxtfSk300jf15IFJEscHeLyhk9yJboIlFOz7yeRHcftFDU7xz6BHhPWfU2cDz8pB+D",
+	"4a63oG36Dyi7hUv37PJZYUcGmwUvVhNWOXur3qo3FHJc88br7WiMGgjpoVTaalbL5VIYv1xctBXOztgc",
+	"DyGpfHG5c5Khnhhh0bACp2+EAmXSn6sp265lI3o0yBy6tLgpUCzMBuOtxEJyhX7NLeuUN16UZrbSrZix",
+	"71VJRR6NnzCGDY4jpDrEQYN+zdkczbb6mjsS0TFUKmANwngLhRTucACW0lgXdz+4dcnX7gxXdomB3fLS",
+	"IzGHbxIYdImWAkjCjLdCVcFq53+ICuc094gS14X4330pn3HDh+c8eA/SiZCbtpHCC4qmhrCqp9qMvdnq",
+	"9CZuVqQdWPnB/Q0Ofr/XkdAL4bYChcWGzJ+497SRsEe1aIRD5xxyavwgOhoV2Je8aU6mUuQZL2giQ7QK",
+	"EznO4+i599PJlhtv/NoDkRs4BpXuGvQTkju0x1/Z80j07VrbcECj8evf5ESh6EikN67x9F57BqI7d01+",
+	"jJw2+6GfQ2w5EmIaDnx+kLJFH2TPkdSDbHrNm+WFboVituWKzf/hr+6UOf3FnHnN2zOeah1zFOJxw2hc",
+	"fmqQWezf1SMhnd7dn9Ifgya/0J2qT9fcP8RXAsvNpzSsE8ufR/RrcBz1+Gx98Ktpt8BNNfJZ8GAV3/Xq",
+	"kFQnTtjpU6gvVE20j/YS0T43c1EKFS9C8otQUzoo0QqOD+gl46yRt57ecQXSju7peWYznC5YZCAibVFx",
+	"FoYuSJYaUxLn1V+/Zn9+9sd/ZZQaw2rhuGxm7BuUp8aAJUNOe5m53cltIy2za+5VdsigqsG5OpJys39f",
+	"cLQB7bPbcHXhJSlcQPGubbiiaGgrKrmUFYY9/Y5UVWeMUJUYPBKwhAFe+VKYi6UUTU1Ltn4FLpkVgSBe",
+	"fcKoK4U6uGw6U7K6clGNrvaH+1ZX5EZDT4VeLoWqKaLbiSkTs9UM8oZmmbNycEUbuxph/RDt1WqVrAp0",
+	"x4FU4I41NInjBqVfA440dJz6Uswfxm5E3P/9zZuXDB9gla5Fln6Hp2oGuR3gEZ1cPbu8HLInnHRDuvfr",
+	"tTaOrcvDYrvNhptdzGSjffQfLYaa/I9yU8Vg5G/YxfDDK4g7CTh2TNZCObncBS47PmRn1JXjTbO7gmN5",
+	"lc7V8UA82vJIiUjykcs+nBOGpkrImkj5SG/yJC9p2Y3YBa1xKE9sSnp9PU85ijErxl8EWJBlvK6NsGVa",
+	"zWL3EXPG9l1SUW0/ICbCEFtwgQdqnS6WPywVLcgWMnlkDeYZhQBABRtc2ZGxKDJPrPus0PepOUwQ/kZ3",
+	"+UDKW9+Hg6cVNoxHgmRnk/RKxtXuXpLepijTj48HxDnBo/1QSXInBKmP5MYRcbKdKw7+AY7xvHLyVrrd",
+	"AfdVMpp3rUB1JyyulrW/r7IWuVsOHiGWPOTQcvJWXCu9PeCBCmPawNKjczcMje4PI1drx5TeTqNjVi+X",
+	"A54DcrxwI8DGIbuPkqow3B64loCEi9xlktZGtmScDa3Y8m1Kc14y6yQGXcF3sO2fUNMpi5nQzOma74b9",
+	"abR/ZxNpIVY4ZWnAu7O/QSOeQSTJ2eMJVaNr/Mzx7hBdJSVCb7M47aBF4HhzvZGqG3VzNrpnHZVrMlzt",
+	"LwOCN9u1bgSjb0+9la0qDifpucptPX8AwOyEHB88mV3bz9sbKBHg4UxBBiRkCSl6a9m5ziSzXGmIKJJH",
+	"kVtKD/KmLqrllK19NLQyYpaHUEJ2YdOpTOelT+8DzOZ48HVfVTkvBBtdeaNBWBS9EIAlBnpODDboWb/f",
+	"+Cut8JWnwUhcLOgyipzM8TaCyrHpqjVxN0i6occvwA+LNSFRrSnVULjYzopmyf7v//4/SC2+EWi2o5Kp",
+	"zYW32IKYw5+CcEQlNaS2lLocfDGorvOVcLTOOV4WO40FK6jRe5bNb4Rlc/+3a940819Ti/1dKZhDCs6p",
+	"Gf+0ba9RuxhhJvGA1rjfniKFFmNzzeVQcLNNdtUJbMFfmr5ksyM2md6yVpieclUoODwm5mhTyKleqnP2",
+	"gbHAaakDg6dACRmKys7hfFFfPObcDZTbI8fQrr4Si042NZU+jTGeRAOobmobvpux5yHAHjKS2FI2kHlL",
+	"ChlKVVUaIQYHtBRDyhSMmMaDScw3Sm/tyTf/FUwqVY30tAtJF3Mk/fWgPnT808H1sH/bxul9JHJNZCJi",
+	"D3m/8Ql3kta4FRhRi586qojgt4dPDHL2ECR5M6pEgtuaMmSzqji6E+X12Vuef/k6lQyWX3+Oediv8du1",
+	"4UvHnl4+vbx48pTVuuo2kOOLN9LfKNn4K4tRQwl/ReM5Jq2Hl2BeWbUYxq+tfyNkj4Rq1ZS0XXl53LbN",
+	"jjXc4cXuUa1H3nxtwyTOY+wjnqUsOz/EPDGFOolgeGQkxjkqz7Icf8q4R0lV77M4POi4nypUKfAg2moI",
+	"5GUScLsO2em1eBdVAvLnySIvcUgm+rfGUxweWdZqK7EOBwV/SlGGdI9kqEIQ+Wdh9Jh9NJ6qH4mSUbjM",
+	"On6bb+8Ve3RbtZ19hJ7tcAgYbcju7eQENwQsPMvojjMcPjv+ENYH3ZJRTDNn+K0wljdU9lUPRQ1atz7I",
+	"ZRpyQTZS5OHfoiRsy5sb1LsD/WPxBOSNDu1Dy4cGLioLZW1j1h7l6oVIRfRKKRwcJDdceBl8GHNY2zzP",
+	"MYwS+airrm+FnKewnFAZGDProq2aKbWwJH/NvLl5Sowh1wryYae0wUTu40dqPHctmYBKnHKyTrEm41rp",
+	"K9NwuWE7/VbeSisd+kE2Z2QxFbfk7olo4xWwyKVpy+K12OpkXhM/hbAE88aRmzO5XLJ5qlhkb7vLyy+r",
+	"f2eOPf/uL+wP+IvT7MVr9t0P337Lvn/F4t/gWcFcCBqgpKsabXsFLeRAiOkZHIb3mho3jfRkJS8JelOW",
+	"Uo2Uk53k4o9E8CzzzPrIcVMofPXXcranUuGD3va4+JD7cszX/qDlwiN5uOcVCI8X9d5r/fEp3//Q0t4P",
+	"zAkJN++0wXU7MPZpORF5hbFuD1yfMz1TnqjpCEwP1B8XAY6M7BkRjgY+Aq8clyBJl6DU56ipFFliZxYu",
+	"h29GRktlOvCt0kUZF3Bu8XKUAx8iSsay4vOs11D1mwVZQrnvVfK5FFmxiI2C0iCGbe65GPHuEeAi94je",
+	"mA6skvJPpUsKX3j1kaXoAC24uEXIh1PaJndMAW+3a731LD1iU7wpB6SkPPKeUiQg+in1jVAEVHFKequ0",
+	"QUhQip9elrHTrOgMzl5rRA3ARynLFcuqhbFr2cZq5Sz4upCNt3MpDRm81iFV75HNU4OnRIEis7blMsRm",
+	"vWIMGoL/4a68JsYpztj+qJhk/E+S5/bu82i4dddoPR2YCne9MrfT5UA2wGmqvBJbEZM/w8FWwXKBAnw8",
+	"wZzN7U5VVLk6n9J/u7bG/2pDf0HKzVNGFQ2BkVGXF9Wmo5xRnrNKG0MnfxEcXUVJ4tLwjdhqc1Pokpyi",
+	"rf6lrNJxNkqng1W3/VJbJFjYmmnwOPojTv/M4ADIpeNvT3bzMa2cu5i2rw7FcBI7/pCi29l9Z5CqIpY7",
+	"4Lo8WmqL4Z3pOCTTuW7RoTDxPeS1WswpGNno6JjHQwfy4IgGXnD++JrSMPo9pMxKyJhVCJoRstpT8jKF",
+	"jCNnS8msBIJnBQAzQPAtv1hB0kgXEyvwI6nm6rB2FwI7WQZLP8CcH5/igO6lvGaivGDs+8yvz2971/6Q",
+	"5nM8So3Jpy65ts9UBfue++Eg9bR0TocIZdjwc7TCVEjwO41ahyWeUzicbkdWO3x6jXDaxhPKhO9ScZsG",
+	"8Ax9VLs9UnKbBc3uVHV7hgAamfgdC2HDp+f3Jcb2pjeFoRJmzYBEutPE49Tm9yXRUGyAaYKLGBZxp0iM",
+	"/U3iBg7XnYqV/WfnpwuBPucfr1IuLvQhU724w8Fgh4lKtfrQauVhPgyrnvbSTqIFVB+tXg6zC5NWugA0",
+	"OafgbJ/vfbjlPxxK7SWSl3kLIfRXxFrp/5mWBDYhJmFSFry3fFfcs8CB3Is7qL6UAdlotbLM6bvev/J7",
+	"3hiVZJyFYUd1zNFocUp1AgKeEDoe0grR5jpizdIOeH4BsvfD4AAPaG75gou5HTtfh2708Bm7m46FrxZ3",
+	"Oh6cQp0K4f+zbh3clPtTqqK5jbXfoEJBgvBVicmLJqQeyyICf1DIa8myCJZevoF9D5WtkLrXy8BrpAWo",
+	"kp03xa1Uq0aQcpq8wADaDE+i4oq+GlytfTgNLy9AHmROhItk93N4ep7JHmhf23S2B6ZJYRyKtkj3MbyU",
+	"h9Mh+uhoCfimWA1WvR/4/q+KdkZnbcSd40clLdX6Z2q25BvZ7KZHnE9QmJR7n65KN1JITvVi1h98b/DK",
+	"SoQYPGoy4I+J4CtBepM25DRbGK6qtTdo+nUBiHyI6aVwe/fwrog8lLajrciwpfb12juiwZ3ilNp3SIcs",
+	"UDrpISqYJczwwtwn9K8SuDDUVOxDWfrvBxfajRCtJUwE4e8jTxBzUHCxEDtNaoRWoh9N/e05y8ag6T4M",
+	"+ZJ2Kt7/093D5+DhiT04vHuzY0769F2Amcg3exCP6YUryhfJ9+WfMnUvOyE9RMzVsKrhcjNie52PX3dH",
+	"bSzLv0pj9sCfBqrFzvG5BVCGwIvKAzoonHeqOppM6nk0M51itRxIw/FG1XEUkp2qwNSBQ7JT1bXp1AGh",
+	"GVw98/CsnZMnXlqYytZoJ4pzAfINSw2ofwXc6k6hq2uxm6a8cjgeO+XWwskqpizGUiL/Uh9C57itnC9r",
+	"SmQZo/nrQLSBQA+Aq5I9HEifpUHqABS5lEratahZ1QiuRrNrTnYx+VVHi4+CPFk8k1umxHYaplXQLkBA",
+	"3aU4TWZudW7ZajSfj6yUw58i/YFYCxn83tqBYBfEP5lenpDDnOqlwrhpMUO7+gM8NZo3iYk3mmK7EaUk",
+	"azMRdJasSwl1DcCWAaDbUxweU6/gAYt3lByYGeQ+1UMSzH+Ocvzk9NYHqC7gr0XAOQQmIOCs9JYRlybA",
+	"WlIHUeZRPAVi7JY3omDXmNKyEWYVgpgR9zSQAdy0FMsI46KZlNEsTAzUlXspQy7WdkJLjJEjMZ7iN3Im",
+	"8i4Sv41DkbLUPrVTEWc2fiw+KAur1+YClcYsAXPe9856fTuow1cks1SRoEUJl+Bs8AKLh7+Af5Siffi3",
+	"aPlGrhfsfSP8d6E7SczgzMaAxBRsYXWWPrN/xDuU4b9afw6vToiqM9LtwCdHpeqtfKNvxMCde65AG0cU",
+	"OwqFccvmzzu31kb+DCS6Yv8huBGG0mfhYcyOnc/YN9zbkwE5g8xQBKDDdBMlRG2/YpwGQXh4NDEzbL8v",
+	"Y1cwv5wFjJeWt3auxaqFlbBufC0BodIIKIPgzZRJaztvZwrD/pA83aBOfoEO77us+oUjzD9I1iAvjTdF",
+	"0bnKpWG8IdF9wqqwVnBkXRD3WHNPJysqI3LIkjegHSUNE1EpI/ATgKDrzgkLNvH0zoulS0LEdJq13aKR",
+	"FbWYsycs8z0sdDnAV75BfTMUAGVhCgnI/xGJsrN8FaAMQ6UMEMBzFWlT2RFhEQM0n+CNg1rfhbABpzUb",
+	"K3gCPbsEnK6Ah5tF1/zYMffLRiRjJ62Tle0hSwJQX25AX2AlPrkmpyWCQvxr0TJE3EqvWoZoRI4AgYVs",
+	"s4imczXBI/AqUuX5yxeT6cQTAMl7OXsyu/THzLNA3srJ1eTL2eXsS6pRAAbxmLfy8e2TxwmvcTUEBv1K",
+	"uM6oIFdygPEpU9wYyABc7FA5h5y4UMOYS+yiaJoKD2yJ8piAHRm3FYJNzdgcRAg6ypyeMyuakO+c4PEI",
+	"daAEyMvt1jjMVfIbcRc9WzSItIQ+gBp+/oAfGu/D7K3CdhhNQ7wM7RHIEWBzcAnPozRO/lxy9hXNC3N7",
+	"Hhzq8FVqT5glJnhOCo6vvdcDkDZZbVve3CCN8RlyH/NU2AWpXYT2IRqLrkRSiUiTCD0b0WeKPCfsqZ+x",
+	"aBpWi6VUor4ipxj+GDLNkDZQzkf3w/PHMAOtttzUdvZWwQUGt33wMMVC+yKLh+4U/uZVwtQo8EYosnRz",
+	"QFWEh8yD2SSjSCP02kPILJ1i8nodfGChn0A/ASmvftx6bYcAUKGmYct3lPwqzEV8EScG097DewUM0C3f",
+	"BVAW+hrb6NuYsRr8ThomrMS2qIL22u+aq1Tzn9cC5BirewtBeFkQKE0diseiOH9RT64m30rrvgm4lnlv",
+	"zn/sYZr5G5NKe3t9BGLJ8GDPTPLvjLfMnJ43Wh7gHBow8y3d35gBUOB4PsZzOrDc3sSiz+SGpRYU/kU8",
+	"MgPK0uCiCv/Xhy4LLbDxAu2hGexFVu+LthgRxE4kFEPp1+MMzafwJ37wZAKUR73vux2bQPRCpsGF6jbg",
+	"UwkuXvRMZh7ezKVy9qb13fWxMmOgOCfKiggbMbQEKk1JCzjNPDptvnmj3mKqvVqe06aK+KIfONE+IH0Q",
+	"6VGSc8c22o72/23kRrpiHtTvcHL15PJyOtnwd3Ljj8CTS/ivVPTfIS/csCM5seHH1B/5/Y+9lsJPLy8P",
+	"tBM+r41wajkz0Ej4YNOZ+2gePJ08w7UMvRHXnHod++efnPn8l2c9/8ez5pMZ5SA0kzn+jx/9ttkAAgOi",
+	"tqQhRO/0UJLJa+yayqn7gl7227LZrJ+zV6okglzGFAMMnGJOl16GQ838oYwJoAiln+CRnl5eQv6XuO25",
+	"4SjlGoofyLAkaPIAbjpNjfwItkDeyrrjDfVUqGV9lQEfFB3yLEJ7to5CXRcgHiNS7CBSAw0eEtsVm4c2",
+	"CXNoSBvjaxts80dI+bXRLTIaqIFC4oLq6qXxolsugYgUA6QmEGAWoVa/6awDW9kIZ3agO+KoEYuh1K6w",
+	"90bUr4ie/6Hr3Vm3Vyvx/RJO19F7jE3/PGc5vctIeKeXIvTj+zJO4Ewn3j8gHyoalYz0NMcd8wehNboS",
+	"1u43Nt/2C3gwNeY3wquefExeVXjc+uwKtyNyqvfT6EgIFtVRV4JbD+H62vvwJwz2iU/uhLNt9zS3z9Z7",
+	"Yb0PWowvwwk4z2bcBz78GHbc3qgPbKvmgBzSFMYhDA8+hBdZJwvoJKpABOktVsq6rcYXLets8FiAKyED",
+	"hIS4/UK7dcDS7FQjrD+P/s053TI8fZRJOWZIFTC9Zyw9atMFoMk/tz6dg78c0ahHkEQ/69Vn69UjomZc",
+	"ww7YbDYHTzgbcv7KM20usWIgdB/DTN7CqfPnnqcTQsQJVaZFwJMiExrVcH0rDCWd7mX+CIWLRSub1HmA",
+	"v083Pl5DaaEq7FRAfOxhnPOaxtOp1pCH6qZsISreWZFzKq9r+1uddd8qwImCK3RfpnwNLp+XGe7S3RTl",
+	"Q9eyHOMk3fbJffOEMbW2AEZFwbDtYfxnPCG07BiOJv7w6tugZwQgnbCnh3n774nXPLv88yfBmwKXSf7f",
+	"QU368S+yfp+p0+Xt+FsEAp48vNgaO6ID/Tl+t5Lq2eWzT+T08JogTvvExzT8A6r3SRjIoJABmF3UxwjQ",
+	"KGeM0xNPECTIvPdLaL2Zvs+evqb2eMHTzrShEgZKsCqhjM5PCgPbLXwNLK8gakdyrzDr6sNz8N6q78gF",
+	"l2N9M0ULHLFXveIvEegNa4CEwbKFHaj22wRgtq+QTClhKgUDQdG+ReBhrlDIo/EB6Ch7QnlfDJd5nQ8j",
+	"hssxPrKL6Swx7GWwdVzV9jOne2hOh6dilNeNiczHBsEpRz1R/8mbG+Q3unMrje3vAshZbLaSYCW5m0+p",
+	"BUZAPM2A1joX8C3yVJk97NYAy8eeF4mIDwJeSaDMyYkP/EdL5S6kgqAYu5ViGzTCleHtGiEiQltTi6iW",
+	"ix14tDCNsuUWiUFGBSxLWrbwj7r1BTbk9J8BSFGbh7dVFeuynDAbqQCaizNIsIJ3UpVVfIkQvrhbA1+n",
+	"/+flnxhHqPRGlLCmznNLAO0mdFOSAv5b8zxjMdt2WpDT+gbRtnm1hrz+0dAIGmMtX8FyytwU7BlHHDoY",
+	"SGAF9lscDzvTSoDVoz61ATThALQJq1ppLEQbcrYE/NohZ0vhajnuaNm/Zznse4ZNeEJWQYmeeIb76U1R",
+	"ERs3LDZLotZJsESQi2o8uszd+dHlh3QjDUAJHxZb+wjAn+XWR/M9lf7PmAEKguAcXT303CZAaMJhDUVZ",
+	"D6OvH5au/h6fGOkpbr0oVdMBOVu0AU+oWVMGTb8/QemphFytF9qsta7PF6L3LU2KdgHeUhBNY1MTkWKy",
+	"hJXJOnWj9FaNmwBZdOdV3P0jxzc0PokCVmNA4orNg9Y1TyXT3nzLGpKigTqXqtKb8sHUW8w/sNBenmf9",
+	"YIbEm6R6+mERN/HfmExjilaYHHwNh59M8aE7pGh9Fnr3JfQC7vGoJ+ogSvFnofcRAy7DGNRnC7z0IS8m",
+	"KByRI4U8mKNqMDaEoQJCr8mx3Ht8KxktCP/wMUQWGDdZ0V1x012PNeSzCfhKmBrhjGwbzOqDHNYpQ0Bz",
+	"/H7BnVKiRITbKQv5AFzZMwvIfMYPO2r7HYJi2J+xHxX7KsWF6D3MbeWh5i/CXCMC1+ytek4TvpP95eeH",
+	"y5SufDS40+jnMH2YXg8V1ojso0+fwpwiLegihACMVku56qB0wDkjFx1kb2B3NzSD498BHHupjbAA00or",
+	"x2YQwYlBVMy/VVqBesnmEZl+zsBOD0vLmqLwqJvmKwQSlzR7+pT9Yd5vDh5PB5j08y9ilQIWi4aD5okN",
+	"QM6U8I6d3qkKpN/jIabFHI4NxgLjh4wRJoD6jxskLMc90MqnCBMSbM4HhghjIfY/U4zw2YPGFJ89ffqJ",
+	"RJGa4FtN9VQhQnDMt+o5y+Nf4o2nMCWCQwwITs+1S2vQ20RWOOBV8yDR5kEtxXwL7JWMVtHRhjveoiq6",
+	"7RQtZgpm3BdCVB2ec7inl8/8ddqKpkk1mZSknU03yoqN9nYN3JyiKp2XvXtW8hbbKscWeCFSxIr5UUxu",
+	"QBRF6JP4G8S9xtymfbk05Gz8C5B2iJMWDO3ZsUZioW7/s6b90FcX7lOhht5Ztc56ET2IMj09fGYSpP6p",
+	"geiM53yciHSKQps8YTen/keLSM/eqoz7HALdyLxAXlsDpr6VViScTqvZFhE29uAxjkFsfJUjDPYQPYBD",
+	"n4W90ePNZDpF/oZttId01XNYIOTDHuaDRQj6gTXKHi7OR453n6lRfo54f7paXBEhj7s6prvZ1Hr8qN8+",
+	"KYV5QQG4lENM9HBv8qMYDVdDDQno5hIY9oorBimtNdZWSwOoHMwbpG6a3t9I1REC644ZrgLutXS9zgf5",
+	"54uO5ZCdm3p7oW/erY0I5adMdYgZCsFmcNYsdRNxA9DnL0U/zPHI5l2kQ/Waf5PyBDAjBzRavcy6rZhO",
+	"2SmrGtlmzbNwKsQOFQsNqUjxBULLCLRPGQu59ye2j4DLiFrnUN+ttb/tAeMdpIQORXwtN64szC27xa5F",
+	"UwNgMYWsENdAYANMG3cqgjstxErSkVNii/h0j2xU9FOPGGrORRjQWV+74GUKzbgILoRMhjnwf6Jvf2v0",
+	"VkV8jiEghtBpns3Rx3Kt9Haek7j3SeydbJ3gdQDpjQ74ALlrEaIiq4skMiKEjd+UgHoCBZsYMCIEkhjH",
+	"wXeuUr+3aCEFcyVQGs6rV0J+FkYHdKxiPaidUOs7Ji2I5FMcaWWuWfLoCEQ6eBSgDAojJPr2IFgFFXpL",
+	"beAftAmIMMQqrvxIThC8UQymhjQ2hFPAq4vlmjWl70AaIVVK0V322krt2UjABcnTQOJpygqsNhrT7qCf",
+	"WOcEhfOqNSTlIaB09jHqZ5c6iRPFDEJf+Ytl4bigAnSV0h3DKyGD/8IKl9ROTzsq5Fns2HwVs36jjuf4",
+	"jQDsZl5f86aZF9uHWChZRLLRahW0SgCyRJkALAmhBFQlTnD30SevndbX/pvzL3pdzfIPB6ikwDxCe5KX",
+	"a24F+zLCPFXa1DZlOVIMq9eCyo+2r76ldOjXJOWOxicJ246uX+gONNLQ9ABKwrgVcjcwgv7MPPMcbnZ6",
+	"CBLhA2f1EWqhwkYdy7sMmLWj+kYPJeKzivopqai4y/JnutNFJgzoMCA0OO3f2Z6MwGZyUO4HT4gJBf4X",
+	"Z6GnEVThENpBnaMcTE+BOYBf+RYFaAaXH/op7NVGZ0DYmEtzXzhr8+zL8yL9hNgYLDiffwlWLlTWcReA",
+	"ysGvsfZGfajYTzARYbDjAG6DT34Ikhv86XMp+ACQm8jgQP1FrDdSXWjV7K4CXCSBgEK40v+KWKE97/SX",
+	"M/ZdbO8fdEcvZYTNSgvp4EMXIjCZwrGC8xE2DDpTNRKUtWQsxKjqWNIt3us7YZ9hLnK8o78VUKZy2p8y",
+	"NhPO9HMp+V8Er78F3NBTqskzmNHPME0fnt00RM7C5VaAwJ6qGmTlLRlkcYGs9wWWlJdcvd+5Lmvw63lr",
+	"tRbVTdmobojppZZgdvKgfudeF7XjRaX7fdTu69g++WRRCso1Hzhbj38JR+X941+Ks3KwarhoAfeRtvvc",
+	"rf71dvpTrvItSHSapXRKq8kpeI6t49XNIL5maUkVPRXH7KmT0pWPt6qcstCM7YSJ7fcJOnV2P04nbXcQ",
+	"DaTPZykCfJhXT7GPU974Ad8OmSfZ1mJ/UdT5I6g5OJo3rWwK+GGZOvWDuzQ2Lc1jovQeOi2T1RhMBnT0",
+	"D+A4vez2+cP9xz8DYfdZxMeMgp7CnopWsSfhcPyeXE5PvvzU8DJ6LHBANtpzwpsAsK+3Fj0GeT/Se4Sj",
+	"K1hD9t8PRafDiX92R/TcEc9DLCwdFkyqBv+x3pJ7jTqAx4fzoOE1ZBMKN2Ov9JbaRArst7fRt1keYh48",
+	"ldi6i8JpAQM1RTrd2uhutYZpUECjjLRlcPZheyl+E05SAvsma2AA0T5UHYD4BxAqOg61qGQtQqQzNf3u",
+	"wUIA9qoXR1ZvRNpRWtZ+HfZBm+JcH8o+8vgDw/LtD/hR0AcHhv2dAMn/WtjxWZYFXJmqMwb7w3KM3aY+",
+	"ttAobN05vVyegicPXzhvbtTsM0uVWDZCuFgDGRMK5vj/vQsfZ+11uRjaTzkN8S3/MICwkSDgTRN/XWi3",
+	"nkU+h82GHXedxZwIqWrRClV7KhGvDQF4rZzhtawg6ApMxHbVGmQHfO3fcfZvu8vLp3/Cb/57nNsOm+SC",
+	"DIFcBZBgB4jb2ZHKTBwlq82Mfwh9CKcT3jQn1WUOtHz87EkMbPoUP2K4UJF+n52Id/b27NFyWJN9/Auw",
+	"/j3vTvZ/Wb8/tYVT3hgmZjAHZbeous/aMhVRw9SjCdWL0dr1K/g6KGwlVFbqgBN05w3fMSvEiB7Lm63X",
+	"OryWWmSrgQa3wUgFVwBgf1mi6N9HCosznaqgEIoe/YrN//bNG1b2zprDFbHEIjPVDi1IDqUlK/hMyHAu",
+	"MvFxSY9szyYJ6Um65rv9rkckJkDAl0lZoIuOKow5Vfzwzy6f5QgAkcAr4faS8PIELxyZUrQWgjk/NKjl",
+	"+yUq4p20bsa+wRZimMsUO2lTy6eBpkgZXgaJk1ygxpQmxEdO6m9oc4QmCRySq1hAGvP7QvujGGyEvpZ+",
+	"qL1u6F6BT4ldkKSoRDYrOm90+qwMjQLiWP2++9hmIJyT4SOF8XMj9iaKpkw+0XDegx1aH1bJs74Dv0br",
+	"kGgip1uV0lIDN0IDrWAGwAJ+M17hT6fKj9d5A/dh9n+SKxk8sU1WpxEvSCO9tinVlGl70RpdX4juyQkO",
+	"29Tg/YPcyP1O/ZnTWBtqH/Wg7uPDzu2syGnAmDsyF3kefX78AC0itrs8EdYniq1wqCjRE3oVl4lDC4nF",
+	"QTFhHYxDo3m94e3jy8uLSkPbT6mVnW2g5ymcsj9O0X+134rdy8fAkbNGXZBXbyCzNVQ6xT/vtdVsGx7S",
+	"7K1ODVRheui0CexXRf0lNP40kK+9oUbPs7dqvuVGSbWyIa04euBg8Ep3DXjIvE4BxfdlTishOoW6d84G",
+	"2p0NKRSeBpkE3XJqNpD3IUzJv1elz4oy0NCZp3SfvuBXoLqrAQ3g5BTvoq1iqcVQ0rERe2L8UdE3kz+4",
+	"5jdjf6VqDh4ImiVNw2YmgMJ0Toa0FNtyFSIFVLSw1OYq0z6KWJ60RYp0oTmQUzMk1WWHDLscgTv3tKO0",
+	"lwYfJhAdvgPXKxTrAUGoosHGQgvwklbcb5qAMiTKWKyFwdoKYexatlRyUBIOZsm4K9Y7Y/8BBdyeDvP4",
+	"7Hww2TuZroFtPaBGkwY5Eiia5t7dpDSmdUtHh96zyc/6zJ31GboyUWh9Vmn+CVQa67iz57g7SrlQVq2F",
+	"Eq7Wm2ZyI9iiq24I6sj/rdKbhVQRvwdyv+RGKAuwOvOV0V17vdjNQ7zlI7eqpukf6lUdZOdIOVmQ+1gl",
+	"hf3SgASEt9XIlUKfxQ9vvmZr3RkLH6whvJXZtFrREFGRQiRg9AEp4vUxszTswFekUxHdqdowt2hTISnR",
+	"DRvsU8ZxirPiF6jFf3BTYbAVD10eZw1UoWGVJiovedMgW4YyKbGEWEqxUPJdgMz9WRh91AuW0ONBNMOZ",
+	"oTFAhaFGTFSKtd+bJaRujCEu2a5xqMRwsxJ9/1XQgahWLXmzgNShQ16n6pz2S6n8fGGq5GHw6pndw5UM",
+	"umhshQhOGwqam7BjEJuqNDfWkyjUq4aPANIA+c0SpSBM+lWEVpsHPSVAWaWrlyAAYEzpEApMVFrVtLQA",
+	"wqmLkqrAweZOswtGhxc0HlDbMFQak2642mEgNN07DFHz1coIr4mzhVhLEvbwBMFz5V7Pkv3EfB6ISTOI",
+	"LbBa2opDCRyNCFTFWriUbaAtKrlWOLbYa1ZM36eK5uw80KPhjkuX8Onona2sk/NzJ3jQ/zdauXX/PPZa",
+	"e+LOTssTGMhTM14ZTb2EuKnWgFeG9FKw41uFbdTxbtN59GyoaAyf2zhIVEIOu9ozLegTv3pf+CHdFRxk",
+	"r70wOw1ENZM7rqQOXIXQ+QHw1PVmwy+s8F91oCBZN4u930A4JfY4xyIbAhHZaFzrpqi12OXlmFhikXBt",
+	"v2I85xQ8gp6EzrOd64WfLwncqWuCoZSwRCJgpJ90rG5dg5MYUtzI3SzetUbYZLavuaobkRIdhFpqCPCh",
+	"MiLetY2uxeRqyRsrhkN7gaUcVE1i79TYzZu0vbLjOOqf+zHJXifV6aRT8qdOvMCvUrqbdbsGaj202Uz2",
+	"1bCvgbd8vAbg913aOjz/Byg6ue+J/53YI5xPUh3kKKJ+YIcHJxJO0ROvJT+ph6LYD97gG5jQIVc98pop",
+	"oZWJDajGmaYMF+d3nAH5idi9eG/2TZqe8VKEkdFaunNaZLCPvM69Omb+9A5Iz3a65U0nbMjii7kWjeBk",
+	"JYRJYpfu9C4U8RXy1p6pnB/NxoR8lmmWcZ6FTAurIaBlRSoU3tAoBf2Oc4OJlikFBm/0Mcj3q0RFBFwC",
+	"G3+tt/BYL3sljoqqXh+2foXZRKFICNFrII8j0ddmqUl27Z8vKnMjWo1/YMb+qjsT05k8T87OAzTHYhxE",
+	"8bJrsk0XvFp/VSpdYSdDyq0TCjg+GBBpNgGEoz/j0lqKfTU/yFaiwxNNJMp2TYqW45BxB3eBA8hkSYCo",
+	"De/fDEqpQhMonpOe6QJ3A4TcV3uhbiRJzN1Cx4JNeZ1a2IFE0sym6+fGnZ9Omll/LuSV9hxm1sXWwmTU",
+	"WLbYHfTd/moqcMEDPmvB96MF7+VyUt5kljCb5Zg+jH58IPGSnB4x8TK/H6cnXsa3BhMv6VdIvPy1Ex77",
+	"DSFobgGPasa+Jf+KRFnK7Q3KmzxBLah/+76fTFMAFuw5kNoh1wdUrqYpDv0fL58MsGWl3bXctI3YCK9s",
+	"zL+4wiGzXilhDRvh7wmGbfdQ11Ko5TRIIX9LvbKB0/Wf9p98O1F6+3YymNYUomyyYrDpORyB22pqpMgW",
+	"uyivo94UPVta38B11RuJ0MfE6ZH59QSSomhk9AjnzZrL/UF/rb3BSONvp6tHJgXOtkE+Gx4fYHj45588",
+	"sKGyl+Oatg3NlLXgjVv/fMAuwRD3di1SD1WjK2Gt1w+7BnsGMtMpBRGMF44tuWws+heCOwTh02QlADB3",
+	"IYRincKxEXkuR0TrtWdwayMsom+DlEW0QcOVlX5pNXd84dmN7hxyGwq+h6DKnvLzd1rz0WvlxDv3uG24",
+	"7F0oCvhNrib6ZuC+Dt6fsH7Ip5W391hcff6p+/LMU5flTt8K5be+NXpBlX/gZlG8eZyE0WMjFp1soPfn",
+	"WIt/L0HscFZcQGOIOTKhDC1p3Wo/GwnhOEPJXhWqdGutRJ6GFI8Cb9iq44YrJ4rIQZZdZK+SScH7qRlk",
+	"8JVpsFk+EiVl6LrDuWCXlL3D+ApJ9TJ+/MGqfWEcOjsfv86XRvcG4Hj+BjzEllJJ+9vqkfhRa3TDjRtN",
+	"z0Aylvejd1ntTlUhJxGu6XlpGhqUOlXJRjx8dsZoM6hXnUIHhl9NbJsCtYrsOf4RFOq88fcjy3jNW89N",
+	"ohqNuRMkK5tduNpemySHmV54/k2A3Ijj0qMvKr9LISgBLfT0rgRb8OrGW8V2p9xaOFmlSCEWo1LLXKl4",
+	"AqhD2PQy9597MZsg4BHQt2szFBq+SXkrgStxm8oBtjz4uzbSWgB+RxsYIMM8xdZGK93Zq9yNldc7g0Mz",
+	"Jot3hBXxX511ESeuV8CBNrE/M63GChKkdy7mkbIF3vx+T0WMg+LLoVyWZr6mvMFeE6vMQthqWF407PEz",
+	"W9Bg/F4l+vWq0tN+bzUgMDe8BSdDdiYGMBxe71T1dTLKH4at+kEO81S4BJ5ID8FUn3xSTX0emKkSu0uH",
+	"BznqRjgjq3HH/utUWupPkQFQkVSXG9VCVHtfGqj3Fp1l4l0sq0crkdCKpRJsDub7NRSZghM3pQB45jHd",
+	"40uBW0u8aJ65eN1lD8bqb9ofFghmQAoWafqVbrzipU1AGkQw5gzmrzKiFspJ3vT9FMczzP8VuXTU/Igm",
+	"yZ3wN+7Elu9Y2y0af4gtm1N8ZR7cP4jzHav+CSAaAalTBlPVdABh4W0Tz4hq0TZ6t0l5CSU/SiGZtHUh",
+	"nrLs8ydIV9/nA/+dzsc9GBu46Sg7rnGnRX3ttOMNuzzVDgkWIUUGeufwkc1P6X3yiocGdEpQt3SjwsWE",
+	"WwpQP+dZueFmViEy4W3O5VJWmY2bkqqjFSot61Q8gSU8OLYwrkMOldF0mkKaOJmu6A8cMhVgEb+W2Ypw",
+	"SaF6PlLjt2jHvoLKvdyQff/+/wUAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/reporting/httpapi/problem/problem.go
+++ b/internal/reporting/httpapi/problem/problem.go
@@ -34,9 +34,15 @@ const (
 	// TypePayloadTooLarge marks a request that carries more than the endpoint
 	// takes at once, such as an event batch above the item limit.
 	TypePayloadTooLarge = "urn:tally:error:payload_too_large"
-	// TypeHistoryTooLong marks a resource whose stored history is longer than
-	// the unpaginated per-resource reads answer at once.
+	// TypeHistoryTooLong marks a resource or project whose stored history is
+	// longer than the unpaginated per-resource reads answer at once.
 	TypeHistoryTooLong = "urn:tally:error:history_too_long"
+	// TypeResultTooLarge marks a query whose answer would be larger than this
+	// API serves unpaginated, such as an event grouping over too wide a window.
+	TypeResultTooLarge = "urn:tally:error:result_too_large"
+	// TypeNotImplemented marks a parameter or a capability a later phase
+	// delivers, such as counting resources at a historic instant.
+	TypeNotImplemented = "urn:tally:error:not_implemented"
 	// TypeRelationCycle marks a relation creation that would close a cycle over
 	// the relation types that attribute cost.
 	TypeRelationCycle = "urn:tally:error:relation_cycle"

--- a/internal/reporting/httpapi/projectsummary.go
+++ b/internal/reporting/httpapi/projectsummary.go
@@ -1,0 +1,251 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/projection"
+	"github.com/b42labs/tally/internal/reporting/stats"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// summaryDetail answers every failure of this route a caller can do nothing
+// about.
+const summaryDetail = "the project summary could not be read"
+
+// maxSummaryEvents is how many events one summary folds. The answer is not
+// paginated, and folding a history means holding it: the memory one request
+// costs is set by how many events the collectors wrote for the resources of the
+// project, which is a number this service does not control.
+//
+// A project above the bound is refused rather than summarized from part of its
+// history, so a client never mistakes a partial fold for a whole one. The Phase
+// 3 usage records are what answer a history that long, because they carry the
+// folded numbers instead of the events they come from.
+const maxSummaryEvents = 100000
+
+// longProjectHistoryDetail answers a project whose stored history is longer than
+// one summary folds. It names where the answer comes from instead, because there
+// is nothing about the request itself the caller can change.
+const longProjectHistoryDetail = "this project has more stored events than one summary folds at once; " +
+	"the Phase 3 usage records answer a history this long"
+
+// GetProjectSummary answers with one project and what each of its resource types
+// did inside the window.
+//
+// The window numbers come from folding the histories of the project's resources
+// with internal/core/timeline, the fold every other read of a history runs, so
+// what the summary reports and what a lifecycle reports are derived from one
+// reading of the same events. A resource that changed hands is folded whole and
+// credited per interval, so its minutes stop here at the transfer rather than
+// running on beside the new owner's. `active_now` is counted off the projection
+// instead: it says what the project runs today, which no window can answer.
+//
+// A from at or past to is an empty window and needs no case of its own: the fold
+// clips every interval to it, so the created, deleted, and minute counts come out
+// zero while active_now stays what it is.
+//
+// The answer names the project and does not carry the registry row: the guard on
+// this route is the one the queries take rather than the one the registry takes,
+// so what a project scope is built out of is not served through it.
+func (s *server) GetProjectSummary(w http.ResponseWriter, r *http.Request, id Uuid, params GetProjectSummaryParams) {
+	ctx := r.Context()
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+
+	project, err := s.queries.GetProject(ctx, id)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		writeInternal(ctx, w, "reading a project", err, summaryDetail)
+		return
+	}
+	// A project this registry does not hold and a project outside the token's
+	// scope leave through the same write, so the two responses are identical byte
+	// for byte and a token holder cannot tell a project it may not read from an
+	// id that names nothing.
+	if err != nil || (!scope.Unfiltered && !reachesPair(scope, project.Cloud, project.ExternalID)) {
+		problem.Write(w, http.StatusNotFound, problem.TypeNotFound, "Not found", unknownProjectDetail)
+		return
+	}
+
+	rows, ok := s.projectHistory(w, r, project, params.To)
+	if !ok {
+		return
+	}
+
+	// One resource is one history, so the events are split per resource before
+	// anything folds them. The query's order is kept inside each group, which is
+	// the order the fold reads a history in.
+	histories := make(map[projection.Key][]event.Stored)
+	for _, row := range rows {
+		key := projection.Key{Cloud: row.Cloud, ResourceType: row.ResourceType, ResourceID: row.ResourceID}
+		histories[key] = append(histories[key], foldEvent(row))
+	}
+
+	folded := make([]stats.History, 0, len(histories))
+	for key, events := range histories {
+		folded = append(folded, stats.History{ResourceType: key.ResourceType, Events: events})
+	}
+	activities := stats.Summarize(folded, project.ExternalID, params.From, params.To, s.now())
+
+	active, err := s.queries.CountProjectResourcesByType(ctx, sqlcgen.CountProjectResourcesByTypeParams{
+		Cloud:     project.Cloud,
+		ProjectID: project.ExternalID,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "counting the resources of a project", err, summaryDetail)
+		return
+	}
+
+	// The project is named rather than served: this route is reachable with a
+	// project token and the registry row it hangs off is not, so what a project
+	// scope is built out of — the name and the operator-set metadata — stays
+	// behind the read_all the registry reads take.
+	writeJSON(w, ProjectSummary{
+		Project: ProjectRef{
+			Id:         project.ID,
+			Cloud:      project.Cloud,
+			ExternalId: project.ExternalID,
+		},
+		ResourceTypes: mergeActivity(activities, active),
+	})
+}
+
+// projectHistory reads the events one summary folds, and answers the request
+// itself when it has no summary to serve.
+//
+// The read is bounded, and a project above the bound is refused rather than
+// summarized short, because the route does not paginate. The bound is decided by
+// counting first, for the reason the per-resource reads count first: the row set
+// of the read is materialized and sorted whole before the caller sees any of it,
+// so deciding the refusal off the rows themselves costs exactly the read the
+// refusal exists to avoid. The count probes the joined set the read returns
+// rather than the project's own events, which bound nothing about it: a resource
+// the project holds a single event of pulls in the events of every project it
+// was transferred between. The count stops one row past the bound, so a set far
+// above it costs the same as one just above it.
+//
+// The read is still asked for one row past the bound, and the answer is refused
+// if it comes back: an event stored between the two queries would otherwise be
+// folded as a history one event short of the whole one.
+//
+// Only the upper bound of the window filters the read. The events before it are
+// what say which resources the project was already running when the window
+// opened, and the fold clips its intervals to the window itself.
+func (s *server) projectHistory(w http.ResponseWriter, r *http.Request,
+	project sqlcgen.Project, to time.Time,
+) ([]sqlcgen.ListProjectFoldEventsRow, bool) {
+	ctx := r.Context()
+
+	count, err := s.queries.CountProjectFoldEvents(ctx, sqlcgen.CountProjectFoldEventsParams{
+		Cloud:      project.Cloud,
+		ProjectID:  project.ExternalID,
+		ToTs:       pgtype.Timestamptz{Time: to, Valid: true},
+		ProbeLimit: maxSummaryEvents + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "counting the history of a project", err, summaryDetail)
+		return nil, false
+	}
+	if count > maxSummaryEvents {
+		refuseLongProjectHistory(ctx, w, project, to)
+		return nil, false
+	}
+
+	rows, err := s.queries.ListProjectFoldEvents(ctx, sqlcgen.ListProjectFoldEventsParams{
+		Cloud:     project.Cloud,
+		ProjectID: project.ExternalID,
+		ToTs:      pgtype.Timestamptz{Time: to, Valid: true},
+		PageSize:  maxSummaryEvents + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "listing the history of a project", err, summaryDetail)
+		return nil, false
+	}
+	if len(rows) > maxSummaryEvents {
+		refuseLongProjectHistory(ctx, w, project, to)
+		return nil, false
+	}
+	return rows, true
+}
+
+// foldEvent renders one read row as the stored event the fold reads. The read
+// carries no payload, because nothing the summary reports is decided by one, so
+// this cannot fail the way decoding a stored event can.
+func foldEvent(row sqlcgen.ListProjectFoldEventsRow) event.Stored {
+	return event.Stored{
+		Event: event.Event{
+			EventID:      row.EventID,
+			Timestamp:    row.Timestamp.Time,
+			EventType:    row.EventType,
+			Platform:     row.Platform,
+			Cloud:        row.Cloud,
+			ResourceType: row.ResourceType,
+			ResourceID:   row.ResourceID,
+			ProjectID:    row.ProjectID,
+			Source:       event.Source(row.Source),
+		},
+		ReceivedAt: row.ReceivedAt.Time,
+	}
+}
+
+// refuseLongProjectHistory answers a project the summary does not fold, and logs
+// which project it was about: the bound being hit at all is an operational
+// signal, and the response says nothing about the project that hit it.
+func refuseLongProjectHistory(ctx context.Context, w http.ResponseWriter,
+	project sqlcgen.Project, to time.Time,
+) {
+	Logger(ctx).Warn("refusing a project history above the bound",
+		"cloud", project.Cloud, "project_id", project.ExternalID, "to", to,
+		"bound", maxSummaryEvents)
+	problem.Write(w, http.StatusUnprocessableEntity, problem.TypeHistoryTooLong,
+		"History too long", longProjectHistoryDetail)
+}
+
+// mergeActivity joins what the window folded with what the project runs today.
+// Neither side contains the other: a resource type the window saw nothing of is
+// still running, and one the project has since given up still spent minutes
+// inside the window. The union of both is what the summary reports, zero-filled
+// on whichever side has no row for a type.
+//
+// The rows come out ordered by resource type, and the slice is never nil: a
+// project with neither events nor resources is answered as the empty array.
+func mergeActivity(activities []stats.Activity,
+	active []sqlcgen.CountProjectResourcesByTypeRow,
+) []ProjectActivity {
+	byType := make(map[string]ProjectActivity, len(activities)+len(active))
+	for _, activity := range activities {
+		byType[activity.ResourceType] = ProjectActivity{
+			ResourceType: activity.ResourceType,
+			Created:      activity.Created,
+			Deleted:      activity.Deleted,
+			TotalMinutes: activity.TotalMinutes,
+		}
+	}
+	for _, row := range active {
+		item := byType[row.ResourceType]
+		item.ResourceType = row.ResourceType
+		item.ActiveNow = int(row.Resources)
+		byType[row.ResourceType] = item
+	}
+
+	items := make([]ProjectActivity, 0, len(byType))
+	for _, item := range byType {
+		items = append(items, item)
+	}
+	slices.SortFunc(items, func(a, b ProjectActivity) int {
+		return strings.Compare(a.ResourceType, b.ResourceType)
+	})
+	return items
+}

--- a/internal/reporting/httpapi/projectsummary_integration_test.go
+++ b/internal/reporting/httpapi/projectsummary_integration_test.go
@@ -1,0 +1,430 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	"github.com/b42labs/tally/internal/reporting/store"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// The project the summarized fixture belongs to. A summary reads the events of
+// one (cloud, external id) pair, so the pair the registry holds has to be the
+// pair the events carry.
+const (
+	summaryCloud     = "os-summary"
+	summaryProjectID = "summary-project"
+)
+
+// The window the summary is asked for and the instant the server takes as now.
+// Both are fixtures: an interval still open is billed up to now, so the minutes
+// the answer reports are only hand-computable when the clock is pinned.
+var (
+	summaryFrom = time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	summaryTo   = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	summaryNow  = time.Date(2026, 2, 15, 12, 0, 0, 0, time.UTC)
+)
+
+// The instants the three resources of the fixture live at: one created before
+// the window and deleted inside it, one created inside it and still running, and
+// one whose history starts mid-life.
+var (
+	summaryCreatedBefore = time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	summaryDeletedInside = time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC)
+	summaryCreatedInside = time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	summaryPickedUp      = time.Date(2026, 2, 12, 0, 0, 0, 0, time.UTC)
+)
+
+// summaryActivity is what the fixture did inside [summaryFrom, summaryTo), with
+// now at 02-15T12:00, hand-computed:
+//
+//	the deleted instance was created before the window and deleted on 02-05, so
+//	it counts as deleted once and bills 02-01 to 02-05, 4 days;
+//
+//	the open instance was created on 02-10 and still runs, so it counts as
+//	created once and bills 02-10 to now, 5 days and 12 hours;
+//
+//	the volume's history starts without a create, so neither counter moves and
+//	the interval its first event opens bills 02-12 to now, 3 days and 12 hours.
+//
+// That is 5760 + 7920 minutes for the instances and 5040 for the volume.
+//
+// active_now comes from the projection instead: the deleted instance keeps its
+// row under state 'deleted' and is left out, the open one is counted, and the
+// volume has no row at all, because its event was stored past the pipeline that
+// writes them.
+var summaryActivity = []ProjectActivity{
+	{ResourceType: "instance", ActiveNow: 1, Created: 1, Deleted: 1, TotalMinutes: 13680},
+	{ResourceType: "volume", TotalMinutes: 5040},
+}
+
+// TestGetProjectSummaryOverHTTP drives GET /api/v1/projects/{id}/summary through
+// the whole stack: the registry lookup, the project scope, the fold of the
+// project's history, and the projection behind active_now.
+//
+// The subtests share one database. Each fixture other than the summarized one
+// gets a cloud and a project of its own, so no history reaches another's answer.
+func TestGetProjectSummaryOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIAtInstant(t, db.Store, summaryNow)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+
+	project := seedProject(t, a, summaryCloud, summaryProjectID)
+	seedSummaryFixture(t, a)
+
+	t.Run("counts what each resource type did inside the window", func(t *testing.T) {
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo), adminToken, nil))
+
+		if got.Project.Id != project {
+			t.Errorf("project id = %s, want %s", got.Project.Id, project)
+		}
+		if got.Project.ExternalId != summaryProjectID || got.Project.Cloud != summaryCloud {
+			t.Errorf("project = (%s, %s), want (%s, %s)", got.Project.Cloud,
+				got.Project.ExternalId, summaryCloud, summaryProjectID)
+		}
+
+		// The rows are the hand-computed ones, in the order the contract states:
+		// what each number stands for is written out at summaryActivity.
+		if !reflect.DeepEqual(got.ResourceTypes, summaryActivity) {
+			t.Errorf("resource types = %+v, want %+v", got.ResourceTypes, summaryActivity)
+		}
+	})
+
+	t.Run("bills no minute past now for a window that ends in the future", func(t *testing.T) {
+		// The window runs a year past the pinned now, and the answer is the one the
+		// window ending at to gives: an interval still open has accrued up to now
+		// and no further, whatever a caller asks for.
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo.AddDate(1, 0, 0)), adminToken, nil))
+
+		if !reflect.DeepEqual(got.ResourceTypes, summaryActivity) {
+			t.Errorf("resource types = %+v, want the %+v the window ending at to reports",
+				got.ResourceTypes, summaryActivity)
+		}
+	})
+
+	t.Run("zeroes the window a from at the to opens while active_now stays what it is", func(t *testing.T) {
+		// The history is read up to the to and folded, so both types still have a
+		// row; what the empty window clips away is every interval and every
+		// lifecycle instant inside it.
+		at := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, at, at), adminToken, nil))
+
+		want := []ProjectActivity{
+			{ResourceType: "instance", ActiveNow: 1},
+			{ResourceType: "volume"},
+		}
+		if !reflect.DeepEqual(got.ResourceTypes, want) {
+			t.Errorf("resource types = %+v, want %+v", got.ResourceTypes, want)
+		}
+	})
+
+	t.Run("reports the projection alone for a window the history does not reach", func(t *testing.T) {
+		// The window ends before the first event of the project, so the fold reads
+		// nothing at all and every number it produces is missing rather than zero.
+		// What the answer carries is the resource types the project runs today,
+		// zero-filled on the side the window would have answered.
+		at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, at, at), adminToken, nil))
+
+		// The volume has no projection row, so this window says nothing about it.
+		want := []ProjectActivity{{ResourceType: "instance", ActiveNow: 1}}
+		if !reflect.DeepEqual(got.ResourceTypes, want) {
+			t.Errorf("resource types = %+v, want %+v", got.ResourceTypes, want)
+		}
+	})
+
+	t.Run("answers a project with neither events nor resources with the empty array", func(t *testing.T) {
+		const cloud = "os-summary-empty"
+		empty := seedProject(t, a, cloud, "summary-empty")
+
+		rec := a.call(t, http.MethodGet, projectSummaryPath(empty, summaryFrom, summaryTo), adminToken, nil)
+
+		if got := projectSummaryOf(t, rec); len(got.ResourceTypes) != 0 {
+			t.Errorf("resource types = %+v, want none for a project with neither", got.ResourceTypes)
+		}
+		// The raw body rather than the decoded one: a client iterates the rows
+		// without a nil check, which null would break and [] does not.
+		if body := rec.Body.String(); !strings.Contains(body, `"resource_types":[]`) {
+			t.Errorf("body = %s, want it to carry \"resource_types\":[]", body)
+		}
+	})
+
+	t.Run("answers a project outside the scope the way it answers an unknown id", func(t *testing.T) {
+		// A token that could tell the two apart would be able to map the projects
+		// of other tokens by asking for summaries one id at a time.
+		const cloud = "os-summary-foreign"
+		foreign := seedProject(t, a, cloud, "summary-foreign")
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{foreign})
+
+		unknown := a.call(t, http.MethodGet,
+			projectSummaryPath(uuid.New(), summaryFrom, summaryTo), token, nil)
+		outside := a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo), token, nil)
+
+		for name, rec := range map[string]*httptest.ResponseRecorder{
+			"an unknown id":                       unknown,
+			"a project outside the token's scope": outside,
+		} {
+			assertProblem(t, rec, http.StatusNotFound, problem.TypeNotFound)
+			if got, want := problemDetail(t, rec), "this project is not registered"; got != want {
+				t.Errorf("detail of %s = %q, want %q", name, got, want)
+			}
+		}
+		if !bytes.Equal(outside.Body.Bytes(), unknown.Body.Bytes()) {
+			t.Errorf("the body of a project outside the scope = %s, want the %s of an unknown id",
+				outside.Body, unknown.Body)
+		}
+	})
+
+	t.Run("refuses a history longer than one summary folds", func(t *testing.T) {
+		const (
+			cloud     = "os-summary-long"
+			projectID = "summary-long"
+		)
+		long := seedProject(t, a, cloud, projectID)
+		// One event past the bound, written through the pool rather than ingested:
+		// what is being pinned is the handler's refusal, and folding a hundred
+		// thousand events through the write path would say nothing more about it.
+		// They sit a second apart below the to, so the read the refusal is decided
+		// on covers all of them.
+		if _, err := a.store.Pool().Exec(t.Context(),
+			`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+			                     resource_type, resource_id, project_id, source, payload)
+			 SELECT 'summary-long-' || n, $1::timestamptz + (n * INTERVAL '1 second'),
+			        'volume.update', $2, $3, 'volume', 'vol-summary-long', $4, 'collector',
+			        '{"state": "available"}'::jsonb
+			 FROM generate_series(1, $5::int) AS n`,
+			summaryFrom, fixturePlatform, cloud, projectID, maxSummaryEvents+1); err != nil {
+			t.Fatalf("writing a project history past the bound: %v", err)
+		}
+
+		rec := a.call(t, http.MethodGet, projectSummaryPath(long, summaryFrom, summaryTo), adminToken, nil)
+
+		assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeHistoryTooLong)
+	})
+
+	t.Run("folds a row whose payload nothing could decode", func(t *testing.T) {
+		// The payload column is typed as an object by the contract, and the write
+		// path stores nothing else; a row written past this API could hold any
+		// JSON. The summary reads no payload at all, because no number it reports
+		// is decided by one, so a row carrying an array folds like every other
+		// row. That is what says the column stays out of this read: were it
+		// selected and unmarshalled, this row is the one that could not be.
+		const (
+			cloud     = "os-summary-undecodable"
+			projectID = "summary-undecodable"
+		)
+		bad := seedProject(t, a, cloud, projectID)
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-summary-undecodable"}
+		insertEventRow(t, a, inProject(res.event("summary-undecodable-update", "volume.update",
+			summaryCreatedInside, event.PayloadEnvelope{}), projectID), []byte(`[1,2]`))
+
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(bad, summaryFrom, summaryTo), adminToken, nil))
+
+		// The one event opens an interval on 02-10 that is still open, so it bills
+		// up to the pinned now on 02-15T12:00: 5 days and 12 hours.
+		want := []ProjectActivity{{ResourceType: "volume", TotalMinutes: 7920}}
+		if !reflect.DeepEqual(got.ResourceTypes, want) {
+			t.Errorf("resource types = %+v, want %+v", got.ResourceTypes, want)
+		}
+	})
+
+	t.Run("bills a transferred resource to one project at a time", func(t *testing.T) {
+		// The transfer writes the new project onto the event that moves the
+		// resource, so the old owner's own events end there. Reading them alone
+		// leaves an interval that never closes and bills up to now, beside the new
+		// owner billing the same resource from the transfer on.
+		const (
+			cloud    = "os-summary-transfer"
+			oldOwner = "summary-transfer-old"
+			newOwner = "summary-transfer-new"
+		)
+		before := seedProject(t, a, cloud, oldOwner)
+		after := seedProject(t, a, cloud, newOwner)
+
+		res := fixture{cloud: cloud, resourceType: "volume", id: "vol-summary-transfer"}
+		ingestEvents(t, a, fixturePlatform, cloud,
+			inProject(res.event("summary-transfer-create", "volume.create",
+				summaryCreatedInside, payloadOf("available", volumeSize(10))), oldOwner),
+			inProject(res.event("summary-transfer-move", "volume.update",
+				summaryPickedUp, payloadOf("available", volumeSize(10))), newOwner))
+
+		// Created on 02-10 and handed over on 02-12: two days for the old owner,
+		// who created it and no longer runs it. The projection follows the
+		// transfer, so active_now is the new owner's.
+		gave := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(before, summaryFrom, summaryTo), adminToken, nil))
+		wantGave := []ProjectActivity{{ResourceType: "volume", Created: 1, TotalMinutes: 2880}}
+		if !reflect.DeepEqual(gave.ResourceTypes, wantGave) {
+			t.Errorf("resource types of the old owner = %+v, want %+v", gave.ResourceTypes, wantGave)
+		}
+
+		// From 02-12 up to the pinned now on 02-15T12:00: three days and twelve
+		// hours. The create belongs to the old owner, so it is not counted here.
+		took := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(after, summaryFrom, summaryTo), adminToken, nil))
+		wantTook := []ProjectActivity{{ResourceType: "volume", ActiveNow: 1, TotalMinutes: 5040}}
+		if !reflect.DeepEqual(took.ResourceTypes, wantTook) {
+			t.Errorf("resource types of the new owner = %+v, want %+v", took.ResourceTypes, wantTook)
+		}
+
+		// What the two of them bill together is the resource's whole life inside
+		// the window and not a minute more, which is the property a transfer must
+		// not break: one resource, one span, one bill.
+		if got, want := gave.ResourceTypes[0].TotalMinutes+took.ResourceTypes[0].TotalMinutes,
+			int64(7920); got != want {
+			t.Errorf("minutes billed by both owners = %d, want the %d of one life", got, want)
+		}
+	})
+
+	t.Run("serves a project token the project it holds", func(t *testing.T) {
+		// The route is guarded lower than the registry read it hangs off: a summary
+		// reports what a project ran, which is what its own token is for.
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{project})
+
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo), token, nil))
+
+		if !reflect.DeepEqual(got.ResourceTypes, summaryActivity) {
+			t.Errorf("resource types = %+v, want %+v", got.ResourceTypes, summaryActivity)
+		}
+	})
+
+	t.Run("serves a read_all token any project", func(t *testing.T) {
+		admin := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo), adminToken, nil))
+
+		got := projectSummaryOf(t, a.call(t, http.MethodGet,
+			projectSummaryPath(project, summaryFrom, summaryTo), readAllToken, nil))
+
+		if !reflect.DeepEqual(got.ResourceTypes, admin.ResourceTypes) {
+			t.Errorf("resource types = %+v, want the %+v an admin token reads",
+				got.ResourceTypes, admin.ResourceTypes)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, projectSummaryPath(project, summaryFrom, summaryTo), "", nil)
+
+		assertChallenged(t, rec)
+	})
+}
+
+// seedSummaryFixture stores the three resources the summary subtests describe.
+//
+// The two instances go in through POST /api/v1/events, so both halves of the
+// answer are real: the events the window folds and the projection rows
+// active_now counts. The volume is written through the pool instead, which
+// stores an event and no projection row, so what the fold reports of it and what
+// the projection reports of it can be told apart.
+func seedSummaryFixture(t *testing.T, a api) {
+	t.Helper()
+
+	gone := fixture{cloud: summaryCloud, resourceType: "instance", id: "inst-summary-gone"}
+	alive := fixture{cloud: summaryCloud, resourceType: "instance", id: "inst-summary-alive"}
+	// A size the seeded (openstack, instance) schema accepts.
+	flavor := map[string]any{"vcpus": 2, "ram_gb": 4, "disk_gb": 20, "flavor": "m1.small"}
+
+	ingestEvents(t, a, fixturePlatform, summaryCloud,
+		inProject(gone.event("summary-gone-create", "instance.create",
+			summaryCreatedBefore, payloadOf("active", flavor)), summaryProjectID),
+		inProject(gone.event("summary-gone-delete", "instance.delete",
+			summaryDeletedInside, event.PayloadEnvelope{}), summaryProjectID),
+		inProject(alive.event("summary-alive-create", "instance.create",
+			summaryCreatedInside, payloadOf("active", flavor)), summaryProjectID))
+
+	// A volume the project was handed mid-life: its history starts with an update,
+	// which is what a missed create leaves behind. The fold opens an interval at
+	// that first event and warns about it, so the volume bills from there on
+	// without ever having been created inside the window.
+	orphan := fixture{cloud: summaryCloud, resourceType: "volume", id: "vol-summary-orphan"}
+	update := inProject(orphan.event("summary-orphan-update", "volume.update",
+		summaryPickedUp, payloadOf("available", volumeSize(10))), summaryProjectID)
+	payload, err := json.Marshal(update.Payload)
+	if err != nil {
+		t.Fatalf("marshaling the payload of %s: %v", update.EventID, err)
+	}
+	insertEventRow(t, a, update, payload)
+}
+
+// newAPIAtInstant builds the full router over s with authentication enforced and
+// the server's clock pinned to now. The shared harness leaves the clock at
+// time.Now, and the summary bills an interval still open up to whatever it
+// reads, so a test that hand-computes those minutes builds its router here.
+func newAPIAtInstant(t *testing.T, s *store.Store, now time.Time) api {
+	t.Helper()
+
+	q := sqlcgen.New(s.Pool())
+	handler, err := NewRouter(Options{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                 s,
+		UnhealthyThreshold: time.Minute,
+		Now:                func() time.Time { return now },
+		Queries:            q,
+		Store:              s,
+		AuthMode:           auth.ModeEnforced,
+		InternalToken:      internalToken,
+		Authenticator:      auth.NewStaticTokenAuthenticator(q),
+		Pipeline:           ingest.New(registry.New(), false, nil, nil),
+		Syncer: reconciliation.New(s, ingest.New(registry.New(), false, nil, nil),
+			reconciliation.Config{}, map[string]reconciliation.Adapter{}, time.Now, nil),
+	})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v, want nil", err)
+	}
+	return api{store: s, queries: q, handler: handler}
+}
+
+// projectSummaryPath is the summary route of one project over one window, as the
+// query string carries it.
+func projectSummaryPath(id uuid.UUID, from, to time.Time) string {
+	return projectPath(id) + "/summary?from=" + instant(from) + "&to=" + instant(to)
+}
+
+// projectSummaryOf decodes the answer of a summary call, which the contract
+// promises is a 200 carrying the project and its resource types.
+func projectSummaryOf(t *testing.T, rec *httptest.ResponseRecorder) ProjectSummary {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var got ProjectSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if got.ResourceTypes == nil {
+		t.Errorf("body %q carries resource_types as null, want an array", rec.Body)
+	}
+	return got
+}

--- a/internal/reporting/httpapi/projectsummary_test.go
+++ b/internal/reporting/httpapi/projectsummary_test.go
@@ -1,0 +1,80 @@
+package httpapi
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/b42labs/tally/internal/reporting/stats"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// TestMergeActivity pins how the two halves of a summary meet: the window folded
+// out of the history and what the project runs today answer different questions,
+// so a resource type named by one of them alone is reported with zeros on the
+// other side rather than dropped.
+func TestMergeActivity(t *testing.T) {
+	tests := map[string]struct {
+		activities []stats.Activity
+		active     []sqlcgen.CountProjectResourcesByTypeRow
+		want       []ProjectActivity
+	}{
+		"a type both sides name carries the window and the present": {
+			activities: []stats.Activity{
+				{ResourceType: "instance", Created: 2, Deleted: 1, TotalMinutes: 4320},
+			},
+			active: []sqlcgen.CountProjectResourcesByTypeRow{
+				{ResourceType: "instance", Resources: 5},
+			},
+			want: []ProjectActivity{
+				{ResourceType: "instance", ActiveNow: 5, Created: 2, Deleted: 1, TotalMinutes: 4320},
+			},
+		},
+		"a type the window never saw still reports what runs today": {
+			activities: nil,
+			active: []sqlcgen.CountProjectResourcesByTypeRow{
+				{ResourceType: "volume", Resources: 3},
+			},
+			want: []ProjectActivity{
+				{ResourceType: "volume", ActiveNow: 3},
+			},
+		},
+		"a type the project has given up still reports its window": {
+			activities: []stats.Activity{
+				{ResourceType: "instance", Created: 1, Deleted: 1, TotalMinutes: 60},
+			},
+			active: nil,
+			want: []ProjectActivity{
+				{ResourceType: "instance", Created: 1, Deleted: 1, TotalMinutes: 60},
+			},
+		},
+		"the union of both sides comes out ordered by resource type": {
+			activities: []stats.Activity{
+				{ResourceType: "volume", Created: 1, TotalMinutes: 30},
+			},
+			active: []sqlcgen.CountProjectResourcesByTypeRow{
+				{ResourceType: "instance", Resources: 2},
+			},
+			want: []ProjectActivity{
+				{ResourceType: "instance", ActiveNow: 2},
+				{ResourceType: "volume", Created: 1, TotalMinutes: 30},
+			},
+		},
+		"a project with neither events nor resources yields no row": {
+			activities: nil,
+			active:     nil,
+			want:       []ProjectActivity{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mergeActivity(tc.activities, tc.active)
+			if got == nil {
+				t.Fatal("rows = nil, want an empty array rather than a null one")
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("rows = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/reporting/httpapi/resources.go
+++ b/internal/reporting/httpapi/resources.go
@@ -370,14 +370,14 @@ func (s *server) loadScopedResource(w http.ResponseWriter, r *http.Request, scop
 // A request naming no status is served the active rows. The contract's default
 // says so, and the generated binding does not apply it, so it is applied here.
 func filterStatus(status *ListResourcesParamsStatus) pgtype.Bool {
-	value := Active
+	value := ListResourcesParamsStatusActive
 	if status != nil {
 		value = *status
 	}
-	if value == All {
+	if value == ListResourcesParamsStatusAll {
 		return pgtype.Bool{}
 	}
-	return pgtype.Bool{Bool: value == Deleted, Valid: true}
+	return pgtype.Bool{Bool: value == ListResourcesParamsStatusDeleted, Valid: true}
 }
 
 // resourceOf renders one projection row as the answer the contract promises. The

--- a/internal/reporting/httpapi/router.go
+++ b/internal/reporting/httpapi/router.go
@@ -143,6 +143,7 @@ func NewRouter(opts Options) (http.Handler, error) {
 		syncer:           opts.Syncer,
 		metrics:          opts.Metrics,
 		metricsEnabled:   opts.MetricsEnabled,
+		now:              now,
 	}
 	// The dispatch middleware is handed to the generated wrapper rather than to
 	// chi, because it needs the route chi matched to know which guard applies.

--- a/internal/reporting/httpapi/server.go
+++ b/internal/reporting/httpapi/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/b42labs/tally/internal/core/health"
 	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
@@ -38,6 +39,10 @@ type server struct {
 	metrics *metrics.Metrics
 	// metricsEnabled is whether the scrape route serves the instruments at all.
 	metricsEnabled bool
+	// now is the clock the project summary clips an open interval at, so that a
+	// window reaching into the future reports no time that has not been served
+	// yet. It comes from Options.Now, which is what pins it in a test.
+	now func() time.Time
 }
 
 // writeJSON sends one successful response body under the 200 almost every

--- a/internal/reporting/httpapi/statsevents.go
+++ b/internal/reporting/httpapi/statsevents.go
@@ -1,0 +1,237 @@
+package httpapi
+
+import (
+	"cmp"
+	"context"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// eventStatsDetail answers every failure of this route a caller can do nothing
+// about.
+const eventStatsDetail = "the event counts could not be read"
+
+// maxEventStatsRows is how many groups this route counts at most. The answer is
+// not paginated, so without a bound the memory one request costs is set by the
+// window and the interval it names: the number of buckets is the window divided
+// by the width, and every bucket carries a row per cloud, event type, and source
+// seen in it.
+//
+// A request above the bound is refused rather than answered short, so a client
+// never mistakes a truncated grouping for a whole one. It is far above what a
+// dashboard reads: a year of hourly buckets is 8760 of them, which the bound
+// holds for a cloud reporting one event type from one pipeline.
+const maxEventStatsRows = 10000
+
+// maxEventStatsWindow is how wide a window one request may count. It bounds the
+// read rather than the response: the query's own LIMIT sits behind a GROUP BY,
+// so the database walks and aggregates every event of the window before a single
+// row can be discarded, and what that costs is set by the events the window
+// holds and not by the buckets it names. A bound read on the buckets would say
+// nothing about it — ten thousand of them at a daily width is twenty-seven years
+// of the archive, aggregated whole into an answer of a few thousand rows.
+//
+// It is a year and a month, which is the longest span a dashboard asks for and
+// leaves a full year reachable from any day of the next one. At the finest width
+// this route buckets by it is 9600 buckets, so it stays under the row bound as
+// well for a fleet reporting one event type from one pipeline into one cloud.
+//
+// A wider window is refused before the count is issued, which is what keeps the
+// cost of the refusal off the database.
+const maxEventStatsWindow = 400 * 24 * time.Hour
+
+// largeResultDetail answers a request that groups into more rows than one answer
+// carries. It names what the caller changes to get through, because the bound
+// itself says nothing about that.
+const largeResultDetail = "this request groups into more rows than the unpaginated statistics serve; " +
+	"ask for a narrower window or a coarser interval"
+
+// GetEventStats answers the stored events of one window counted per time bucket
+// and per combination of the dimensions the request groups by.
+//
+// The bucketing is the database's, so what decides which bucket an event falls
+// into is the same time_bucket call the hypertable is chunked along, and the
+// handler adds the rows up onto the requested dimensions afterwards.
+//
+// The counts are event-scoped the way the event list is: a project token counts
+// every event whose project_id names one of its projects, including the events a
+// resource carried before it was transferred away.
+func (s *server) GetEventStats(w http.ResponseWriter, r *http.Request, params GetEventStatsParams) {
+	ctx := r.Context()
+
+	// cloud and event_type are what an item is read by, so a grouping without
+	// them counts events it cannot name. The rule spans two members of one list,
+	// which the contract cannot express; a dimension outside the enum and a
+	// repeated one are refused by the validator in front of this.
+	if !slices.Contains(params.GroupBy, GetEventStatsParamsGroupByCloud) ||
+		!slices.Contains(params.GroupBy, GetEventStatsParamsGroupByEventType) {
+		problem.Write(w, http.StatusBadRequest, problem.TypeValidation,
+			"Validation failed", "group_by must name cloud and event_type")
+		return
+	}
+
+	width, ok := bucketWidth(params.Interval)
+	if !ok {
+		// The contract's enum is what keeps this unreachable, so a request that
+		// gets here means the contract declares a width this route does not
+		// bucket by. It is refused the way a route no guard covers is: taking the
+		// case offline says so, where bucketing it by some other width would not.
+		Logger(ctx).Error("no bucket width covers this interval", "interval", params.Interval)
+		problem.Write(w, http.StatusInternalServerError, problem.TypeInternal,
+			"Internal error", eventStatsDetail)
+		return
+	}
+	// The window is refused on how wide it is, before anything is read: what the
+	// aggregate costs is the events the window holds, which is a number this
+	// service does not control, so the request is turned away where the refusal
+	// costs nothing rather than after the database has walked the archive. A
+	// window ending at or before its start is negative here and passes, which is
+	// the empty answer the half-open window means.
+	if params.To.Sub(params.From) > maxEventStatsWindow {
+		refuseLargeResult(ctx, w, params)
+		return
+	}
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+	// A filtered scope holding no project reaches no event at all, so the empty
+	// answer is given here rather than asked of the database.
+	if !scope.Unfiltered && len(scope.Refs) == 0 {
+		writeJSON(w, EventStatsList{Items: []EventStatsItem{}})
+		return
+	}
+
+	clouds, projects := scopeFilter(scope)
+
+	// A from at or past to counts nothing, which is what the half-open window
+	// means and needs no case of its own: each bound is a valid instant on its
+	// own, and the contract cannot express a rule spanning two parameters.
+	rows, err := s.queries.CountEventBuckets(ctx, sqlcgen.CountEventBucketsParams{
+		BucketWidth:   width,
+		FromTs:        pgtype.Timestamptz{Time: params.From, Valid: true},
+		ToTs:          pgtype.Timestamptz{Time: params.To, Valid: true},
+		ScopeClouds:   clouds,
+		ScopeProjects: projects,
+		RowCap:        maxEventStatsRows + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "counting event buckets", err, eventStatsDetail)
+		return
+	}
+	// The query reads one row past the bound, so a row set of exactly the bound
+	// is a whole answer and one longer is the refusal.
+	if len(rows) > maxEventStatsRows {
+		refuseLargeResult(ctx, w, params)
+		return
+	}
+
+	writeJSON(w, EventStatsList{Items: groupEventCounts(rows, params.GroupBy)})
+}
+
+// bucketWidth maps the interval a request names onto the literal the query casts
+// to an interval.
+//
+// The contract's enum makes these two cases exhaustive, and the second return
+// value is what says so rather than assuming it: an interval added to the enum
+// compiles and validates without touching this, and a width silently substituted
+// for the one asked for is a count the answer carries no field to detect.
+func bucketWidth(interval GetEventStatsParamsInterval) (string, bool) {
+	switch interval {
+	case N1h:
+		return "1 hour", true
+	case N1d:
+		return "1 day", true
+	}
+	return "", false
+}
+
+// refuseLargeResult answers a request above one of the two bounds, the span its
+// window covers or the rows its grouping fills, and logs what was asked for: the
+// bound being hit at all is an operational signal, and the response says nothing
+// about the request that hit it.
+//
+// The row bound counts what the query returns, which is the finest grouping
+// there is, so dropping a dimension does not lower it: the query groups by all
+// of them, and the collapsing happens on rows the refusal has already been
+// decided on. A narrower window is what gets a request through either bound, and
+// a coarser interval the row bound alone.
+func refuseLargeResult(ctx context.Context, w http.ResponseWriter, params GetEventStatsParams) {
+	Logger(ctx).Warn("refusing an event grouping above the bound",
+		"from", params.From, "to", params.To, "interval", params.Interval,
+		"bound", maxEventStatsRows)
+	problem.Write(w, http.StatusUnprocessableEntity, problem.TypeResultTooLarge,
+		"Result too large", largeResultDetail)
+}
+
+// eventGroup is the combination of values one item stands for, which is what the
+// counts are keyed by while they are added up. The source stays the empty string
+// for a request that did not group by it, so the rows of one bucket that differ
+// in nothing else merge there.
+//
+// The bucket is keyed in UTC, the zone the answer states it in, which is also
+// what makes two rows of one bucket compare equal.
+type eventGroup struct {
+	bucket    time.Time
+	cloud     string
+	eventType string
+	source    string
+}
+
+// groupEventCounts adds the counted rows up onto the dimensions the request
+// asked for and renders them as the answer the contract promises. The source
+// member is set exactly when the grouping names it: the count stands for one
+// pipeline only when it was taken per pipeline.
+//
+// The items come out ordered the way the contract states, and the slice is never
+// nil: a window holding no event is answered as the empty array.
+func groupEventCounts(rows []sqlcgen.CountEventBucketsRow,
+	groupBy []GetEventStatsParamsGroupBy,
+) []EventStatsItem {
+	bySource := slices.Contains(groupBy, GetEventStatsParamsGroupBySource)
+
+	counts := make(map[eventGroup]int64, len(rows))
+	for _, row := range rows {
+		group := eventGroup{
+			bucket:    row.Bucket.Time.UTC(),
+			cloud:     row.Cloud,
+			eventType: row.EventType,
+		}
+		if bySource {
+			group.source = row.Source
+		}
+		counts[group] += row.Events
+	}
+
+	items := make([]EventStatsItem, 0, len(counts))
+	for _, group := range slices.SortedFunc(maps.Keys(counts), compareEventGroups) {
+		items = append(items, EventStatsItem{
+			Bucket:    group.bucket,
+			Cloud:     group.cloud,
+			EventType: group.eventType,
+			Source:    groupedValue(bySource, group.source),
+			Count:     counts[group],
+		})
+	}
+	return items
+}
+
+// compareEventGroups orders two groups by their bucket first and by their
+// dimensions after it, in the order the contract states.
+func compareEventGroups(a, b eventGroup) int {
+	return cmp.Or(
+		a.bucket.Compare(b.bucket),
+		strings.Compare(a.cloud, b.cloud),
+		strings.Compare(a.eventType, b.eventType),
+		strings.Compare(a.source, b.source),
+	)
+}

--- a/internal/reporting/httpapi/statsevents_integration_test.go
+++ b/internal/reporting/httpapi/statsevents_integration_test.go
@@ -1,0 +1,505 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// eventStatsRoute is the route the event statistics tests call, spelled once
+// because every one of them addresses it.
+const eventStatsRoute = "/api/v1/stats/events"
+
+// The clouds the counted events live in. This route narrows on the window and
+// on nothing else, so each fixture gets a window of its own and the cloud is
+// what names its part of the answer.
+const (
+	eventStatsCloudA     = "os-evstats-a"
+	eventStatsCloudB     = "os-evstats-b"
+	eventStatsCloudDays  = "os-evstats-days"
+	eventStatsCloudScope = "os-evstats-scope"
+	eventStatsCloudBulk  = "os-evstats-bulk"
+	eventStatsCloudBulkB = "os-evstats-bulk-b"
+)
+
+// eventStatsBulkBuckets is how many buckets the bulk fixture fills. Two clouds
+// report in every one of them, so the finest grouping carries two rows per
+// bucket and the row bound is met by a window naming half as many buckets as the
+// bound counts rows. That is what keeps the two bounds apart: those hours are
+// under seven months, well inside the window bound, so what refuses the request
+// is the rows it fills rather than how wide it is.
+const eventStatsBulkBuckets = maxEventStatsRows / 2
+
+// The projects of the scope fixture. Both store an event in one window and one
+// cloud, so what a project token counts is decided by the project alone.
+const (
+	eventStatsProjectMine  = "evstats-project-mine"
+	eventStatsProjectOther = "evstats-project-other"
+)
+
+// Where each fixture's window starts. They are whole hours in UTC, which is what
+// the buckets are aligned on, so a bucket start is an instant the test names
+// rather than one it computes.
+var (
+	eventStatsHourly = time.Date(2026, 3, 1, 5, 0, 0, 0, time.UTC)
+	eventStatsDaily  = time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	eventStatsScoped = time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	eventStatsBulk   = time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// TestGetEventStatsOverHTTP drives GET /api/v1/stats/events through the whole
+// stack: the contract validator, the grouping rule the handler enforces, the
+// bucketing the database does, and the project scope.
+//
+// The subtests share one database. Every one of them counts a window of its own,
+// so the events another subtest stores are outside what it asks for.
+func TestGetEventStatsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+
+	seedEventStatsEvents(t, a)
+
+	// The three hours the hourly fixture was stored in, which most subtests below
+	// ask for in full.
+	hourlyWindow := eventStatsPath("cloud,event_type", eventStatsHourly,
+		eventStatsHourly.Add(3*time.Hour), "1h")
+
+	t.Run("counts the events of each hour of a window", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, hourlyWindow, adminToken, nil)
+
+		list := eventStatsOf(t, rec)
+		// The two pipelines of the six o'clock hour are summed into one count:
+		// this grouping does not name source, so it does not keep them apart.
+		want := []string{
+			"2026-03-01T05:00:00Z|" + eventStatsCloudA + "|volume.create|-=1",
+			"2026-03-01T05:00:00Z|" + eventStatsCloudA + "|volume.resize|-=1",
+			"2026-03-01T06:00:00Z|" + eventStatsCloudA + "|volume.create|-=2",
+			"2026-03-01T07:00:00Z|" + eventStatsCloudB + "|volume.create|-=1",
+		}
+		if got := renderEventItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted buckets = %q, want %q", got, want)
+		}
+		// The rendered instant rather than the decoded one: a bucket stated in a
+		// zone of the server's own would decode to the same instant, and the
+		// contract states every bucket in UTC.
+		if body := rec.Body.String(); !strings.Contains(body, `"bucket":"2026-03-01T05:00:00Z"`) {
+			t.Errorf("body = %s, want it to carry \"bucket\":\"2026-03-01T05:00:00Z\"", body)
+		}
+	})
+
+	t.Run("buckets a window by day across a month boundary", func(t *testing.T) {
+		// The two events of the thirty-first are ninety minutes apart across
+		// midnight from the third, so the days they fall into are what separates
+		// them rather than any distance between them.
+		list := eventStatsOf(t, a.call(t, http.MethodGet,
+			eventStatsPath("cloud,event_type", eventStatsDaily, eventStatsDaily.Add(48*time.Hour), "1d"),
+			adminToken, nil))
+
+		want := []string{
+			"2026-01-31T00:00:00Z|" + eventStatsCloudDays + "|volume.update|-=2",
+			"2026-02-01T00:00:00Z|" + eventStatsCloudDays + "|volume.update|-=1",
+		}
+		if got := renderEventItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted buckets = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keeps the pipelines apart when the grouping names source", func(t *testing.T) {
+		list := eventStatsOf(t, a.call(t, http.MethodGet,
+			eventStatsPath("cloud,event_type,source", eventStatsHourly,
+				eventStatsHourly.Add(3*time.Hour), "1h"), adminToken, nil))
+
+		// The six o'clock hour is two items here and one above, which is the whole
+		// difference the source dimension makes.
+		want := []string{
+			"2026-03-01T05:00:00Z|" + eventStatsCloudA + "|volume.create|collector=1",
+			"2026-03-01T05:00:00Z|" + eventStatsCloudA + "|volume.resize|collector=1",
+			"2026-03-01T06:00:00Z|" + eventStatsCloudA + "|volume.create|collector=1",
+			"2026-03-01T06:00:00Z|" + eventStatsCloudA + "|volume.create|reconciliation=1",
+			"2026-03-01T07:00:00Z|" + eventStatsCloudB + "|volume.create|collector=1",
+		}
+		if got := renderEventItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted buckets = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("answers a window holding no event with the empty array", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			target string
+		}{
+			{
+				name: "a window nothing was stored in",
+				target: eventStatsPath("cloud,event_type", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC), "1d"),
+			},
+			{
+				// The instant of a stored event, taken as both bounds: the window
+				// is half-open, so it holds nothing even there.
+				name: "a from at the to",
+				target: eventStatsPath("cloud,event_type", eventStatsHourly.Add(10*time.Minute),
+					eventStatsHourly.Add(10*time.Minute), "1h"),
+			},
+			{
+				// Each bound is a valid instant on its own, and the window between
+				// them is empty, which is an answer rather than a refusal.
+				name: "a from past the to",
+				target: eventStatsPath("cloud,event_type", eventStatsHourly.Add(3*time.Hour),
+					eventStatsHourly, "1h"),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, tc.target, adminToken, nil)
+
+				if got := rec.Code; got != http.StatusOK {
+					t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+				}
+				// The raw body rather than the decoded one: a client iterates items
+				// without a nil check, which null would break and [] does not.
+				want := `{"items":[]}`
+				if got := strings.TrimSpace(rec.Body.String()); got != want {
+					t.Errorf("body = %s, want %s", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a grouping that cannot name what it counted", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			groupBy string
+		}{
+			{name: "without cloud", groupBy: "event_type"},
+			{name: "without event_type", groupBy: "cloud"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, eventStatsPath(tc.groupBy, eventStatsHourly,
+					eventStatsHourly.Add(3*time.Hour), "1h"), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec),
+					"group_by must name cloud and event_type"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a request the contract does not allow", func(t *testing.T) {
+		// The window and the width are what bound this answer, so each of them is
+		// required and a request leaving one out is refused rather than answered
+		// over whatever the other two imply.
+		from, to := instant(eventStatsHourly), instant(eventStatsHourly.Add(3*time.Hour))
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "no from", query: "group_by=cloud,event_type&to=" + to + "&interval=1h"},
+			{name: "no to", query: "group_by=cloud,event_type&from=" + from + "&interval=1h"},
+			{name: "no interval", query: "group_by=cloud,event_type&from=" + from + "&to=" + to},
+			{name: "an interval outside the two", query: "group_by=cloud,event_type&from=" + from +
+				"&to=" + to + "&interval=1w"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, eventStatsRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			})
+		}
+	})
+
+	t.Run("refuses a grouping above the bound", func(t *testing.T) {
+		seedEventStatsBulk(t, a)
+
+		rec := a.call(t, http.MethodGet, eventStatsPath("cloud,event_type", eventStatsBulk,
+			eventStatsBulk.Add(time.Duration(eventStatsBulkBuckets+1)*time.Hour), "1h"), adminToken, nil)
+
+		assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeResultTooLarge)
+
+		t.Run("serves a grouping exactly as large as the bound", func(t *testing.T) {
+			// The row one past the bound is what the refusal is decided on, so the
+			// window that fills it exactly is the boundary the answer still holds.
+			// The window is half-open, so the last hour it covers is the one before
+			// its end, and each of those hours carries one group per cloud.
+			list := eventStatsOf(t, a.call(t, http.MethodGet,
+				eventStatsPath("cloud,event_type", eventStatsBulk,
+					eventStatsBulk.Add(eventStatsBulkBuckets*time.Hour), "1h"), adminToken, nil))
+
+			if got := len(list.Items); got != maxEventStatsRows {
+				t.Errorf("counted groups = %d, want the %d the bound allows", got, maxEventStatsRows)
+			}
+		})
+	})
+
+	t.Run("refuses a window wider than the bound", func(t *testing.T) {
+		// The count aggregates every event of the window before its own limit can
+		// discard a row, so what a window costs is the events it holds and not the
+		// buckets it names. Nothing is seeded for these: what is being pinned is
+		// that the width of the window alone decides the refusal.
+		for _, tc := range []struct {
+			name     string
+			from, to time.Time
+			interval string
+		}{
+			{
+				name:     "one hour past the bound",
+				from:     eventStatsBulk,
+				to:       eventStatsBulk.Add(maxEventStatsWindow + time.Hour),
+				interval: "1h",
+			},
+			{
+				// A window the buckets alone would have let through: at a daily
+				// width it names 9862 of them, under the number of rows one answer
+				// carries, while the aggregate behind it walks and decompresses
+				// every chunk of the archive.
+				name:     "twenty-seven years of daily buckets",
+				from:     eventStatsBulk,
+				to:       eventStatsBulk.AddDate(27, 0, 0),
+				interval: "1d",
+			},
+			{
+				// Every instant the contract's date-time can name. The distance
+				// between the two overflows a duration, which saturates rather than
+				// wrapping into a window that would pass the bound.
+				name:     "every instant there is",
+				from:     time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
+				to:       time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC),
+				interval: "1d",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					eventStatsPath("cloud,event_type", tc.from, tc.to, tc.interval), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeResultTooLarge)
+			})
+		}
+
+		t.Run("serves a window exactly as wide as the bound", func(t *testing.T) {
+			// The window one hour longer is what the refusal is decided on, so the
+			// one that meets the bound exactly is the boundary the answer still
+			// holds. It runs out before the earliest fixture of this test starts, so
+			// what comes back is the empty array rather than a grouping the other
+			// bound would then decide.
+			empty := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			list := eventStatsOf(t, a.call(t, http.MethodGet,
+				eventStatsPath("cloud,event_type", empty,
+					empty.Add(maxEventStatsWindow), "1h"), adminToken, nil))
+
+			if len(list.Items) != 0 {
+				t.Errorf("counted groups = %d, want the empty window answered as none", len(list.Items))
+			}
+		})
+	})
+
+	t.Run("confines a project token to the projects it holds", func(t *testing.T) {
+		held := seedProject(t, a, eventStatsCloudScope, eventStatsProjectMine)
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{held})
+		window := eventStatsPath("cloud,event_type", eventStatsScoped,
+			eventStatsScoped.Add(time.Hour), "1h")
+
+		// The other project stored its event in the same hour and the same cloud,
+		// so the count an unfiltered token reads is what the scoped one is told
+		// from.
+		admin := eventStatsOf(t, a.call(t, http.MethodGet, window, adminToken, nil))
+		if got, want := renderEventItems(admin.Items),
+			[]string{"2026-04-01T09:00:00Z|" + eventStatsCloudScope + "|volume.create|-=2"}; !slices.Equal(got, want) {
+			t.Fatalf("counted buckets = %q, want %q", got, want)
+		}
+
+		list := eventStatsOf(t, a.call(t, http.MethodGet, window, token, nil))
+
+		want := []string{"2026-04-01T09:00:00Z|" + eventStatsCloudScope + "|volume.create|-=1"}
+		if got := renderEventItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted buckets = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet, hourlyWindow, "", nil)
+
+		assertChallenged(t, rec)
+	})
+
+	t.Run("serves a read_all token the whole window", func(t *testing.T) {
+		admin := eventStatsOf(t, a.call(t, http.MethodGet, hourlyWindow, adminToken, nil))
+
+		list := eventStatsOf(t, a.call(t, http.MethodGet, hourlyWindow, readAllToken, nil))
+
+		if got, want := renderEventItems(list.Items), renderEventItems(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("counted buckets = %q, want the %q an admin token counts", got, want)
+		}
+	})
+}
+
+// TestGetEventStatsReportsAFailedQuery drives the handler's own failure path.
+// With authentication disabled nothing reads the database before the count does,
+// so a database that is gone stops the request inside the query rather than at
+// the credential lookup in front of it.
+func TestGetEventStatsReportsAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	rec := a.call(t, http.MethodGet, eventStatsPath("cloud,event_type", eventStatsHourly,
+		eventStatsHourly.Add(3*time.Hour), "1h"), "", nil)
+
+	assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+	// The detail is what tells the internal problems of this route apart: the
+	// count failed, rather than a scope that could not be resolved.
+	if got, want := problemDetail(t, rec), "the event counts could not be read"; got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+
+	// The same request over a window past the bound, against the same database
+	// that is gone. A 422 rather than the 500 above is what says the window was
+	// refused before anything was read, which is the whole point of bounding it:
+	// the refusal of a window too wide to aggregate must not cost the aggregation.
+	rec = a.call(t, http.MethodGet, eventStatsPath("cloud,event_type", eventStatsHourly,
+		eventStatsHourly.Add(maxEventStatsWindow+time.Hour), "1h"), "", nil)
+
+	assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeResultTooLarge)
+}
+
+// seedEventStatsEvents stores the events the counting subtests describe, each
+// fixture in the window its subtest asks for.
+//
+// They go in through POST /api/v1/events, so the counts are taken off the rows
+// the write path really stored. One of them cannot come from that path: the
+// pipeline records the pipeline it ran under whatever a collector claims, so the
+// reconciliation row is inserted through the pool.
+func seedEventStatsEvents(t *testing.T, a api) {
+	t.Helper()
+
+	first := fixture{cloud: eventStatsCloudA, resourceType: "volume", id: "vol-evstats-first"}
+	second := fixture{cloud: eventStatsCloudA, resourceType: "volume", id: "vol-evstats-second"}
+	third := fixture{cloud: eventStatsCloudA, resourceType: "volume", id: "vol-evstats-third"}
+	sibling := fixture{cloud: eventStatsCloudB, resourceType: "volume", id: "vol-evstats-sibling"}
+
+	ingestEvents(t, a, fixturePlatform, eventStatsCloudA,
+		// Two events of one hour that differ in their type, so the first bucket
+		// carries two items rather than one count of two.
+		first.event("evstats-first-create", "volume.create",
+			eventStatsHourly.Add(10*time.Minute), payloadOf("available", volumeSize(10))),
+		first.event("evstats-first-resize", "volume.resize",
+			eventStatsHourly.Add(40*time.Minute), payloadOf("available", volumeSize(20))),
+		// On the hour exactly, which is the bucket that instant opens: a bucket
+		// covers its width from its start on, the start included.
+		second.event("evstats-second-create", "volume.create",
+			eventStatsHourly.Add(time.Hour), payloadOf("available", volumeSize(30))))
+
+	// A synthetic event of the reconciliation pipeline, which no request can
+	// store: the ingest path records the pipeline it ran under itself. It carries
+	// the hour, the cloud, and the type of the collector's create above, so the
+	// two are one group until a request groups by source.
+	reconciled := third.event("evstats-third-create", "volume.create",
+		eventStatsHourly.Add(90*time.Minute), payloadOf("available", volumeSize(40)))
+	reconciled.Source = event.SourceReconciliation
+	payload, err := json.Marshal(reconciled.Payload)
+	if err != nil {
+		t.Fatalf("marshaling the payload of %s: %v", reconciled.EventID, err)
+	}
+	insertEventRow(t, a, reconciled, payload)
+
+	ingestEvents(t, a, fixturePlatform, eventStatsCloudB,
+		sibling.event("evstats-sibling-create", "volume.create",
+			eventStatsHourly.Add(2*time.Hour+15*time.Minute), payloadOf("available", volumeSize(50))))
+
+	// The daily fixture: two events on the last day of January and one on the
+	// first of February, the last two ninety minutes apart across midnight.
+	days := fixture{cloud: eventStatsCloudDays, resourceType: "volume", id: "vol-evstats-days"}
+	ingestEvents(t, a, fixturePlatform, eventStatsCloudDays,
+		days.event("evstats-days-first", "volume.update",
+			eventStatsDaily.Add(22*time.Hour), payloadOf("available", volumeSize(10))),
+		days.event("evstats-days-second", "volume.update",
+			eventStatsDaily.Add(23*time.Hour), payloadOf("in-use", volumeSize(10))),
+		days.event("evstats-days-third", "volume.update",
+			eventStatsDaily.Add(24*time.Hour+30*time.Minute), payloadOf("available", volumeSize(10))))
+
+	// The scope fixture: one event per project in one hour of one cloud.
+	mine := fixture{cloud: eventStatsCloudScope, resourceType: "volume", id: "vol-evstats-mine"}
+	other := fixture{cloud: eventStatsCloudScope, resourceType: "volume", id: "vol-evstats-other"}
+	ingestEvents(t, a, fixturePlatform, eventStatsCloudScope,
+		inProject(mine.event("evstats-scope-mine", "volume.create",
+			eventStatsScoped.Add(10*time.Minute), payloadOf("available", volumeSize(10))),
+			eventStatsProjectMine),
+		inProject(other.event("evstats-scope-other", "volume.create",
+			eventStatsScoped.Add(40*time.Minute), payloadOf("available", volumeSize(20))),
+			eventStatsProjectOther))
+}
+
+// seedEventStatsBulk stores one event per hour and cloud, one hour past what the
+// bound serves, in a window of its own.
+//
+// They are written through the pool rather than ingested: what is being pinned
+// is the handler's refusal, and pushing ten thousand events through the write
+// path would say nothing more about it. The two clouds share a type and a
+// pipeline, so the finest grouping there is holds exactly two rows per bucket
+// and the number of rows is what the bound is met with, over a window far
+// narrower than the one the window bound refuses.
+func seedEventStatsBulk(t *testing.T, a api) {
+	t.Helper()
+
+	for _, cloud := range []string{eventStatsCloudBulk, eventStatsCloudBulkB} {
+		if _, err := a.store.Pool().Exec(t.Context(),
+			`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+			                     resource_type, resource_id, project_id, source, payload)
+			 SELECT 'evstats-bulk-' || $3 || '-' || n, $1::timestamptz + (n * INTERVAL '1 hour'),
+			        'volume.update', $2, $3, 'volume', 'vol-evstats-bulk', $4, 'collector',
+			        '{"state": "available"}'::jsonb
+			 FROM generate_series(0, $5::int) AS n`,
+			eventStatsBulk, fixturePlatform, cloud, fixtureProject,
+			eventStatsBulkBuckets); err != nil {
+			t.Fatalf("writing an event grouping past the bound: %v", err)
+		}
+	}
+}
+
+// eventStatsPath is one statistics request: the grouping, the half-open window,
+// and the width of a bucket, as the query string carries them.
+func eventStatsPath(groupBy string, from, to time.Time, interval string) string {
+	return fmt.Sprintf("%s?group_by=%s&from=%s&to=%s&interval=%s",
+		eventStatsRoute, groupBy, instant(from), instant(to), interval)
+}
+
+// eventStatsOf decodes the answer of an event statistics call, which the
+// contract promises is a 200 carrying the counted buckets.
+func eventStatsOf(t *testing.T, rec *httptest.ResponseRecorder) EventStatsList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var list EventStatsList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if list.Items == nil {
+		t.Errorf("body %q carries items as null, want an array", rec.Body)
+	}
+	return list
+}

--- a/internal/reporting/httpapi/statsevents_test.go
+++ b/internal/reporting/httpapi/statsevents_test.go
@@ -1,0 +1,138 @@
+package httpapi
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// TestGroupEventCounts pins what the handler does with the counted buckets: the
+// source is summed away unless the request grouped by it, the bucket is stated
+// in UTC, and the items keep the order the contract states.
+func TestGroupEventCounts(t *testing.T) {
+	// The rows arrive as the query orders them, one bucket at a time. The second
+	// one is read in a zone other than UTC, which a connection may hand over: a
+	// bucket is one instant whatever zone it was decoded in, so it has to fold
+	// into the same item as the first and to be stated in UTC.
+	berlin := time.FixedZone("CEST", 2*60*60)
+	rows := []sqlcgen.CountEventBucketsRow{
+		{Bucket: bucketAt(t, "2026-07-01T00:00:00Z", time.UTC), Cloud: "os-prod-eu1", EventType: "instance.create", Source: "collector", Events: 4},
+		{Bucket: bucketAt(t, "2026-07-01T00:00:00Z", berlin), Cloud: "os-prod-eu1", EventType: "instance.create", Source: "reconciliation", Events: 1},
+		{Bucket: bucketAt(t, "2026-07-01T00:00:00Z", time.UTC), Cloud: "os-prod-eu1", EventType: "volume.delete", Source: "collector", Events: 2},
+		{Bucket: bucketAt(t, "2026-07-01T01:00:00Z", time.UTC), Cloud: "os-dev-eu1", EventType: "instance.create", Source: "collector", Events: 3},
+	}
+
+	tests := map[string]struct {
+		rows    []sqlcgen.CountEventBucketsRow
+		groupBy []GetEventStatsParamsGroupBy
+		want    []string
+	}{
+		"a grouping without source sums the pipelines of a bucket": {
+			rows: rows,
+			groupBy: []GetEventStatsParamsGroupBy{
+				GetEventStatsParamsGroupByCloud,
+				GetEventStatsParamsGroupByEventType,
+			},
+			want: []string{
+				"2026-07-01T00:00:00Z|os-prod-eu1|instance.create|-=5",
+				"2026-07-01T00:00:00Z|os-prod-eu1|volume.delete|-=2",
+				"2026-07-01T01:00:00Z|os-dev-eu1|instance.create|-=3",
+			},
+		},
+		"a grouping naming source keeps the pipelines apart": {
+			rows: rows,
+			groupBy: []GetEventStatsParamsGroupBy{
+				GetEventStatsParamsGroupByCloud,
+				GetEventStatsParamsGroupByEventType,
+				GetEventStatsParamsGroupBySource,
+			},
+			want: []string{
+				"2026-07-01T00:00:00Z|os-prod-eu1|instance.create|collector=4",
+				"2026-07-01T00:00:00Z|os-prod-eu1|instance.create|reconciliation=1",
+				"2026-07-01T00:00:00Z|os-prod-eu1|volume.delete|collector=2",
+				"2026-07-01T01:00:00Z|os-dev-eu1|instance.create|collector=3",
+			},
+		},
+		"a window holding no event yields no item": {
+			rows: nil,
+			groupBy: []GetEventStatsParamsGroupBy{
+				GetEventStatsParamsGroupByCloud,
+				GetEventStatsParamsGroupByEventType,
+			},
+			want: []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			items := groupEventCounts(tc.rows, tc.groupBy)
+			if items == nil {
+				t.Fatal("items = nil, want an empty array rather than a null one")
+			}
+			if got := renderEventItems(items); !slices.Equal(got, tc.want) {
+				t.Errorf("items = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBucketWidth pins the two widths the route offers against the literals the
+// query casts to an interval: the enum of the contract is what a caller names,
+// and Postgres is what reads the result.
+//
+// The last case is the one the enum keeps unreachable today. It is here because
+// an interval added to the contract regenerates the constants and validates
+// without touching the mapping, and answering it as an hour would bucket a
+// request by a width the answer carries no field to report.
+func TestBucketWidth(t *testing.T) {
+	tests := map[GetEventStatsParamsInterval]struct {
+		width string
+		ok    bool
+	}{
+		N1h:  {width: "1 hour", ok: true},
+		N1d:  {width: "1 day", ok: true},
+		"5m": {},
+		"1w": {},
+		"":   {},
+	}
+
+	for interval, want := range tests {
+		t.Run(string(interval), func(t *testing.T) {
+			width, ok := bucketWidth(interval)
+			if width != want.width || ok != want.ok {
+				t.Errorf("bucketWidth(%q) = %q, %v, want %q, %v",
+					interval, width, ok, want.width, want.ok)
+			}
+		})
+	}
+}
+
+// bucketAt is one bucket start as the query hands it over, read in the zone the
+// connection decoded it in.
+func bucketAt(t *testing.T, instant string, zone *time.Location) pgtype.Timestamptz {
+	t.Helper()
+
+	at, err := time.Parse(time.RFC3339, instant)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", instant, err)
+	}
+	return pgtype.Timestamptz{Time: at.In(zone), Valid: true}
+}
+
+// renderEventItems states the items as strings, so that a mismatch prints what
+// the members hold rather than the address the optional source carries. An
+// absent source renders as a dash, which is what tells it from one holding the
+// empty string.
+func renderEventItems(items []EventStatsItem) []string {
+	rendered := make([]string, len(items))
+	for i, item := range items {
+		rendered[i] = fmt.Sprintf("%s|%s|%s|%s=%d", item.Bucket.Format(time.RFC3339),
+			item.Cloud, item.EventType, renderOptional(item.Source), item.Count)
+	}
+	return rendered
+}

--- a/internal/reporting/httpapi/statsresources.go
+++ b/internal/reporting/httpapi/statsresources.go
@@ -1,0 +1,221 @@
+package httpapi
+
+import (
+	"cmp"
+	"context"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// resourceStatsDetail answers every failure of this route a caller can do
+// nothing about.
+const resourceStatsDetail = "the resource counts could not be read"
+
+// maxResourceStatsRows is how many groups this route counts at most. The answer
+// is not paginated, so without a bound the memory one request costs is set by
+// what the fleet holds: four of the five dimensions carry a handful of values
+// each, but project_id carries one per tenant, so the row set grows with the
+// number of projects a cloud has and every row of it is held three times over
+// before a byte is written.
+//
+// A request above the bound is refused rather than answered short, so a client
+// never mistakes a truncated grouping for a whole one. It is the bound the event
+// statistics count under, because both routes answer out of one unpaginated
+// slice and neither is worth more of a pod's memory than the other.
+const maxResourceStatsRows = 10000
+
+// largeFleetDetail answers a fleet carrying more groups than one answer holds.
+// It names what the caller changes to get through: the query counts along all
+// five dimensions whatever the request groups by, so a coarser grouping does not
+// lower the row set the refusal is decided on, and the part of the fleet the
+// request covers is what does.
+const largeFleetDetail = "this fleet carries more groups than the unpaginated statistics serve; " +
+	"a narrower status is what lowers it, and a coarser group_by does not"
+
+// historicCountsDetail answers a request that names the instant to count at. The
+// projection holds the present alone, and replaying the histories of a whole
+// fleet is what the Phase 3 usage records are for.
+const historicCountsDetail = "historic counts arrive with the Phase 3 usage records; " +
+	"omit at for the current counts"
+
+// GetResourceStats answers the projection counted along the dimensions the
+// request groups by, one item per combination of values the fleet carries.
+//
+// One static query counts along all five dimensions and the handler adds its
+// rows up onto the requested ones. Counts are additive, so a coarser grouping is
+// the sum of the finer rows over the dimensions it drops, and the thirty-one
+// groupings the route takes need one query rather than thirty-one.
+//
+// A project token counts the resources whose (cloud, project_id) pair one of its
+// projects names, which is the pair the resource list narrows its rows by.
+func (s *server) GetResourceStats(w http.ResponseWriter, r *http.Request, params GetResourceStatsParams) {
+	ctx := r.Context()
+
+	// cloud and resource_type are what an item is read by, so a grouping without
+	// them counts resources it cannot name. The rule spans two members of one
+	// list, which the contract cannot express; a dimension outside the enum and a
+	// repeated one are refused by the validator in front of this.
+	if !slices.Contains(params.GroupBy, GetResourceStatsParamsGroupByCloud) ||
+		!slices.Contains(params.GroupBy, GetResourceStatsParamsGroupByResourceType) {
+		problem.Write(w, http.StatusBadRequest, problem.TypeValidation,
+			"Validation failed", "group_by must name cloud and resource_type")
+		return
+	}
+	// Every at is refused, whatever instant it names. The projection holds the
+	// present alone, and an instant meaning "now" cannot be told from a historic
+	// one: the two differ by however long the request took to arrive.
+	if params.At != nil {
+		problem.Write(w, http.StatusNotImplemented, problem.TypeNotImplemented,
+			"Not implemented", historicCountsDetail)
+		return
+	}
+
+	scope, ok := s.queryScope(w, r)
+	if !ok {
+		return
+	}
+	// A filtered scope holding no project reaches no resource at all, so the
+	// empty answer is given here rather than asked of the database.
+	if !scope.Unfiltered && len(scope.Refs) == 0 {
+		writeJSON(w, ResourceStatsList{Items: []ResourceStatsItem{}})
+		return
+	}
+
+	clouds, projects := scopeFilter(scope)
+	rows, err := s.queries.CountCurrentResourcesGrouped(ctx, sqlcgen.CountCurrentResourcesGroupedParams{
+		Deleted:       statsStatusFilter(params.Status),
+		ScopeClouds:   clouds,
+		ScopeProjects: projects,
+		RowCap:        maxResourceStatsRows + 1,
+	})
+	if err != nil {
+		writeInternal(ctx, w, "counting resources", err, resourceStatsDetail)
+		return
+	}
+	// The query reads one row past the bound, so a row set of exactly the bound
+	// is a whole answer and one longer is the refusal.
+	if len(rows) > maxResourceStatsRows {
+		refuseLargeFleet(ctx, w, params)
+		return
+	}
+
+	writeJSON(w, ResourceStatsList{Items: groupResourceCounts(rows, params.GroupBy)})
+}
+
+// refuseLargeFleet answers a request whose grouping fills more rows than one
+// answer carries, and logs what was asked for: the bound being hit at all is an
+// operational signal, and the response says nothing about the request that hit
+// it.
+func refuseLargeFleet(ctx context.Context, w http.ResponseWriter, params GetResourceStatsParams) {
+	Logger(ctx).Warn("refusing a resource grouping above the bound",
+		"group_by", params.GroupBy, "status", params.Status, "bound", maxResourceStatsRows)
+	problem.Write(w, http.StatusUnprocessableEntity, problem.TypeResultTooLarge,
+		"Result too large", largeFleetDetail)
+}
+
+// resourceGroup is the combination of values one item stands for, which is what
+// the counts are keyed by while they are added up. A dimension the request did
+// not group by stays the empty string, so every row of the query projects onto
+// the same key and the counts of the rows merge there.
+type resourceGroup struct {
+	cloud        string
+	resourceType string
+	state        string
+	platform     string
+	projectID    string
+}
+
+// groupResourceCounts adds the counted rows up onto the dimensions the request
+// asked for and renders them as the answer the contract promises.
+//
+// An optional member is set exactly when the grouping names its dimension: the
+// value stands for the resources of one state, platform, or project only when
+// the count was taken per state, platform, or project.
+//
+// The items come out ordered the way the contract states, with a dimension
+// outside the grouping compared as the empty string it was keyed by, and the
+// slice is never nil: a fleet the grouping counts nothing of is answered as the
+// empty array.
+func groupResourceCounts(rows []sqlcgen.CountCurrentResourcesGroupedRow,
+	groupBy []GetResourceStatsParamsGroupBy,
+) []ResourceStatsItem {
+	byState := slices.Contains(groupBy, GetResourceStatsParamsGroupByState)
+	byPlatform := slices.Contains(groupBy, GetResourceStatsParamsGroupByPlatform)
+	byProject := slices.Contains(groupBy, GetResourceStatsParamsGroupByProjectId)
+
+	counts := make(map[resourceGroup]int64, len(rows))
+	for _, row := range rows {
+		group := resourceGroup{cloud: row.Cloud, resourceType: row.ResourceType}
+		if byState {
+			group.state = row.State
+		}
+		if byPlatform {
+			group.platform = row.Platform
+		}
+		if byProject {
+			group.projectID = row.ProjectID
+		}
+		counts[group] += row.Resources
+	}
+
+	items := make([]ResourceStatsItem, 0, len(counts))
+	for _, group := range slices.SortedFunc(maps.Keys(counts), compareResourceGroups) {
+		items = append(items, ResourceStatsItem{
+			Cloud:        group.cloud,
+			ResourceType: group.resourceType,
+			State:        groupedValue(byState, group.state),
+			Platform:     groupedValue(byPlatform, group.platform),
+			ProjectId:    groupedValue(byProject, group.projectID),
+			Count:        counts[group],
+		})
+	}
+	return items
+}
+
+// compareResourceGroups orders two groups over their five dimensions, in the
+// order the contract states.
+func compareResourceGroups(a, b resourceGroup) int {
+	return cmp.Or(
+		strings.Compare(a.cloud, b.cloud),
+		strings.Compare(a.resourceType, b.resourceType),
+		strings.Compare(a.state, b.state),
+		strings.Compare(a.platform, b.platform),
+		strings.Compare(a.projectID, b.projectID),
+	)
+}
+
+// groupedValue renders one optional dimension of a statistics item: the value
+// when the request grouped by it, and nothing otherwise. The two statistics
+// routes share it, because both carry the members a grouping names and leave the
+// others out rather than sending the empty string.
+func groupedValue(grouped bool, value string) *string {
+	if !grouped {
+		return nil
+	}
+	return &value
+}
+
+// statsStatusFilter maps the status parameter of this route onto the one boolean
+// the query splits the fleet with: false counts the rows that live, true the
+// deleted ones, and NULL both. It is filterStatus for the second operation that
+// declares the parameter, which the generator types apart from the first.
+//
+// A request naming no status counts the active rows. The contract's default says
+// so, and the generated binding does not apply it, so it is applied here.
+func statsStatusFilter(status *GetResourceStatsParamsStatus) pgtype.Bool {
+	value := GetResourceStatsParamsStatusActive
+	if status != nil {
+		value = *status
+	}
+	if value == GetResourceStatsParamsStatusAll {
+		return pgtype.Bool{}
+	}
+	return pgtype.Bool{Bool: value == GetResourceStatsParamsStatusDeleted, Valid: true}
+}

--- a/internal/reporting/httpapi/statsresources_integration_test.go
+++ b/internal/reporting/httpapi/statsresources_integration_test.go
@@ -1,0 +1,483 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi/problem"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// resourceStatsRoute is the route the resource statistics tests call, spelled
+// once because every one of them addresses it.
+const resourceStatsRoute = "/api/v1/stats/resources"
+
+// The clouds the counted fleet lives in, and the platform of the third. This
+// route carries no filter at all, so what it counts is the whole projection:
+// the clouds are what the assertions tell the fixture's parts apart by.
+const (
+	statsCloudA    = "os-stats-a"
+	statsCloudB    = "os-stats-b"
+	statsCloudC    = "tally-stats-c"
+	statsPlatformC = "tallytest"
+)
+
+// The projects the fleet names. The second one shares a cloud with the first,
+// and the first is also the project of a resource in another cloud, so a scope
+// narrowing on the (cloud, project) pair answers something neither half of the
+// pair answers alone.
+const (
+	statsProjectA = "stats-project-a"
+	statsProjectB = "stats-project-b"
+)
+
+// The instants the fleet is built at: a create, a change, and a delete an hour
+// apart. What is counted is the projection rather than the events, so the
+// instants matter only in that the delete comes last.
+var (
+	statsCreated = time.Date(2026, 5, 1, 6, 0, 0, 0, time.UTC)
+	statsChanged = statsCreated.Add(time.Hour)
+	statsRemoved = statsCreated.Add(2 * time.Hour)
+)
+
+// statsFlavor is a size the seeded (openstack, instance) schema accepts.
+var statsFlavor = map[string]any{"vcpus": 2, "ram_gb": 4, "disk_gb": 20, "flavor": "m1.small"}
+
+// TestGetResourceStatsOverHTTP drives GET /api/v1/stats/resources through the
+// whole stack: the contract validator, the grouping rule the handler enforces,
+// the project scope, and the projection rows the counts come from.
+//
+// The subtests share one database and run in order. The route counts the whole
+// projection, so the fleet is seeded between the one subtest that describes an
+// empty projection and the ones that describe the fleet; the subtests after
+// those register projects, which counts no resource of their own.
+func TestGetResourceStatsOverHTTP(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	_, readAllToken := seedAPIToken(t, a.queries, auth.RoleReadAll, nil)
+
+	t.Run("answers a projection holding nothing with the empty array", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type", adminToken, nil)
+
+		if got := rec.Code; got != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+		}
+		// The raw body rather than the decoded one: a client iterates items
+		// without a nil check, which null would break and [] does not.
+		want := `{"items":[]}`
+		if got := strings.TrimSpace(rec.Body.String()); got != want {
+			t.Errorf("body = %s, want %s", got, want)
+		}
+	})
+
+	seedStatsFleet(t, a)
+
+	t.Run("counts the live fleet along the two dimensions an item is read by", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type", adminToken, nil)
+
+		list := resourceStatsOf(t, rec)
+		// The deleted volume is not in these counts: the contract's default is
+		// active, and the status subtests below are what say so in full.
+		want := []string{
+			statsCloudA + "/instance/-/-/-=2",
+			statsCloudA + "/volume/-/-/-=2",
+			statsCloudB + "/instance/-/-/-=1",
+			statsCloudC + "/widget/-/-/-=1",
+		}
+		if got := renderResourceItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted groups = %q, want %q", got, want)
+		}
+		// A dash stands for a member that decoded to nil, which a member holding
+		// the empty string would not produce; the raw body is what says the three
+		// dimensions this grouping did not name are off the wire entirely.
+		body := rec.Body.String()
+		for _, member := range []string{`"state"`, `"platform"`, `"project_id"`} {
+			if strings.Contains(body, member) {
+				t.Errorf("body = %s, want it to carry no %s", body, member)
+			}
+		}
+	})
+
+	t.Run("carries every optional member a grouping names", func(t *testing.T) {
+		list := resourceStatsOf(t, a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type,state,platform,project_id", adminToken, nil))
+
+		// The finest grouping there is: one item per resource, since no two live
+		// resources of the fleet agree on all five dimensions.
+		want := []string{
+			statsCloudA + "/instance/active/openstack/" + statsProjectA + "=1",
+			statsCloudA + "/instance/shutoff/openstack/" + statsProjectA + "=1",
+			statsCloudA + "/volume/available/openstack/" + statsProjectA + "=1",
+			statsCloudA + "/volume/available/openstack/" + statsProjectB + "=1",
+			statsCloudB + "/instance/active/openstack/" + statsProjectA + "=1",
+			statsCloudC + "/widget/ready/" + statsPlatformC + "/" + statsProjectA + "=1",
+		}
+		if got := renderResourceItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted groups = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("counts the fleet the status names", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+			want  []string
+		}{
+			{
+				// No status at all: the contract's default is active, and the
+				// deleted volume missing from the counts is what says it was
+				// applied.
+				name:  "no status",
+				query: "",
+				want: []string{
+					statsCloudA + "/instance/active/-/-=1",
+					statsCloudA + "/instance/shutoff/-/-=1",
+					statsCloudA + "/volume/available/-/-=2",
+					statsCloudB + "/instance/active/-/-=1",
+					statsCloudC + "/widget/ready/-/-=1",
+				},
+			},
+			{
+				name:  "status=all",
+				query: "&status=all",
+				want: []string{
+					statsCloudA + "/instance/active/-/-=1",
+					statsCloudA + "/instance/shutoff/-/-=1",
+					statsCloudA + "/volume/available/-/-=2",
+					statsCloudA + "/volume/deleted/-/-=1",
+					statsCloudB + "/instance/active/-/-=1",
+					statsCloudC + "/widget/ready/-/-=1",
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				list := resourceStatsOf(t, a.call(t, http.MethodGet,
+					resourceStatsRoute+"?group_by=cloud,resource_type,state"+tc.query, adminToken, nil))
+
+				if got := renderResourceItems(list.Items); !slices.Equal(got, tc.want) {
+					t.Errorf("counted groups = %q, want %q", got, tc.want)
+				}
+			})
+		}
+
+		t.Run("counts every row the metrics gauge counts", func(t *testing.T) {
+			// The gauge and this route read the same projection through two
+			// queries, and the fixture is the whole of it, so the counts of one
+			// have to be the counts of the other. The gauge groups by platform as
+			// well, which is a dimension this grouping drops, so its rows are
+			// summed over it the way a coarser grouping sums them.
+			list := resourceStatsOf(t, a.call(t, http.MethodGet,
+				resourceStatsRoute+"?group_by=cloud,resource_type,state&status=all", adminToken, nil))
+
+			counted := make(map[string]int64, len(list.Items))
+			for _, item := range list.Items {
+				if item.State == nil {
+					t.Fatalf("item %+v carries no state, want the dimension it was grouped by", item)
+				}
+				counted[item.Cloud+"/"+item.ResourceType+"/"+*item.State] += item.Count
+			}
+
+			if want := gaugeGroups(t, a); !maps.Equal(counted, want) {
+				t.Errorf("counted groups = %v, want the %v the gauge reports", counted, want)
+			}
+		})
+	})
+
+	t.Run("refuses a grouping that cannot name what it counted", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "without cloud", query: "group_by=resource_type"},
+			{name: "without resource_type", query: "group_by=cloud"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, resourceStatsRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+				if got, want := problemDetail(t, rec),
+					"group_by must name cloud and resource_type"; got != want {
+					t.Errorf("detail = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a grouping the contract does not allow", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "a dimension outside the enum", query: "group_by=cloud,resource_type,bogus"},
+			{name: "a dimension named twice", query: "group_by=cloud,cloud,resource_type"},
+			{name: "no grouping at all", query: ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet, resourceStatsRoute+"?"+tc.query, adminToken, nil)
+
+				assertProblem(t, rec, http.StatusBadRequest, problem.TypeValidation)
+			})
+		}
+	})
+
+	t.Run("refuses every at, whatever instant it names", func(t *testing.T) {
+		// The projection holds the present alone, and an instant meaning "now"
+		// cannot be told from a historic one, so both are refused rather than one
+		// of them answered from the rows that happen to be there.
+		for _, tc := range []struct {
+			name string
+			at   time.Time
+		}{
+			{name: "an instant in the past", at: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+			{name: "an instant meaning now", at: time.Now().UTC()},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rec := a.call(t, http.MethodGet,
+					resourceStatsRoute+"?group_by=cloud,resource_type&at="+instant(tc.at), adminToken, nil)
+
+				assertProblem(t, rec, http.StatusNotImplemented, problem.TypeNotImplemented)
+			})
+		}
+	})
+
+	t.Run("confines a project token to the projects it holds", func(t *testing.T) {
+		// The fleet holds the other project of this cloud and the same project id
+		// under another cloud, so what the token counts says the scope narrows on
+		// the pair rather than on either half of it.
+		held := seedProject(t, a, statsCloudA, statsProjectA)
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{held})
+
+		list := resourceStatsOf(t, a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type", token, nil))
+
+		want := []string{
+			statsCloudA + "/instance/-/-/-=2",
+			statsCloudA + "/volume/-/-/-=1",
+		}
+		if got := renderResourceItems(list.Items); !slices.Equal(got, want) {
+			t.Errorf("counted groups = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("answers a token whose scope holds no project with the empty array", func(t *testing.T) {
+		// A project token always carries at least one project id, which the table
+		// constrains; what it names may be gone, and the scope then narrows to
+		// nothing rather than widening to everything.
+		_, token := seedAPIToken(t, a.queries, auth.RoleProject, []uuid.UUID{uuid.New()})
+
+		rec := a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type", token, nil)
+
+		if got := rec.Code; got != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+		}
+		want := `{"items":[]}`
+		if got := strings.TrimSpace(rec.Body.String()); got != want {
+			t.Errorf("body = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("refuses a request this API cannot authenticate", func(t *testing.T) {
+		rec := a.call(t, http.MethodGet,
+			resourceStatsRoute+"?group_by=cloud,resource_type", "", nil)
+
+		assertChallenged(t, rec)
+	})
+
+	t.Run("serves a read_all token the whole fleet", func(t *testing.T) {
+		query := resourceStatsRoute + "?group_by=cloud,resource_type,state&status=all"
+		admin := resourceStatsOf(t, a.call(t, http.MethodGet, query, adminToken, nil))
+
+		list := resourceStatsOf(t, a.call(t, http.MethodGet, query, readAllToken, nil))
+
+		if got, want := renderResourceItems(list.Items), renderResourceItems(admin.Items); !slices.Equal(got, want) {
+			t.Errorf("counted groups = %q, want the %q an admin token counts", got, want)
+		}
+	})
+}
+
+// TestGetResourceStatsRefusesAFleetAboveTheBound pins the row bound of the
+// route, on a database of its own: the counts cover the whole projection, so a
+// fleet this size seeded beside the fixture above would move every count the
+// subtests there assert on.
+//
+// The grouping names project_id, which is the one dimension that carries a value
+// per tenant and so the one the row set grows along.
+func TestGetResourceStatsRefusesAFleetAboveTheBound(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPI(t, db.Store)
+
+	_, adminToken := seedAPIToken(t, a.queries, auth.RoleAdmin, nil)
+	query := resourceStatsRoute + "?group_by=cloud,resource_type,project_id"
+
+	seedStatsBulkFleet(t, a, 1, maxResourceStatsRows)
+
+	// The row one past the bound is what the refusal is decided on, so a fleet
+	// filling it exactly is the boundary the answer still holds.
+	list := resourceStatsOf(t, a.call(t, http.MethodGet, query, adminToken, nil))
+	if got := len(list.Items); got != maxResourceStatsRows {
+		t.Fatalf("counted groups = %d, want the %d the bound allows", got, maxResourceStatsRows)
+	}
+
+	seedStatsBulkFleet(t, a, maxResourceStatsRows+1, maxResourceStatsRows+1)
+
+	rec := a.call(t, http.MethodGet, query, adminToken, nil)
+
+	assertProblem(t, rec, http.StatusUnprocessableEntity, problem.TypeResultTooLarge)
+}
+
+// seedStatsBulkFleet writes one live projection row per project in the numbered
+// range, all of them in one cloud and of one type, so the number of groups the
+// finest counting sees is the number of rows written.
+//
+// They go in through the pool rather than through ingestion: what is being
+// pinned is the handler's refusal, and folding ten thousand events into the
+// projection would say nothing more about it.
+func seedStatsBulkFleet(t *testing.T, a api, first, last int) {
+	t.Helper()
+
+	if _, err := a.store.Pool().Exec(t.Context(),
+		`INSERT INTO current_resources (cloud, platform, resource_type, resource_id,
+		                                project_id, state, last_event_type, last_event_at)
+		 SELECT $1, $2, 'volume', 'vol-stats-bulk-' || n, 'stats-bulk-project-' || n,
+		        'available', 'volume.create', $3::timestamptz
+		 FROM generate_series($4::int, $5::int) AS n`,
+		statsCloudA, fixturePlatform, statsCreated, first, last); err != nil {
+		t.Fatalf("writing a fleet past the bound: %v", err)
+	}
+}
+
+// TestGetResourceStatsReportsAFailedQuery drives the handler's own failure path.
+// With authentication disabled nothing reads the database before the count does,
+// so a database that is gone stops the request inside the query rather than at
+// the credential lookup in front of it.
+func TestGetResourceStatsReportsAFailedQuery(t *testing.T) {
+	db := storetest.NewDB(t)
+	a := newAPIInMode(t, db.Store, auth.ModeDisabled)
+
+	// How long the database gets to shut down cleanly.
+	stopTimeout := 10 * time.Second
+	if err := db.Container.Stop(t.Context(), &stopTimeout); err != nil {
+		t.Fatalf("stopping the database container: %v", err)
+	}
+
+	rec := a.call(t, http.MethodGet, resourceStatsRoute+"?group_by=cloud,resource_type", "", nil)
+
+	assertProblem(t, rec, http.StatusInternalServerError, problem.TypeInternal)
+	// The detail is what tells the internal problems of this route apart: the
+	// count failed, rather than a scope that could not be resolved.
+	if got, want := problemDetail(t, rec), "the resource counts could not be read"; got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+// seedStatsFleet stores the resources the counting subtests describe. They go in
+// through POST /api/v1/events, so the counts are taken off the rows the write
+// path really folded.
+//
+// The fleet is shaped so that every dimension of the grouping separates
+// something: two instances of one project in one state each, two volumes of two
+// projects in one cloud, a third volume that was deleted, an instance of the
+// first project in another cloud, and a resource of a platform of its own.
+func seedStatsFleet(t *testing.T, a api) {
+	t.Helper()
+
+	active := fixture{cloud: statsCloudA, resourceType: "instance", id: "inst-stats-active"}
+	off := fixture{cloud: statsCloudA, resourceType: "instance", id: "inst-stats-off"}
+	alive := fixture{cloud: statsCloudA, resourceType: "volume", id: "vol-stats-alive"}
+	gone := fixture{cloud: statsCloudA, resourceType: "volume", id: "vol-stats-gone"}
+	sibling := fixture{cloud: statsCloudA, resourceType: "volume", id: "vol-stats-sibling"}
+	elsewhere := fixture{cloud: statsCloudB, resourceType: "instance", id: "inst-stats-elsewhere"}
+	widget := fixture{cloud: statsCloudC, resourceType: "widget", id: "widget-stats"}
+
+	ingestEvents(t, a, fixturePlatform, statsCloudA,
+		inProject(active.event("inst-stats-active-create", "instance.create",
+			statsCreated, payloadOf("active", statsFlavor)), statsProjectA),
+		// The one instance that was powered off, which is the state that keeps
+		// this cloud's two instances apart under a grouping by state.
+		inProject(off.event("inst-stats-off-create", "instance.create",
+			statsCreated, payloadOf("active", statsFlavor)), statsProjectA),
+		inProject(off.event("inst-stats-off-power-off", "instance.power_off",
+			statsChanged, payloadOf("shutoff", nil)), statsProjectA),
+		inProject(alive.event("vol-stats-alive-create", "volume.create",
+			statsCreated, payloadOf("available", volumeSize(10))), statsProjectA),
+		// A deleted resource keeps its projection row under state 'deleted', so it
+		// is what the status filter is readable on.
+		inProject(gone.event("vol-stats-gone-create", "volume.create",
+			statsCreated, payloadOf("available", volumeSize(20))), statsProjectA),
+		inProject(gone.event("vol-stats-gone-delete", "volume.delete",
+			statsRemoved, event.PayloadEnvelope{}), statsProjectA),
+		inProject(sibling.event("vol-stats-sibling-create", "volume.create",
+			statsCreated, payloadOf("available", volumeSize(30))), statsProjectB))
+
+	ingestEvents(t, a, fixturePlatform, statsCloudB,
+		inProject(elsewhere.event("inst-stats-elsewhere-create", "instance.create",
+			statsCreated, payloadOf("active", statsFlavor)), statsProjectA))
+
+	built := inProject(widget.event("widget-stats-create", "widget.create",
+		statsCreated, payloadOf("ready", map[string]any{"units": 1})), statsProjectA)
+	built.Platform = statsPlatformC
+	ingestEvents(t, a, statsPlatformC, statsCloudC, built)
+}
+
+// inProject stamps which project an event's resource belongs to. The shared
+// fixture builds every event under one project, and which project a resource
+// belongs to is a dimension these counts are grouped and scoped by.
+func inProject(e event.Event, projectID string) event.Event {
+	e.ProjectID = projectID
+	return e
+}
+
+// gaugeGroups is the projection as the metrics gauge counts it, keyed the way a
+// grouping by cloud, resource type, and state keys its items. The gauge counts
+// per platform too, so its rows are summed over that dimension here.
+func gaugeGroups(t *testing.T, a api) map[string]int64 {
+	t.Helper()
+
+	rows, err := a.queries.CountCurrentResources(t.Context())
+	if err != nil {
+		t.Fatalf("CountCurrentResources() error = %v, want nil", err)
+	}
+
+	counts := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		counts[row.Cloud+"/"+row.ResourceType+"/"+row.State] += row.Resources
+	}
+	return counts
+}
+
+// resourceStatsOf decodes the answer of a resource statistics call, which the
+// contract promises is a 200 carrying the counted groups.
+func resourceStatsOf(t *testing.T, rec *httptest.ResponseRecorder) ResourceStatsList {
+	t.Helper()
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body %q)", got, http.StatusOK, rec.Body)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+
+	var list ResourceStatsList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decoding the body %q: %v", rec.Body.String(), err)
+	}
+	if list.Items == nil {
+		t.Errorf("body %q carries items as null, want an array", rec.Body)
+	}
+	return list
+}

--- a/internal/reporting/httpapi/statsresources_test.go
+++ b/internal/reporting/httpapi/statsresources_test.go
@@ -1,0 +1,152 @@
+package httpapi
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// TestGroupResourceCounts pins the property the one static query stands on: a
+// coarser grouping is the sum of the counted rows over the dimensions it drops,
+// so every grouping the route takes is answered from the rows counted along all
+// five. The items carry the optional members the request grouped by and no
+// others, and they come out in the order the contract states.
+func TestGroupResourceCounts(t *testing.T) {
+	rows := []sqlcgen.CountCurrentResourcesGroupedRow{
+		{
+			Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+			State: "active", ProjectID: "p-1", Resources: 2,
+		},
+		{
+			Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+			State: "shutoff", ProjectID: "p-1", Resources: 3,
+		},
+		{
+			Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+			State: "active", ProjectID: "p-2", Resources: 5,
+		},
+		{
+			Cloud: "os-dev-eu1", Platform: "openstack", ResourceType: "volume",
+			State: "active", ProjectID: "p-1", Resources: 7,
+		},
+	}
+
+	tests := map[string]struct {
+		rows    []sqlcgen.CountCurrentResourcesGroupedRow
+		groupBy []GetResourceStatsParamsGroupBy
+		want    []string
+	}{
+		"the coarsest grouping sums every row of a resource type": {
+			rows: rows,
+			groupBy: []GetResourceStatsParamsGroupBy{
+				GetResourceStatsParamsGroupByCloud,
+				GetResourceStatsParamsGroupByResourceType,
+			},
+			want: []string{
+				"os-dev-eu1/volume/-/-/-=7",
+				"os-prod-eu1/instance/-/-/-=10",
+			},
+		},
+		"grouping by state keeps the states apart and sums the projects": {
+			rows: rows,
+			groupBy: []GetResourceStatsParamsGroupBy{
+				GetResourceStatsParamsGroupByCloud,
+				GetResourceStatsParamsGroupByResourceType,
+				GetResourceStatsParamsGroupByState,
+			},
+			want: []string{
+				"os-dev-eu1/volume/active/-/-=7",
+				"os-prod-eu1/instance/active/-/-=7",
+				"os-prod-eu1/instance/shutoff/-/-=3",
+			},
+		},
+		"grouping by project and platform carries both members": {
+			rows: rows,
+			groupBy: []GetResourceStatsParamsGroupBy{
+				GetResourceStatsParamsGroupByCloud,
+				GetResourceStatsParamsGroupByResourceType,
+				GetResourceStatsParamsGroupByPlatform,
+				GetResourceStatsParamsGroupByProjectId,
+			},
+			want: []string{
+				"os-dev-eu1/volume/-/openstack/p-1=7",
+				"os-prod-eu1/instance/-/openstack/p-1=5",
+				"os-prod-eu1/instance/-/openstack/p-2=5",
+			},
+		},
+		"a fleet the query counted nothing of yields no item": {
+			rows: nil,
+			groupBy: []GetResourceStatsParamsGroupBy{
+				GetResourceStatsParamsGroupByCloud,
+				GetResourceStatsParamsGroupByResourceType,
+			},
+			want: []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			items := groupResourceCounts(tc.rows, tc.groupBy)
+			if items == nil {
+				t.Fatal("items = nil, want an empty array rather than a null one")
+			}
+			if got := renderResourceItems(items); !slices.Equal(got, tc.want) {
+				t.Errorf("items = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStatsStatusFilter pins how the status parameter reaches the counting
+// query, the default a request that names none included: the contract declares
+// it and the generated binding does not apply it.
+func TestStatsStatusFilter(t *testing.T) {
+	active := GetResourceStatsParamsStatusActive
+	deleted := GetResourceStatsParamsStatusDeleted
+	all := GetResourceStatsParamsStatusAll
+
+	tests := map[string]struct {
+		status *GetResourceStatsParamsStatus
+		want   pgtype.Bool
+	}{
+		"no status counts the fleet that lives": {status: nil, want: pgtype.Bool{Valid: true}},
+		"active counts the fleet that lives":    {status: &active, want: pgtype.Bool{Valid: true}},
+		"deleted counts the gone ones alone":    {status: &deleted, want: pgtype.Bool{Bool: true, Valid: true}},
+		"all counts both, which is no filter":   {status: &all, want: pgtype.Bool{}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := statsStatusFilter(tc.status); got != tc.want {
+				t.Errorf("statsStatusFilter() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// renderResourceItems states the items as strings, so that a mismatch prints
+// what the members hold rather than the addresses the optional ones carry. An
+// absent member renders as a dash, which is what tells it from one holding the
+// empty string.
+func renderResourceItems(items []ResourceStatsItem) []string {
+	rendered := make([]string, len(items))
+	for i, item := range items {
+		rendered[i] = fmt.Sprintf("%s/%s/%s/%s/%s=%d", item.Cloud, item.ResourceType,
+			renderOptional(item.State), renderOptional(item.Platform),
+			renderOptional(item.ProjectId), item.Count)
+	}
+	return rendered
+}
+
+// renderOptional states one optional member of a statistics item, a dash for the
+// member the answer leaves out.
+func renderOptional(value *string) string {
+	if value == nil {
+		return "-"
+	}
+	return *value
+}

--- a/internal/reporting/stats/stats.go
+++ b/internal/reporting/stats/stats.go
@@ -1,0 +1,153 @@
+// Package stats aggregates folded resource histories into the per-window
+// activity the project summary reports: per resource type, how many resources
+// began or ended their life inside the window, and how many minutes they ran
+// within it. It folds through internal/core/timeline, so the summary counts the
+// same intervals every other consumer of a history counts.
+//
+// The package does no I/O. Loading the histories is the caller's job, which
+// keeps the arithmetic answerable without a database.
+//
+// The normative specification is roadmap/02-phase-2-reporting-dashboards.md,
+// WP 2.1.
+package stats
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/timeline"
+)
+
+// secondsPerMinute converts the second sums the intervals add up to into the
+// minutes the summary reports.
+const secondsPerMinute = 60
+
+// History is one resource's stored events together with the type of resource
+// they describe. Each resource folds on its own, so a caller passes one History
+// per resource rather than one merged event slice.
+type History struct {
+	ResourceType string
+	Events       []event.Stored
+}
+
+// Activity is what one resource type did inside a window.
+type Activity struct {
+	ResourceType string
+	// Created and Deleted count the resources of the type whose life began or
+	// ended inside the window.
+	Created int
+	Deleted int
+	// TotalMinutes is the time every resource of the type ran within the window,
+	// truncated to whole minutes.
+	TotalMinutes int64
+}
+
+// Summarize folds each history and aggregates the results per resource type
+// over the half-open window [from, to), for the project projectID names. A
+// create or a delete counts when the folded timestamp falls inside the window.
+// An interval contributes the seconds it overlaps the window, whatever state the
+// resource was in: what a state is worth is a rating question, and rating is
+// Phase 3. An interval still open ends at now, so a window reaching into the
+// future bills no time that has not been served yet.
+//
+// The histories are whole ones, and projectID is what says which part of each
+// belongs to this summary. A resource that changed hands accrues its seconds
+// here only over the intervals it carried this project through: the transfer
+// closes the interval the resource ran under the old owner and opens one under
+// the new, so a resource is billed to one project at a time rather than to both
+// for the rest of its life. What a project created and deleted is read off its
+// own events instead, because a transfer moves a resource rather than its birth.
+//
+// A resource type gets a row once one of the project's histories of it folds
+// into a life or an interval, even when the window holds nothing of it. A
+// history the project has no event in folds into nothing and gets no row.
+//
+// The result is sorted by resource type and is never nil.
+func Summarize(histories []History, projectID string, from, to, now time.Time) []Activity {
+	type totals struct {
+		created int
+		deleted int
+		seconds int64
+	}
+
+	byType := make(map[string]totals, len(histories))
+	for _, h := range histories {
+		tl := timeline.Build(h.Events)
+		own := timeline.Build(eventsOf(h.Events, projectID))
+		if own.CreatedAt == nil && own.DeletedAt == nil && len(own.Intervals) == 0 {
+			continue
+		}
+
+		t := byType[h.ResourceType]
+		if inWindow(own.CreatedAt, from, to) {
+			t.created++
+		}
+		if inWindow(own.DeletedAt, from, to) {
+			t.deleted++
+		}
+		for _, interval := range tl.Intervals {
+			if interval.ProjectID != projectID {
+				continue
+			}
+			t.seconds += overlapSeconds(interval, from, to, now)
+		}
+		byType[h.ResourceType] = t
+	}
+
+	activities := make([]Activity, 0, len(byType))
+	for resourceType, t := range byType {
+		activities = append(activities, Activity{
+			ResourceType: resourceType,
+			Created:      t.created,
+			Deleted:      t.deleted,
+			TotalMinutes: t.seconds / secondsPerMinute,
+		})
+	}
+	slices.SortFunc(activities, func(a, b Activity) int {
+		return strings.Compare(a.ResourceType, b.ResourceType)
+	})
+	return activities
+}
+
+// eventsOf is the part of a history one project wrote, which is what its own
+// lifecycle is folded from: a transfer carries the new project on the event that
+// moves the resource, so an event names the project that held it when it
+// happened.
+func eventsOf(events []event.Stored, projectID string) []event.Stored {
+	own := make([]event.Stored, 0, len(events))
+	for _, e := range events {
+		if e.ProjectID == projectID {
+			own = append(own, e)
+		}
+	}
+	return own
+}
+
+// inWindow reports whether a lifecycle timestamp falls inside the half-open
+// window [from, to). A nil timestamp is a life that never began or has not
+// ended, and neither happened in any window.
+func inWindow(ts *time.Time, from, to time.Time) bool {
+	return ts != nil && !ts.Before(from) && ts.Before(to)
+}
+
+// overlapSeconds is the whole seconds an interval ran inside [from, to). An open
+// interval ends at now, which is as far as it has accrued; clipping it to a
+// later to would bill time the resource has not spent yet.
+func overlapSeconds(interval timeline.Interval, from, to, now time.Time) int64 {
+	start, end := interval.Start, now
+	if interval.End != nil {
+		end = *interval.End
+	}
+	if start.Before(from) {
+		start = from
+	}
+	if to.Before(end) {
+		end = to
+	}
+	if !end.After(start) {
+		return 0
+	}
+	return int64(end.Sub(start) / time.Second)
+}

--- a/internal/reporting/stats/stats_test.go
+++ b/internal/reporting/stats/stats_test.go
@@ -1,0 +1,311 @@
+package stats_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/stats"
+)
+
+// The window every case is measured against, unless the case names its own. It
+// is a day long, so a resource that runs through all of it bills 1440 minutes.
+var (
+	windowFrom = time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	windowTo   = windowFrom.Add(24 * time.Hour)
+)
+
+// summaryProject is the project every fixture belongs to unless the case moves a
+// resource out of it, and otherProject is where a transferred resource ends up.
+const (
+	summaryProject = "p-1"
+	otherProject   = "p-2"
+)
+
+// ev builds a stored event with the identity every fixture here shares. These
+// tests vary only the event type and the timestamps.
+func ev(id, eventType string, ts time.Time) event.Stored {
+	return event.Stored{
+		Event: event.Event{
+			EventID:      id,
+			Timestamp:    ts,
+			EventType:    eventType,
+			Platform:     "openstack",
+			Cloud:        "os-prod-eu1",
+			ResourceType: "instance",
+			ResourceID:   "i-1",
+			ProjectID:    summaryProject,
+			Source:       event.SourceCollector,
+		},
+		ReceivedAt: ts,
+	}
+}
+
+// createEvent builds a create, which carries the state and size a create is
+// required to.
+func createEvent(id string, ts time.Time) event.Stored {
+	e := ev(id, "compute.instance.create.end", ts)
+	state := "active"
+	e.Payload.State = &state
+	e.Payload.Size = map[string]any{"vcpus": 2}
+	return e
+}
+
+// deleteEvent builds a delete, which carries no payload: the fold reads a
+// resource's fate from the event type.
+func deleteEvent(id string, ts time.Time) event.Stored {
+	return ev(id, "compute.instance.delete.end", ts)
+}
+
+// transferEvent builds the event that moves a resource to another project. It
+// is an ordinary update, so what says the resource changed hands is the project
+// it names rather than its type.
+func transferEvent(id, projectID string, ts time.Time) event.Stored {
+	e := ev(id, "compute.instance.update.end", ts)
+	e.ProjectID = projectID
+	return e
+}
+
+func TestSummarize(t *testing.T) {
+	tests := []struct {
+		name      string
+		histories []stats.History
+		// projectID is whose summary this is. It is summaryProject unless the
+		// case names another one, which is what the two transfer cases do.
+		projectID string
+		from      time.Time
+		to        time.Time
+		now       time.Time
+		want      []stats.Activity
+	}{
+		{
+			name:      "nil histories",
+			histories: nil,
+			from:      windowFrom,
+			to:        windowTo,
+			now:       windowTo,
+			want:      []stats.Activity{},
+		},
+		{
+			name:      "no histories",
+			histories: []stats.History{},
+			from:      windowFrom,
+			to:        windowTo,
+			now:       windowTo,
+			want:      []stats.Activity{},
+		},
+		{
+			// The history names a resource type but says nothing about it, so
+			// there is no row to open for it.
+			name:      "a history without events opens no row",
+			histories: []stats.History{{ResourceType: "instance"}},
+			from:      windowFrom,
+			to:        windowTo,
+			now:       windowTo,
+			want:      []stats.Activity{},
+		},
+		{
+			name: "an interval covering the window bills every minute of it",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom.Add(-time.Hour)),
+				},
+			}},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			// The create is older than the window, so only the minutes count.
+			want: []stats.Activity{{ResourceType: "instance", TotalMinutes: 1440}},
+		},
+		{
+			// Both ends of the half-open window at once: the create sits on from
+			// and counts, the delete sits on to and does not, and the interval
+			// stops at to rather than reaching past it.
+			name: "a create at from is inside the window and a delete at to is not",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom),
+					deleteEvent("e2", windowTo),
+				},
+			}},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance", Created: 1, TotalMinutes: 1440}},
+		},
+		{
+			// The fold takes a resource's fate from its newest lifecycle event,
+			// so the comeback leaves the resource created and not deleted. Both
+			// lives bill: one hour before the delete, 21 hours after the second
+			// create.
+			name: "a create after a delete counts one life and bills both intervals",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom.Add(time.Hour)),
+					deleteEvent("e2", windowFrom.Add(2*time.Hour)),
+					createEvent("e3", windowFrom.Add(3*time.Hour)),
+				},
+			}},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance", Created: 1, TotalMinutes: 1320}},
+		},
+		{
+			name: "an open interval bills up to now, not to the end of a future window",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events:       []event.Stored{createEvent("e1", windowFrom)},
+			}},
+			from: windowFrom,
+			to:   windowFrom.Add(48 * time.Hour),
+			now:  windowFrom.Add(24 * time.Hour),
+			want: []stats.Activity{{ResourceType: "instance", Created: 1, TotalMinutes: 1440}},
+		},
+		{
+			name: "a window that ends where it starts holds nothing",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events:       []event.Stored{createEvent("e1", windowFrom)},
+			}},
+			from: windowFrom,
+			to:   windowFrom,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance"}},
+		},
+		{
+			name: "a window that ends before it starts holds nothing",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events:       []event.Stored{createEvent("e1", windowFrom)},
+			}},
+			from: windowTo,
+			to:   windowFrom,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance"}},
+		},
+		{
+			// 119 seconds are one minute and 59 seconds the summary drops: a
+			// minute is reported once it has been served in full.
+			name: "seconds short of a minute are dropped",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom),
+					deleteEvent("e2", windowFrom.Add(119*time.Second)),
+				},
+			}},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance", Created: 1, Deleted: 1, TotalMinutes: 1}},
+		},
+		{
+			// The volume comes first in the input and second in the result.
+			name: "histories of one type add up and the rows come out sorted",
+			histories: []stats.History{
+				{
+					ResourceType: "volume",
+					Events:       []event.Stored{createEvent("v1", windowFrom.Add(time.Hour))},
+				},
+				{
+					ResourceType: "instance",
+					Events: []event.Stored{
+						createEvent("a1", windowFrom),
+						deleteEvent("a2", windowFrom.Add(time.Hour)),
+					},
+				},
+				{
+					ResourceType: "instance",
+					Events: []event.Stored{
+						createEvent("b1", windowFrom.Add(2*time.Hour)),
+						deleteEvent("b2", windowFrom.Add(3*time.Hour)),
+					},
+				},
+			},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			want: []stats.Activity{
+				{ResourceType: "instance", Created: 2, Deleted: 2, TotalMinutes: 120},
+				{ResourceType: "volume", Created: 1, TotalMinutes: 1380},
+			},
+		},
+		{
+			// The transfer moves the resource six hours into the window. The old
+			// owner accrues those six hours and stops there: its own events end at
+			// the transfer, and reading them alone would leave an interval that
+			// never closes and bills up to now beside the new owner's.
+			name: "a resource transferred away stops accruing at the transfer",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom),
+					transferEvent("e2", otherProject, windowFrom.Add(6*time.Hour)),
+				},
+			}},
+			from: windowFrom,
+			to:   windowTo,
+			now:  windowTo,
+			want: []stats.Activity{{ResourceType: "instance", Created: 1, TotalMinutes: 360}},
+		},
+		{
+			// The same history read as the new owner: the eighteen hours after the
+			// transfer and not one minute before it. The create belongs to the old
+			// owner, so it is not counted here even though it falls in the window,
+			// and the two summaries together bill the window exactly once.
+			name: "a resource transferred in accrues from the transfer",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events: []event.Stored{
+					createEvent("e1", windowFrom),
+					transferEvent("e2", otherProject, windowFrom.Add(6*time.Hour)),
+				},
+			}},
+			projectID: otherProject,
+			from:      windowFrom,
+			to:        windowTo,
+			now:       windowTo,
+			want:      []stats.Activity{{ResourceType: "instance", TotalMinutes: 1080}},
+		},
+		{
+			// A history the project never held opens no row, whatever the fold
+			// makes of it: the intervals belong to someone else and the lifecycle
+			// is not this project's either.
+			name: "a history of another project alone opens no row",
+			histories: []stats.History{{
+				ResourceType: "instance",
+				Events:       []event.Stored{createEvent("e1", windowFrom)},
+			}},
+			projectID: otherProject,
+			from:      windowFrom,
+			to:        windowTo,
+			now:       windowTo,
+			want:      []stats.Activity{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			projectID := tc.projectID
+			if projectID == "" {
+				projectID = summaryProject
+			}
+
+			got := stats.Summarize(tc.histories, projectID, tc.from, tc.to, tc.now)
+
+			// A caller encodes the result as a JSON array, which a nil slice
+			// would turn into null rather than [].
+			if got == nil {
+				t.Fatal("Summarize returned nil, want an empty slice")
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Summarize() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/reporting/store/migrate_test.go
+++ b/internal/reporting/store/migrate_test.go
@@ -275,6 +275,60 @@ func TestMigrate(t *testing.T) {
 		}
 	})
 
+	t.Run("the stats index migration repeats after one that built without recording", func(t *testing.T) {
+		// 0007 swaps one index for another and runs outside a transaction, so
+		// neither direction is atomic: goose records the migration only once both
+		// statements have gone through. A concurrent drop waits for every
+		// transaction that can still see the index, and current_resources is
+		// written from inside the ingest transaction, so a lock_timeout or a lost
+		// connection between the build and the drop is ordinary. What that leaves
+		// is the index built and the version unrecorded, in either direction. The
+		// rerun is the operator's only repair, and it only works if the build
+		// tolerates the index a previous run already left behind.
+		half := db.NewSiblingDB(t, "migrate_half_built")
+		if _, err := store.Migrate(t.Context(), half); err != nil {
+			t.Fatalf("Migrate() error = %v, want nil", err)
+		}
+		s, err := store.New(t.Context(), half, 1)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		defer s.Close()
+
+		// A rollback that built the fleet index back and died before recording it.
+		if _, err := s.Pool().Exec(t.Context(),
+			`CREATE INDEX idx_current_resources_fleet
+			     ON current_resources (platform, cloud, resource_type, state)`); err != nil {
+			t.Fatalf("building the index an interrupted rollback leaves: %v", err)
+		}
+		if _, err := store.MigrateDownTo(t.Context(), half, 6); err != nil {
+			t.Fatalf("MigrateDownTo(6) error = %v, want nil", err)
+		}
+		if !indexExists(t, s, "idx_current_resources_fleet") {
+			t.Error("the fleet index is missing after the rollback")
+		}
+		if indexExists(t, s, "idx_current_resources_stats") {
+			t.Error("the stats index survived the rollback")
+		}
+
+		// An upgrade that built the stats index and died before dropping the one
+		// it makes redundant.
+		if _, err := s.Pool().Exec(t.Context(),
+			`CREATE INDEX idx_current_resources_stats
+			     ON current_resources (platform, cloud, resource_type, state, project_id)`); err != nil {
+			t.Fatalf("building the index an interrupted upgrade leaves: %v", err)
+		}
+		if _, err := store.Migrate(t.Context(), half); err != nil {
+			t.Fatalf("Migrate() error = %v, want nil", err)
+		}
+		if !indexExists(t, s, "idx_current_resources_stats") {
+			t.Error("the stats index is missing after the repeated upgrade")
+		}
+		if indexExists(t, s, "idx_current_resources_fleet") {
+			t.Error("the fleet index survived the repeated upgrade")
+		}
+	})
+
 	t.Run("rolling back the seed empties the registry", func(t *testing.T) {
 		rolledBack, err := store.MigrateDownTo(t.Context(), db.URL, 1)
 		if err != nil {
@@ -595,6 +649,22 @@ func jsonEqual(t *testing.T, a, b []byte) bool {
 		t.Fatalf("parsing %s: %v", b, err)
 	}
 	return reflect.DeepEqual(parsedA, parsedB)
+}
+
+// indexExists says whether the database s is opened on carries an index of that
+// name, which is what the migration tests read the index swap of 0007 off.
+func indexExists(t *testing.T, s *store.Store, name string) bool {
+	t.Helper()
+
+	var exists bool
+	if err := s.Pool().QueryRow(t.Context(),
+		`SELECT EXISTS (
+		     SELECT 1 FROM pg_indexes
+		     WHERE schemaname = 'public' AND indexname = $1
+		 )`, name).Scan(&exists); err != nil {
+		t.Fatalf("querying pg_indexes: %v", err)
+	}
+	return exists
 }
 
 // eventsTableExists reports whether the hypertable the chain creates first and

--- a/internal/reporting/store/queries.sql
+++ b/internal/reporting/store/queries.sql
@@ -401,3 +401,133 @@ SELECT pg_advisory_unlock(hashtextextended('sync:' || $1::text, 0));
 SELECT platform, cloud, resource_type, state, COUNT(*) AS resources
 FROM current_resources
 GROUP BY platform, cloud, resource_type, state;
+
+-- The projection counted along all five dimensions the resource statistics can
+-- group by. The route takes any non-empty combination of them, which is
+-- thirty-one groupings and would be thirty-one static queries. A coarser
+-- grouping is the sum of these rows over the dimensions it drops, so this one
+-- query answers every combination and the handler adds the rows up in Go.
+--
+-- The status filter and the scope pair are the ones ListCurrentResources runs,
+-- so the counts cover the rows the list serves and nothing else.
+--
+-- row_cap bounds what one request materializes. Four of the five dimensions are
+-- low-cardinality, but project_id is one value per tenant, so the row set grows
+-- with the fleet's tenants rather than with the shapes it shows, and the answer
+-- is not paginated.
+-- name: CountCurrentResourcesGrouped :many
+SELECT cloud, platform, resource_type, state, project_id, count(*) AS resources
+FROM current_resources
+WHERE (sqlc.narg('deleted')::boolean IS NULL OR (state = 'deleted') = sqlc.narg('deleted'))
+  AND (sqlc.narg('scope_clouds')::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                         unnest(sqlc.narg('scope_projects')::text[])))
+GROUP BY cloud, platform, resource_type, state, project_id
+LIMIT sqlc.arg('row_cap');
+
+-- The event statistics route, as one row per bucket and group. The window is
+-- required and half-open, which is what keeps the read on the time dimension the
+-- hypertable is chunked by: a query without both bounds has every chunk there is
+-- to walk.
+--
+-- Both casts are there for sqlc rather than for Postgres. time_bucket is not in
+-- its catalog, so without ::timestamptz the bucket column comes out as an
+-- interface{} in the generated row; and the width reaches interval through text
+-- because a placeholder cast straight to interval generates a pgtype.Interval,
+-- where the width the route carries is a string.
+--
+-- row_cap bounds what one request materializes: the number of buckets grows with
+-- the window divided by the width, and each bucket carries a row per cloud,
+-- event type and source seen in it.
+-- name: CountEventBuckets :many
+SELECT time_bucket((sqlc.arg('bucket_width')::text)::interval, timestamp)::timestamptz AS bucket,
+       cloud, event_type, source, count(*) AS events
+FROM events
+WHERE timestamp >= sqlc.arg('from_ts')::timestamptz
+  AND timestamp < sqlc.arg('to_ts')::timestamptz
+  AND (sqlc.narg('scope_clouds')::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest(sqlc.narg('scope_clouds')::text[]),
+                                         unnest(sqlc.narg('scope_projects')::text[])))
+GROUP BY 1, 2, 3, 4
+ORDER BY 1, 2, 3, 4
+LIMIT sqlc.arg('row_cap');
+
+-- How many events one project summary folds, counted no further than
+-- probe_limit. The summary asks this before it runs the read below, and it
+-- counts that read's own row set rather than a narrower one: a project's own
+-- events say nothing about how long the histories they pull in are, because a
+-- resource it holds a single event of carries the events of every project it was
+-- transferred between. Counting the project's events alone would therefore bound
+-- nothing about the read, which materializes and sorts the joined set whole
+-- before the caller sees the first row. The inner LIMIT is what stops the walk
+-- at the rows the decision needs, and the answer saturates there rather than
+-- reporting how long the set is.
+-- name: CountProjectFoldEvents :one
+SELECT count(*)
+FROM (
+    SELECT 1
+    FROM events e
+    JOIN (
+        SELECT DISTINCT own.resource_type, own.resource_id
+        FROM events own
+        WHERE own.cloud = $1 AND own.project_id = $2
+          AND own.timestamp < sqlc.arg('to_ts')::timestamptz
+    ) touched ON touched.resource_type = e.resource_type
+             AND touched.resource_id = e.resource_id
+    WHERE e.cloud = $1 AND e.timestamp < sqlc.arg('to_ts')::timestamptz
+    LIMIT sqlc.arg('probe_limit')
+) probe;
+
+-- The events one project summary folds: for every resource the project holds an
+-- event of, that resource's whole history up to an instant, ordered the way the
+-- per-resource history read orders.
+--
+-- The set is taken per resource rather than per event because a project's own
+-- events do not say when a resource left it. An ownership transfer writes the
+-- new project onto the event that moves the resource, so a slice narrowed to
+-- project_id ends at the last event before the transfer and folds into an
+-- interval that never closes, which the summary would then accrue up to the
+-- instant of the request while the new owner accrues the same resource from the
+-- transfer on. Reading each resource whole puts the transfer inside the fold,
+-- where the project every interval carries is what says whose it is. The read
+-- narrows on (cloud, resource_type, resource_id), which is what
+-- idx_events_resource leads with and whose first two columns are what the
+-- hypertable segments its compressed chunks by.
+--
+-- No payload is read. The fold takes state and size out of it only to split a
+-- run of intervals where the billable configuration changed, and the pieces of a
+-- split run add up to the run itself, so no number this summary reports depends
+-- on them. They are what this read would cost: the column is JSONB the schema
+-- puts no bound on, and every row of it would be unmarshalled into a map.
+--
+-- Only the upper bound of the window filters the read. The events before it are
+-- what says which resources the project was already running when the window
+-- opened, and the fold clips its intervals to the window itself. An event at or
+-- after the bound cannot change anything inside [from, to), so that is the one
+-- end the read can drop.
+-- name: ListProjectFoldEvents :many
+SELECT e.event_id, e.timestamp, e.received_at, e.event_type, e.platform, e.cloud,
+       e.resource_type, e.resource_id, e.project_id, e.source
+FROM events e
+JOIN (
+    SELECT DISTINCT own.resource_type, own.resource_id
+    FROM events own
+    WHERE own.cloud = $1 AND own.project_id = $2
+      AND own.timestamp < sqlc.arg('to_ts')::timestamptz
+) touched ON touched.resource_type = e.resource_type
+         AND touched.resource_id = e.resource_id
+WHERE e.cloud = $1 AND e.timestamp < sqlc.arg('to_ts')::timestamptz
+ORDER BY e.timestamp, e.received_at, e.event_id
+LIMIT sqlc.arg('page_size');
+
+-- What the project summary calls active now: per resource type, the resources
+-- the projection holds for the project as it stands. It counts the present
+-- rather than the window, so a resource that was transferred away counts for its
+-- new owner and never here, whatever the window saw it do under this project. A
+-- deleted resource keeps its projection row, so it is excluded by its state
+-- rather than by its absence.
+-- name: CountProjectResourcesByType :many
+SELECT resource_type, count(*) AS resources
+FROM current_resources
+WHERE cloud = $1 AND project_id = $2 AND state <> 'deleted'
+GROUP BY resource_type;

--- a/internal/reporting/store/sqlcgen/queries.sql.go
+++ b/internal/reporting/store/sqlcgen/queries.sql.go
@@ -95,6 +95,156 @@ func (q *Queries) CountCurrentResources(ctx context.Context) ([]CountCurrentReso
 	return items, nil
 }
 
+const countCurrentResourcesGrouped = `-- name: CountCurrentResourcesGrouped :many
+SELECT cloud, platform, resource_type, state, project_id, count(*) AS resources
+FROM current_resources
+WHERE ($1::boolean IS NULL OR (state = 'deleted') = $1)
+  AND ($2::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest($2::text[]),
+                                         unnest($3::text[])))
+GROUP BY cloud, platform, resource_type, state, project_id
+LIMIT $4
+`
+
+type CountCurrentResourcesGroupedParams struct {
+	Deleted       pgtype.Bool
+	ScopeClouds   []string
+	ScopeProjects []string
+	RowCap        int32
+}
+
+type CountCurrentResourcesGroupedRow struct {
+	Cloud        string
+	Platform     string
+	ResourceType string
+	State        string
+	ProjectID    string
+	Resources    int64
+}
+
+// The projection counted along all five dimensions the resource statistics can
+// group by. The route takes any non-empty combination of them, which is
+// thirty-one groupings and would be thirty-one static queries. A coarser
+// grouping is the sum of these rows over the dimensions it drops, so this one
+// query answers every combination and the handler adds the rows up in Go.
+//
+// The status filter and the scope pair are the ones ListCurrentResources runs,
+// so the counts cover the rows the list serves and nothing else.
+//
+// row_cap bounds what one request materializes. Four of the five dimensions are
+// low-cardinality, but project_id is one value per tenant, so the row set grows
+// with the fleet's tenants rather than with the shapes it shows, and the answer
+// is not paginated.
+func (q *Queries) CountCurrentResourcesGrouped(ctx context.Context, arg CountCurrentResourcesGroupedParams) ([]CountCurrentResourcesGroupedRow, error) {
+	rows, err := q.db.Query(ctx, countCurrentResourcesGrouped,
+		arg.Deleted,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.RowCap,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountCurrentResourcesGroupedRow
+	for rows.Next() {
+		var i CountCurrentResourcesGroupedRow
+		if err := rows.Scan(
+			&i.Cloud,
+			&i.Platform,
+			&i.ResourceType,
+			&i.State,
+			&i.ProjectID,
+			&i.Resources,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const countEventBuckets = `-- name: CountEventBuckets :many
+SELECT time_bucket(($1::text)::interval, timestamp)::timestamptz AS bucket,
+       cloud, event_type, source, count(*) AS events
+FROM events
+WHERE timestamp >= $2::timestamptz
+  AND timestamp < $3::timestamptz
+  AND ($4::text[] IS NULL
+       OR (cloud, project_id) IN (SELECT unnest($4::text[]),
+                                         unnest($5::text[])))
+GROUP BY 1, 2, 3, 4
+ORDER BY 1, 2, 3, 4
+LIMIT $6
+`
+
+type CountEventBucketsParams struct {
+	BucketWidth   string
+	FromTs        pgtype.Timestamptz
+	ToTs          pgtype.Timestamptz
+	ScopeClouds   []string
+	ScopeProjects []string
+	RowCap        int32
+}
+
+type CountEventBucketsRow struct {
+	Bucket    pgtype.Timestamptz
+	Cloud     string
+	EventType string
+	Source    string
+	Events    int64
+}
+
+// The event statistics route, as one row per bucket and group. The window is
+// required and half-open, which is what keeps the read on the time dimension the
+// hypertable is chunked by: a query without both bounds has every chunk there is
+// to walk.
+//
+// Both casts are there for sqlc rather than for Postgres. time_bucket is not in
+// its catalog, so without ::timestamptz the bucket column comes out as an
+// interface{} in the generated row; and the width reaches interval through text
+// because a placeholder cast straight to interval generates a pgtype.Interval,
+// where the width the route carries is a string.
+//
+// row_cap bounds what one request materializes: the number of buckets grows with
+// the window divided by the width, and each bucket carries a row per cloud,
+// event type and source seen in it.
+func (q *Queries) CountEventBuckets(ctx context.Context, arg CountEventBucketsParams) ([]CountEventBucketsRow, error) {
+	rows, err := q.db.Query(ctx, countEventBuckets,
+		arg.BucketWidth,
+		arg.FromTs,
+		arg.ToTs,
+		arg.ScopeClouds,
+		arg.ScopeProjects,
+		arg.RowCap,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountEventBucketsRow
+	for rows.Next() {
+		var i CountEventBucketsRow
+		if err := rows.Scan(
+			&i.Bucket,
+			&i.Cloud,
+			&i.EventType,
+			&i.Source,
+			&i.Events,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countEventsForResource = `-- name: CountEventsForResource :one
 SELECT count(*)
 FROM (
@@ -142,6 +292,95 @@ func (q *Queries) CountEventsForResource(ctx context.Context, arg CountEventsFor
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const countProjectFoldEvents = `-- name: CountProjectFoldEvents :one
+SELECT count(*)
+FROM (
+    SELECT 1
+    FROM events e
+    JOIN (
+        SELECT DISTINCT own.resource_type, own.resource_id
+        FROM events own
+        WHERE own.cloud = $1 AND own.project_id = $2
+          AND own.timestamp < $3::timestamptz
+    ) touched ON touched.resource_type = e.resource_type
+             AND touched.resource_id = e.resource_id
+    WHERE e.cloud = $1 AND e.timestamp < $3::timestamptz
+    LIMIT $4
+) probe
+`
+
+type CountProjectFoldEventsParams struct {
+	Cloud      string
+	ProjectID  string
+	ToTs       pgtype.Timestamptz
+	ProbeLimit int32
+}
+
+// How many events one project summary folds, counted no further than
+// probe_limit. The summary asks this before it runs the read below, and it
+// counts that read's own row set rather than a narrower one: a project's own
+// events say nothing about how long the histories they pull in are, because a
+// resource it holds a single event of carries the events of every project it was
+// transferred between. Counting the project's events alone would therefore bound
+// nothing about the read, which materializes and sorts the joined set whole
+// before the caller sees the first row. The inner LIMIT is what stops the walk
+// at the rows the decision needs, and the answer saturates there rather than
+// reporting how long the set is.
+func (q *Queries) CountProjectFoldEvents(ctx context.Context, arg CountProjectFoldEventsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countProjectFoldEvents,
+		arg.Cloud,
+		arg.ProjectID,
+		arg.ToTs,
+		arg.ProbeLimit,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countProjectResourcesByType = `-- name: CountProjectResourcesByType :many
+SELECT resource_type, count(*) AS resources
+FROM current_resources
+WHERE cloud = $1 AND project_id = $2 AND state <> 'deleted'
+GROUP BY resource_type
+`
+
+type CountProjectResourcesByTypeParams struct {
+	Cloud     string
+	ProjectID string
+}
+
+type CountProjectResourcesByTypeRow struct {
+	ResourceType string
+	Resources    int64
+}
+
+// What the project summary calls active now: per resource type, the resources
+// the projection holds for the project as it stands. It counts the present
+// rather than the window, so a resource that was transferred away counts for its
+// new owner and never here, whatever the window saw it do under this project. A
+// deleted resource keeps its projection row, so it is excluded by its state
+// rather than by its absence.
+func (q *Queries) CountProjectResourcesByType(ctx context.Context, arg CountProjectResourcesByTypeParams) ([]CountProjectResourcesByTypeRow, error) {
+	rows, err := q.db.Query(ctx, countProjectResourcesByType, arg.Cloud, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountProjectResourcesByTypeRow
+	for rows.Next() {
+		var i CountProjectResourcesByTypeRow
+		if err := rows.Scan(&i.ResourceType, &i.Resources); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const createAPIToken = `-- name: CreateAPIToken :one
@@ -1027,6 +1266,105 @@ func (q *Queries) ListEventsForResource(ctx context.Context, arg ListEventsForRe
 			&i.ProjectID,
 			&i.Source,
 			&i.Payload,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProjectFoldEvents = `-- name: ListProjectFoldEvents :many
+SELECT e.event_id, e.timestamp, e.received_at, e.event_type, e.platform, e.cloud,
+       e.resource_type, e.resource_id, e.project_id, e.source
+FROM events e
+JOIN (
+    SELECT DISTINCT own.resource_type, own.resource_id
+    FROM events own
+    WHERE own.cloud = $1 AND own.project_id = $2
+      AND own.timestamp < $3::timestamptz
+) touched ON touched.resource_type = e.resource_type
+         AND touched.resource_id = e.resource_id
+WHERE e.cloud = $1 AND e.timestamp < $3::timestamptz
+ORDER BY e.timestamp, e.received_at, e.event_id
+LIMIT $4
+`
+
+type ListProjectFoldEventsParams struct {
+	Cloud     string
+	ProjectID string
+	ToTs      pgtype.Timestamptz
+	PageSize  int32
+}
+
+type ListProjectFoldEventsRow struct {
+	EventID      string
+	Timestamp    pgtype.Timestamptz
+	ReceivedAt   pgtype.Timestamptz
+	EventType    string
+	Platform     string
+	Cloud        string
+	ResourceType string
+	ResourceID   string
+	ProjectID    string
+	Source       string
+}
+
+// The events one project summary folds: for every resource the project holds an
+// event of, that resource's whole history up to an instant, ordered the way the
+// per-resource history read orders.
+//
+// The set is taken per resource rather than per event because a project's own
+// events do not say when a resource left it. An ownership transfer writes the
+// new project onto the event that moves the resource, so a slice narrowed to
+// project_id ends at the last event before the transfer and folds into an
+// interval that never closes, which the summary would then accrue up to the
+// instant of the request while the new owner accrues the same resource from the
+// transfer on. Reading each resource whole puts the transfer inside the fold,
+// where the project every interval carries is what says whose it is. The read
+// narrows on (cloud, resource_type, resource_id), which is what
+// idx_events_resource leads with and whose first two columns are what the
+// hypertable segments its compressed chunks by.
+//
+// No payload is read. The fold takes state and size out of it only to split a
+// run of intervals where the billable configuration changed, and the pieces of a
+// split run add up to the run itself, so no number this summary reports depends
+// on them. They are what this read would cost: the column is JSONB the schema
+// puts no bound on, and every row of it would be unmarshalled into a map.
+//
+// Only the upper bound of the window filters the read. The events before it are
+// what says which resources the project was already running when the window
+// opened, and the fold clips its intervals to the window itself. An event at or
+// after the bound cannot change anything inside [from, to), so that is the one
+// end the read can drop.
+func (q *Queries) ListProjectFoldEvents(ctx context.Context, arg ListProjectFoldEventsParams) ([]ListProjectFoldEventsRow, error) {
+	rows, err := q.db.Query(ctx, listProjectFoldEvents,
+		arg.Cloud,
+		arg.ProjectID,
+		arg.ToTs,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListProjectFoldEventsRow
+	for rows.Next() {
+		var i ListProjectFoldEventsRow
+		if err := rows.Scan(
+			&i.EventID,
+			&i.Timestamp,
+			&i.ReceivedAt,
+			&i.EventType,
+			&i.Platform,
+			&i.Cloud,
+			&i.ResourceType,
+			&i.ResourceID,
+			&i.ProjectID,
+			&i.Source,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/reporting/store/statsplan_integration_test.go
+++ b/internal/reporting/store/statsplan_integration_test.go
@@ -1,0 +1,415 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// The fixture the plan is taken over. Two clouds, two projects, two event types
+// and two sources, so a bucket of the count carries more than one group.
+const (
+	planPlatform     = "openstack"
+	planCloud        = "os-plan"
+	planOtherCloud   = "os-plan-second"
+	planProject      = "project-a"
+	planOtherProject = "project-b"
+	planResourceType = "volume"
+)
+
+// The window the count is planned for. The fixture spans it, so every seeded
+// event is inside the bounds the read carries.
+var (
+	planWindowStart = time.Date(2026, 5, 4, 8, 0, 0, 0, time.UTC)
+	planWindowEnd   = planWindowStart.Add(72 * time.Hour)
+)
+
+// planTransferEvents is how long the history of the transferred resource is. The
+// last of them moves it to planProject, so that project stores one event of a
+// resource whose fold reads all of them.
+const planTransferEvents = 6
+
+// planRowCap is what the count is capped at. It is far above the number of
+// groups the fixture can produce, so the cap never decides what comes back.
+const planRowCap = 1000
+
+// TestCountEventBucketsBoundedWindowNeedsNoSeqScan takes the plan of the
+// bucketed event count over a bounded window and fails when any node of it reads
+// the events hypertable sequentially.
+//
+// The plan is taken with enable_seqscan off, which only makes a sequential scan
+// expensive and cannot forbid one. A Seq Scan that survives the setting is
+// therefore one the planner had no index path to put in its place, which is the
+// regression this pins: the count runs over the table that grows without bound,
+// and a window is worth asking for only while the answer costs what the window
+// holds rather than what the table does. The index that serves it is
+// events_timestamp_idx, the one create_hypertable puts on the time dimension;
+// idx_events_type leads with the event type, which this read does not filter on.
+func TestCountEventBucketsBoundedWindowNeedsNoSeqScan(t *testing.T) {
+	db := storetest.NewDB(t)
+	seedPlanEvents(t, db)
+
+	pool, recorder := tracedPool(t, db)
+
+	rows, err := sqlcgen.New(pool).CountEventBuckets(t.Context(), sqlcgen.CountEventBucketsParams{
+		BucketWidth: "1 hour",
+		FromTs:      pgtype.Timestamptz{Time: planWindowStart, Valid: true},
+		ToTs:        pgtype.Timestamptz{Time: planWindowEnd, Valid: true},
+		RowCap:      planRowCap,
+	})
+	if err != nil {
+		t.Fatalf("CountEventBuckets() error = %v, want nil", err)
+	}
+	// A window the fixture misses would leave the planner nothing to prove: an
+	// empty range is cheap to answer from anywhere, chunk included.
+	if len(rows) == 0 {
+		t.Fatal("CountEventBuckets() rows = 0, want the seeded window counted")
+	}
+
+	// Every later call through this pool replaces what the recorder holds, so
+	// the statement is read before the EXPLAIN is issued.
+	sql, args := recorder.sql, recorder.args
+
+	conn, err := pool.Acquire(t.Context())
+	if err != nil {
+		t.Fatalf("acquiring a connection: %v", err)
+	}
+	defer conn.Release()
+
+	// The setting lives for the session, so it and the EXPLAIN run on the one
+	// connection.
+	setPlannerFlag(t, conn, "enable_seqscan", "off")
+
+	plan, explained := explainPlan(t, conn, sql, args)
+	if scanned := seqScanned(plan, eventChunk); len(scanned) > 0 {
+		t.Errorf("relations of the events hypertable scanned sequentially = %v, want none\nplan: %s",
+			scanned, explained)
+	}
+
+	// The control, with the settings the other way round. With the index paths
+	// priced out and the sequential scan no longer penalized the planner has
+	// nothing else to take, so the walk has to find one. Were it blind to them,
+	// because the shape of the plan or the keys of its JSON stopped matching what
+	// planNode reads, the assertion above would pass just as quietly on the
+	// regression it exists to catch.
+	//
+	// Every one of these settings is a price rather than a prohibition, which is
+	// why the first plan is taken with only enable_seqscan off: penalizing the
+	// index paths as well would leave both in the running and decide nothing.
+	setPlannerFlag(t, conn, "enable_seqscan", "on")
+	for _, flag := range []string{"enable_indexscan", "enable_indexonlyscan", "enable_bitmapscan"} {
+		setPlannerFlag(t, conn, flag, "off")
+	}
+	plan, explained = explainPlan(t, conn, sql, args)
+	if scanned := seqScanned(plan, eventChunk); len(scanned) == 0 {
+		t.Errorf("sequential scans seen with every index path off = 0, want the walk to find them\nplan: %s",
+			explained)
+	}
+}
+
+// TestCountCurrentResourcesGroupedNeedsNoSeqScan takes the plan of the grouped
+// resource count and fails when it reads the projection sequentially.
+//
+// It is read the way the bucketed count above is, and for the same reason: the
+// count runs once per request over a table that only grows, because a deleted
+// resource keeps its row, and that heap is wide — size and last_payload are
+// JSONB on every one of them. The index that serves it is
+// idx_current_resources_stats from 0007, which leads with the five columns the
+// query groups by and so answers it index-only; without it the planner has the
+// heap and a hash aggregate and nothing else.
+func TestCountCurrentResourcesGroupedNeedsNoSeqScan(t *testing.T) {
+	db := storetest.NewDB(t)
+	seedPlanResources(t, db)
+
+	pool, recorder := tracedPool(t, db)
+
+	rows, err := sqlcgen.New(pool).CountCurrentResourcesGrouped(t.Context(),
+		sqlcgen.CountCurrentResourcesGroupedParams{RowCap: planRowCap})
+	if err != nil {
+		t.Fatalf("CountCurrentResourcesGrouped() error = %v, want nil", err)
+	}
+	// A projection the query counts nothing of would leave the planner nothing to
+	// prove: an empty table is cheap to answer from anywhere.
+	if len(rows) == 0 {
+		t.Fatal("CountCurrentResourcesGrouped() rows = 0, want the seeded fleet counted")
+	}
+
+	sql, args := recorder.sql, recorder.args
+
+	conn, err := pool.Acquire(t.Context())
+	if err != nil {
+		t.Fatalf("acquiring a connection: %v", err)
+	}
+	defer conn.Release()
+
+	setPlannerFlag(t, conn, "enable_seqscan", "off")
+
+	plan, explained := explainPlan(t, conn, sql, args)
+	if scanned := seqScanned(plan, currentResources); len(scanned) > 0 {
+		t.Errorf("relations of the projection scanned sequentially = %v, want none\nplan: %s",
+			scanned, explained)
+	}
+
+	// The control the bucketed count takes as well: with every index path priced
+	// out the walk has to find the scan, or the assertion above would pass just as
+	// quietly on a plan its reader no longer understands.
+	setPlannerFlag(t, conn, "enable_seqscan", "on")
+	for _, flag := range []string{"enable_indexscan", "enable_indexonlyscan", "enable_bitmapscan"} {
+		setPlannerFlag(t, conn, flag, "off")
+	}
+	plan, explained = explainPlan(t, conn, sql, args)
+	if scanned := seqScanned(plan, currentResources); len(scanned) == 0 {
+		t.Errorf("sequential scans seen with every index path off = 0, want the walk to find them\nplan: %s",
+			explained)
+	}
+}
+
+// TestCountProjectFoldEventsProbesTheJoinedSet counts the events one project
+// summary folds and fails when the answer is the project's own events instead of
+// the set the fold reads.
+//
+// The summary refuses a project whose fold is longer than one answer holds, and
+// it decides that off this count because the read it guards materializes and
+// sorts its rows whole before the first one reaches the caller. The two have to
+// measure one set: a transfer writes the new project onto the event that moves
+// the resource, so a project holding a single event of a resource pulls in the
+// whole history it was handed with, and a count of the project's own events
+// would leave the read it guards bounded by nothing.
+func TestCountProjectFoldEventsProbesTheJoinedSet(t *testing.T) {
+	db := storetest.NewDB(t)
+	seedPlanTransfer(t, db)
+
+	queries := sqlcgen.New(db.Store.Pool())
+	params := sqlcgen.CountProjectFoldEventsParams{
+		Cloud:      planCloud,
+		ProjectID:  planProject,
+		ToTs:       pgtype.Timestamptz{Time: planWindowEnd, Valid: true},
+		ProbeLimit: planRowCap,
+	}
+
+	count, err := queries.CountProjectFoldEvents(t.Context(), params)
+	if err != nil {
+		t.Fatalf("CountProjectFoldEvents() error = %v, want nil", err)
+	}
+	if want := int64(planTransferEvents); count != want {
+		t.Errorf("CountProjectFoldEvents() = %d, want the %d events the fold reads", count, want)
+	}
+
+	// What the project stored under its own name, which is the number the count
+	// must not answer with: it is the whole difference the join makes, and a fold
+	// bounded by it would read every event of the resource under a bound of one.
+	var own int64
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		`SELECT count(*) FROM events WHERE cloud = $1 AND project_id = $2`,
+		planCloud, planProject).Scan(&own); err != nil {
+		t.Fatalf("counting the events of the project: %v", err)
+	}
+	if own != 1 {
+		t.Fatalf("events stored under the project = %d, want the 1 the transfer leaves it", own)
+	}
+
+	// The probe limit is what keeps the answer cheap on a set far past the bound:
+	// it saturates there rather than reporting how long the set is.
+	params.ProbeLimit = planTransferEvents - 1
+	saturated, err := queries.CountProjectFoldEvents(t.Context(), params)
+	if err != nil {
+		t.Fatalf("CountProjectFoldEvents() error = %v, want nil", err)
+	}
+	if want := int64(planTransferEvents - 1); saturated != want {
+		t.Errorf("CountProjectFoldEvents() = %d, want the %d the probe limit stops at", saturated, want)
+	}
+}
+
+// tracedPool opens a pool of its own that records the statement it last sent, so
+// that the EXPLAIN a test issues runs on the statement sqlc generated rather
+// than on a copy of it kept in the test, which nothing would keep in step with
+// queries.sql.
+func tracedPool(t *testing.T, db storetest.DB) (*pgxpool.Pool, *queryRecorder) {
+	t.Helper()
+
+	config, err := pgxpool.ParseConfig(db.URL)
+	if err != nil {
+		t.Fatalf("parsing the database url: %v", err)
+	}
+	recorder := &queryRecorder{}
+	config.ConnConfig.Tracer = recorder
+	// One connection: the recorder holds one statement, and a second connection
+	// establishing itself alongside the query could be what wrote it.
+	config.MaxConns = 1
+
+	pool, err := pgxpool.NewWithConfig(t.Context(), config)
+	if err != nil {
+		t.Fatalf("opening the traced pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool, recorder
+}
+
+// setPlannerFlag turns one planner setting on or off for the session conn holds.
+func setPlannerFlag(t *testing.T, conn *pgxpool.Conn, flag, value string) {
+	t.Helper()
+
+	if _, err := conn.Exec(t.Context(), "SET "+flag+" = "+value); err != nil {
+		t.Fatalf("setting %s to %s: %v", flag, value, err)
+	}
+}
+
+// explainPlan takes the plan of sql with args and returns its root node together
+// with the JSON it was read from, which is what a failure prints.
+func explainPlan(t *testing.T, conn *pgxpool.Conn, sql string, args []any) (planNode, []byte) {
+	t.Helper()
+
+	var explained []byte
+	if err := conn.QueryRow(t.Context(), "EXPLAIN (FORMAT JSON) "+sql, args...).Scan(&explained); err != nil {
+		t.Fatalf("explaining the bucket count: %v", err)
+	}
+
+	var plans []struct {
+		Plan planNode `json:"Plan"`
+	}
+	if err := json.Unmarshal(explained, &plans); err != nil {
+		t.Fatalf("decoding the plan: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans in the EXPLAIN output = %d, want 1", len(plans))
+	}
+	return plans[0].Plan, explained
+}
+
+// queryRecorder keeps the statement a pgx connection sent last, together with
+// the arguments it sent with it. It is what turns a generated query into
+// something EXPLAIN can be run on.
+type queryRecorder struct {
+	sql  string
+	args []any
+}
+
+func (r *queryRecorder) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	r.sql, r.args = data.SQL, data.Args
+	return ctx
+}
+
+func (r *queryRecorder) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+// planNode is the part of an EXPLAIN (FORMAT JSON) node the assertion reads.
+// The output is a tree: every node carries the nodes it draws its rows from.
+type planNode struct {
+	NodeType     string     `json:"Node Type"`
+	RelationName string     `json:"Relation Name"`
+	Plans        []planNode `json:"Plans"`
+}
+
+// seqScanned reports the relations a plan reads sequentially, out of the ones
+// the predicate names, walking the whole tree because the scans sit at its
+// leaves.
+func seqScanned(node planNode, relation func(string) bool) []string {
+	var scanned []string
+	if node.NodeType == "Seq Scan" && relation(node.RelationName) {
+		scanned = append(scanned, node.RelationName)
+	}
+	for _, child := range node.Plans {
+		scanned = append(scanned, seqScanned(child, relation)...)
+	}
+	return scanned
+}
+
+// eventChunk names a relation of the events hypertable. A plan names the chunks
+// it touches rather than the hypertable, and TimescaleDB names a chunk
+// _hyper_<hypertable>_<chunk>_chunk.
+func eventChunk(relation string) bool {
+	return relation == "events" || strings.HasPrefix(relation, "_hyper")
+}
+
+// currentResources names the projection, which is a plain table and so appears
+// in a plan under the name it was created with.
+func currentResources(relation string) bool {
+	return relation == "current_resources"
+}
+
+// seedPlanEvents writes the events the plan is taken over. Only the columns the
+// count groups and filters by vary; the payload it never reads stays NULL.
+func seedPlanEvents(t *testing.T, db storetest.DB) {
+	t.Helper()
+
+	queries := sqlcgen.New(db.Store.Pool())
+	for _, e := range []struct {
+		id        string
+		at        time.Time
+		eventType string
+		cloud     string
+		projectID string
+		source    event.Source
+	}{
+		{"plan-1", planWindowStart, "volume.create", planCloud, planProject, event.SourceCollector},
+		{"plan-2", planWindowStart.Add(90 * time.Minute), "volume.delete", planCloud, planProject, event.SourceCollector},
+		{"plan-3", planWindowStart.Add(26 * time.Hour), "volume.create", planOtherCloud, planOtherProject, event.SourceCollector},
+		// Inside the bucket plan-3 opened, under another cloud and another
+		// source: one bucket, two groups.
+		{"plan-4", planWindowStart.Add(26*time.Hour + 20*time.Minute), "volume.create", planCloud, planOtherProject, event.SourceReconciliation},
+		{"plan-5", planWindowStart.Add(50 * time.Hour), "volume.delete", planOtherCloud, planProject, event.SourceReconciliation},
+		{"plan-6", planWindowStart.Add(71 * time.Hour), "volume.create", planCloud, planProject, event.SourceCollector},
+	} {
+		if _, err := queries.InsertEvent(t.Context(), sqlcgen.InsertEventParams{
+			EventID:      e.id,
+			Timestamp:    pgtype.Timestamptz{Time: e.at, Valid: true},
+			EventType:    e.eventType,
+			Platform:     planPlatform,
+			Cloud:        e.cloud,
+			ResourceType: planResourceType,
+			ResourceID:   "vol-" + e.id,
+			ProjectID:    e.projectID,
+			Source:       string(e.source),
+		}); err != nil {
+			t.Fatalf("seeding event %s: %v", e.id, err)
+		}
+	}
+}
+
+// seedPlanTransfer writes the history of one resource that changed hands inside
+// the plan window. Every event but the last names the project that held it
+// first; the last one is the transfer, which is the only event the new project
+// stores under its own name and the only one a count narrowed to it would see.
+func seedPlanTransfer(t *testing.T, db storetest.DB) {
+	t.Helper()
+
+	if _, err := db.Store.Pool().Exec(t.Context(),
+		`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+		                     resource_type, resource_id, project_id, source)
+		 SELECT 'plan-transfer-' || n, $1::timestamptz + (n * INTERVAL '1 minute'),
+		        'volume.update', $2, $3, $4, 'vol-plan-transfer',
+		        CASE WHEN n = $5::int THEN $7 ELSE $6 END, 'collector'
+		 FROM generate_series(1, $5::int) AS n`,
+		planWindowStart, planPlatform, planCloud, planResourceType,
+		planTransferEvents, planOtherProject, planProject); err != nil {
+		t.Fatalf("seeding the history of a transferred resource: %v", err)
+	}
+}
+
+// seedPlanResources writes the projection rows the resource plan is taken over.
+// Every one of the five dimensions varies across them, so the grouping the query
+// runs has more than one row to fold.
+func seedPlanResources(t *testing.T, db storetest.DB) {
+	t.Helper()
+
+	if _, err := db.Store.Pool().Exec(t.Context(),
+		`INSERT INTO current_resources (cloud, platform, resource_type, resource_id,
+		                                project_id, state, last_event_type, last_event_at)
+		 VALUES ($1, $2, 'volume',   'vol-plan-1', $3, 'available', 'volume.create',   $5),
+		        ($1, $2, 'volume',   'vol-plan-2', $4, 'in-use',    'volume.update',   $5),
+		        ($1, $2, 'instance', 'i-plan-1',   $3, 'active',    'instance.create', $5),
+		        ($6, $2, 'instance', 'i-plan-2',   $4, 'deleted',   'instance.delete', $5)`,
+		planCloud, planPlatform, planProject, planOtherProject, planWindowStart,
+		planOtherCloud); err != nil {
+		t.Fatalf("seeding the projection: %v", err)
+	}
+}

--- a/migrations/reporting/0007_current_resources_stats_index.sql
+++ b/migrations/reporting/0007_current_resources_stats_index.sql
@@ -1,0 +1,68 @@
+-- The index the resource statistics are counted through. Their query groups by
+-- (cloud, platform, resource_type, state, project_id) over the whole table, and
+-- none of the access paths current_resources has leads with all five:
+-- idx_current_resources_fleet from 0005 carries the first four in another order
+-- but not project_id, the primary key is (cloud, resource_type, resource_id),
+-- idx_current_resources_project indexes project_id alone, and
+-- idx_current_resources_type indexes (resource_type, state). The planner is left
+-- with a sequential scan of the heap plus a hash aggregate, and that heap is
+-- wide — size and last_payload are JSONB on every row — and grows monotonically,
+-- because a deleted resource keeps its row (0001_init.sql). GET
+-- /api/v1/stats/resources runs that shape once per request, on demand, rather
+-- than on the metrics ticker 0005 was written for.
+--
+-- Adding project_id to the fleet index rather than building a second one is what
+-- keeps the write side where 0005 left it: projection.Apply upserts
+-- current_resources inside the ingest transaction, so every index over the
+-- columns an update touches is maintained per folded event. The gauge 0005 built
+-- its index for groups by (platform, cloud, resource_type, state), which is a
+-- prefix of this one, so it keeps its index-only scan and the table carries one
+-- btree where it would otherwise carry two.
+--
+-- The five columns are bounded by event.Validate at 512 bytes each, which leaves
+-- the widest possible tuple inside the 2704 bytes a btree entry may take. 0005
+-- repaired the rows a state above that bound could have left behind, so the
+-- values this index is built over are already within it.
+--
+-- The normative specification is roadmap/02-phase-2-reporting-dashboards.md,
+-- WP 2.1.
+--
+-- The build runs concurrently and therefore outside a transaction, for the
+-- reason 0005 gives: a plain CREATE INDEX takes a SHARE lock on the table for
+-- the length of the build, and SHARE conflicts with the ROW EXCLUSIVE an INSERT
+-- needs, so it would stop ingestion until the index is there. The drop is
+-- concurrent for the same reason.
+--
+-- Neither direction is a single statement and neither runs in a transaction, so
+-- goose records the migration only once both statements have gone through: a
+-- build that aborts, a lock_timeout on the drop, or a connection lost between
+-- them leaves the chain recorded one version below with half the work done.
+-- Every statement here is therefore written to be rerunnable. The drops say IF
+-- EXISTS, and every build is preceded by a concurrent drop of the name it
+-- builds, which clears whatever the failed run left behind: the INVALID index a
+-- failed concurrent build leaves, which the planner ignores, or the finished one
+-- a run that died after it never got to record. The rerun rebuilds the index
+-- rather than recording the migration over it, which is what CREATE INDEX
+-- CONCURRENTLY IF NOT EXISTS would do to the INVALID case, and it needs no
+-- operator with DDL rights in the middle of a deploy.
+--
+-- The order matters in both directions: the index the last statement drops is
+-- the one the statement before it made redundant, so no read is left without a
+-- path at any point.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+DROP INDEX CONCURRENTLY IF EXISTS idx_current_resources_stats;
+
+CREATE INDEX CONCURRENTLY idx_current_resources_stats
+    ON current_resources (platform, cloud, resource_type, state, project_id);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_current_resources_fleet;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_current_resources_fleet;
+
+CREATE INDEX CONCURRENTLY idx_current_resources_fleet
+    ON current_resources (platform, cloud, resource_type, state);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_current_resources_stats;

--- a/migrations/reporting/embed.go
+++ b/migrations/reporting/embed.go
@@ -18,4 +18,4 @@ var FS embed.FS
 // schema its code is newer than.
 //
 // Adding a migration means raising this; a test fails otherwise.
-const Version int64 = 6
+const Version int64 = 7


### PR DESCRIPTION
Closes #27

Adds the three aggregation endpoints of WP 2.1 to the Reporting API: grouped resource counts, time-bucketed event counts, and a per-project activity summary. All three compute over SQL against the event store and the projection (decision D5), join the OpenAPI contract, and are guarded by the fail-closed dispatch table at `auth.RoleProject`, the way the Phase 1 query endpoints are.

## The change, in commit order

**`c19af37` Add the stats summary fold as `internal/reporting/stats`**

The I/O-free arithmetic lands first, so the handler that follows has a seam unit tests pin exactly. `Summarize(histories, from, to, now)` folds each resource's history with `internal/core/timeline`, counts a resource created when the folded `CreatedAt` falls in `[from, to)` and deleted when `DeletedAt` does, and sums interval overlap with the window in whole seconds — clipping an open interval at `now` before clipping to `to`, so a `to` in the future bills no time that has not been served yet. `TotalMinutes` is the per-type second sum divided by 60, truncated. The package holds no SQL: `sqlc.yaml` compiles exactly one queries file, so the queries belong there instead. This is the roadmap deviation the issue already surfaced under guardrail 10.

**`682afc4` Add the stats queries and the query-plan regression test**

Five static queries in `internal/reporting/store/queries.sql`: `CountCurrentResourcesGrouped` (the projection counted along all five dimensions the route can group by), `CountEventBuckets` (the `time_bucket` grouping the event statistics serve), and `CountEventsForProject` / `ListEventsForProject` / `CountProjectResourcesByType` (the saturating probe, the history read, and the active-now count the summary folds). One grouped count answers every `group_by` combination, because a coarser grouping is the sum of its rows over the dimensions it drops.

`internal/reporting/store/statsplan_integration_test.go` pins what the roadmap prescribes: a bounded window is index-served on the events hypertable. It captures the statement sqlc generated through a pgx `QueryTracer`, runs `EXPLAIN (FORMAT JSON)` over it with `enable_seqscan = off` — which prices a sequential scan rather than forbidding it, so one that survives is a shape no index can serve — and fails on any `Seq Scan` over `events` or a `_hyper` chunk. A second plan, taken with the index paths priced out instead, proves the walk can see a sequential scan at all.

**`3e2e175` Expose the three stats endpoints on the Reporting API**

The contract, the regenerated wiring, the dispatch entries, and the three handlers land together, because the generated `ServerInterface` grows one method per operation: a commit carrying part of them either does not compile or serves a route the dispatch table refuses. The `authdispatch_test.go` subtest lands with them, which is what keeps that table fail-closed.

- `GET /api/v1/stats/resources` counts the projection along the dimensions one request groups by, collapsing the single grouped query's rows in Go and sorting deterministically. A `group_by` missing `cloud` or `resource_type` is 400; `status` defaults to `active` in the handler, since the generated binding does not apply contract defaults. An `at` of any value is answered 501 `urn:tally:error:not_implemented` — the projection holds the present, and telling a value meaning *now* from a historic one over the wire is a race, so the contract documents omission as the way to ask for current counts.
- `GET /api/v1/stats/events` buckets a half-open window with `time_bucket`, mapping `1h`/`1d` to interval literals and collapsing `source` unless requested.
- `GET /api/v1/projects/{id}/summary` folds the project's own history per resource type beside what it runs today. A project outside the token's scope is answered the 404 an unknown id gets, byte for byte.

Neither list is paginated, and both are bounded by refusal rather than truncation: 10000 grouped rows for the event counts (422 `urn:tally:error:result_too_large`), 100000 events for one summary (422 `urn:tally:error:history_too_long`). The summary reads *now* from a new `now func() time.Time` field on the `server` struct, which `NewRouter` sets from the already-resolved clock, so tests pin it.

**`3e5e037` Cover the stats endpoints with integration tests**

All three routes driven over the real-database `storetest` harness: resource counts against a hand-computed fleet and the gauge the metrics route reads, event counts against hand-computed hourly and daily buckets including a month boundary, and the project summary against a fold whose open interval is pinned by a fixed clock. Each route is read through an `admin`, a `read_all`, and a `project` token, so what a scope narrows is asserted rather than assumed. The refusals are covered too: the rejected groupings, the two unpaginated bounds one row past and exactly at their limit, the shared 404, and the 500 a failed query answers.

## Divergences from the issue

- **A new migration, `migrations/reporting/0007_current_resources_stats_index.sql`, is in the diff; the issue lists none.** The resource-statistics query groups by all five of `(cloud, platform, resource_type, state, project_id)`, and no access path `current_resources` had leads with all five — so the planner was left with a sequential scan of a heap that carries `size` and `last_payload` as JSONB on every row and grows monotonically, now on demand per request rather than on the metrics ticker `0005` was written for. `0007` extends `idx_current_resources_fleet` with `project_id` under the new name `idx_current_resources_stats` and drops the old one, rather than adding a second index, so the write side stays where `0005` left it — `projection.Apply` upserts inside the ingest transaction, so every index is maintained per folded event — and the `0005` gauge keeps its index-only scan on the prefix. It builds `CONCURRENTLY` and therefore outside a transaction, so every statement is written to be rerunnable; `migrate_test.go` covers the rerun after a run that built without recording, in both directions. `migrations/reporting/embed.go` raises `Version` to 7, and the `stateMaxLen` doc comment in `internal/core/event/event.go` is retargeted at the index that now bounds it.
- **`internal/reporting/httpapi/resources.go` changed although the issue did not list it.** Regenerating the contract renamed the `ListResourcesParams` status constants: the second operation declaring that enum made oapi-codegen prefix both sets, so `Active`/`All`/`Deleted` became `ListResourcesParamsStatusActive` and siblings, and `filterStatus` reads them under their new names. The issue anticipated the new type's name but not the rename of the existing constants.
- The handler-level unit tests (`statsresources_test.go`, `statsevents_test.go`, `projectsummary_test.go`) are additions beyond the file list in the issue; the integration tests it does name are all present.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
