### PR TITLE
Deploy Grafana and provision the four dashboards as code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ up:
 	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/timescaledb --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/victoriametrics --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/otel-collector --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/grafana --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) wait gateway/tally --for=condition=Programmed --timeout=300s
 	@# The API stays unready until the database carries its schema, and it never
 	@# migrates on its own, so the chain has to be applied before the rollout can
@@ -90,6 +91,7 @@ up:
 	@echo 'Stack is up:'
 	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1  Reporting API'
 	@echo '  https://vm.tally.127-0-0-1.nip.io:8443          VictoriaMetrics'
+	@echo '  https://grafana.tally.127-0-0-1.nip.io:8443     Grafana'
 	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443        OTLP/HTTP'
 	@echo '  db.tally.127-0-0-1.nip.io:5432                  TimescaleDB'
 	@echo

--- a/Tiltfile
+++ b/Tiltfile
@@ -38,3 +38,8 @@ k8s_resource(
     labels=['infrastructure'],
     links=[link('https://otlp.tally.127-0-0-1.nip.io:8443', 'OTLP/HTTP')],
 )
+k8s_resource(
+    'grafana',
+    labels=['infrastructure'],
+    links=[link('https://grafana.tally.127-0-0-1.nip.io:8443', 'Grafana')],
+)

--- a/deploy/kubernetes/base/grafana/dashboards/fleet-overview.json
+++ b/deploy/kubernetes/base/grafana/dashboards/fleet-overview.json
@@ -1,0 +1,313 @@
+{
+  "uid": "tally-fleet-overview",
+  "title": "Tally / Fleet Overview",
+  "description": "What the fleet holds: resources by type and state, the clouds reporting, and the projects with the most instances.",
+  "tags": ["tally"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "utc",
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "platform",
+        "label": "Platform",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources, platform)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      },
+      {
+        "name": "cloud",
+        "label": "Cloud",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources{platform=~\"$platform\"}, cloud)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "barchart",
+      "title": "Resources by type and state",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "xField": "resource_type",
+        "colorByField": "state",
+        "orientation": "auto",
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (resource_type, state) (tally_current_resources{platform=~\"$platform\", cloud=~\"$cloud\"})",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Resource count trend",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (resource_type, state) (tally_current_resources{platform=~\"$platform\", cloud=~\"$cloud\"})",
+          "legendFormat": "{{resource_type}} {{state}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Clouds reporting",
+      "description": "Counts every cloud with at least one resource series, whatever the variables select.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(count by (cloud) (tally_current_resources))",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Projects (OpenStack)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "none",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum(openstack_identity_projects{cloud=~\"$cloud\"})",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Top 10 projects by instance count",
+      "description": "The project id is the tenant_id label the nova limits collector writes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "topk(10, sum by (tenant_id) (openstack_nova_limits_instances_used{cloud=~\"$cloud\"}))",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/kubernetes/base/grafana/dashboards/ingestion-health.json
+++ b/deploy/kubernetes/base/grafana/dashboards/ingestion-health.json
@@ -1,0 +1,446 @@
+{
+  "uid": "tally-ingestion-health",
+  "title": "Tally / Ingestion Health",
+  "description": "Whether events still arrive, get accepted, and get projected. A cloud that stops delivering here is a billing period that comes out short.",
+  "tags": ["tally"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "utc",
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "platform",
+        "label": "Platform",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources, platform)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      },
+      {
+        "name": "cloud",
+        "label": "Cloud",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources{platform=~\"$platform\"}, cloud)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Event ingest rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud, source) (rate(tally_events_ingested_total{platform=~\"$platform\", cloud=~\"$cloud\"}[5m]))",
+          "legendFormat": "{{cloud}} {{source}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Dedup rate",
+      "description": "Deduplicated events carry only a cloud label, so the platform variable does not filter this panel.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud) (rate(tally_events_deduplicated_total{cloud=~\"$cloud\"}[5m]))",
+          "legendFormat": "{{cloud}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Rejected events",
+      "description": "Rejections per hour by reason. A rising reason is schema drift, and every rejected event is usage that never reaches a bill.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud, reason) (increase(tally_events_rejected_total{cloud=~\"$cloud\"}[1h]))",
+          "legendFormat": "{{cloud}} {{reason}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Collector buffer depth",
+      "description": "The gauge carries no labels, so the variables do not filter it. Every collector reports on its own instance label.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "tally_collector_buffer_depth",
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Oldest buffered event age",
+      "description": "How long the oldest event has waited in a collector buffer. Warning at one minute, critical at ten.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "tally_collector_oldest_buffered_seconds",
+          "legendFormat": "{{instance}}",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Projection replays",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud) (rate(tally_projection_replays_total{cloud=~\"$cloud\"}[15m]))",
+          "legendFormat": "{{cloud}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Scrape health",
+      "description": "The four scrape jobs of the VictoriaMetrics configuration. A job whose targets all disappear leaves no series here at all rather than a zero.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "down",
+                  "color": "red",
+                  "index": 0
+                },
+                "1": {
+                  "text": "up",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "up{job=~\"reporting-api|openstack-db-exporter|ceilometer|otel-collector\"}",
+          "legendFormat": "{{job}} {{instance}}",
+          "instant": true,
+          "range": false
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/kubernetes/base/grafana/dashboards/project-drilldown.json
+++ b/deploy/kubernetes/base/grafana/dashboards/project-drilldown.json
@@ -1,0 +1,388 @@
+{
+  "uid": "tally-project-drilldown",
+  "title": "Tally / Project Drilldown",
+  "description": "One project: what it holds, how much volume capacity it uses, how close it runs to its compute quota, and the lifecycle events its cloud reports.",
+  "tags": ["tally"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "utc",
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "platform",
+        "label": "Platform",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources, platform)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      },
+      {
+        "name": "cloud",
+        "label": "Cloud",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources{platform=~\"$platform\"}, cloud)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      },
+      {
+        "name": "project_id",
+        "label": "Project",
+        "description": "The owning project, which the exporter labels tenant_id. Read from the nova limits gauge: it carries one series per project, where the per-resource series carry one per instance and volume.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(openstack_nova_limits_instances_used, tenant_id)",
+        "refresh": 1,
+        "sort": 1,
+        "current": {},
+        "options": []
+      },
+      {
+        "name": "api_base",
+        "label": "Reporting API",
+        "description": "Base URL the event link points at. The dev overlay serves the API on port 8443.",
+        "type": "textbox",
+        "query": "https://api.tally.127-0-0-1.nip.io:8443",
+        "current": {
+          "selected": false,
+          "text": "https://api.tally.127-0-0-1.nip.io:8443",
+          "value": "https://api.tally.127-0-0-1.nip.io:8443"
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Resources by type",
+      "description": "Nova, cinder and glance name the owning project tenant_id; neutron and octavia name it project_id.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_nova_server_status{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "instances",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_cinder_volume_status{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "volumes",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_neutron_floating_ip{cloud=~\"$cloud\", project_id=~\"$project_id\"})",
+          "legendFormat": "floating IPs",
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_neutron_router{cloud=~\"$cloud\", project_id=~\"$project_id\"})",
+          "legendFormat": "routers",
+          "range": true
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_glance_image_bytes{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "images",
+          "range": true
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "count(openstack_loadbalancer_loadbalancer_status{cloud=~\"$cloud\", project_id=~\"$project_id\"})",
+          "legendFormat": "load balancers",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Volume capacity",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decgbytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum(openstack_cinder_volume_gb{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "capacity",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Quota usage",
+      "description": "Used over max, from the nova limits collector, which is the only quota source that carries a project id.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.95
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum(openstack_nova_limits_instances_used{cloud=~\"$cloud\", tenant_id=~\"$project_id\"}) / sum(openstack_nova_limits_instances_max{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "instances",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum(openstack_nova_limits_vcpus_used{cloud=~\"$cloud\", tenant_id=~\"$project_id\"}) / sum(openstack_nova_limits_vcpus_max{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "vcpus",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum(openstack_nova_limits_memory_used{cloud=~\"$cloud\", tenant_id=~\"$project_id\"}) / sum(openstack_nova_limits_memory_max{cloud=~\"$cloud\", tenant_id=~\"$project_id\"})",
+          "legendFormat": "memory",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Recent lifecycle activity",
+      "description": "Ingested events carry no project label, so this panel is cloud-level. The link opens the project's events on the Reporting API.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "links": [
+        {
+          "title": "Event content (Reporting API)",
+          "url": "${api_base}/api/v1/events?project_id=${project_id}",
+          "targetBlank": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (event_type) (rate(tally_events_ingested_total{cloud=~\"$cloud\"}[5m]))",
+          "legendFormat": "{{event_type}}",
+          "range": true
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/kubernetes/base/grafana/dashboards/reconciliation-drift.json
+++ b/deploy/kubernetes/base/grafana/dashboards/reconciliation-drift.json
@@ -1,0 +1,230 @@
+{
+  "uid": "tally-reconciliation-drift",
+  "title": "Tally / Reconciliation Drift",
+  "description": "What reconciliation changed against the cloud's own inventory. Anything but an updated resource means the event stream and the cloud had drifted apart.",
+  "tags": ["tally"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "utc",
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "platform",
+        "label": "Platform",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources, platform)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      },
+      {
+        "name": "cloud",
+        "label": "Cloud",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": "label_values(tally_current_resources{platform=~\"$platform\"}, cloud)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Reconciled resources by action",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud, action) (increase(tally_sync_resources_reconciled_total{cloud=~\"$cloud\"}[1h]))",
+          "legendFormat": "{{cloud}} {{action}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Sync errors",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud) (increase(tally_sync_errors_total{cloud=~\"$cloud\"}[1h]))",
+          "legendFormat": "{{cloud}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Sync runs by status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "victoriametrics"
+          },
+          "expr": "sum by (cloud, status) (increase(tally_sync_runs_total{cloud=~\"$cloud\"}[6h]))",
+          "legendFormat": "{{cloud}} {{status}}",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "text",
+      "title": "Drift interpretation",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "options": {
+        "mode": "markdown",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Non-zero `created`/`deleted` here = collectors missed events → investigate before period finalization\n"
+      }
+    }
+  ]
+}

--- a/deploy/kubernetes/base/grafana/dashboards_test.go
+++ b/deploy/kubernetes/base/grafana/dashboards_test.go
@@ -1,0 +1,245 @@
+// Package grafana_test pins the JSON contract of the provisioned dashboards:
+// the file set the ConfigMap ships, that every file parses, the fixed uids and
+// titles, the datasource each query target names, the template variables the
+// expressions read, and the drift note. Grafana loads these files at startup
+// and reports a broken one only in its own log, so without this test a
+// truncated file or a renamed datasource reaches a cluster before anyone sees
+// it. The test reads the files from disk and needs no Grafana and no cluster.
+package grafana_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// dashboardDir holds the files the provisioning ConfigMap generates from.
+const dashboardDir = "dashboards"
+
+// datasourceUID is the uid of the provisioned VictoriaMetrics datasource. A
+// target naming anything else queries a datasource Grafana does not have and
+// renders an error where the panel should be.
+const datasourceUID = "victoriametrics"
+
+// sharedVariables are the variables every dashboard filters by. Both are
+// multi-select, which is what lets the "All" option expand to the .* the
+// expressions match against.
+var sharedVariables = []string{"platform", "cloud"}
+
+// dashboards is the full set of provisioned files, each with the uid saved
+// links and dashboard links address it by, and the variables it carries beyond
+// the shared two.
+var dashboards = map[string]struct {
+	uid       string
+	variables []string
+}{
+	"fleet-overview.json":       {uid: "tally-fleet-overview"},
+	"project-drilldown.json":    {uid: "tally-project-drilldown", variables: []string{"project_id", "api_base"}},
+	"ingestion-health.json":     {uid: "tally-ingestion-health"},
+	"reconciliation-drift.json": {uid: "tally-reconciliation-drift"},
+}
+
+// dashboard is the part of the Grafana model this test asserts over. Every
+// other field passes through untouched.
+type dashboard struct {
+	UID        string  `json:"uid"`
+	Title      string  `json:"title"`
+	Panels     []panel `json:"panels"`
+	Templating struct {
+		List []templateVar `json:"list"`
+	} `json:"templating"`
+}
+
+type templateVar struct {
+	Name  string `json:"name"`
+	Multi bool   `json:"multi"`
+	Query string `json:"query"`
+}
+
+// panel carries a nested panel list of its own: a row panel holds the panels
+// below it once the row is collapsed.
+type panel struct {
+	Title   string   `json:"title"`
+	Panels  []panel  `json:"panels"`
+	Targets []target `json:"targets"`
+}
+
+type target struct {
+	RefID      string `json:"refId"`
+	Datasource struct {
+		UID string `json:"uid"`
+	} `json:"datasource"`
+}
+
+func TestDashboardDirectory(t *testing.T) {
+	t.Run("holds exactly the provisioned files", func(t *testing.T) {
+		// The ConfigMap generator ships the whole directory, so a file that is
+		// added without a test is provisioned without one too, and a file that is
+		// renamed leaves the dashboard it stood for missing from Grafana.
+		entries, err := os.ReadDir(dashboardDir)
+		if err != nil {
+			t.Fatalf("reading %s: %v", dashboardDir, err)
+		}
+
+		present := make(map[string]bool, len(entries))
+		for _, entry := range entries {
+			present[entry.Name()] = true
+		}
+
+		var missing, unexpected []string
+		for name := range dashboards {
+			if !present[name] {
+				missing = append(missing, name)
+			}
+		}
+		for name := range present {
+			if _, known := dashboards[name]; !known {
+				unexpected = append(unexpected, name)
+			}
+		}
+		slices.Sort(missing)
+		slices.Sort(unexpected)
+
+		if len(missing) > 0 {
+			t.Errorf("%s is missing %v", dashboardDir, missing)
+		}
+		if len(unexpected) > 0 {
+			t.Errorf("%s holds %v, which no test pins", dashboardDir, unexpected)
+		}
+	})
+}
+
+func TestDashboards(t *testing.T) {
+	for name, want := range dashboards {
+		t.Run(name, func(t *testing.T) {
+			// A file that does not parse fails here, with the position
+			// encoding/json reports. Grafana would skip it just as silently.
+			d := load(t, name)
+
+			t.Run("carries its fixed uid and a title", func(t *testing.T) {
+				if d.UID != want.uid {
+					t.Errorf("uid = %q, want %q; a changed uid breaks every saved link", d.UID, want.uid)
+				}
+				if d.Title == "" {
+					t.Error("title is empty, so the dashboard list shows the file under no name")
+				}
+			})
+
+			t.Run("queries VictoriaMetrics from every target", func(t *testing.T) {
+				var targets int
+				for _, p := range flatten(d.Panels) {
+					targets += len(p.Targets)
+					for _, tgt := range p.Targets {
+						if tgt.Datasource.UID != datasourceUID {
+							t.Errorf("panel %q target %q names datasource uid %q, want %q",
+								p.Title, tgt.RefID, tgt.Datasource.UID, datasourceUID)
+						}
+					}
+				}
+				if targets == 0 {
+					t.Error("no panel carries a query target, so the dashboard renders nothing")
+				}
+			})
+
+			t.Run("declares the variables its expressions read", func(t *testing.T) {
+				declared := make(map[string]templateVar, len(d.Templating.List))
+				for _, v := range d.Templating.List {
+					declared[v.Name] = v
+				}
+
+				for _, variable := range sharedVariables {
+					v, ok := declared[variable]
+					if !ok {
+						t.Errorf("no %q variable, so the panels filter by an unresolved $%s", variable, variable)
+						continue
+					}
+					if !v.Multi {
+						t.Errorf("variable %q is not multi-select, so it cannot expand to more than one value", variable)
+					}
+				}
+				for _, variable := range want.variables {
+					if _, ok := declared[variable]; !ok {
+						t.Errorf("no %q variable, so the panels filter by an unresolved $%s", variable, variable)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestProjectDrilldown(t *testing.T) {
+	t.Run("reads the project list from a per-project series", func(t *testing.T) {
+		// label_values scans every series its matcher selects, and refresh 1
+		// re-runs it on every dashboard load. The per-resource series are the
+		// wrong thing to scan: openstack_nova_server_status carries one series
+		// per instance and openstack_cinder_volume_status one per volume, and
+		// four of the nova labels change on reboot, migration and address
+		// reassignment, so the set over the dashboard window is a multiple of
+		// the fleet rather than equal to it. The limits gauge carries one
+		// series per project, which is the list the dropdown wants.
+		const want = "label_values(openstack_nova_limits_instances_used, tenant_id)"
+
+		d := load(t, "project-drilldown.json")
+
+		for _, v := range d.Templating.List {
+			if v.Name != "project_id" {
+				continue
+			}
+			if v.Query != want {
+				t.Errorf("project_id query = %q, want %q", v.Query, want)
+			}
+			return
+		}
+		t.Error("project-drilldown.json declares no project_id variable")
+	})
+}
+
+func TestReconciliationDrift(t *testing.T) {
+	t.Run("keeps the note that reads the drift numbers", func(t *testing.T) {
+		// The panel is what tells an operator that a created or deleted count is a
+		// missed event rather than routine reconciliation work.
+		const note = "investigate before period finalization"
+
+		raw := read(t, "reconciliation-drift.json")
+
+		if !bytes.Contains(raw, []byte(note)) {
+			t.Errorf("reconciliation-drift.json carries no %q", note)
+		}
+	})
+}
+
+// load reads and decodes one dashboard file.
+func load(t *testing.T, name string) dashboard {
+	t.Helper()
+
+	var d dashboard
+	if err := json.Unmarshal(read(t, name), &d); err != nil {
+		t.Fatalf("parsing %s: %v", filepath.Join(dashboardDir, name), err)
+	}
+	return d
+}
+
+// read returns the raw bytes of one dashboard file.
+func read(t *testing.T, name string) []byte {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(dashboardDir, name))
+	if err != nil {
+		t.Fatalf("reading the dashboard: %v", err)
+	}
+	return raw
+}
+
+// flatten returns every panel of the dashboard, including the ones a row panel
+// nests under itself.
+func flatten(panels []panel) []panel {
+	all := make([]panel, 0, len(panels))
+	for _, p := range panels {
+		all = append(all, p)
+		all = append(all, flatten(p.Panels)...)
+	}
+	return all
+}

--- a/deploy/kubernetes/base/grafana/grafana.yaml
+++ b/deploy/kubernetes/base/grafana/grafana.yaml
@@ -1,0 +1,233 @@
+# The dashboard frontend. Its datasource, its dashboard provider, and the four
+# dashboards all come from generated ConfigMaps, so a pod that restarts comes
+# back serving what this repository says it should.
+#
+# Nothing is written that has to survive that restart. Grafana keeps its own
+# SQLite database on the container's writable layer on purpose: the dashboards
+# and the datasource are provisioned from this tree, the admin user is seeded
+# from the Secret below on every start, and no alert rule, annotation or extra
+# user is configured. A volume would only add a one-way migration floor on the
+# image tag. Configuring any of those is what would make storage a requirement.
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:13.1.3
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            # A placeholder every overlay patches, the same way it patches the
+            # Certificate's dnsNames. Grafana builds its redirects and the
+            # links it renders from this value, so an unpatched one points the
+            # browser at a host that answers nothing.
+            - name: GF_SERVER_ROOT_URL
+              value: https://grafana.tally.example.com
+            # Secrets follow the *_FILE convention so they arrive as a mounted
+            # file rather than an environment value.
+            - name: GF_SECURITY_ADMIN_PASSWORD__FILE
+              value: /run/secrets/tally-grafana/admin-password
+            # Grafana derives the Secure attribute of its session cookie from
+            # its own protocol, not from the root URL. TLS terminates at the
+            # Gateway and Grafana speaks plain HTTP behind it, so it would leave
+            # the attribute off and a browser would attach the session to the
+            # cleartext request that the port-80 listener answers with its
+            # redirect. Setting it here says what the browser actually speaks.
+            - name: GF_SECURITY_COOKIE_SECURE
+              value: "true"
+            # No GF_AUTH_ANONYMOUS_* variable is set here. Without an overlay
+            # saying otherwise, Grafana serves a login page.
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          # Grafana buffers a whole datasource response in memory before it
+          # re-encodes it for the client, and this is the pod that answers
+          # queries against a 13-month store. Without a ceiling a wide enough
+          # query grows the process until the node's OOM killer picks a victim,
+          # and the datastores beside it are the candidates.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+            - name: provisioning-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: provisioning-dashboards
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: admin-password
+              mountPath: /run/secrets/tally-grafana
+              readOnly: true
+        # The address the provisioned datasource names, and the reason it does
+        # not name http://victoriametrics:8428
+        # (provisioning/datasources/vm.yaml). Grafana forwards a
+        # caller-supplied path to the datasource URL from
+        # /api/datasources/proxy/uid/<uid>/<path> and from
+        # /api/datasources/uid/<uid>/resources/<path>, under the
+        # datasources:query permission the viewer role holds. The second is what
+        # fills the variable dropdowns, so the Gateway cannot withhold it, which
+        # leaves the datasource URL itself as the place to bound what that
+        # tunnel reaches. vmauth carries the Prometheus read paths on to the
+        # store and refuses every other path (vmauth/auth.yaml).
+        #
+        # It listens on the loopback of this pod rather than on the pod IP, so
+        # the only process that reaches it is the one beside it. That is also
+        # why it carries no probe: the kubelet reaches a container on the pod
+        # IP, and opening the port there would publish the read proxy to the
+        # namespace for nothing.
+        #
+        # A vmauth that is down is not a panel that cannot query. A Pod is Ready
+        # only while every one of its containers is, and with the single replica
+        # above that drops this pod out of the grafana EndpointSlice: the host
+        # answers 503 for everything, login page included. Both flags below are
+        # there because the sidecar's failure is the whole UI's failure.
+        - name: vmauth
+          image: victoriametrics/vmauth:v1.148.0
+          args:
+            - -auth.config=/etc/vmauth/auth.yaml
+            - -httpListenAddr=127.0.0.1:8427
+            # /health, /metrics, /flags, /-/reload and /debug/pprof/* are
+            # answered by vmauth itself, ahead of the route map, so on 8427
+            # alone they sit inside the tunnel rather than behind url_map.
+            # Naming a second address moves them off the port the datasource
+            # URL names, where url_map then refuses them like any other path.
+            # Without it /debug/pprof/trace?seconds=300 is one dashboard away.
+            - -httpInternalListenAddr=127.0.0.1:8426
+            # Only the Grafana beside it sends requests here, and the default of
+            # 1000 in flight is well above what the memory limit below survives.
+            # Queueing a query and then refusing it costs one panel; being
+            # OOM-killed costs the host.
+            - -maxConcurrentRequests=64
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: vmauth-config
+              mountPath: /etc/vmauth
+              readOnly: true
+      volumes:
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+        - name: provisioning-datasources
+          configMap:
+            name: grafana-provisioning-datasources
+        - name: provisioning-dashboards
+          configMap:
+            name: grafana-provisioning-dashboards
+        - name: vmauth-config
+          configMap:
+            name: grafana-vmauth
+        # The base defines no tally-grafana Secret. The overlay generates it,
+        # the same convention tally-db follows. Naming the key makes a Secret
+        # that carries a different one fail the mount: Grafana's __FILE resolver
+        # logs an unreadable path and carries on with its built-in password, so
+        # without this the pod would come up healthy on admin/admin.
+        - name: admin-password
+          secret:
+            secretName: tally-grafana
+            items:
+              - key: admin-password
+                path: admin-password
+---
+# The response the deny rule below sends. Envoy Gateway's extension filter, the
+# Gateway API having no core way to answer a request without a backend.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: grafana-deny-datasource-proxy
+spec:
+  directResponse:
+    statusCode: 403
+    contentType: text/plain
+    body:
+      type: Inline
+      inline: "The Grafana datasource proxy is not published.\n"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - grafana.tally.example.com
+  rules:
+    # Nothing here needs the datasource proxy: a provisioned dashboard queries
+    # through /api/ds/query, so the prefix is refused rather than published.
+    #
+    # This is the outer of two rings and the weaker one. It closes one spelling
+    # of one endpoint: /api/datasources/uid/<uid>/resources forwards a
+    # caller-supplied path the same way and cannot be denied without emptying
+    # every variable dropdown, and a percent-encoded spelling of the prefix
+    # below reaches Grafana as this path all the same, because Grafana routes on
+    # the decoded one. What actually bounds the tunnel is the far end: the
+    # datasource URL names the vmauth container in the Grafana pod, which serves
+    # reads and refuses everything else.
+    #
+    # Gateway API resolves path prefixes longest-match-first, so this rule wins
+    # over the / below wherever it matches, whatever the order in this list.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/datasources/proxy
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: grafana-deny-datasource-proxy
+    # Everything else. Naming paths here would break the asset and API calls
+    # the UI makes to render a page, so the whole host is published.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grafana
+          port: 80

--- a/deploy/kubernetes/base/grafana/kustomization.yaml
+++ b/deploy/kubernetes/base/grafana/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - grafana.yaml
+
+# Generating the ConfigMaps from the files means editing any provisioning or
+# dashboard file re-rolls the pod through the generated name hash, rather than
+# leaving it serving a stale datasource or an old dashboard.
+configMapGenerator:
+  - name: grafana-provisioning-datasources
+    files:
+      - provisioning/datasources/vm.yaml
+  - name: grafana-provisioning-dashboards
+    files:
+      - provisioning/dashboards/tally.yaml
+  - name: grafana-vmauth
+    files:
+      - vmauth/auth.yaml
+  - name: grafana-dashboards
+    files:
+      - dashboards/fleet-overview.json
+      - dashboards/project-drilldown.json
+      - dashboards/ingestion-health.json
+      - dashboards/reconciliation-drift.json

--- a/deploy/kubernetes/base/grafana/manifest_test.go
+++ b/deploy/kubernetes/base/grafana/manifest_test.go
@@ -1,0 +1,510 @@
+// This file pins the manifest properties that keep an anonymous request from
+// reaching further than a dashboard. Every one of them fails silently: a pod
+// that mounts the wrong Secret key still passes its readiness probe, a route
+// that publishes the datasource proxy still renders every panel, and a session
+// cookie without Secure looks the same in the browser. The test reads the YAML
+// from disk and needs no cluster.
+package grafana_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The four files that between them bound what the datasource proxy reaches.
+// Denying the proxy prefix at the Gateway is the weakest of them: the variable
+// queries read /api/datasources/uid/<uid>/resources, which forwards a
+// caller-supplied path the same way and cannot be denied without emptying every
+// dropdown, and a percent-encoded spelling of the prefix reaches Grafana as the
+// decoded path regardless. What bounds the tunnel is its far end, so the
+// datasource file, the route map of the container it names, and the delete key
+// on the store are asserted here alongside the route rather than apart.
+const (
+	grafanaManifest = "grafana.yaml"
+	vmManifest      = "../victoriametrics/victoriametrics.yaml"
+	datasourceFile  = "provisioning/datasources/vm.yaml"
+	vmauthConfig    = "vmauth/auth.yaml"
+)
+
+// object is the part of a manifest document this test asserts over. yaml.v3
+// ignores every field not named here, so one shape covers all four kinds.
+type object struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		// HTTPRouteFilter
+		DirectResponse struct {
+			StatusCode int `yaml:"statusCode"`
+		} `yaml:"directResponse"`
+		// Deployment and StatefulSet
+		Template struct {
+			Spec struct {
+				Containers []container `yaml:"containers"`
+				Volumes    []volume    `yaml:"volumes"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+		// HTTPRoute
+		Rules []routeRule `yaml:"rules"`
+	} `yaml:"spec"`
+}
+
+type container struct {
+	Name      string   `yaml:"name"`
+	Args      []string `yaml:"args"`
+	Env       []envVar `yaml:"env"`
+	Resources struct {
+		Limits map[string]string `yaml:"limits"`
+	} `yaml:"resources"`
+}
+
+type envVar struct {
+	Name      string `yaml:"name"`
+	Value     string `yaml:"value"`
+	ValueFrom struct {
+		SecretKeyRef struct {
+			Name string `yaml:"name"`
+			Key  string `yaml:"key"`
+		} `yaml:"secretKeyRef"`
+	} `yaml:"valueFrom"`
+}
+
+type volume struct {
+	Name   string `yaml:"name"`
+	Secret struct {
+		SecretName string `yaml:"secretName"`
+		Items      []struct {
+			Key  string `yaml:"key"`
+			Path string `yaml:"path"`
+		} `yaml:"items"`
+	} `yaml:"secret"`
+}
+
+type routeRule struct {
+	Matches []struct {
+		Path struct {
+			Value string `yaml:"value"`
+		} `yaml:"path"`
+	} `yaml:"matches"`
+	Filters []struct {
+		Type         string `yaml:"type"`
+		ExtensionRef struct {
+			Kind string `yaml:"kind"`
+			Name string `yaml:"name"`
+		} `yaml:"extensionRef"`
+	} `yaml:"filters"`
+	BackendRefs []struct {
+		Name string `yaml:"name"`
+	} `yaml:"backendRefs"`
+}
+
+func TestGrafanaDeployment(t *testing.T) {
+	c := grafanaContainer(t)
+
+	t.Run("mounts the admin password by name", func(t *testing.T) {
+		// Grafana's __FILE resolver logs an unreadable path and carries on with
+		// its built-in password rather than exiting, so a Secret carrying a
+		// differently-named key would leave admin/admin live on a pod that
+		// passes its probes. Naming the key fails the mount instead.
+		v := volumeNamed(t, objects(t, grafanaManifest), "Deployment", "grafana", "admin-password")
+
+		if v.Secret.SecretName != "tally-grafana" {
+			t.Errorf("secretName = %q, want %q", v.Secret.SecretName, "tally-grafana")
+		}
+		if len(v.Secret.Items) != 1 {
+			t.Fatalf("the volume names %d keys, want exactly admin-password; any other key would mount and start the pod on the built-in password",
+				len(v.Secret.Items))
+		}
+		if got := v.Secret.Items[0].Key; got != "admin-password" {
+			t.Errorf("mounted key = %q, want %q", got, "admin-password")
+		}
+	})
+
+	t.Run("marks the session cookie Secure", func(t *testing.T) {
+		// Grafana derives the attribute from its own protocol, which is plain
+		// HTTP behind the Gateway that terminates TLS. Without this the browser
+		// attaches the session to the cleartext request the port-80 listener
+		// answers with its redirect, where anyone on the path reads it.
+		if got := envValue(c, "GF_SECURITY_COOKIE_SECURE"); got != "true" {
+			t.Errorf("GF_SECURITY_COOKIE_SECURE = %q, want %q", got, "true")
+		}
+	})
+
+	t.Run("caps the memory a query can take", func(t *testing.T) {
+		// Grafana buffers a whole datasource response before re-encoding it. No
+		// cgroup ceiling here leaves the node's OOM killer to choose, and the
+		// datastores beside it are the candidates.
+		if c.Resources.Limits["memory"] == "" {
+			t.Error("no memory limit, so a wide query grows the process until the node evicts something")
+		}
+	})
+
+	t.Run("caps what the read proxy runs at once", func(t *testing.T) {
+		// vmauth defaults to 1000 requests in flight, against a memory limit
+		// two orders of magnitude below Grafana's own. A Pod is Ready only
+		// while every container is, so an OOM-killed sidecar drops the single
+		// replica out of the EndpointSlice and the host answers 503 for
+		// everything, login page included. Refusing a query costs one panel.
+		vmauth := containerNamed(t, objects(t, grafanaManifest), "Deployment", "grafana", "vmauth")
+
+		if _, ok := argValue(vmauth, "-maxConcurrentRequests="); !ok {
+			t.Error("vmauth names no -maxConcurrentRequests, so a burst through the datasource proxy runs at the default of 1000 and an OOM kill takes the whole Grafana host with it")
+		}
+	})
+}
+
+func TestGrafanaRoute(t *testing.T) {
+	docs := objects(t, grafanaManifest)
+
+	t.Run("denies the datasource proxy", func(t *testing.T) {
+		// /api/datasources/proxy/uid/<uid>/<path> forwards <path> to the
+		// datasource URL and checks only datasources:query, which the viewer
+		// role holds. Nothing here needs it, so it is refused. This is the
+		// outer ring; TestDatasourceReachesReadsOnly covers the one that holds.
+		const prefix = "/api/datasources/proxy"
+
+		rule, ok := ruleMatching(docs, "grafana", prefix)
+		if !ok {
+			t.Fatalf("the grafana HTTPRoute has no rule for %s, so the / rule carries it to Grafana", prefix)
+		}
+		if len(rule.BackendRefs) != 0 {
+			t.Errorf("the %s rule names %d backends, so the request is forwarded rather than refused",
+				prefix, len(rule.BackendRefs))
+		}
+		if len(rule.Filters) != 1 || rule.Filters[0].Type != "ExtensionRef" {
+			t.Fatalf("the %s rule carries no ExtensionRef filter, so it answers 500 rather than a refusal", prefix)
+		}
+
+		ref := rule.Filters[0].ExtensionRef
+		for _, doc := range docs {
+			if doc.Kind != ref.Kind || doc.Metadata.Name != ref.Name {
+				continue
+			}
+			if doc.Spec.DirectResponse.StatusCode != 403 {
+				t.Errorf("%s %s responds %d, want 403", ref.Kind, ref.Name, doc.Spec.DirectResponse.StatusCode)
+			}
+			return
+		}
+		t.Errorf("the rule references %s/%s, which this file does not define", ref.Kind, ref.Name)
+	})
+}
+
+func TestDatasourceReachesReadsOnly(t *testing.T) {
+	// Grafana forwards a caller-supplied path to the datasource URL from
+	// /api/datasources/proxy/uid/<uid>/<path> and from
+	// /api/datasources/uid/<uid>/resources/<path>, and both check
+	// datasources:query alone. The dev overlay hands that permission to a
+	// request without a session, and the second endpoint is what fills the
+	// variable dropdowns, so it cannot be withheld at the Gateway. Whatever the
+	// datasource URL answers is therefore reachable by anyone who can open a
+	// dashboard: named at the store, it would publish /api/v1/write and the
+	// admin API with it.
+	vmauth := containerNamed(t, objects(t, grafanaManifest), "Deployment", "grafana", "vmauth")
+
+	t.Run("names the read proxy rather than the store", func(t *testing.T) {
+		addr, ok := argValue(vmauth, "-httpListenAddr=")
+		if !ok {
+			t.Fatal("the vmauth container names no -httpListenAddr, so it listens wherever its default is rather than where the datasource points")
+		}
+		if !strings.HasPrefix(addr, "127.0.0.1:") {
+			t.Errorf("vmauth listens on %q, want the pod loopback; on the pod IP the read proxy is published to the namespace", addr)
+		}
+		if got, want := datasourceURL(t, "VictoriaMetrics"), "http://"+addr; got != want {
+			t.Errorf("datasource url = %q, want %q; the url is what the two proxy endpoints reach", got, want)
+		}
+	})
+
+	t.Run("keeps vmauth's own endpoints off the datasource port", func(t *testing.T) {
+		// /health, /metrics, /flags, /-/reload and /debug/pprof/* are answered
+		// by vmauth ahead of url_map, so on the port the datasource URL names
+		// they would sit inside the tunnel with no src_paths entry bounding
+		// them: /debug/pprof/trace?seconds=300 buffered in Grafana, /-/reload
+		// on demand, /flags and /metrics read off. A second address is what
+		// makes the route map below the only thing that port consults.
+		addr, _ := argValue(vmauth, "-httpListenAddr=")
+
+		internal, ok := argValue(vmauth, "-httpInternalListenAddr=")
+		if !ok {
+			t.Fatal("vmauth names no -httpInternalListenAddr, so /debug/pprof, /metrics, /flags and /-/reload answer on the port the datasource URL names")
+		}
+		if internal == addr {
+			t.Errorf("-httpInternalListenAddr = %q, the same address as -httpListenAddr; the built-in endpoints stay inside the tunnel", internal)
+		}
+		if !strings.HasPrefix(internal, "127.0.0.1:") {
+			t.Errorf("-httpInternalListenAddr = %q, want the pod loopback", internal)
+		}
+	})
+
+	t.Run("carries the read paths and refuses the rest", func(t *testing.T) {
+		// Where the read paths carry on to.
+		const store = "http://victoriametrics:8428"
+
+		if got, ok := argValue(vmauth, "-auth.config="); !ok || got != "/etc/vmauth/auth.yaml" {
+			t.Fatalf("vmauth reads its route map from %q, not the mounted %s this test asserts over", got, vmauthConfig)
+		}
+
+		routes := vmauthRoutes(t)
+		for _, tc := range []struct {
+			path string
+			read bool
+		}{
+			// What a panel, a variable query and the datasource itself ask for.
+			{"/api/v1/query", true},
+			{"/api/v1/query_range", true},
+			{"/api/v1/series", true},
+			{"/api/v1/labels", true},
+			{"/api/v1/label/cloud/values", true},
+			{"/api/v1/metadata", true},
+			{"/api/v1/status/buildinfo", true},
+			// What port 8428 also serves and nothing here may reach.
+			{"/api/v1/write", false},
+			{"/api/v1/import", false},
+			{"/api/v1/import/prometheus", false},
+			{"/api/v1/admin/tsdb/delete_series", false},
+			{"/snapshot/create", false},
+		} {
+			backend := vmauthBackend(routes, tc.path)
+			switch {
+			case tc.read && backend == "":
+				t.Errorf("%s is refused, and a dashboard does not render without it", tc.path)
+			case tc.read && backend != store:
+				t.Errorf("%s reaches %q, want %q", tc.path, backend, store)
+			case !tc.read && backend != "":
+				t.Errorf("%s reaches %q, so whoever can open a dashboard reaches it through the datasource proxy", tc.path, backend)
+			}
+		}
+	})
+}
+
+func TestVictoriaMetricsDeleteAPI(t *testing.T) {
+	t.Run("takes a delete key from a Secret", func(t *testing.T) {
+		// With no key, /api/v1/admin/tsdb/delete_series answers whoever reaches
+		// port 8428 and drops a match of every series in the 13-month window.
+		// The port is open to every pod in the namespace, so the Gateway route
+		// is not what closes this.
+		const arg = "-deleteAuthKey=$(VM_DELETE_AUTH_KEY)"
+
+		c := containerNamed(t, objects(t, vmManifest), "StatefulSet", "victoriametrics", "victoriametrics")
+
+		if !slices.Contains(c.Args, arg) {
+			t.Errorf("args = %v, want one of them %q", c.Args, arg)
+		}
+		for _, e := range c.Env {
+			if e.Name != "VM_DELETE_AUTH_KEY" {
+				continue
+			}
+			if e.ValueFrom.SecretKeyRef.Name == "" || e.ValueFrom.SecretKeyRef.Key == "" {
+				t.Error("VM_DELETE_AUTH_KEY is not read from a Secret, so the key is in the manifest")
+			}
+			return
+		}
+		t.Error("no VM_DELETE_AUTH_KEY variable, so the flag expands to the empty key and the endpoint stays open")
+	})
+}
+
+// objects decodes every document of one manifest file.
+func objects(t *testing.T, path string) []object {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the manifest: %v", err)
+	}
+
+	var docs []object
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc object
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			return docs
+		}
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		docs = append(docs, doc)
+	}
+}
+
+// grafanaContainer returns the one container of the Grafana Deployment.
+func grafanaContainer(t *testing.T) container {
+	t.Helper()
+	return containerNamed(t, objects(t, grafanaManifest), "Deployment", "grafana", "grafana")
+}
+
+// containerNamed returns one container of one workload, failing if either is
+// missing rather than asserting over a zero value.
+func containerNamed(t *testing.T, docs []object, kind, workload, name string) container {
+	t.Helper()
+
+	for _, doc := range docs {
+		if doc.Kind != kind || doc.Metadata.Name != workload {
+			continue
+		}
+		for _, c := range doc.Spec.Template.Spec.Containers {
+			if c.Name == name {
+				return c
+			}
+		}
+		t.Fatalf("%s %s carries no container %q", kind, workload, name)
+	}
+	t.Fatalf("no %s named %q", kind, workload)
+	return container{}
+}
+
+// volumeNamed returns one volume of one workload.
+func volumeNamed(t *testing.T, docs []object, kind, workload, name string) volume {
+	t.Helper()
+
+	for _, doc := range docs {
+		if doc.Kind != kind || doc.Metadata.Name != workload {
+			continue
+		}
+		for _, v := range doc.Spec.Template.Spec.Volumes {
+			if v.Name == name {
+				return v
+			}
+		}
+		t.Fatalf("%s %s carries no volume %q", kind, workload, name)
+	}
+	t.Fatalf("no %s named %q", kind, workload)
+	return volume{}
+}
+
+// ruleMatching returns the rule of one HTTPRoute whose path prefix is exactly
+// the one given.
+func ruleMatching(docs []object, route, prefix string) (routeRule, bool) {
+	for _, doc := range docs {
+		if doc.Kind != "HTTPRoute" || doc.Metadata.Name != route {
+			continue
+		}
+		for _, rule := range doc.Spec.Rules {
+			for _, m := range rule.Matches {
+				if m.Path.Value == prefix {
+					return rule, true
+				}
+			}
+		}
+	}
+	return routeRule{}, false
+}
+
+// envValue returns the literal value of one environment variable, or "".
+func envValue(c container, name string) string {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
+}
+
+// argValue returns the value of one flag argument, written -flag=value.
+func argValue(c container, flag string) (string, bool) {
+	for _, a := range c.Args {
+		if v, ok := strings.CutPrefix(a, flag); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// datasourceURL returns the url of one provisioned datasource.
+func datasourceURL(t *testing.T, name string) string {
+	t.Helper()
+
+	var file struct {
+		Datasources []struct {
+			Name string `yaml:"name"`
+			URL  string `yaml:"url"`
+		} `yaml:"datasources"`
+	}
+	decodeFile(t, datasourceFile, &file)
+
+	for _, ds := range file.Datasources {
+		if ds.Name == name {
+			return ds.URL
+		}
+	}
+	t.Fatalf("%s declares no datasource %q", datasourceFile, name)
+	return ""
+}
+
+// vmauthRoute is one url_map entry, with its src_paths compiled the way vmauth
+// compiles them: anchored, so an entry matches a request path whole or not at
+// all, and a path no entry matches never leaves the pod.
+type vmauthRoute struct {
+	paths  []*regexp.Regexp
+	prefix string
+}
+
+// vmauthRoutes returns the route map the read proxy runs with.
+func vmauthRoutes(t *testing.T) []vmauthRoute {
+	t.Helper()
+
+	var cfg struct {
+		UnauthorizedUser struct {
+			URLMap []struct {
+				SrcPaths  []string `yaml:"src_paths"`
+				URLPrefix string   `yaml:"url_prefix"`
+			} `yaml:"url_map"`
+		} `yaml:"unauthorized_user"`
+	}
+	decodeFile(t, vmauthConfig, &cfg)
+
+	if len(cfg.UnauthorizedUser.URLMap) == 0 {
+		t.Fatalf("%s carries no unauthorized_user route map, so vmauth refuses every request and no panel renders", vmauthConfig)
+	}
+
+	routes := make([]vmauthRoute, 0, len(cfg.UnauthorizedUser.URLMap))
+	for _, m := range cfg.UnauthorizedUser.URLMap {
+		r := vmauthRoute{prefix: m.URLPrefix}
+		for _, p := range m.SrcPaths {
+			re, err := regexp.Compile("^(?:" + p + ")$")
+			if err != nil {
+				t.Fatalf("src_paths %q does not compile, and vmauth exits on it: %v", p, err)
+			}
+			r.paths = append(r.paths, re)
+		}
+		routes = append(routes, r)
+	}
+	return routes
+}
+
+// vmauthBackend returns the backend a request path reaches, or "" when no entry
+// matches it and vmauth answers "missing route". That "" means refused for
+// every path, rather than for every path vmauth does not answer itself, only
+// because -httpInternalListenAddr moves the latter off this port; the subtest
+// above is what holds that.
+func vmauthBackend(routes []vmauthRoute, path string) string {
+	for _, r := range routes {
+		for _, re := range r.paths {
+			if re.MatchString(path) {
+				return r.prefix
+			}
+		}
+	}
+	return ""
+}
+
+// decodeFile parses one single-document file into v.
+func decodeFile(t *testing.T, path string, v any) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	if err := yaml.Unmarshal(raw, v); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+}

--- a/deploy/kubernetes/base/grafana/provisioning/dashboards/tally.yaml
+++ b/deploy/kubernetes/base/grafana/provisioning/dashboards/tally.yaml
@@ -1,0 +1,14 @@
+# The provider that loads the dashboards Grafana serves. The files reach the
+# pod through the grafana-dashboards ConfigMap, mounted at the path below.
+apiVersion: 1
+
+providers:
+  - name: tally
+    folder: Tally
+    type: file
+    # The dashboards are kept in the repository. An edit or a delete in the UI
+    # would last until the next pod restart, so neither is allowed.
+    disableDeletion: true
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/kubernetes/base/grafana/provisioning/datasources/vm.yaml
+++ b/deploy/kubernetes/base/grafana/provisioning/datasources/vm.yaml
@@ -1,0 +1,28 @@
+# The datasource every provisioned dashboard queries.
+#
+# The uid is fixed here because every panel target in the dashboard JSON names
+# it. A generated uid would leave each panel pointing at a datasource Grafana
+# does not have.
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    type: prometheus
+    uid: victoriametrics
+    access: proxy
+    # Not http://victoriametrics:8428. Grafana hands whoever can open a
+    # dashboard a tunnel to whatever this URL is: both
+    # /api/datasources/proxy/uid/<uid>/<path> and
+    # /api/datasources/uid/<uid>/resources/<path> forward <path> to it under the
+    # datasources:query permission the viewer role holds, and the second is what
+    # fills the variable dropdowns, so no Gateway rule closes them. The vmauth
+    # container in the Grafana pod (grafana.yaml) is the read-only face of the
+    # store: it carries the Prometheus read paths on to
+    # http://victoriametrics:8428 and refuses everything else, /api/v1/write and
+    # /api/v1/admin/tsdb/delete_series included. It listens on this pod's
+    # loopback alone, so nothing outside the pod reaches it either.
+    url: http://127.0.0.1:8427
+    isDefault: true
+    # The definition lives in this file, so the UI must not offer edits that
+    # the next pod restart discards.
+    editable: false

--- a/deploy/kubernetes/base/grafana/vmauth/auth.yaml
+++ b/deploy/kubernetes/base/grafana/vmauth/auth.yaml
@@ -1,0 +1,37 @@
+# The read-only face of VictoriaMetrics, and the only address the provisioned
+# datasource names.
+#
+# Grafana forwards a caller-supplied path to the datasource URL from two
+# endpoints the viewer role reaches: /api/datasources/proxy/uid/<uid>/<path> and
+# /api/datasources/uid/<uid>/resources/<path>. Both check datasources:query
+# alone, the second is what fills every variable dropdown, and neither can be
+# withheld at the Gateway without taking the dashboards with it. Whatever the
+# datasource URL answers is therefore reachable by anyone who can open a
+# dashboard, so it answers reads and nothing else.
+#
+# src_paths entries are regular expressions matched against the whole request
+# path. A path no entry matches is refused here with "missing route" and never
+# leaves the pod, which is what keeps /api/v1/write, /api/v1/import and
+# /api/v1/admin/tsdb/delete_series out of reach. Adding an entry widens what a
+# viewer can reach, so the list holds the Prometheus read API and stops there.
+#
+# /health, /metrics, /flags, /-/reload and /debug/pprof/* are answered by vmauth
+# itself, ahead of this map, so no entry here would bound them. They are moved
+# off the port the datasource URL names with -httpInternalListenAddr
+# (grafana.yaml), which is what leaves this map the only thing that port
+# consults and makes "no matching entry" mean "refused" for every path.
+unauthorized_user:
+  url_map:
+    - src_paths:
+        # What a panel query goes through.
+        - "/api/v1/query"
+        - "/api/v1/query_range"
+        # What the variable queries and the metrics browser go through.
+        - "/api/v1/series"
+        - "/api/v1/labels"
+        - "/api/v1/label/[^/]+/values"
+        - "/api/v1/metadata"
+        # What the datasource reads once to learn which of the two label-value
+        # endpoints above it may use.
+        - "/api/v1/status/buildinfo"
+      url_prefix: "http://victoriametrics:8428"

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - victoriametrics
   - otel-collector
   - reporting-api
+  - grafana

--- a/deploy/kubernetes/base/victoriametrics/victoriametrics.yaml
+++ b/deploy/kubernetes/base/victoriametrics/victoriametrics.yaml
@@ -79,6 +79,23 @@ spec:
             - -retentionPeriod=13
             - -promscrape.config=/etc/vm/scrape.yaml
             - -storageDataPath=/victoria-metrics-data
+            # Without a key, /api/v1/admin/tsdb/delete_series answers whoever
+            # reaches port 8428 and drops a match of every series in the
+            # 13-month window. The Gateway route below withholds the path, but
+            # the route is not the only way in: the port is open to every pod in
+            # the namespace, so the endpoint has to be closed here rather than
+            # one hop away.
+            #
+            # The key arrives as an environment value rather than the mounted
+            # file the other components take, because the flag reads its value
+            # from the argument and Kubernetes expands $(VAR) in it.
+            - -deleteAuthKey=$(VM_DELETE_AUTH_KEY)
+          env:
+            - name: VM_DELETE_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tally-vm-admin
+                  key: delete-auth-key
           ports:
             - name: http
               containerPort: 8428
@@ -125,12 +142,11 @@ spec:
   hostnames:
     - vm.tally.example.com
   rules:
-    # Only the read paths are published. Port 8428 also serves
-    # /api/v1/write and /api/v1/admin/tsdb/delete_series, and VictoriaMetrics
-    # gates neither: it takes a remote write from anyone who reaches it, and
-    # with no -deleteAuthKey set one request to the delete API drops a match of
-    # every series in the 13-month window. Routing the whole port would publish
-    # both to the internet, so the route names the paths a reader needs instead.
+    # Only the read paths are published. Port 8428 also serves /api/v1/write,
+    # which VictoriaMetrics takes from anyone who reaches it, and
+    # /api/v1/admin/tsdb/delete_series, which -deleteAuthKey above now closes.
+    # Routing the whole port would publish the write API to the internet, so the
+    # route names the paths a reader needs instead.
     - matches:
         - path:
             type: PathPrefix

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -31,6 +31,19 @@ secretGenerator:
   - name: tally-otlp-auth
     literals:
       - htpasswd=tally:tally-dev-otlp-password
+  # The key has to be admin-password: the Grafana Deployment reads the secret
+  # from /run/secrets/tally-grafana/admin-password and mounts that one key, so
+  # any other key fails the mount and the pod never starts.
+  - name: tally-grafana
+    literals:
+      - admin-password=tally-dev-grafana-password
+  # What VictoriaMetrics takes as -deleteAuthKey. Its only job is to stop
+  # /api/v1/admin/tsdb/delete_series answering an unauthenticated caller, which
+  # anything that can reach the store is otherwise able to do; a dev value in
+  # the clear is enough for that, the same as the credentials above.
+  - name: tally-vm-admin
+    literals:
+      - delete-auth-key=tally-dev-vm-delete-key
 
 patches:
   # Route every service to its nip.io hostname.
@@ -69,6 +82,15 @@ patches:
       - op: replace
         path: /spec/hostnames/0
         value: otlp-grpc.tally.127-0-0-1.nip.io
+
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: grafana
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: grafana.tally.127-0-0-1.nip.io
 
   # Serve that domain, signed by the dev CA.
   - target:
@@ -118,3 +140,31 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Never
+
+  # The one strategic merge patch in this file. It merges env entries by name,
+  # so it names the three variables it sets instead of indexing into the base
+  # env list, where a reorder in the base would move the values onto the wrong
+  # variables.
+  #
+  # The root URL carries the 8443 host port for the same reason the redirect
+  # above does: kind publishes https there, so a link Grafana renders without
+  # the port sends the browser to a closed port. The anonymous settings give an
+  # unauthenticated request the viewer role, which reads dashboards and saves
+  # nothing; admin still signs in with the generated password.
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: grafana
+      spec:
+        template:
+          spec:
+            containers:
+              - name: grafana
+                env:
+                  - name: GF_SERVER_ROOT_URL
+                    value: https://grafana.tally.127-0-0-1.nip.io:8443
+                  - name: GF_AUTH_ANONYMOUS_ENABLED
+                    value: "true"
+                  - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+                    value: Viewer

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -1,0 +1,429 @@
+# Grafana dashboards
+
+Grafana reads the metrics store and serves four dashboards over it. Its
+datasource, its dashboard provider, and the dashboard files all come from this
+repository, so a pod that restarts comes back serving what the tree says. This
+document describes what is provisioned, how to reach it on a dev cluster, and
+how to fill all four dashboards with data.
+
+## What is provisioned
+
+### The datasource
+
+[`provisioning/datasources/vm.yaml`](../deploy/kubernetes/base/grafana/provisioning/datasources/vm.yaml)
+declares one datasource: `VictoriaMetrics`, type `prometheus`, and the default.
+Its uid is fixed at `victoriametrics` because every panel target in the
+dashboard JSON names that uid; a generated one would leave each panel pointing
+at a datasource Grafana does not have. `editable: false` keeps the UI from
+offering edits that the next pod restart discards.
+
+It is proxied to `http://127.0.0.1:8427` rather than to
+`http://victoriametrics:8428`, and that is a deliberate hop. Grafana forwards a
+caller-supplied path to the datasource URL from two endpoints that check
+`datasources:query` alone — `/api/datasources/proxy/uid/<uid>/<path>` and
+`/api/datasources/uid/<uid>/resources/<path>` — and the viewer role holds that
+permission. The second is what fills every variable dropdown, so neither the
+route nor Grafana can withhold it, and whatever the datasource URL answers is
+reachable by anyone who can open a dashboard. The address is therefore a
+[vmauth](../deploy/kubernetes/base/grafana/vmauth/auth.yaml) container beside
+Grafana in the same pod, listening on that pod's loopback: it carries the
+Prometheus read paths on to `http://victoriametrics:8428` and answers every
+other path, `/api/v1/write` and `/api/v1/admin/tsdb/delete_series` included,
+with `missing route`. Widening the list in `vmauth/auth.yaml` widens what a
+viewer reaches, which is what
+[`manifest_test.go`](../deploy/kubernetes/base/grafana/manifest_test.go) pins.
+
+### The dashboard provider
+
+[`provisioning/dashboards/tally.yaml`](../deploy/kubernetes/base/grafana/provisioning/dashboards/tally.yaml)
+declares one file provider, `tally`. It reads `/var/lib/grafana/dashboards` and
+puts what it finds in the folder `Tally`. `disableDeletion: true` and
+`allowUiUpdates: false` say where the dashboards live: an edit or a delete made
+in the UI would last until the next pod restart, so neither is allowed.
+
+### The four dashboards
+
+Four files under
+[`dashboards/`](../deploy/kubernetes/base/grafana/dashboards), each mounted into
+the pod from the generated `grafana-dashboards` ConfigMap:
+
+| File | uid | Series it reads |
+| --- | --- | --- |
+| `fleet-overview.json` | `tally-fleet-overview` | `tally_current_resources`, `openstack_identity_projects`, `openstack_nova_limits_instances_used` |
+| `project-drilldown.json` | `tally-project-drilldown` | the per-project nova, cinder, neutron, glance and octavia series, plus `tally_events_ingested_total` |
+| `ingestion-health.json` | `tally-ingestion-health` | `tally_events_ingested_total`, `tally_events_deduplicated_total`, `tally_events_rejected_total`, `tally_projection_replays_total`, `tally_collector_buffer_depth`, `tally_collector_oldest_buffered_seconds`, `up` |
+| `reconciliation-drift.json` | `tally-reconciliation-drift` | `tally_sync_resources_reconciled_total`, `tally_sync_errors_total`, `tally_sync_runs_total` |
+
+Each uid is written in the file rather than generated, because a saved link and
+a dashboard link address a dashboard by it.
+
+Every dashboard carries the multi-select variables `platform` and `cloud`, both
+read off `tally_current_resources` and both with an "All" option whose value is
+`.*`. `project-drilldown.json` adds `project_id`, read off the exporter's
+`tenant_id` label, and the `api_base` textbox its event link is built from.
+
+[`dashboards_test.go`](../deploy/kubernetes/base/grafana/dashboards_test.go)
+pins that contract in CI: the file set the ConfigMap ships, that every file
+parses, the uids and the titles, the datasource uid on every query target, the
+variables the expressions read, and the drift note on the reconciliation
+dashboard. Grafana reports a broken dashboard file in its own log alone, so
+without the test a truncated file or a renamed datasource reaches a cluster
+before anyone sees it.
+
+### Editing a provisioned file
+
+The datasource, the provider, and the dashboards are three
+`configMapGenerator` entries in
+[`kustomization.yaml`](../deploy/kubernetes/base/grafana/kustomization.yaml).
+Kustomize appends a content hash to each generated ConfigMap name, so editing
+any of those files changes the name, which changes the pod spec that mounts it,
+which rolls the pod. Grafana is never left serving a datasource or a dashboard
+that no longer matches the file in the tree. It is the pattern the collector and
+scrape configs follow, described under
+[Editing either config](openstack-metrics.md#editing-either-config).
+
+## Dev access
+
+`make up` publishes Grafana on the dev overlay's hostname:
+
+```text
+https://grafana.tally.127-0-0-1.nip.io:8443
+```
+
+The overlay patches the HTTPRoute to that hostname and sets
+`GF_SERVER_ROOT_URL` to the same URL including the `:8443` host port, because
+kind publishes https there
+([`deploy/kind/kind.yaml`](../deploy/kind/kind.yaml)) and a link Grafana renders
+without the port sends the browser to a closed port.
+
+The reachability check needs the dev CA that signed the Gateway's certificate:
+
+```sh
+make -s ca > tally-ca.crt
+curl --cacert tally-ca.crt https://grafana.tally.127-0-0-1.nip.io:8443/api/health
+```
+
+It answers 200 with a JSON body whose `database` member is `ok`.
+
+The overlay sets `GF_AUTH_ANONYMOUS_ENABLED` to `"true"` and
+`GF_AUTH_ANONYMOUS_ORG_ROLE` to `Viewer`, so a request without a session renders
+every dashboard and saves nothing. `admin` signs in with
+`tally-dev-grafana-password`, the `admin-password` key of the generated
+`tally-grafana` Secret
+([`overlays/dev/kustomization.yaml`](../deploy/kubernetes/overlays/dev/kustomization.yaml)).
+
+The route publishes the whole host bar one prefix: `/api/datasources/proxy`
+answers 403 from the Gateway. The dashboards do not use it — they query through
+`/api/ds/query` — so it is refused rather than published. That rule is the outer
+of two rings and the weaker one: the sibling endpoint
+`/api/datasources/uid/<uid>/resources` forwards a caller-supplied path the same
+way and cannot be denied without emptying every variable dropdown, and a
+percent-encoded spelling of the prefix reaches Grafana as the decoded path
+regardless. What bounds the tunnel is the far end, the read-only datasource URL
+described under [The datasource](#the-datasource).
+
+The base sets no `GF_AUTH_ANONYMOUS_*` variable and leaves the hostname at the
+placeholder `grafana.tally.example.com`. Without an overlay saying otherwise,
+Grafana serves a login page.
+
+## What a fresh cluster shows
+
+On a cluster nothing has reported to, every panel backed by an exporter series
+or a collector series shows "No data" rather than a query error. The `platform`
+and `cloud` variables read `label_values(tally_current_resources, ...)`, which
+resolves to nothing while the projection is empty. What keeps an empty variable
+from breaking a panel is its "All" value `.*`: a selector `cloud=~".*"` matches
+whatever the store holds, including nothing.
+
+The scrape-health stat on Tally / Ingestion Health reports `up == 0` for
+`openstack-db-exporter` and `ceilometer`. Both are static targets for exporters
+that run beside an OpenStack control plane rather than in this cluster. That is
+the designed dev state, described under
+[Replacing the placeholders](openstack-metrics.md#replacing-the-placeholders),
+and not a fault to chase.
+
+## Acceptance drill
+
+The drill fills all four dashboards on a dev cluster, in two parts. The first
+pushes real events through the Reporting API, which is what moves the `tally_`
+series and the projection the variables read. The second pushes the OpenStack
+exporter series the resource panels read, which no dev cluster produces, to the
+OTLP endpoint.
+
+Everything below runs from the repository root against a running dev cluster and
+uses the dev CA:
+
+```sh
+make -s ca > tally-ca.crt
+```
+
+### Part 1: real series through the Reporting API
+
+Ingest is authenticated per (platform, cloud), so the first step issues a
+credential. The command prints the raw token to stdout and the id plus the
+one-time notice to stderr, which is what lets the token be captured while the
+notice stays readable:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TOKEN="$(go run ./cmd/tally-reporting-admin create-ingest-credential \
+  --platform openstack --cloud os-prod-eu1)"
+```
+
+Push a small batch for cloud `os-prod-eu1` and project `drill-project`. The
+fields are the canonical event schema of
+[`roadmap/00-conventions.md`](../roadmap/00-conventions.md) section 4, and each
+`payload.size` validates against the schema the migration chain seeds for its
+resource type:
+
+```sh
+curl --cacert tally-ca.crt -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events' \
+  --data-binary @- <<'EOF'
+[
+  {
+    "event_id": "drill-instance-create",
+    "timestamp": "2026-08-19T09:00:00Z",
+    "event_type": "compute.instance.create.end",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "instance",
+    "resource_id": "drill-instance-1",
+    "project_id": "drill-project",
+    "source": "collector",
+    "payload": {
+      "state": "active",
+      "size": {"vcpus": 4, "ram_gb": 16, "disk_gb": 80, "flavor": "m1.large"}
+    }
+  },
+  {
+    "event_id": "drill-volume-create",
+    "timestamp": "2026-08-19T09:05:00Z",
+    "event_type": "volume.create.end",
+    "platform": "openstack",
+    "cloud": "os-prod-eu1",
+    "resource_type": "volume",
+    "resource_id": "drill-volume-1",
+    "project_id": "drill-project",
+    "source": "collector",
+    "payload": {
+      "state": "available",
+      "size": {"size_gb": 100, "type": "ssd"}
+    }
+  }
+]
+EOF
+```
+
+The answer names what the batch did:
+
+```json
+{"accepted": 2, "duplicates": 0, "rejected": []}
+```
+
+That moves `tally_events_ingested_total` and, once the refresher has run,
+`tally_current_resources`, which is the series both variables are read from.
+
+Send the identical batch a second time. Ingestion is idempotent on
+`(event_id, timestamp)`, so nothing is stored and the dedup counter moves:
+
+```json
+{"accepted": 0, "duplicates": 2, "rejected": []}
+```
+
+Send one create without `payload.size`, alone. The request itself is authorized
+and readable, so the call is still answered 200; the item is refused inside the
+batch and kept server-side under the reason it was refused, which
+`GET /api/v1/rejected-events` serves:
+
+```sh
+curl --cacert tally-ca.crt -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events' \
+  --data-binary @- <<'EOF'
+{
+  "event_id": "drill-volume-sizeless",
+  "timestamp": "2026-08-19T09:10:00Z",
+  "event_type": "volume.create.end",
+  "platform": "openstack",
+  "cloud": "os-prod-eu1",
+  "resource_type": "volume",
+  "resource_id": "drill-volume-2",
+  "project_id": "drill-project",
+  "source": "collector",
+  "payload": {"state": "available"}
+}
+EOF
+```
+
+```json
+{
+  "accepted": 0,
+  "duplicates": 0,
+  "rejected": [
+    {
+      "index": 0,
+      "event_id": "drill-volume-sizeless",
+      "reason": "schema: payload.size: required on create events"
+    }
+  ]
+}
+```
+
+`tally_events_rejected_total` counts that under the check that refused it, so
+the reason label reads `schema` rather than the full sentence.
+
+Send one update on the instance whose timestamp lies before its create. The
+incremental fold cannot place a late event, so the ingest transaction replays
+the resource's projection row from its whole history and
+`tally_projection_replays_total` counts the replay:
+
+```sh
+curl --cacert tally-ca.crt -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events' \
+  --data-binary @- <<'EOF'
+{
+  "event_id": "drill-instance-late-update",
+  "timestamp": "2026-08-19T08:30:00Z",
+  "event_type": "compute.instance.update",
+  "platform": "openstack",
+  "cloud": "os-prod-eu1",
+  "resource_type": "instance",
+  "resource_id": "drill-instance-1",
+  "project_id": "drill-project",
+  "source": "collector",
+  "payload": {"state": "active"}
+}
+EOF
+```
+
+```json
+{"accepted": 1, "duplicates": 0, "rejected": []}
+```
+
+The instance history now starts with an update, which the fold reports as the
+warning `history_starts_without_create` on
+`GET /api/v1/resources/os-prod-eu1/instance/drill-instance-1/lifecycle`. That is
+the drill's doing, not drift.
+
+The counters reach the store on the next scrape of the `reporting-api` job,
+which runs every 30 seconds. `tally_current_resources` takes longer: the gauge
+is re-derived from the projection every `TALLY_REPORTING_METRICS_REFRESH_S`
+seconds, 60 by default, and the scrape follows that, so the fleet panels and the
+two variables fill within about 90 seconds of the first batch.
+
+### Part 2: synthetic series through OTLP
+
+The OpenStack panels read the database exporter's series, and no dev cluster
+runs that exporter. One OTLP push writes exactly the series those panels read
+and no others.
+
+The project label differs per service, and the payload follows that: nova,
+cinder and glance name the owning project `tenant_id`, neutron and octavia name
+it `project_id`, and `openstack_identity_projects` carries no project label at
+all (see the coverage table under
+[Coverage against the concept](openstack-metrics.md#coverage-against-the-concept)).
+The `CLOUD`, `TENANT`, and `PROJECT` attribute sets below carry that difference.
+The exporter's per-resource labels, `id` and `name` among them, are left out:
+the panels count series and filter on the cloud and the project, so nothing
+reads them.
+
+The three `tally_sync_*` series are cumulative monotonic sums with two
+datapoints two minutes apart and growing values, because the panels read them
+through `increase()` and a single point has no slope. Their label values are the
+ones the reconciliation service emits: `completed` or `failed` for a run status,
+and `created`, `updated` or `deleted` for a reconciled resource.
+
+```sh
+NOW="$(date +%s)000000000"
+THEN="$(( $(date +%s) - 120 ))000000000"
+CLOUD='[{"key":"platform","value":{"stringValue":"openstack"}},{"key":"cloud","value":{"stringValue":"os-prod-eu1"}}]'
+TENANT='[{"key":"platform","value":{"stringValue":"openstack"}},{"key":"cloud","value":{"stringValue":"os-prod-eu1"}},{"key":"tenant_id","value":{"stringValue":"drill-project"}}]'
+PROJECT='[{"key":"platform","value":{"stringValue":"openstack"}},{"key":"cloud","value":{"stringValue":"os-prod-eu1"}},{"key":"project_id","value":{"stringValue":"drill-project"}}]'
+RUNS='[{"key":"cloud","value":{"stringValue":"os-prod-eu1"}},{"key":"status","value":{"stringValue":"completed"}}]'
+RECONCILED='[{"key":"cloud","value":{"stringValue":"os-prod-eu1"}},{"key":"action","value":{"stringValue":"created"}}]'
+ERRORS='[{"key":"cloud","value":{"stringValue":"os-prod-eu1"}}]'
+
+curl --cacert tally-ca.crt -X POST \
+  --user tally:tally-dev-otlp-password \
+  -H 'Content-Type: application/json' \
+  'https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics' \
+  --data-binary @- <<EOF
+{"resourceMetrics":[{"scopeMetrics":[{"metrics":[
+{"name":"openstack_identity_projects","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$CLOUD}]}},
+{"name":"openstack_nova_limits_instances_used","gauge":{"dataPoints":[{"asDouble":3,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_limits_instances_max","gauge":{"dataPoints":[{"asDouble":10,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_limits_vcpus_used","gauge":{"dataPoints":[{"asDouble":12,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_limits_vcpus_max","gauge":{"dataPoints":[{"asDouble":40,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_limits_memory_used","gauge":{"dataPoints":[{"asDouble":24576,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_limits_memory_max","gauge":{"dataPoints":[{"asDouble":81920,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_nova_server_status","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_cinder_volume_status","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_cinder_volume_gb","gauge":{"dataPoints":[{"asDouble":100,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_glance_image_bytes","gauge":{"dataPoints":[{"asDouble":21474836480,"timeUnixNano":"$NOW","attributes":$TENANT}]}},
+{"name":"openstack_neutron_floating_ip","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$PROJECT}]}},
+{"name":"openstack_neutron_router","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$PROJECT}]}},
+{"name":"openstack_loadbalancer_loadbalancer_status","gauge":{"dataPoints":[{"asDouble":1,"timeUnixNano":"$NOW","attributes":$PROJECT}]}},
+{"name":"tally_collector_buffer_depth","gauge":{"dataPoints":[{"asDouble":12,"timeUnixNano":"$NOW"}]}},
+{"name":"tally_collector_oldest_buffered_seconds","gauge":{"dataPoints":[{"asDouble":4,"timeUnixNano":"$NOW"}]}},
+{"name":"tally_sync_runs_total","sum":{"aggregationTemporality":2,"isMonotonic":true,"dataPoints":[
+  {"asDouble":4,"timeUnixNano":"$THEN","attributes":$RUNS},
+  {"asDouble":5,"timeUnixNano":"$NOW","attributes":$RUNS}]}},
+{"name":"tally_sync_resources_reconciled_total","sum":{"aggregationTemporality":2,"isMonotonic":true,"dataPoints":[
+  {"asDouble":11,"timeUnixNano":"$THEN","attributes":$RECONCILED},
+  {"asDouble":13,"timeUnixNano":"$NOW","attributes":$RECONCILED}]}},
+{"name":"tally_sync_errors_total","sum":{"aggregationTemporality":2,"isMonotonic":true,"dataPoints":[
+  {"asDouble":2,"timeUnixNano":"$THEN","attributes":$ERRORS},
+  {"asDouble":3,"timeUnixNano":"$NOW","attributes":$ERRORS}]}}
+]}]}]}
+EOF
+```
+
+The push answers 200 with an empty OTLP export response, `{}` or
+`{"partialSuccess":{}}`. Anything the collector rejects comes back as a 4xx with
+the reason in the body.
+
+Two costs of this part, both accepted:
+
+- The synthetic series stay in the dev store for the 13-month retention
+  VictoriaMetrics runs with, and nothing ages the points out inside a year.
+  Removing them means reaching the pod directly:
+  `/api/v1/admin/tsdb/delete_series` is on neither the read route the Gateway
+  publishes nor the read paths the Grafana datasource goes through, and it takes
+  the `-deleteAuthKey` that the generated `tally-vm-admin` Secret holds.
+  `make down` deletes the cluster and its volume, and that is the shorter way
+  out.
+- The drill is for dev clusters. Its labels claim a cloud, a project, and
+  reconciliation runs that never happened, so running it against a store any
+  invoice is derived from puts invented usage into the billing record.
+
+### Closing checks
+
+Open `https://grafana.tally.127-0-0-1.nip.io:8443`, go to the folder `Tally`,
+and select `os-prod-eu1` in the Cloud variable. On Tally / Project Drilldown
+select `drill-project` in the Project variable, which the drill's
+`openstack_nova_limits_instances_used` series supplies. Every panel on all four
+dashboards then carries a value. The panels built on `rate()` and `increase()`
+show the drill as one spike over their window rather than a level, because the
+drill pushed each series once.
+
+On the scrape-health stat, `openstack-db-exporter` and `ceilometer` report
+`up == 0` while `reporting-api` and `otel-collector` report `up == 1`. Those two
+jobs stay down for the reason above: the designed dev state, not a failure.
+
+The same OTLP push without `--user` answers `401` and
+`{"code":16,"message":"no basic auth provided"}`, and writes nothing. That is
+the check that the receivers are not open to whoever resolves the hostname.
+
+A panel that is still empty within 30 seconds of a push has lost no point.
+VictoriaMetrics evaluates queries behind wall clock by `-search.latencyOffset`,
+30 seconds by default, so a query over the window still being written comes back
+empty; the dashboards refresh every minute, and the panel fills on one of the
+next refreshes. The full explanation is in the
+[acceptance drill](openstack-metrics.md#acceptance-drill) of the metrics
+pipeline.


### PR DESCRIPTION
Closes #28

Grafana joins the deployment as a kustomize base component, provisioned entirely from this repository: the VictoriaMetrics datasource, the dashboard provider, and the four WP 2.3 dashboards all arrive as generated ConfigMaps, so editing any of them re-rolls the pod. The dev overlay publishes it on the existing Gateway with anonymous viewer access. No new host ports, no `deploy/kind/kind.yaml` change.

## The change, in commit order

**`0bd3bfa` Add the four Grafana dashboards and their validation test**

The four hand-authored dashboards (`fleet-overview`, `project-drilldown`, `ingestion-health`, `reconciliation-drift`) under `deploy/kubernetes/base/grafana/dashboards/`, plus `dashboards_test.go`. Every target names the `victoriametrics` datasource uid; `platform` and `cloud` are multi-select with an `allValue` of `.*` so an empty store still matches everything, and panels filter by them only where the series carries the label. The test pins the JSON contract from disk — file set, parseability, fixed uids, the datasource uid on every target including those nested in row panels, the template variables, and the verbatim drift note — so a renamed file or a changed uid fails in CI rather than in Grafana's startup log.

**`3301c64` Add the Grafana base component, provisioned from the repository**

Deployment, Service, and HTTPRoute on the `grafana.tally.example.com` placeholder, plus the provisioning files and the four `configMapGenerator` entries. All ConfigMaps are generated, so an edit re-rolls the pod through the name hash instead of leaving it serving a stale datasource. The admin password arrives as a mounted file from a `tally-grafana` Secret, following the `tally-db` convention, with the key named in `items` so a wrong key fails the mount rather than silently falling back to `admin/admin`.

This commit also carries the security reasoning that drove three of the deviations below — see *Divergences* .

**`94e1d4b` Publish Grafana on the dev overlay with anonymous viewer access**

Hostname patch to `grafana.tally.127-0-0-1.nip.io`, a `tally-grafana` secretGenerator entry, and a strategic-merge env patch (merging by `name`, so it lists the three variables it sets rather than indexing into the base env list) setting `GF_SERVER_ROOT_URL` with the `:8443` host port kind publishes https on, plus anonymous viewer access. Also adds the `tally-vm-admin` secretGenerator entry the VictoriaMetrics change below needs.

**`5e4353e` Wait for Grafana in make up and link it from the Tiltfile**

`rollout status deployment/grafana` beside the `otel-collector` wait — before the migration step, since Grafana has no database dependency of its own — the URL in the closing "Stack is up:" block, and a matching `k8s_resource` under the `infrastructure` label. No `SERVICES`/`IMAGES` change and no `kind load`: the image is pulled from Docker Hub.

**`2d23ae5` Document Grafana provisioning and the dashboard acceptance drill**

`docs/grafana-dashboards.md`: what is provisioned, how the dev overlay publishes it, what a fresh cluster shows before any data arrives, and the two-part acceptance drill (real events through the Reporting API, then one OTLP push carrying the exporter, collector and sync series the panels read). Both costs of the second part are recorded — the synthetic series sit in the dev store for the 13-month retention with no cleanup path, and the drill is for dev clusters only.

## Divergences from the issue

Four things in the diff differ from what the issue specified. Three of them follow from one finding, recorded in `3301c64` and pinned by `manifest_test.go`.

1. **The datasource URL is `http://127.0.0.1:8427`, not `http://victoriametrics:8428`.** Grafana forwards a caller-supplied path to the datasource URL from both `/api/datasources/proxy/uid/<uid>/<path>` and `/api/datasources/uid/<uid>/resources/<path>`, each under the `datasources:query` permission a viewer holds. The second is what fills the variable dropdowns, so neither can be withheld at the Gateway without emptying them — which makes the datasource URL itself the only place to bound what an anonymous viewer reaches. It therefore names a `vmauth` sidecar on the pod's loopback, whose route map carries the Prometheus read paths on to the store and refuses every other path (`/api/v1/write` and `/api/v1/admin/tsdb/delete_series` included). This adds `vmauth/auth.yaml`, a fourth `configMapGenerator` entry, a second container, and an `HTTPRouteFilter` that denies the `/api/datasources/proxy` prefix at the edge — the outer and weaker of the two rings, kept as defence in depth.
2. **`victoriametrics.yaml` gains `-deleteAuthKey`** (with a `tally-vm-admin` secretGenerator entry in the dev overlay), outside the issue's Affected Areas. Port 8428 is open to every pod in the namespace, so the delete endpoint had to be closed at the store rather than one hop away; the route comment there is updated to match.
3. **No `emptyDir` at `/var/lib/grafana`.** The issue specified one mounted ahead of the dashboards ConfigMap. Nothing Grafana must remember survives a restart by design — everything is provisioned at startup — so the SQLite state file lives on the container layer instead, and the volume would only add a one-way migration floor on the image tag. The dashboards ConfigMap still mounts at `/var/lib/grafana/dashboards`.
4. **`manifest_test.go` is a second test file the issue does not name.** It reads the four manifests from disk, without a cluster, and pins the properties above that all fail silently: the Secret key in `items`, the denied proxy prefix, `GF_SECURITY_COOKIE_SECURE`, the vmauth route map, and the delete key.

Smaller additions the issue did not name: `GF_SECURITY_COOKIE_SECURE=true` (Grafana derives the cookie's `Secure` attribute from its own protocol, which is plain HTTP behind the Gateway), and resource requests/limits on both containers.

The four deviations the issue itself surfaced — the exporter series that do not exist, the fourth scrape job, the `api_base` textbox for the events link, and unfiltered panels where the series carries no `platform`/`cloud` label — are implemented as the issue describes.

## Not verified here

This session pushed and opened the PR only. The cluster-side acceptance criteria — `kubectl kustomize` render, `make up`, the drill making every panel show data — were exercised by the implement session, not re-run here.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
