### PR TITLE
Add alerting with vmalert and Alertmanager for the billing-critical failure modes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,9 @@ jobs:
 
       - name: test
         run: go test ./...
+
+      # The rules file and the Alertmanager config are validated by the pinned
+      # images the cluster runs, so this step needs the same Docker the note
+      # above names.
+      - name: alerting
+        run: make check-alerting

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,17 @@ KUBECTL := kubectl --context $(KUBE_CONTEXT)
 # a developer's psql takes.
 TALLY_DEV_DB_URL ?= postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable
 
-.PHONY: up down dev ca test lint fmt migrate generate images
+# Read from the manifests rather than pinned a second time here, so
+# `check-alerting` always validates the configs with the versions the cluster
+# runs.
+# The character class is what a tag may hold and nothing else. := expands the
+# shell once and stores the result, so whatever the manifest carries here is
+# what `docker run` below is handed: a class that admitted ';' or '$$' would let
+# a manifest line decide what CI runs.
+VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' deploy/kubernetes/base/vmalert/vmalert.yaml | head -n1)
+ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
+
+.PHONY: up down dev ca test lint fmt check-alerting migrate generate images
 
 ## up: create the kind cluster, install the add-ons, and deploy the dev overlay
 up:
@@ -80,6 +90,8 @@ up:
 	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/victoriametrics --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/otel-collector --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/grafana --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/alertmanager --timeout=300s
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/vmalert --timeout=300s
 	$(KUBECTL) -n $(NAMESPACE) wait gateway/tally --for=condition=Programmed --timeout=300s
 	@# The API stays unready until the database carries its schema, and it never
 	@# migrates on its own, so the chain has to be applied before the rollout can
@@ -89,11 +101,15 @@ up:
 	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/reporting-api --timeout=300s
 	@echo
 	@echo 'Stack is up:'
-	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1  Reporting API'
-	@echo '  https://vm.tally.127-0-0-1.nip.io:8443          VictoriaMetrics'
-	@echo '  https://grafana.tally.127-0-0-1.nip.io:8443     Grafana'
-	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443        OTLP/HTTP'
-	@echo '  db.tally.127-0-0-1.nip.io:5432                  TimescaleDB'
+	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1        Reporting API'
+	@echo '  https://vm.tally.127-0-0-1.nip.io:8443                VictoriaMetrics'
+	@echo '  https://grafana.tally.127-0-0-1.nip.io:8443           Grafana'
+	@# vmalert is listed with its /vmalert/ prefix because the route publishes
+	@# that prefix and the two read endpoints, not the root.
+	@echo '  https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/  vmalert'
+	@echo '  https://alertmanager.tally.127-0-0-1.nip.io:8443      Alertmanager'
+	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443              OTLP/HTTP'
+	@echo '  db.tally.127-0-0-1.nip.io:5432                        TimescaleDB'
 	@echo
 	@echo 'Trust the dev CA with: make -s ca > tally-ca.crt'
 
@@ -131,6 +147,25 @@ lint:
 ## fmt: format every Go file with gofumpt, through golangci-lint's formatter
 fmt:
 	golangci-lint fmt
+
+# Each file is loaded by the binary that will evaluate it, so an expression or a
+# routing field the pinned version rejects fails here rather than in the
+# cluster. Docker is the only prerequisite; no cluster is involved.
+## check-alerting: validate the alert rules and the Alertmanager config
+check-alerting:
+	@[ -n '$(VMALERT_IMAGE)' ] || { \
+		echo 'ERROR: no vmalert image found in deploy/kubernetes/base/vmalert/vmalert.yaml' >&2; \
+		exit 1; \
+	}
+	@[ -n '$(ALERTMANAGER_IMAGE)' ] || { \
+		echo 'ERROR: no Alertmanager image found in deploy/kubernetes/base/alertmanager/alertmanager.yaml' >&2; \
+		exit 1; \
+	}
+	docker run --rm -v "$(CURDIR)/deploy/kubernetes/base/vmalert:/etc/vmalert:ro" \
+		'$(VMALERT_IMAGE)' -dryRun -rule=/etc/vmalert/rules.yaml
+	docker run --rm --entrypoint amtool \
+		-v "$(CURDIR)/deploy/kubernetes/base/alertmanager:/etc/alertmanager:ro" \
+		'$(ALERTMANAGER_IMAGE)' check-config /etc/alertmanager/config.yaml
 
 ## migrate: apply the reporting migration chain through the admin CLI
 migrate:

--- a/Tiltfile
+++ b/Tiltfile
@@ -43,3 +43,13 @@ k8s_resource(
     labels=['infrastructure'],
     links=[link('https://grafana.tally.127-0-0-1.nip.io:8443', 'Grafana')],
 )
+k8s_resource(
+    'alertmanager',
+    labels=['infrastructure'],
+    links=[link('https://alertmanager.tally.127-0-0-1.nip.io:8443', 'Alertmanager')],
+)
+k8s_resource(
+    'vmalert',
+    labels=['infrastructure'],
+    links=[link('https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/', 'vmalert')],
+)

--- a/deploy/kubernetes/base/alertmanager/alertmanager.yaml
+++ b/deploy/kubernetes/base/alertmanager/alertmanager.yaml
@@ -1,0 +1,253 @@
+# The notifier. What fires is posted here, and this is where it is grouped,
+# deduplicated, silenced, and handed to a receiver (config.yaml).
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  labels:
+    app.kubernetes.io/name: alertmanager
+spec:
+  selector:
+    app.kubernetes.io/name: alertmanager
+  ports:
+    - name: http
+      port: 9093
+      targetPort: http
+---
+# A StatefulSet rather than a Deployment, for the same reason VictoriaMetrics
+# and TimescaleDB are one: what --storage.path holds is state. The notification
+# log is what keeps a receiver from being told a second time about a group it
+# was already told about, and the silence store is what an on-call engineer put
+# a maintenance window into.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: alertmanager
+  labels:
+    app.kubernetes.io/name: alertmanager
+spec:
+  serviceName: alertmanager
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alertmanager
+    spec:
+      # prom/alertmanager ends its Dockerfile with USER nobody, and the chown of
+      # /alertmanager that image does at build time is undone the moment a
+      # volume is mounted over that path. An emptyDir would still have worked,
+      # because the kubelet creates one mode 0777; the claim below does not.
+      # Most CSI drivers hand a freshly formatted volume back owned root:root
+      # 0755, and Kubernetes chowns a mount to the pod's fsGroup or not at all,
+      # so without one UID 65534 cannot create the notification log or a silence
+      # under --storage.path and the pod crash-loops. kind's local-path
+      # provisioner happens to mkdir 0777, so the failure would show up only
+      # where this base is deployed for real.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: alertmanager
+          image: prom/alertmanager:v0.34.0
+          # What the block above does not reach. Those fields name an identity;
+          # these four are per-container and default the permissive way, so a
+          # pod that stops at the identity still allows a setuid binary to raise
+          # this container's privileges, still carries the capability set the
+          # runtime grants by default, still has the whole image to write to,
+          # and still runs unconfined by seccomp. Alertmanager needs none of it:
+          # it binds 9093, which is above the privileged range, --config.file is
+          # a read-only ConfigMap mount, and --storage.path is the claim below,
+          # so the notification log and the silence store are the only things it
+          # writes and both land on a mounted volume.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --config.file=/etc/alertmanager/config.yaml
+            - --storage.path=/alertmanager
+            # The flag reads its value from the argument and Kubernetes expands
+            # $(VAR) in it, the same way -deleteAuthKey takes its key in
+            # victoriametrics.yaml.
+            - --web.external-url=$(ALERTMANAGER_EXTERNAL_URL)
+            # The empty value turns the gossip cluster off. There is one
+            # replica, so there is no peer to settle with, and left at its
+            # default Alertmanager opens the port and logs "gossip not settled"
+            # at every start while it waits for members that never arrive.
+            - --cluster.listen-address=
+          env:
+            # A placeholder every overlay patches, the same way it patches
+            # GF_SERVER_ROOT_URL. Alertmanager builds the links it renders and
+            # the ones it puts in a notification from this value, so an
+            # unpatched one points a reader at a host that answers nothing.
+            - name: ALERTMANAGER_EXTERNAL_URL
+              value: https://alertmanager.tally.example.com
+          ports:
+            - name: http
+              containerPort: 9093
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alertmanager
+              readOnly: true
+            - name: data
+              mountPath: /alertmanager
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager-config
+  # Editing config.yaml changes the generated ConfigMap name by design, which
+  # rolls the pod. On scratch storage that roll would take the notification log
+  # and every silence with it: each firing group would be delivered again at the
+  # next group_wait, and a maintenance window set minutes earlier would be gone.
+  # One replica with --cluster.listen-address= has no peer to replicate either
+  # back from, so the loss would be total rather than partial.
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+---
+# The response the deny rule below sends. Envoy Gateway's extension filter, the
+# Gateway API having no core way to answer a request without a backend.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: alertmanager-deny-writes
+  labels:
+    app.kubernetes.io/name: alertmanager
+spec:
+  directResponse:
+    statusCode: 403
+    contentType: text/plain
+    body:
+      type: Inline
+      inline: "The Alertmanager write API is not published.\n"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+  labels:
+    app.kubernetes.io/name: alertmanager
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - alertmanager.tally.example.com
+  rules:
+    # Port 9093 answers reads and writes on one API. Under /api/v2 a POST
+    # creates a silence or injects an alert, a PUT edits one and a DELETE
+    # expires one; /-/reload re-reads the config on demand, and /debug carries
+    # the pprof endpoints. The rule below publishes none of them, so this one is
+    # not what keeps them off the host: it is what answers them, so the UI's
+    # silence form is told why it was turned away rather than left with a 404.
+    #
+    # The rule below names longer prefixes than /api/v2, and the Gateway API
+    # ranks a longer prefix above a method match. Its matches therefore name
+    # GET, so a POST /api/v2/silences never reaches it and lands here.
+    #
+    # Silences are created from inside the cluster instead, with the amtool the
+    # image ships; docs/alerting.md carries the command.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v2
+          method: POST
+        - path:
+            type: PathPrefix
+            value: /api/v2
+          method: PUT
+        - path:
+            type: PathPrefix
+            value: /api/v2
+          method: DELETE
+        - path:
+            type: PathPrefix
+            value: /-/reload
+        - path:
+            type: PathPrefix
+            value: /debug
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: alertmanager-deny-writes
+    # The published reads, named one at a time the way the vmalert and
+    # VictoriaMetrics routes name theirs. Carrying the rest of the host instead
+    # would publish two more: GET /api/v2/status answers with the loaded config,
+    # which is where config.yaml tells every deployment to put its
+    # webhook_configs or email_configs, and GET /metrics names the delivery
+    # integrations it is configured with alongside its alert counts. Neither is
+    # named here, so both get the Gateway's 404.
+    #
+    # What is named is what the UI calls: /api/v2/alerts with its /groups
+    # sub-path, /api/v2/silences for the list and /api/v2/silence/<id> for one
+    # of them, /api/v2/receivers for the filter bar, and the index with the
+    # hashed bundle under /assets and the icon. The UI routes on the fragment,
+    # so the index is matched exactly rather than by prefix. Its Status page
+    # reads /api/v2/status and therefore reports an error; that endpoint is the
+    # one this rule withholds.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v2/alerts
+          method: GET
+        - path:
+            type: PathPrefix
+            value: /api/v2/silences
+          method: GET
+        - path:
+            type: PathPrefix
+            value: /api/v2/silence
+          method: GET
+        - path:
+            type: PathPrefix
+            value: /api/v2/receivers
+          method: GET
+        - path:
+            type: PathPrefix
+            value: /assets
+          method: GET
+        - path:
+            type: Exact
+            value: /favicon.ico
+          method: GET
+        - path:
+            type: Exact
+            value: /
+          method: GET
+      backendRefs:
+        - name: alertmanager
+          port: 9093

--- a/deploy/kubernetes/base/alertmanager/config.yaml
+++ b/deploy/kubernetes/base/alertmanager/config.yaml
@@ -1,0 +1,31 @@
+# Alertmanager routing.
+#
+# The single receiver names no integration, and it does so on purpose. Where an
+# alert is delivered is a property of a deployment, not of this repository, so
+# until one says otherwise an alert is grouped and held here, where the UI and
+# amtool show it.
+#
+# A deployment adds its own webhook_configs or email_configs by replacing this
+# generated ConfigMap from its overlay rather than by patching this file: a
+# configMapGenerator entry of its own for alertmanager-config, marked
+# behavior: replace, carrying the overlay's config.yaml. That is the mechanism
+# docs/openstack-metrics.md records for scrape.yaml under "Replacing the
+# placeholders".
+#
+# The child route below inherits the receiver from its parent and tightens
+# repeat_interval alone, so a deployment that names a receiver at the root
+# covers both branches with it.
+global:
+  resolve_timeout: 5m
+route:
+  receiver: default
+  group_by: [alertname, cloud]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity="critical"
+      repeat_interval: 1h
+receivers:
+  - name: default

--- a/deploy/kubernetes/base/alertmanager/kustomization.yaml
+++ b/deploy/kubernetes/base/alertmanager/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - alertmanager.yaml
+
+# Generating the ConfigMap from the file means editing config.yaml re-rolls the
+# pod through the generated name hash, rather than leaving it routing alerts by
+# a config that no longer matches the tree.
+configMapGenerator:
+  - name: alertmanager-config
+    files:
+      - config.yaml

--- a/deploy/kubernetes/base/alertmanager/manifest_test.go
+++ b/deploy/kubernetes/base/alertmanager/manifest_test.go
@@ -1,0 +1,491 @@
+// This file pins the manifest properties that decide who may change
+// Alertmanager's state and where a firing alert ends up. Each of them fails
+// quietly: a route that forwards POST /api/v2/silences renders exactly like one
+// that refuses it, a receiver that grew a delivery integration in this
+// repository would notify a stranger from every deployment that takes the base,
+// and a critical alert that repeats no sooner than the rest is only noticeable
+// once an incident is four hours old. The test reads the YAML from disk and
+// needs no cluster.
+package alertmanager_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"maps"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	manifestFile = "alertmanager.yaml"
+	configFile   = "config.yaml"
+)
+
+// object is the part of a manifest document this test asserts over. yaml.v3
+// ignores every field not named here, so one shape covers all three kinds.
+type object struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		// HTTPRouteFilter
+		DirectResponse struct {
+			StatusCode int `yaml:"statusCode"`
+		} `yaml:"directResponse"`
+		// StatefulSet
+		Template struct {
+			Spec struct {
+				// Pointers, so a field the manifest leaves out is told apart
+				// from one set to 0, which is root.
+				SecurityContext struct {
+					RunAsUser  *int64 `yaml:"runAsUser"`
+					RunAsGroup *int64 `yaml:"runAsGroup"`
+					FSGroup    *int64 `yaml:"fsGroup"`
+				} `yaml:"securityContext"`
+				Containers []container `yaml:"containers"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+		VolumeClaimTemplates []struct{} `yaml:"volumeClaimTemplates"`
+		// HTTPRoute
+		Rules []routeRule `yaml:"rules"`
+	} `yaml:"spec"`
+}
+
+type container struct {
+	Name            string   `yaml:"name"`
+	Args            []string `yaml:"args"`
+	SecurityContext struct {
+		// Pointers for the same reason the pod's are: a field the manifest
+		// leaves out defaults to the permissive value, and one written as
+		// false has to be told apart from that.
+		AllowPrivilegeEscalation *bool `yaml:"allowPrivilegeEscalation"`
+		ReadOnlyRootFilesystem   *bool `yaml:"readOnlyRootFilesystem"`
+		Capabilities             struct {
+			Drop []string `yaml:"drop"`
+		} `yaml:"capabilities"`
+		SeccompProfile struct {
+			Type string `yaml:"type"`
+		} `yaml:"seccompProfile"`
+	} `yaml:"securityContext"`
+}
+
+type routeRule struct {
+	Matches []routeMatch `yaml:"matches"`
+	Filters []struct {
+		Type         string `yaml:"type"`
+		ExtensionRef struct {
+			Kind string `yaml:"kind"`
+			Name string `yaml:"name"`
+		} `yaml:"extensionRef"`
+	} `yaml:"filters"`
+	BackendRefs []struct {
+		Name string `yaml:"name"`
+	} `yaml:"backendRefs"`
+}
+
+// routeMatch carries the match type and the method as well as the path. All
+// three decide what a rule intercepts: /api/v2 as Exact matches no silence path
+// at all, and the same prefix is published for GET and refused for POST.
+type routeMatch struct {
+	Path struct {
+		Type  string `yaml:"type"`
+		Value string `yaml:"value"`
+	} `yaml:"path"`
+	Method string `yaml:"method"`
+}
+
+// publishedRead is one match the forwarding rule may carry, and publishedReads
+// is every one of them. The two subtests over it read it from both sides: one
+// fails on an entry that was dropped, the other on a match this list does not
+// name. Both properties are needed, because what withholds GET /api/v2/status
+// and GET /metrics is not a rule that names them but the absence of any match
+// wide enough to reach them: consolidating the four /api/v2 reads into one
+// PathPrefix /api/v2 names neither and publishes both.
+type publishedRead struct {
+	matchType string
+	path      string
+	carries   string
+}
+
+var publishedReads = []publishedRead{
+	{"PathPrefix", "/api/v2/alerts", "the alert list and its groups"},
+	{"PathPrefix", "/api/v2/silences", "the silence list"},
+	{"PathPrefix", "/api/v2/silence", "one silence by id"},
+	{"PathPrefix", "/api/v2/receivers", "the filter bar's receiver list"},
+	{"PathPrefix", "/assets", "the UI's hashed bundle"},
+	{"Exact", "/favicon.ico", "the icon"},
+	{"Exact", "/", "the index the UI is served from"},
+}
+
+// alertConfig is the routing tree and the receiver list of config.yaml.
+type alertConfig struct {
+	// A pointer, so a file that declares no route at all is told apart from
+	// one whose route is empty.
+	Route     *routeNode       `yaml:"route"`
+	Receivers []map[string]any `yaml:"receivers"`
+}
+
+type routeNode struct {
+	Receiver       string      `yaml:"receiver"`
+	RepeatInterval string      `yaml:"repeat_interval"`
+	Matchers       []string    `yaml:"matchers"`
+	Routes         []routeNode `yaml:"routes"`
+}
+
+func TestAlertmanagerRoute(t *testing.T) {
+	docs := objects(t, manifestFile)
+	route := objectNamed(t, docs, "HTTPRoute", "alertmanager")
+
+	var deny, forward []routeRule
+	for _, rule := range route.Spec.Rules {
+		if len(rule.BackendRefs) == 0 {
+			deny = append(deny, rule)
+			continue
+		}
+		forward = append(forward, rule)
+	}
+	if len(deny) != 1 {
+		t.Fatalf("the alertmanager HTTPRoute has %d rules without a backend, want the one that refuses the write API; without it every write path is answered by a 404 that says nothing",
+			len(deny))
+	}
+	if len(forward) != 1 {
+		t.Fatalf("the alertmanager HTTPRoute has %d rules with a backend, want the one that carries the UI", len(forward))
+	}
+	rule := deny[0]
+
+	t.Run("answers the refused paths itself", func(t *testing.T) {
+		// The Gateway API has no core way to answer without a backend, so the
+		// refusal is Envoy Gateway's extension filter. A rule that names
+		// neither a backend nor a filter answers 500, which reads as an outage
+		// rather than as a decision.
+		if len(rule.Filters) != 1 || rule.Filters[0].Type != "ExtensionRef" {
+			t.Fatalf("the deny rule carries %d filters, want exactly one ExtensionRef; a rule with neither backend nor filter answers 500 rather than a refusal",
+				len(rule.Filters))
+		}
+
+		ref := rule.Filters[0].ExtensionRef
+		if ref.Kind != "HTTPRouteFilter" {
+			t.Fatalf("the deny rule references kind %q, want HTTPRouteFilter", ref.Kind)
+		}
+		for _, doc := range docs {
+			if doc.Kind != ref.Kind || doc.Metadata.Name != ref.Name {
+				continue
+			}
+			if doc.Spec.DirectResponse.StatusCode != 403 {
+				t.Errorf("%s %s responds %d, want 403", ref.Kind, ref.Name, doc.Spec.DirectResponse.StatusCode)
+			}
+			return
+		}
+		t.Errorf("the rule references %s/%s, which this file does not define, so the Gateway rejects the route and the host answers nothing",
+			ref.Kind, ref.Name)
+	})
+
+	t.Run("names every write path", func(t *testing.T) {
+		// Port 9093 answers reads and writes on one API, and the UI needs the
+		// reads. What separates them is the method, so a missing entry here
+		// publishes a write to whoever opens the host.
+		for _, want := range []struct {
+			prefix string
+			method string
+			opens  string
+		}{
+			{"/api/v2", "POST", "creating a silence and injecting an alert"},
+			{"/api/v2", "PUT", "editing a silence"},
+			{"/api/v2", "DELETE", "expiring a silence"},
+			{"/-/reload", "", "re-reading the config on demand"},
+			{"/debug", "", "the pprof endpoints"},
+		} {
+			if covers(rule, "PathPrefix", want.prefix, want.method) {
+				continue
+			}
+			target := want.prefix
+			if want.method != "" {
+				target = want.method + " " + want.prefix
+			}
+			t.Errorf("the deny rule has no PathPrefix match for %s, so %s is answered by the Gateway's 404 rather than by a refusal that says why",
+				target, want.opens)
+		}
+	})
+
+	t.Run("publishes the reads the UI needs", func(t *testing.T) {
+		// One side of the allowlist: a path dropped from publishedReads takes a
+		// part of the UI with it.
+		for _, want := range publishedReads {
+			if !covers(forward[0], want.matchType, want.path, "GET") {
+				t.Errorf("the forwarding rule has no GET match of type %s for %s, so %s is not published",
+					want.matchType, want.path, want.carries)
+			}
+		}
+		if got := forward[0].BackendRefs[0].Name; got != "alertmanager" {
+			t.Errorf("the forwarding rule sends the host to %q, want alertmanager", got)
+		}
+	})
+
+	t.Run("withholds what answers with the config", func(t *testing.T) {
+		// The other side, and the reason the read side names paths rather than
+		// the host. GET /api/v2/status and GET /metrics are reads, so the deny
+		// rule above never sees them: what keeps them off the published host is
+		// that no match here carries them. Asserting the absence of those two
+		// values would not say that, because any match wider than the ones
+		// above carries both without naming either.
+		for _, m := range forward[0].Matches {
+			if !slices.ContainsFunc(publishedReads, func(r publishedRead) bool {
+				return r.matchType == m.Path.Type && r.path == m.Path.Value
+			}) {
+				t.Errorf("the forwarding rule publishes %s %s, which is not one of the reads the UI needs; a match wider than those carries GET /api/v2/status and the loaded config with it, and GET /metrics the delivery integrations it names",
+					m.Path.Type, m.Path.Value)
+			}
+			// A match that names no method applies to every one of them, and
+			// the Gateway API ranks its longer prefix above the deny rule's
+			// PathPrefix /api/v2 plus method: the write API becomes reachable
+			// from the published host without any match here naming it.
+			if m.Method != "GET" {
+				t.Errorf("the match for %s %s names method %q rather than GET, so it outranks the deny rule's /api/v2 method match and forwards POST %s to Alertmanager",
+					m.Path.Type, m.Path.Value, m.Method, m.Path.Value)
+			}
+		}
+	})
+}
+
+func TestAlertmanagerStatefulSet(t *testing.T) {
+	t.Run("can write to the volume it claims", func(t *testing.T) {
+		// prom/alertmanager runs as nobody, UID and GID 65534. Kubernetes
+		// chowns a mounted volume to the pod's fsGroup or not at all, and most
+		// CSI drivers hand a fresh claim back owned root:root 0755, so without
+		// one Alertmanager cannot create the notification log or a silence
+		// under --storage.path and the pod crash-loops. kind's local-path
+		// provisioner mkdirs 0777 and an emptyDir is created 0777 by the
+		// kubelet, so neither the dev overlay nor the shape this StatefulSet
+		// replaced would have shown it.
+		const nobody = int64(65534)
+
+		sts := objectNamed(t, objects(t, manifestFile), "StatefulSet", "alertmanager")
+		if len(sts.Spec.VolumeClaimTemplates) == 0 {
+			t.Fatal("the StatefulSet claims no volume, so the notification log and the silence store are back on storage a pod roll drops")
+		}
+
+		sc := sts.Spec.Template.Spec.SecurityContext
+		for _, f := range []struct {
+			name string
+			got  *int64
+		}{
+			{"fsGroup", sc.FSGroup},
+			{"runAsUser", sc.RunAsUser},
+			{"runAsGroup", sc.RunAsGroup},
+		} {
+			if f.got == nil {
+				t.Errorf("the pod names no %s, so the claim stays owned by root and the container's %d cannot write to it", f.name, nobody)
+				continue
+			}
+			if *f.got != nobody {
+				t.Errorf("the pod names %s %d, want %d, which is the user prom/alertmanager runs as; a mismatch leaves the claim owned by someone else",
+					f.name, *f.got, nobody)
+			}
+		}
+	})
+
+	t.Run("keeps the container controls off their defaults", func(t *testing.T) {
+		// The pod-level block above names an identity and stops there. These
+		// four are per-container and every one of them defaults the permissive
+		// way, so a pod that names only the identity still lets a setuid binary
+		// in the image raise this container's privileges, still carries the
+		// capability set the runtime grants by default, still has the whole
+		// image to write to, and still runs unconfined by seccomp. Alertmanager
+		// needs none of it: it binds 9093, --config.file is a read-only
+		// ConfigMap mount, and --storage.path is the claim, so the notification
+		// log and the silence store are the only things it writes and both land
+		// on a mounted volume. Nothing here fails a deployment, which is why it
+		// is asserted rather than noticed: the pod runs identically either way.
+		c := containerNamed(t, objects(t, manifestFile), "StatefulSet", "alertmanager", "alertmanager")
+		sc := c.SecurityContext
+
+		if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+			t.Error("the container does not set allowPrivilegeEscalation: false, so a setuid binary in the image can still raise its privileges")
+		}
+		if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+			t.Error("the container does not set readOnlyRootFilesystem: true, so the whole image is writable although every write goes to the claim under --storage.path")
+		}
+		if !slices.Contains(sc.Capabilities.Drop, "ALL") {
+			t.Errorf("capabilities.drop = %v, want it to name ALL; a process binding 9093 needs none of the default set", sc.Capabilities.Drop)
+		}
+		if want := "RuntimeDefault"; sc.SeccompProfile.Type != want {
+			t.Errorf("seccompProfile.type = %q, want %q; without it the container runs with seccomp unconfined", sc.SeccompProfile.Type, want)
+		}
+	})
+
+	t.Run("turns the gossip cluster off", func(t *testing.T) {
+		// One replica has no peer to settle with. Left at its default,
+		// Alertmanager opens the cluster port and logs "gossip not settled" at
+		// every start while it waits for members that never arrive, which is
+		// noise no reader of these logs can act on.
+		const arg = "--cluster.listen-address="
+
+		c := containerNamed(t, objects(t, manifestFile), "StatefulSet", "alertmanager", "alertmanager")
+
+		if !slices.Contains(c.Args, arg) {
+			t.Errorf("args = %v, want one of them %q", c.Args, arg)
+		}
+	})
+}
+
+func TestAlertmanagerConfig(t *testing.T) {
+	cfg := config(t)
+
+	t.Run("routes everything to one receiver", func(t *testing.T) {
+		// The child route below inherits this receiver, so a deployment that
+		// names its own at the root covers both branches with it.
+		if cfg.Route.Receiver != "default" {
+			t.Errorf("the root route sends to %q, want default; a route whose receiver is not declared below stops Alertmanager from starting",
+				cfg.Route.Receiver)
+		}
+	})
+
+	t.Run("leaves delivery to the deployment", func(t *testing.T) {
+		// Where an alert is delivered is a property of a deployment. An
+		// integration written here would be carried by every overlay that takes
+		// this base, dev clusters included, and notify whoever it names.
+		if len(cfg.Receivers) != 1 {
+			t.Fatalf("config.yaml declares %d receivers, want the one the routes name", len(cfg.Receivers))
+		}
+
+		r := cfg.Receivers[0]
+		if name, _ := r["name"].(string); name != "default" {
+			t.Errorf("the receiver is named %q, want default; the routes above name default and Alertmanager refuses a config whose receiver is missing", name)
+		}
+		for _, key := range slices.Sorted(maps.Keys(r)) {
+			if key == "name" {
+				continue
+			}
+			t.Errorf("the receiver carries %q, so this repository decides where a deployment's alerts go; an integration belongs in the overlay's replacement ConfigMap", key)
+		}
+	})
+
+	t.Run("repeats a critical alert sooner", func(t *testing.T) {
+		// The point of the child route. Inheriting the root's interval would
+		// leave a critical alert as quiet as the rest of them.
+		const matcher = `severity="critical"`
+
+		var child *routeNode
+		for i, r := range cfg.Route.Routes {
+			if slices.Contains(r.Matchers, matcher) {
+				child = &cfg.Route.Routes[i]
+				break
+			}
+		}
+		if child == nil {
+			t.Fatalf("no child route matches %s, so a critical alert repeats on the root's interval", matcher)
+		}
+
+		root := interval(t, "the root route", cfg.Route.RepeatInterval)
+		crit := interval(t, "the critical route", child.RepeatInterval)
+		if crit >= root {
+			t.Errorf("the critical route repeats every %s against the root's %s, so severity buys a reader nothing", crit, root)
+		}
+	})
+}
+
+// objects decodes every document of one manifest file.
+func objects(t *testing.T, path string) []object {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the manifest: %v", err)
+	}
+
+	var docs []object
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc object
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			return docs
+		}
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		docs = append(docs, doc)
+	}
+}
+
+// objectNamed returns one document, failing if it is missing rather than
+// asserting over a zero value.
+func objectNamed(t *testing.T, docs []object, kind, name string) object {
+	t.Helper()
+
+	for _, doc := range docs {
+		if doc.Kind == kind && doc.Metadata.Name == name {
+			return doc
+		}
+	}
+	t.Fatalf("no %s named %q", kind, name)
+	return object{}
+}
+
+// containerNamed returns one container of one workload.
+func containerNamed(t *testing.T, docs []object, kind, workload, name string) container {
+	t.Helper()
+
+	for _, c := range objectNamed(t, docs, kind, workload).Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("%s %s carries no container %q", kind, workload, name)
+	return container{}
+}
+
+// covers reports whether a rule carries a match of exactly this type, path and
+// method. The type is asserted because it is what decides whether a match
+// intercepts a sub-path: PathPrefix /api/v2 covers POST /api/v2/silences and
+// Exact /api/v2 covers nothing a caller would send. An empty method means the
+// match names none, which is what makes it apply to every method rather than to
+// one.
+func covers(rule routeRule, matchType, path, method string) bool {
+	for _, m := range rule.Matches {
+		if m.Path.Type == matchType && m.Path.Value == path && m.Method == method {
+			return true
+		}
+	}
+	return false
+}
+
+// config parses the routing tree Alertmanager runs with.
+func config(t *testing.T) alertConfig {
+	t.Helper()
+
+	raw, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", configFile, err)
+	}
+
+	var cfg alertConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parsing %s, which Alertmanager refuses to start on: %v", configFile, err)
+	}
+	if cfg.Route == nil {
+		t.Fatalf("%s declares no route, so Alertmanager refuses to start and nothing is notified", configFile)
+	}
+	return cfg
+}
+
+// interval parses one repeat_interval, failing on a value Alertmanager would
+// reject at startup.
+func interval(t *testing.T, what, value string) time.Duration {
+	t.Helper()
+
+	if value == "" {
+		t.Fatalf("%s names no repeat_interval", what)
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		t.Fatalf("%s repeats every %q, which is not a duration: %v", what, value, err)
+	}
+	return d
+}

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - reporting-api
   - grafana
   - alertmanager
+  - vmalert

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - otel-collector
   - reporting-api
   - grafana
+  - alertmanager

--- a/deploy/kubernetes/base/vmalert/kustomization.yaml
+++ b/deploy/kubernetes/base/vmalert/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - vmalert.yaml
+
+# Generating the ConfigMap from the file means editing rules.yaml re-rolls the
+# pod through the generated name hash, rather than leaving it evaluating rules
+# that are no longer in the repository.
+configMapGenerator:
+  - name: vmalert-rules
+    files:
+      - rules.yaml

--- a/deploy/kubernetes/base/vmalert/manifest_test.go
+++ b/deploy/kubernetes/base/vmalert/manifest_test.go
@@ -1,0 +1,176 @@
+// This file pins the manifest properties that decide whether an evaluated rule
+// reaches anyone and what the Gateway hands a stranger. Both fail quietly: a
+// vmalert that has lost -notifier.url still starts, still evaluates every rule
+// in rules.yaml and still answers its probes, while nothing is ever posted to
+// Alertmanager, and a route that carries the root serves /-/reload, /flags,
+// /metrics and /debug/pprof to whoever opens the host. `make check-alerting`
+// reads rules.yaml and never this file. The test reads the YAML from disk and
+// needs no cluster.
+package vmalert_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const manifestFile = "vmalert.yaml"
+
+// object is the part of a manifest document this test asserts over. yaml.v3
+// ignores every field not named here, so one shape covers both kinds.
+type object struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		// Deployment
+		Template struct {
+			Spec struct {
+				Containers []container `yaml:"containers"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+		// HTTPRoute
+		Rules []routeRule `yaml:"rules"`
+	} `yaml:"spec"`
+}
+
+type container struct {
+	Name string   `yaml:"name"`
+	Args []string `yaml:"args"`
+}
+
+type routeRule struct {
+	Matches []struct {
+		Path struct {
+			Type  string `yaml:"type"`
+			Value string `yaml:"value"`
+		} `yaml:"path"`
+	} `yaml:"matches"`
+}
+
+func TestVmalertDeployment(t *testing.T) {
+	c := containerNamed(t, objects(t, manifestFile), "Deployment", "vmalert", "vmalert")
+
+	t.Run("names what it queries and where it posts", func(t *testing.T) {
+		// Without -notifier.url vmalert evaluates every rule and posts none of
+		// them. The pod stays Ready, the rules API keeps reporting their state,
+		// and the only symptom is an Alertmanager that never receives anything.
+		for _, arg := range []string{
+			"-datasource.url=http://victoriametrics:8428",
+			"-notifier.url=http://alertmanager:9093",
+		} {
+			if !slices.Contains(c.Args, arg) {
+				t.Errorf("args = %v, want one of them %q", c.Args, arg)
+			}
+		}
+	})
+
+	t.Run("keeps the for timers outside the process", func(t *testing.T) {
+		// The pair writes ALERTS_FOR_STATE to the store and reads it back at
+		// startup. Editing rules.yaml rolls the pod by design, through the
+		// generated ConfigMap name, so without either half every `for` in the
+		// file silently restarts its clock on every edit: TallyScrapeTargetDown
+		// waits out its 5m again and TallyExporterServiceSilent its 15m.
+		for _, arg := range []string{
+			"-remoteWrite.url=http://victoriametrics:8428",
+			"-remoteRead.url=http://victoriametrics:8428",
+		} {
+			if !slices.Contains(c.Args, arg) {
+				t.Errorf("args = %v, want one of them %q; the flags are a pair, and either alone leaves the state it carries in the process", c.Args, arg)
+			}
+		}
+	})
+}
+
+func TestRouteWithholdsTheRoot(t *testing.T) {
+	// vmalert answers /-/reload, /flags, /metrics and /debug/pprof at the root
+	// alone. Under the /vmalert prefix they answer 400, so what keeps them off
+	// the published host is that the route names prefixes instead of carrying
+	// the host whole.
+	want := []string{"/api/v1/alerts", "/api/v1/rules", "/vmalert"}
+
+	route := routeNamed(t, objects(t, manifestFile), "vmalert")
+	if len(route.Spec.Rules) != 1 {
+		t.Fatalf("the vmalert HTTPRoute has %d rules, want the one that names the published prefixes", len(route.Spec.Rules))
+	}
+
+	var got []string
+	for _, m := range route.Spec.Rules[0].Matches {
+		if m.Path.Type != "PathPrefix" {
+			t.Errorf("a match is of type %q, want PathPrefix", m.Path.Type)
+			continue
+		}
+		got = append(got, m.Path.Value)
+	}
+	slices.Sort(got)
+
+	if slices.Contains(got, "/") {
+		t.Error("the route publishes the root, so /-/reload, /flags, /metrics and /debug/pprof are reachable through the Gateway")
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the route publishes %v, want %v", got, want)
+	}
+}
+
+// objects decodes every document of one manifest file.
+func objects(t *testing.T, path string) []object {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the manifest: %v", err)
+	}
+
+	var docs []object
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc object
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			return docs
+		}
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		docs = append(docs, doc)
+	}
+}
+
+// routeNamed returns one HTTPRoute, failing if it is missing rather than
+// asserting over a zero value.
+func routeNamed(t *testing.T, docs []object, name string) object {
+	t.Helper()
+
+	for _, doc := range docs {
+		if doc.Kind == "HTTPRoute" && doc.Metadata.Name == name {
+			return doc
+		}
+	}
+	t.Fatalf("no HTTPRoute named %q", name)
+	return object{}
+}
+
+// containerNamed returns one container of one workload.
+func containerNamed(t *testing.T, docs []object, kind, workload, name string) container {
+	t.Helper()
+
+	for _, doc := range docs {
+		if doc.Kind != kind || doc.Metadata.Name != workload {
+			continue
+		}
+		for _, c := range doc.Spec.Template.Spec.Containers {
+			if c.Name == name {
+				return c
+			}
+		}
+		t.Fatalf("%s %s carries no container %q", kind, workload, name)
+	}
+	t.Fatalf("no %s named %q", kind, workload)
+	return container{}
+}

--- a/deploy/kubernetes/base/vmalert/rules.yaml
+++ b/deploy/kubernetes/base/vmalert/rules.yaml
@@ -1,0 +1,169 @@
+# The rules vmalert evaluates against the store, in one group at a one-minute
+# interval: eleven alerting rules and the one series recorded for the anomaly
+# rule among them to read. The five critical alerts carry a runbook annotation
+# naming the page under docs/runbooks/ that a reader opens when the alert
+# arrives.
+#
+# rules_test.go pins the shape of this file: the alert names and their order,
+# the severities, the runbooks, the recorded series the anomaly rule reads, and
+# the scrape jobs the last three rules name.
+# `make check-alerting` loads it into the vmalert binary the cluster runs, which
+# is what says the expressions parse.
+groups:
+  - name: tally
+    interval: 1m
+    rules:
+      - alert: TallyCloudEventsSilent
+        expr: |
+          sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[1h])) == 0
+          and sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[24h])) > 0
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No collector events from {{ $labels.cloud }} for >1h (was active in last 24h)"
+          runbook: docs/runbooks/TallyCloudEventsSilent.md
+
+      - alert: TallyEventsRejected
+        expr: sum by (cloud, reason) (increase(tally_events_rejected_total[15m])) > 10
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $value | printf "%.0f" }} events from {{ $labels.cloud }} rejected in 15m (reason {{ $labels.reason }})'
+
+      - alert: TallySyncErrors
+        expr: sum by (cloud) (increase(tally_sync_errors_total[1h])) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciliation of {{ $labels.cloud }} reported errors in the last hour"
+
+      - alert: TallySyncStale
+        expr: sum by (cloud) (increase(tally_sync_runs_total{status="completed"}[30m])) == 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "No completed reconciliation run for {{ $labels.cloud }} in 30m"
+          runbook: docs/runbooks/TallySyncStale.md
+
+      - alert: TallyReconciliationDriftHigh
+        expr: sum by (cloud) (increase(tally_sync_resources_reconciled_total[6h])) > 50
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Reconciliation corrected {{ $value | printf "%.0f" }} resources in {{ $labels.cloud }} over 6h'
+
+      - alert: TallyCollectorBufferAging
+        expr: tally_collector_oldest_buffered_seconds > 600
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Oldest buffered collector event is {{ $value | printf "%.0f" }}s old; the Reporting API is unreachable from the provider side'
+
+      # Recorded so the rule below reads one pre-aggregated series. Written as a
+      # subquery over the raw ones instead, the baseline made the engine repeat
+      # the aggregation once per step of the seven-day window on every one of
+      # the group's minute evaluations, against the single store that also
+      # serves Grafana and the Reporting API's query path. vmalert writes this
+      # series back through -remoteWrite.url and reads it through
+      # -datasource.url, the same pair that carries ALERTS_FOR_STATE.
+      - record: tally:current_resources:sum
+        expr: sum by (cloud, resource_type) (tally_current_resources)
+
+      # The offset keeps the current value out of the baseline it is measured
+      # against. Without it a rise pulls its own reference up as it goes, and
+      # the comparison is against an average that already contains the sample on
+      # the left. It also means the rule cannot fire before the store holds six
+      # hours of the recorded series, so a fresh cluster stays quiet rather than
+      # reporting every count as an anomaly against an empty window.
+      - alert: TallyResourceCountAnomaly
+        expr: |
+          tally:current_resources:sum
+            > 1.5 * (avg_over_time(tally:current_resources:sum[7d] offset 6h) + 10)
+        for: 30m
+        labels:
+          severity: info
+        annotations:
+          summary: "{{ $labels.resource_type }} count in {{ $labels.cloud }} is above 1.5x its 7-day baseline"
+
+      # What watches the pair above. Reading the recorded series put both sides
+      # of that comparison behind vmalert's -remoteWrite.url: a queue that
+      # overflows or a store that was briefly unavailable leaves a hole in
+      # tally:current_resources:sum, the instant selector goes absent past the
+      # store's lookbehind, and the expression returns nothing on every
+      # evaluation. No `for` timer starts, nothing fires, and nothing is logged,
+      # so the rule above stops watching without saying so.
+      #
+      # The second clause is what keeps this quiet where it should be. absent()
+      # alone fires wherever nothing writes tally_current_resources at all: a
+      # dev cluster, or a production one before its first reconciliation run.
+      # Paired with the raw series it reports the one case that is a fault, the
+      # scrape path filling while the write path does not.
+      - alert: TallyRecordedSeriesMissing
+        expr: |
+          absent(tally:current_resources:sum)
+            and on () (count(tally_current_resources) > 0)
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "vmalert is not writing tally:current_resources:sum while tally_current_resources is still scraped, so TallyResourceCountAnomaly evaluates nothing"
+
+      # The regex names the four jobs of scrape.yaml, one more than the roadmap
+      # lists: the recorded Ceilometer default pushes to a gateway the
+      # ceilometer job scrapes (docs/openstack-metrics.md), so on that path the
+      # job carries metering data and a target of it that stops answering costs
+      # samples the same way the other three do.
+      - alert: TallyScrapeTargetDown
+        expr: up{job=~"reporting-api|openstack-db-exporter|ceilometer|otel-collector"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Scrape target {{ $labels.instance }} of job {{ $labels.job }} is down"
+          runbook: docs/runbooks/TallyScrapeTargetDown.md
+
+      # Scrape job gone entirely. `up` is a per-target series, and `reporting-api`
+      # and `otel-collector` discover their targets (see the scrape config), so a
+      # job that resolves to no targets emits no `up` series at all and
+      # TallyScrapeTargetDown stays silent. A Deployment scaled to zero, a
+      # renamed Service or port, a removed RoleBinding, or an unreachable API
+      # server all land here rather than there.
+      - alert: TallyScrapeJobMissing
+        expr: absent(up{job="reporting-api"}) or absent(up{job="otel-collector"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Scrape job {{ $labels.job }} resolves to no targets"
+          runbook: docs/runbooks/TallyScrapeJobMissing.md
+
+      # Exporter answering 200 with a service missing. The database exporter opens
+      # one connection pool per service, and a scrape that runs out of connections
+      # on the exporter's database account (docs/openstack-metrics.md) loses whole
+      # services: their collectors emit nothing while the target stays up and the
+      # scrape duration stays normal, so neither of the two rules above sees it and
+      # the gap surfaces a month later as a short invoice. One series per billed
+      # resource is enough to see it. At a 300s scrape interval `for: 15m` wants
+      # three short scrapes in a row, so this reports a cap that is too low, not a
+      # single slow scrape.
+      #
+      # Matched on (cloud, instance) rather than on (cloud) alone: the left side is
+      # per-target, so a deployment running a second exporter target for one cloud
+      # would have the healthy one's series answer for the silent one and the rule
+      # would never fire. The right side carries the job selector for the same
+      # reason. Any other producer of a series by that name, a recording rule or a
+      # remote-write feed included, would otherwise suppress it for good.
+      - alert: TallyExporterServiceSilent
+        expr: |
+          (up{job="openstack-db-exporter"} == 1) unless on (cloud, instance) openstack_nova_total_vms{job="openstack-db-exporter"}
+          or (up{job="openstack-db-exporter"} == 1) unless on (cloud, instance) openstack_cinder_volumes{job="openstack-db-exporter"}
+          or (up{job="openstack-db-exporter"} == 1) unless on (cloud, instance) openstack_neutron_floating_ips{job="openstack-db-exporter"}
+          or (up{job="openstack-db-exporter"} == 1) unless on (cloud, instance) openstack_glance_images{job="openstack-db-exporter"}
+          or (up{job="openstack-db-exporter"} == 1) unless on (cloud, instance) openstack_loadbalancer_total_loadbalancers{job="openstack-db-exporter"}
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database exporter for {{ $labels.cloud }} is up but a whole service emits no series"
+          runbook: docs/runbooks/TallyExporterServiceSilent.md

--- a/deploy/kubernetes/base/vmalert/rules_test.go
+++ b/deploy/kubernetes/base/vmalert/rules_test.go
@@ -1,0 +1,354 @@
+// This file pins what turns a metric into a page. Every one of these fails
+// quietly: a rule dropped in an edit leaves the condition it watched unwatched
+// and nothing reports the gap, a runbook annotation naming a page that was
+// renamed hands whoever is woken at 03:00 a dead link, and a scrape job added
+// without a matching rule is a target nobody hears about once it stops
+// answering. Whether the expressions parse is what `make check-alerting`
+// answers, by loading them into the vmalert binary the cluster runs; this test
+// reads the YAML from disk and needs no cluster.
+package vmalert_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	rulesFile  = "rules.yaml"
+	scrapeFile = "../victoriametrics/scrape.yaml"
+	// The runbook annotations are written from the repository root, which is
+	// four levels up from this directory.
+	repoRoot = "../../../.."
+
+	// The job TallyExporterServiceSilent selects, the pair the anomaly rule is
+	// split into, and the rule that watches that pair.
+	exporterJob       = "openstack-db-exporter"
+	anomalyAlert      = "TallyResourceCountAnomaly"
+	coverageAlert     = "TallyRecordedSeriesMissing"
+	recordedSeries    = "tally:current_resources:sum"
+	rawResourceSeries = "tally_current_resources"
+)
+
+// alerts is the rule set in the order rules.yaml carries it. The order is
+// asserted rather than the set alone, so a rule that is moved out of the block
+// its comment explains is noticed.
+var alerts = []string{
+	"TallyCloudEventsSilent",
+	"TallyEventsRejected",
+	"TallySyncErrors",
+	"TallySyncStale",
+	"TallyReconciliationDriftHigh",
+	"TallyCollectorBufferAging",
+	"TallyResourceCountAnomaly",
+	"TallyRecordedSeriesMissing",
+	"TallyScrapeTargetDown",
+	"TallyScrapeJobMissing",
+	"TallyExporterServiceSilent",
+}
+
+// criticalAlerts are the ones a deployment's Alertmanager repeats on the short
+// interval and that carry a runbook. Severity decides what wakes a person, so
+// which rules hold it is a decision of this repository rather than a detail.
+var criticalAlerts = []string{
+	"TallyCloudEventsSilent",
+	"TallyExporterServiceSilent",
+	"TallyScrapeJobMissing",
+	"TallyScrapeTargetDown",
+	"TallySyncStale",
+}
+
+// The headings a runbook answers with. A page that is linked from a critical
+// alert and stops at a description leaves the reader where the alert did.
+var runbookHeadings = []string{"## Symptom", "## Impact on billing", "## First checks"}
+
+type ruleFile struct {
+	Groups []group `yaml:"groups"`
+}
+
+type group struct {
+	Name     string `yaml:"name"`
+	Interval string `yaml:"interval"`
+	Rules    []rule `yaml:"rules"`
+}
+
+// rule is either an alerting rule, which names an Alert, or a recording rule,
+// which names a Record. Only one of the two is ever set.
+type rule struct {
+	Alert       string            `yaml:"alert"`
+	Record      string            `yaml:"record"`
+	Expr        string            `yaml:"expr"`
+	For         string            `yaml:"for"`
+	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+func TestRuleGroup(t *testing.T) {
+	groups := rules(t)
+
+	// vmalert evaluates every group on its own timer, and a second group would
+	// evaluate on a timer this test says nothing about.
+	if len(groups) != 1 {
+		t.Fatalf("%s declares %d groups, want 1", rulesFile, len(groups))
+	}
+	if got := groups[0].Name; got != "tally" {
+		t.Errorf("group name = %q, want %q", got, "tally")
+	}
+	if got := groups[0].Interval; got != "1m" {
+		t.Errorf("group interval = %q, want %q; the interval is how long a condition may hold before the first evaluation sees it", got, "1m")
+	}
+}
+
+func TestRulesAreTheOnesThisRepositoryDecidedOn(t *testing.T) {
+	got := alertNames(t)
+
+	if !slices.Equal(got, alerts) {
+		t.Fatalf("%s carries\n  %v\nwant\n  %v\na rule removed here stops watching what it watched, and nothing else reports that it is gone",
+			rulesFile, got, alerts)
+	}
+}
+
+func TestEveryRuleTellsAReaderWhatHappened(t *testing.T) {
+	severities := []string{"critical", "warning", "info"}
+
+	for _, r := range alertRules(t) {
+		// An unknown severity routes as if it had none: Alertmanager's tree
+		// matches severity="critical" and falls through to the root for the
+		// rest, so a typo turns a page into a four-hour repeat interval.
+		if !slices.Contains(severities, r.Labels["severity"]) {
+			t.Errorf("%s has severity %q, want one of %v; an unmatched severity takes the root route's repeat interval", r.Alert, r.Labels["severity"], severities)
+		}
+		// The summary is what a receiver renders. Without one, a notification
+		// carries the alert name and the labels alone.
+		if strings.TrimSpace(r.Annotations["summary"]) == "" {
+			t.Errorf("%s carries no summary, so a notification of it says no more than its name", r.Alert)
+		}
+	}
+}
+
+func TestCriticalRules(t *testing.T) {
+	all := alertRules(t)
+
+	t.Run("are the ones that wake someone", func(t *testing.T) {
+		var got []string
+		for _, r := range all {
+			if r.Labels["severity"] == "critical" {
+				got = append(got, r.Alert)
+			}
+		}
+		slices.Sort(got)
+
+		if !slices.Equal(got, criticalAlerts) {
+			t.Fatalf("critical rules are\n  %v\nwant\n  %v\nseverity is what Alertmanager's short repeat interval matches on",
+				got, criticalAlerts)
+		}
+	})
+
+	t.Run("link a runbook that answers", func(t *testing.T) {
+		for _, r := range all {
+			if r.Labels["severity"] != "critical" {
+				continue
+			}
+
+			want := "docs/runbooks/" + r.Alert + ".md"
+			got := r.Annotations["runbook"]
+			if got != want {
+				t.Errorf("%s links runbook %q, want %q", r.Alert, got, want)
+				continue
+			}
+
+			path := filepath.Join(repoRoot, filepath.FromSlash(got))
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("%s links %s, which does not read, so the alert hands its reader a dead link: %v", r.Alert, path, err)
+				continue
+			}
+			for _, heading := range runbookHeadings {
+				if !strings.Contains(string(raw), heading) {
+					t.Errorf("%s has no %q section, so the alert it answers for leaves the reader where it found them", got, heading)
+				}
+			}
+		}
+	})
+}
+
+func TestScrapeJobsAreCovered(t *testing.T) {
+	// The three rules that name jobs rather than metrics. A job added to the
+	// scrape config or renamed there is invisible to all of them until this file
+	// names it too, and neither the scrape nor the rules fail on their own.
+	var cfg struct {
+		ScrapeConfigs []struct {
+			JobName      string           `yaml:"job_name"`
+			KubernetesSD []map[string]any `yaml:"kubernetes_sd_configs"`
+		} `yaml:"scrape_configs"`
+	}
+	raw, err := os.ReadFile(scrapeFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", scrapeFile, err)
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parsing %s: %v", scrapeFile, err)
+	}
+	if len(cfg.ScrapeConfigs) == 0 {
+		t.Fatalf("%s declares no scrape jobs, so this test would assert over nothing", scrapeFile)
+	}
+
+	byName := map[string]rule{}
+	for _, r := range alertRules(t) {
+		byName[r.Alert] = r
+	}
+	targetDown := byName["TallyScrapeTargetDown"].Expr
+	jobMissing := byName["TallyScrapeJobMissing"].Expr
+	exporterSilent := byName["TallyExporterServiceSilent"].Expr
+
+	var declaresExporterJob bool
+	for _, job := range cfg.ScrapeConfigs {
+		if job.JobName == exporterJob {
+			declaresExporterJob = true
+		}
+		if !strings.Contains(targetDown, job.JobName) {
+			t.Errorf("TallyScrapeTargetDown does not name job %q of %s, so a target of it that stops answering is reported by nothing",
+				job.JobName, scrapeFile)
+		}
+		if len(job.KubernetesSD) == 0 {
+			continue
+		}
+		// A discovered job that resolves to no targets emits no up series at
+		// all rather than up == 0, so TallyScrapeTargetDown stays silent and
+		// absent() is what sees it.
+		want := fmt.Sprintf("absent(up{job=%q})", job.JobName)
+		if !strings.Contains(jobMissing, want) {
+			t.Errorf("TallyScrapeJobMissing has no %s, so job %q resolving to zero targets is reported by nothing",
+				want, job.JobName)
+		}
+	}
+
+	// TallyExporterServiceSilent pins one job on both sides of every `unless`,
+	// and it is the only rule watching for an exporter that answers a scrape
+	// with a whole service missing. Renamed in the scrape config alone, that
+	// selector matches no series: every branch has an empty left side, the `or`
+	// chain returns nothing, and the rule can never fire again. It stays a legal
+	// expression, so `make check-alerting` reports nothing either.
+	selector := fmt.Sprintf("job=%q", exporterJob)
+	if !strings.Contains(exporterSilent, selector) {
+		t.Errorf("TallyExporterServiceSilent no longer selects %s, so this test asserts nothing about the job %s declares",
+			selector, scrapeFile)
+	}
+	if !declaresExporterJob {
+		t.Errorf("%s declares no job %q while TallyExporterServiceSilent selects it, so the rule matches no series and the short invoice it exists to prevent goes unreported",
+			scrapeFile, exporterJob)
+	}
+}
+
+// TestTheAnomalyRuleReadsARecordedSeries pins the pair that keeps the baseline
+// off the raw series, and the third rule that watches the pair. Aggregated
+// inline, the baseline made the store repeat that aggregation once per step of
+// the seven-day window on every minute evaluation, against the single replica
+// that also serves Grafana and the Reporting API. Reading the record instead put
+// both sides of the comparison behind vmalert's -remoteWrite.url: a queue that
+// overflows leaves a hole in the recorded series, the anomaly rule returns
+// nothing on every evaluation, and legal, silent and never firing is what that
+// looks like from outside.
+func TestTheAnomalyRuleReadsARecordedSeries(t *testing.T) {
+	var recorded, anomaly, coverage *rule
+	all := allRules(t)
+	for i := range all {
+		switch {
+		case all[i].Record == recordedSeries:
+			recorded = &all[i]
+		case all[i].Alert == anomalyAlert:
+			anomaly = &all[i]
+		case all[i].Alert == coverageAlert:
+			coverage = &all[i]
+		}
+	}
+
+	if recorded == nil {
+		t.Fatalf("%s records no %s, so %s reads a series nothing writes and can never fire", rulesFile, recordedSeries, anomalyAlert)
+	}
+	if anomaly == nil {
+		t.Fatalf("%s carries no %s", rulesFile, anomalyAlert)
+	}
+	if !strings.Contains(anomaly.Expr, recordedSeries) {
+		t.Errorf("%s does not read %s:\n%s", anomalyAlert, recordedSeries, anomaly.Expr)
+	}
+	if strings.Contains(anomaly.Expr, rawResourceSeries) {
+		t.Errorf("%s selects %s directly, so its baseline re-aggregates the raw series on every evaluation instead of reading the recorded one:\n%s",
+			anomalyAlert, rawResourceSeries, anomaly.Expr)
+	}
+
+	// Nothing else in this group reads the write path vmalert records through,
+	// so without this rule a stalled remote-write queue takes the anomaly rule
+	// off the air and no alert, no `for` timer and no log line says so.
+	if coverage == nil {
+		t.Fatalf("%s carries no %s, so a hole in %s silently stops %s from evaluating", rulesFile, coverageAlert, recordedSeries, anomalyAlert)
+	}
+	if want := "absent(" + recordedSeries + ")"; !strings.Contains(coverage.Expr, want) {
+		t.Errorf("%s does not carry %s, so it no longer reports the recorded series going missing:\n%s", coverageAlert, want, coverage.Expr)
+	}
+	// The second clause. absent() alone fires wherever nothing writes the raw
+	// series either, which is every dev cluster and every production one before
+	// its first reconciliation run.
+	if !strings.Contains(coverage.Expr, rawResourceSeries) {
+		t.Errorf("%s does not pair its absent() with %s, so it fires on any cluster that has not reconciled yet rather than on a stalled write path:\n%s",
+			coverageAlert, rawResourceSeries, coverage.Expr)
+	}
+}
+
+// rules parses the groups vmalert evaluates.
+func rules(t *testing.T) []group {
+	t.Helper()
+
+	raw, err := os.ReadFile(rulesFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", rulesFile, err)
+	}
+
+	var file ruleFile
+	if err := yaml.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parsing %s, which vmalert refuses to start on: %v", rulesFile, err)
+	}
+	return file.Groups
+}
+
+// allRules returns the rules of the one group, in file order.
+func allRules(t *testing.T) []rule {
+	t.Helper()
+
+	groups := rules(t)
+	if len(groups) != 1 {
+		t.Fatalf("%s declares %d groups, want 1", rulesFile, len(groups))
+	}
+	return groups[0].Rules
+}
+
+// alertRules returns the alerting rules of the one group, in file order. A
+// recording rule carries no severity, no summary and no runbook, so the
+// assertions over those read this rather than allRules.
+func alertRules(t *testing.T) []rule {
+	t.Helper()
+
+	var alerting []rule
+	for _, r := range allRules(t) {
+		if r.Alert != "" {
+			alerting = append(alerting, r)
+		}
+	}
+	return alerting
+}
+
+// alertNames returns the alert of every alerting rule, in file order.
+func alertNames(t *testing.T) []string {
+	t.Helper()
+
+	var names []string
+	for _, r := range alertRules(t) {
+		names = append(names, r.Alert)
+	}
+	return names
+}

--- a/deploy/kubernetes/base/vmalert/vmalert.yaml
+++ b/deploy/kubernetes/base/vmalert/vmalert.yaml
@@ -1,0 +1,126 @@
+# The rule evaluator. It queries the store on the group's interval, and an
+# expression that keeps returning a series for as long as its `for` says is
+# posted to Alertmanager as a firing alert (rules.yaml).
+apiVersion: v1
+kind: Service
+metadata:
+  name: vmalert
+  labels:
+    app.kubernetes.io/name: vmalert
+spec:
+  selector:
+    app.kubernetes.io/name: vmalert
+  ports:
+    - name: http
+      port: 8880
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmalert
+  labels:
+    app.kubernetes.io/name: vmalert
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vmalert
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vmalert
+    spec:
+      containers:
+        - name: vmalert
+          image: victoriametrics/vmalert:v1.148.0
+          args:
+            - -rule=/etc/vmalert/rules.yaml
+            - -datasource.url=http://victoriametrics:8428
+            - -notifier.url=http://alertmanager:9093
+            # The pair keeps the state of a pending alert outside the process.
+            # vmalert writes the ALERTS and ALERTS_FOR_STATE series to the store
+            # and reads them back at startup, so an alert that has been pending
+            # for ten of its fifteen minutes resumes there rather than starting
+            # its timer again. Without them an edit to rules.yaml, which rolls
+            # the pod through the generated ConfigMap name, would silently reset
+            # every `for` in the file.
+            - -remoteWrite.url=http://victoriametrics:8428
+            - -remoteRead.url=http://victoriametrics:8428
+            # The flag reads its value from the argument and Kubernetes expands
+            # $(VAR) in it, the same way -deleteAuthKey takes its key in
+            # victoriametrics.yaml. vmalert puts this value into the
+            # generatorURL of every alert it sends, which is the "Source" link
+            # the Alertmanager UI offers on an alert, so an unpatched one sends
+            # a reader to a host that answers nothing.
+            - -external.url=$(VMALERT_EXTERNAL_URL)
+          env:
+            # A placeholder every overlay patches, the same way it patches
+            # ALERTMANAGER_EXTERNAL_URL and GF_SERVER_ROOT_URL.
+            - name: VMALERT_EXTERNAL_URL
+              value: https://vmalert.tally.example.com
+          ports:
+            - name: http
+              containerPort: 8880
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: rules
+              mountPath: /etc/vmalert
+              readOnly: true
+      volumes:
+        - name: rules
+          configMap:
+            name: vmalert-rules
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalert
+  labels:
+    app.kubernetes.io/name: vmalert
+spec:
+  parentRefs:
+    - name: tally
+      sectionName: https
+  hostnames:
+    - vmalert.tally.example.com
+  rules:
+    # Three prefixes rather than the host. The UI and the JSON its pages read
+    # live under /vmalert/ and reference their assets relative to that prefix,
+    # and /api/v1/rules and /api/v1/alerts are the two read endpoints vmalert
+    # answers at the top level. What is left is /-/reload, /flags, /metrics and
+    # /debug/pprof, which vmalert serves at the root alone: under the /vmalert
+    # prefix they answer 400, and the route does not carry the root, so none of
+    # them is published. /-/reload stays reachable from inside the cluster,
+    # where it re-reads the mounted files and therefore changes nothing on its
+    # own.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /vmalert
+        - path:
+            type: PathPrefix
+            value: /api/v1/rules
+        - path:
+            type: PathPrefix
+            value: /api/v1/alerts
+      backendRefs:
+        - name: vmalert
+          port: 8880

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -92,6 +92,24 @@ patches:
         path: /spec/hostnames/0
         value: grafana.tally.127-0-0-1.nip.io
 
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: vmalert
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: vmalert.tally.127-0-0-1.nip.io
+
+  - target:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: alertmanager
+    patch: |
+      - op: replace
+        path: /spec/hostnames/0
+        value: alertmanager.tally.127-0-0-1.nip.io
+
   # Serve that domain, signed by the dev CA.
   - target:
       group: cert-manager.io
@@ -141,10 +159,10 @@ patches:
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Never
 
-  # The one strategic merge patch in this file. It merges env entries by name,
-  # so it names the three variables it sets instead of indexing into the base
-  # env list, where a reorder in the base would move the values onto the wrong
-  # variables.
+  # The three strategic merge patches in this file. They merge env entries by
+  # name, so each names only the variables it sets instead of indexing into the
+  # base env list, where a reorder in the base would move the values onto the
+  # wrong variables.
   #
   # The root URL carries the 8443 host port for the same reason the redirect
   # above does: kind publishes https there, so a link Grafana renders without
@@ -168,3 +186,33 @@ patches:
                     value: "true"
                   - name: GF_AUTH_ANONYMOUS_ORG_ROLE
                     value: Viewer
+
+  # The placeholder external URL, in the host-port form for the same reason.
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: vmalert
+      spec:
+        template:
+          spec:
+            containers:
+              - name: vmalert
+                env:
+                  - name: VMALERT_EXTERNAL_URL
+                    value: https://vmalert.tally.127-0-0-1.nip.io:8443
+
+  # The same placeholder on the other side of the pair.
+  - patch: |
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: alertmanager
+      spec:
+        template:
+          spec:
+            containers:
+              - name: alertmanager
+                env:
+                  - name: ALERTMANAGER_EXTERNAL_URL
+                    value: https://alertmanager.tally.127-0-0-1.nip.io:8443

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,291 @@
+# Alerting
+
+Two components turn the metrics store into notifications. vmalert evaluates the
+rules of this repository against VictoriaMetrics once a minute and posts what
+fires to Alertmanager, which groups it, deduplicates it, and hands it to a
+receiver. No Prometheus server is involved: VictoriaMetrics is the only store,
+and vmalert queries it over the Prometheus API the store answers. This document
+describes what is deployed, what the rules ask, how to reach both on a dev
+cluster, and how a deployment says where an alert is delivered.
+
+## What is deployed
+
+### vmalert
+
+[`vmalert.yaml`](../deploy/kubernetes/base/vmalert/vmalert.yaml) runs one
+replica of `victoriametrics/vmalert` behind the Service `vmalert` on port 8880.
+Every flag it takes:
+
+| Flag | Why it is set |
+| --- | --- |
+| `-rule=/etc/vmalert/rules.yaml` | The rules, mounted from the generated `vmalert-rules` ConfigMap. |
+| `-datasource.url=http://victoriametrics:8428` | The store every expression is evaluated against, reached in-cluster by Service name. |
+| `-notifier.url=http://alertmanager:9093` | Where a firing alert is posted, again in-cluster. |
+| `-remoteWrite.url=http://victoriametrics:8428` | vmalert writes the `ALERTS` and `ALERTS_FOR_STATE` series for every pending and firing alert back into the store. |
+| `-remoteRead.url=http://victoriametrics:8428` | At startup it reads `ALERTS_FOR_STATE` back and restores the pending timers from it. |
+| `-external.url=$(VMALERT_EXTERNAL_URL)` | The value goes into the `generatorURL` of every alert vmalert sends, which is the "Source" link the Alertmanager UI offers. |
+
+The remote pair is what keeps a `for` from restarting on every pod roll. An
+alert that has been pending for ten of its fifteen minutes resumes at ten
+minutes rather than at zero, and that matters here because editing `rules.yaml`
+rolls the pod through the generated ConfigMap name. Without the pair, every edit
+to the file would silently reset every timer in it.
+
+`-external.url` reads its value from the argument, and Kubernetes expands
+`$(VAR)` in an argument from the container's own environment. The base sets
+`VMALERT_EXTERNAL_URL` to the placeholder `https://vmalert.tally.example.com`,
+and each overlay patches that variable rather than the argument. An unpatched
+value sends a reader who follows a Source link to a host that answers nothing.
+
+### Alertmanager
+
+[`alertmanager.yaml`](../deploy/kubernetes/base/alertmanager/alertmanager.yaml)
+runs one replica of `prom/alertmanager` behind the Service `alertmanager` on
+port 9093. Its flags:
+
+| Flag | Why it is set |
+| --- | --- |
+| `--config.file=/etc/alertmanager/config.yaml` | The routing tree, mounted from the generated `alertmanager-config` ConfigMap. |
+| `--storage.path=/alertmanager` | Where silences and the notification log are kept. |
+| `--web.external-url=$(ALERTMANAGER_EXTERNAL_URL)` | Alertmanager builds the links it renders and the ones it puts into a notification from this value, so it is patched per overlay for the same reason `-external.url` is. |
+| `--cluster.listen-address=` | The empty value turns the gossip cluster off. There is one replica and therefore no peer to settle with, and at its default Alertmanager opens the port and logs "gossip not settled" at every start while it waits for members that never arrive. |
+
+The storage path is backed by a 1 GiB volume claim, which is why Alertmanager is
+a StatefulSet rather than a Deployment, as VictoriaMetrics and TimescaleDB are.
+What it holds is state: the notification log, which keeps a receiver from being
+told a second time about a group it was already told about, and the silences an
+on-call engineer set. Editing `config.yaml` rolls the pod by design (see below),
+and on scratch storage that roll would deliver every firing group again at the
+next `group_wait` and drop every silence. One replica with
+`--cluster.listen-address=` has no peer to replicate either back from, so the
+loss would be total rather than partial.
+
+The claim is also why the pod carries a `securityContext` where nothing else in
+the base does. `prom/alertmanager` runs as `nobody`, UID and GID 65534, and
+Kubernetes chowns a mounted volume to the pod's `fsGroup` or not at all. Most
+CSI drivers hand a freshly provisioned volume back owned `root:root` 0755, so
+without `fsGroup: 65534` Alertmanager cannot create the notification log or a
+silence under `--storage.path` and the pod crash-loops. kind's `local-path`
+provisioner happens to create its directory 0777, so this would pass in the dev
+overlay and fail wherever the base is deployed for real.
+
+### The rules
+
+[`rules.yaml`](../deploy/kubernetes/base/vmalert/rules.yaml) holds one group,
+`tally`, evaluated every minute. The five critical rules carry a `runbook`
+annotation naming the page a reader opens when the alert arrives.
+
+| Alert | What the expression asks | `for` | Severity | Runbook |
+| --- | --- | --- | --- | --- |
+| `TallyCloudEventsSilent` | No collector event from a cloud in an hour, while it had one in the last 24 hours | 15m | critical | [TallyCloudEventsSilent.md](runbooks/TallyCloudEventsSilent.md) |
+| `TallyEventsRejected` | More than 10 rejected events per (cloud, reason) in 15 minutes | none | warning | |
+| `TallySyncErrors` | Any reconciliation error for a cloud in the last hour | none | warning | |
+| `TallySyncStale` | No completed reconciliation run for a cloud in 30 minutes | none | critical | [TallySyncStale.md](runbooks/TallySyncStale.md) |
+| `TallyReconciliationDriftHigh` | More than 50 resources corrected in a cloud over 6 hours | none | warning | |
+| `TallyCollectorBufferAging` | `tally_collector_oldest_buffered_seconds` above 600 | none | warning | |
+| `TallyResourceCountAnomaly` | A per (cloud, resource_type) count above `1.5 * (7-day baseline + 10)`, the baseline offset by 6h so the count is not inside it | 30m | info | |
+| `TallyRecordedSeriesMissing` | `tally:current_resources:sum` absent while `tally_current_resources` is still scraped | 15m | warning | |
+| `TallyScrapeTargetDown` | `up == 0` on one of four scrape jobs | 5m | critical | [TallyScrapeTargetDown.md](runbooks/TallyScrapeTargetDown.md) |
+| `TallyScrapeJobMissing` | `absent(up{job=...})` for `reporting-api` or `otel-collector` | 5m | critical | [TallyScrapeJobMissing.md](runbooks/TallyScrapeJobMissing.md) |
+| `TallyExporterServiceSilent` | The database exporter answers a scrape while a whole service emits no series for a cloud | 15m | critical | [TallyExporterServiceSilent.md](runbooks/TallyExporterServiceSilent.md) |
+
+A rule without a `for` fires at the first evaluation whose expression returns a
+series, so at most a minute after the condition holds. A `for` is on the rules
+where one evaluation is not evidence. `TallyScrapeTargetDown` waits out a single
+failed scrape, and `TallyExporterServiceSilent` waits three of the exporter's
+300-second scrapes, so it reports a database connection cap that is too low
+rather than one slow scrape.
+
+`TallyScrapeTargetDown` matches
+`up{job=~"reporting-api|openstack-db-exporter|ceilometer|otel-collector"}`. That
+regex names four jobs, one more than
+[`roadmap/02-phase-2-reporting-dashboards.md`](../roadmap/02-phase-2-reporting-dashboards.md)
+lists, and the fourth is `ceilometer`. The recorded Ceilometer default pushes to
+a gateway that job scrapes ([`openstack-metrics.md`](openstack-metrics.md)), so
+on that path the job carries metering data, and a target of it that stops
+answering costs samples the same way a target of the other three does.
+
+`TallyResourceCountAnomaly` reads a recorded series, `tally:current_resources:sum`,
+which the same group writes one rule earlier. Aggregating
+`tally_current_resources` inside the baseline instead would make the store repeat
+that aggregation once per step of the seven-day window on every minute
+evaluation, and that store is the single replica Grafana and the Reporting API's
+query path also read. vmalert writes the recorded series through
+`-remoteWrite.url` and reads it back through `-datasource.url`, the same pair
+that carries `ALERTS_FOR_STATE`.
+
+`TallyRecordedSeriesMissing` is what watches that pair, because reading the
+recorded series put both sides of the anomaly rule's comparison behind the
+write path. A remote-write queue that overflows, or a store that was briefly
+unavailable, leaves a hole in `tally:current_resources:sum`: past the store's
+lookbehind the instant selector goes absent, the expression returns nothing on
+every evaluation, and the anomaly rule stops watching with no `for` timer, no
+notification and no log line to say so. The second clause,
+`count(tally_current_resources) > 0`, is what keeps the rule quiet where the
+absence is expected — `absent()` alone fires on any cluster that has not
+reconciled yet, dev clusters included — so it reports the one case that is a
+fault: the scrape path filling while the write path does not.
+
+`TallyExporterServiceSilent` matches `up` against the exporter's series on
+`(cloud, instance)` and selects `job="openstack-db-exporter"` on both sides. On
+`(cloud)` alone, a deployment running a second exporter target for one cloud
+would have the healthy target's series answer for the silent one, and any other
+producer of a series by one of those names would suppress the alert for good.
+
+`TallyScrapeJobMissing` covers what `TallyScrapeTargetDown` cannot see.
+`reporting-api` and `otel-collector` discover their targets, so a job that
+resolves to no targets emits no `up` series at all and the `up == 0` rule stays
+silent. A Deployment scaled to zero, a renamed Service or port, a removed
+RoleBinding, and an unreachable API server all land in the `absent()` rule.
+
+### Editing rules.yaml or config.yaml
+
+Neither file is applied as a file. Each is the source of a `configMapGenerator`
+in its component's `kustomization.yaml`, generating `vmalert-rules` and
+`alertmanager-config`, and kustomize appends a content hash to each name.
+Editing a file changes the generated name, which changes the pod spec that
+mounts it, which rolls the pod. Neither component is left evaluating rules or
+routing by a config that no longer matches the tree. It is the pattern the
+collector and scrape configs follow, described under
+[Editing either config](openstack-metrics.md#editing-either-config).
+
+### Where an alert is delivered
+
+[`config.yaml`](../deploy/kubernetes/base/alertmanager/config.yaml) groups by
+`alertname` and `cloud`, waits 30 seconds for a group to collect (`group_wait`),
+sends an update at most every 5 minutes (`group_interval`), and repeats an
+unresolved group every 4 hours (`repeat_interval`). One child route matches
+`severity="critical"` and tightens `repeat_interval` alone, to 1 hour. It
+inherits the receiver from its parent, so a deployment that names a receiver at
+the root covers both branches with it.
+
+The single receiver, `default`, names no integration, and it does so on purpose.
+Where an alert is delivered is a property of a deployment and not of this
+repository, so until one says otherwise an alert is grouped and held in
+Alertmanager, where the UI and `amtool` show it.
+
+A deployment adds its own delivery by replacing the generated ConfigMap from its
+overlay rather than by patching the file in the base:
+
+```yaml
+configMapGenerator:
+  - name: alertmanager-config
+    behavior: replace
+    files:
+      - config.yaml
+```
+
+The overlay's own `config.yaml` then carries the `webhook_configs` or
+`email_configs` under its receiver. That is the mechanism
+[Replacing the placeholders](openstack-metrics.md#replacing-the-placeholders)
+records for the scrape config, used here for the same reason: a file the base
+owns stays the base's, and the deployment's copy is a file of its own.
+
+## Dev access
+
+`make up` publishes both on the dev overlay's hostnames:
+
+```text
+https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/
+https://alertmanager.tally.127-0-0-1.nip.io:8443
+```
+
+The vmalert URL carries the `/vmalert/` path because the route publishes three
+prefixes rather than the host: `/vmalert` for the UI and the JSON its pages
+read, plus the two read endpoints `/api/v1/rules` and `/api/v1/alerts`. What is
+left is `/-/reload`, `/flags`, `/metrics` and `/debug/pprof`, which vmalert
+serves at the root alone, and the route does not carry the root, so each of them
+gets the Gateway's 404. `/-/reload` stays reachable from inside the cluster,
+where it re-reads the mounted files and therefore changes nothing on its own.
+
+Alertmanager answers reads and writes on one API and one port, so its route
+names what it publishes rather than carrying the host: `GET` on
+`/api/v2/alerts`, `/api/v2/silences`, `/api/v2/silence/<id>` and
+`/api/v2/receivers`, plus the index, its bundle under `/assets` and the icon.
+Everything else gets the Gateway's 404, which includes the two reads that would
+otherwise come with the host: `/api/v2/status` answers with the loaded config,
+and therefore with whatever `webhook_configs` or `email_configs` a deployment
+put into it, and `/metrics` names the delivery integrations it is configured
+with. The UI's Status page reads the first of those and reports an error; that
+is the endpoint the route withholds.
+
+A second rule answers `POST`, `PUT` and `DELETE` under `/api/v2`, plus
+`/-/reload` and `/debug`, with a 403. None of those is published either, so what
+this rule adds is an answer that says why: the "New Silence" form the UI offers
+is told it was refused rather than left with a 404. The read matches name `GET`
+for that to work, because the Gateway API ranks a longer path prefix above a
+method match and `/api/v2/silences` is longer than `/api/v2`.
+
+Silences are created from inside the cluster instead, with the `amtool` the
+image ships:
+
+```sh
+kubectl --context kind-tally -n tally exec statefulset/alertmanager -- \
+  amtool --alertmanager.url=http://127.0.0.1:9093 silence add \
+  --author=<who> --comment='<why>' --duration=2h alertname=<name>
+```
+
+Both hostnames need the dev CA that signed the Gateway's certificate:
+
+```sh
+make -s ca > tally-ca.crt
+curl --cacert tally-ca.crt \
+  https://vmalert.tally.127-0-0-1.nip.io:8443/api/v1/rules
+```
+
+The base leaves both hostnames at `vmalert.tally.example.com` and
+`alertmanager.tally.example.com`, and both external URLs at the matching
+placeholder. An overlay that publishes either component patches the route
+hostname and the environment variable together, which is what the dev overlay
+does.
+
+## What a fresh cluster shows
+
+About five minutes after `make up`, `TallyScrapeTargetDown` fires for the jobs
+`openstack-db-exporter` and `ceilometer`. Both are static targets for exporters
+that run beside an OpenStack control plane rather than in this cluster, which is
+the designed dev state described under
+[Replacing the placeholders](openstack-metrics.md#replacing-the-placeholders),
+and not a fault to chase.
+
+No other rule fires on a cluster nothing has reported to. `TallyScrapeJobMissing`
+stays silent because both discovered jobs resolve to targets, and
+`TallyExporterServiceSilent` needs an exporter target that answers a scrape,
+which is the target that is down. The remaining seven read `tally_` series the
+store does not carry yet, and an expression over nothing returns nothing.
+`TallyRecordedSeriesMissing` is quiet for a different reason: its `absent()`
+clause is true here, and the `count(tally_current_resources) > 0` it is paired
+with is what keeps it from reporting a cluster that has not reconciled yet as a
+stalled write path.
+
+## When an expected alert does not appear
+
+Read `/api/v1/rules` on the vmalert hostname and find the rule. A non-empty
+`lastError` on it means the datasource query failed rather than that the
+condition was false, and the message names what VictoriaMetrics answered.
+
+`TallyCloudEventsSilent` never fires for a cloud that has never reported. Its
+second clause,
+`sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[24h])) > 0`,
+is empty for such a cloud, and an `and` with an empty side returns nothing. That
+is what keeps a cloud that is idle by design or decommissioned from firing
+forever, and it is also why the drill for the rule seeds an event first. The
+scripted run is in [drills/phase2.md](drills/phase2.md).
+
+## How CI validates
+
+`make check-alerting` loads each file into the pinned image the cluster runs, so
+Docker is the only prerequisite and no cluster is involved. It runs `rules.yaml`
+through `vmalert -dryRun`, which catches an expression the deployed binary
+cannot parse, and `config.yaml` through `amtool check-config`, which catches an
+unknown or misspelled routing field. CI runs the target after the tests
+([`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml)).
+
+The shape of the rules file is pinned separately by
+[`rules_test.go`](../deploy/kubernetes/base/vmalert/rules_test.go): the alert
+names and their order, the severities, the runbook annotations, the recorded
+series the anomaly rule reads, and the scrape jobs the last three rules name.
+The flags of both Deployments are pinned by their
+[`manifest_test.go`](../deploy/kubernetes/base/vmalert/manifest_test.go) files.
+Parsing says an expression is legal, not that it is the expression this
+repository means to run.

--- a/docs/drills/phase2.md
+++ b/docs/drills/phase2.md
@@ -1,0 +1,207 @@
+# Phase 2 acceptance drill: TallyCloudEventsSilent
+
+`TallyCloudEventsSilent` is the alert the concept asks for under
+[Reconciliation](../../README.md#reconciliation): a cloud whose collector has
+gone quiet while the cloud kept creating and deleting resources. This drill
+takes one dev cluster from a seeded event through the pending state, the firing
+state, the notification in Alertmanager, and the resolution, and it checks on
+the way that the pending timer survives a vmalert restart.
+
+The rule and the components it runs on are described in
+[`../alerting.md`](../alerting.md). Every command below runs from the repository
+root against a running dev cluster. The drill takes about 80 minutes of wall
+clock, most of it waiting.
+
+## Preparation
+
+The Gateway's certificate is signed by the dev CA, so every call needs it:
+
+```sh
+make -s ca > tally-ca.crt
+```
+
+Both components answer before anything is seeded:
+
+```sh
+curl --cacert tally-ca.crt \
+  https://vmalert.tally.127-0-0-1.nip.io:8443/api/v1/rules
+curl --cacert tally-ca.crt \
+  https://alertmanager.tally.127-0-0-1.nip.io:8443/api/v2/receivers
+```
+
+The first lists one group, `tally`, with the eleven alerting rules of
+[`rules.yaml`](../../deploy/kubernetes/base/vmalert/rules.yaml) and the one
+recording rule `TallyResourceCountAnomaly` reads. The second
+answers 200 with the one receiver `config.yaml` declares, `default`.
+`/api/v2/status`, which would answer with the loaded config, is not published
+([alerting.md](../alerting.md#dev-access)); read it from inside the cluster if
+you need it.
+
+## Seed one collector event
+
+The rule compares two windows over the same counter, and on a cluster nothing
+has reported to both are empty. The second clause,
+`increase(tally_events_ingested_total{source="collector"}[24h]) > 0`, then
+returns nothing, and an `and` with an empty side returns nothing, so the rule
+cannot fire and there is nothing to observe. The drill therefore seeds first:
+one event now makes the 24-hour window non-empty for the next 24 hours, and the
+1-hour window empties again an hour after it.
+
+A seed the dashboard drill posted within the last 24 hours serves the same
+purpose. If
+[`../grafana-dashboards.md`](../grafana-dashboards.md#part-1-real-series-through-the-reporting-api)
+has been run against this cluster inside that window, its events already satisfy
+the second clause, and the timeline below runs from its last post rather than
+from a fresh seed.
+
+Ingest is authenticated per (platform, cloud), so issue a credential for cloud
+`os-prod-eu1` the same way that drill does:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TOKEN="$(go run ./cmd/tally-reporting-admin create-ingest-credential \
+  --platform openstack --cloud os-prod-eu1)"
+```
+
+Post one create event. The heredoc delimiter is unquoted, unlike the one in the
+dashboard drill, because the body has to expand its `$(date ...)` calls:
+
+```sh
+curl --cacert tally-ca.crt -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events' \
+  --data-binary @- <<EOF
+{
+  "event_id": "drill-alert-seed-$(date +%s)",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "event_type": "compute.instance.create.end",
+  "platform": "openstack",
+  "cloud": "os-prod-eu1",
+  "resource_type": "instance",
+  "resource_id": "drill-alert-instance-$(date +%s)",
+  "project_id": "drill-project",
+  "source": "collector",
+  "payload": {
+    "state": "active",
+    "size": {"vcpus": 4, "ram_gb": 16, "disk_gb": 80, "flavor": "m1.large"}
+  }
+}
+EOF
+```
+
+The epoch suffix on both ids is what makes a repeated drill work. Ingestion is
+idempotent on `(event_id, timestamp)`, so an id posted again with a timestamp it
+already carries is stored as a duplicate and moves `tally_events_ingested_total`
+by nothing, which is the one counter this drill reads.
+
+The answer names what the batch did:
+
+```json
+{"accepted": 1, "duplicates": 0, "rejected": []}
+```
+
+Within 60 seconds, the 30-second scrape of the `reporting-api` job plus the
+30-second query latency offset, the counter is readable in the store:
+
+```sh
+curl --cacert tally-ca.crt -G \
+  'https://vm.tally.127-0-0-1.nip.io:8443/api/v1/query' \
+  --data-urlencode 'query=sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[1h]))'
+```
+
+It answers a value above 0 for `os-prod-eu1`. That is the drill's starting
+state: both windows carry the seed, and the rule stays silent because its first
+clause is false.
+
+## Wait out the silence
+
+Post nothing further for `os-prod-eu1`. Note the time of the seed; the timeline
+runs from it.
+
+At about 60 minutes the 1-hour window has emptied while the 24-hour window has
+not, so the expression starts returning a series and the rule enters its 15
+minute `for`:
+
+```sh
+curl --cacert tally-ca.crt \
+  https://vmalert.tally.127-0-0-1.nip.io:8443/api/v1/alerts
+```
+
+It lists `TallyCloudEventsSilent{cloud="os-prod-eu1"}` with state `pending`.
+
+At about 75 minutes the same call lists it as `firing`. Within `group_wait`, 30
+seconds, Alertmanager has it too:
+
+```sh
+curl --cacert tally-ca.crt \
+  https://alertmanager.tally.127-0-0-1.nip.io:8443/api/v2/alerts
+```
+
+The entry carries `receivers: [{"name": "default"}]` and
+`status.state: active`. The receiver delivers nothing, which is the point: the
+alert is held where the UI and `amtool` show it until a deployment names a
+receiver of its own.
+
+Open `https://alertmanager.tally.127-0-0-1.nip.io:8443` and follow the alert's
+Source link. It opens
+`https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/alert?group_id=<id>&alert_id=<id>`,
+the rule's own page in vmalert, and that URL is the one `-external.url` supplies.
+
+## Restart vmalert while it fires
+
+The state of a firing alert lives in the store rather than in the process, and
+this is what says so. While the alert fires, delete the pod:
+
+```sh
+kubectl --context kind-tally -n tally delete pod \
+  -l app.kubernetes.io/name=vmalert
+kubectl --context kind-tally -n tally rollout status deploy/vmalert
+```
+
+Once the new pod is Ready, `GET /api/v1/alerts` on the vmalert hostname lists
+`TallyCloudEventsSilent{cloud="os-prod-eu1"}` as firing again, without another
+15-minute pending phase. vmalert read `ALERTS_FOR_STATE` back through
+`-remoteRead.url` and restored the timer. A run without that flag would show the
+alert pending and start the 15 minutes over.
+
+## Resolve it
+
+Post one more event of the same shape, with fresh ids and a fresh timestamp:
+rerun the seed command above. The 1-hour window is non-empty again, so the first
+clause of the expression turns false.
+
+Within about two minutes (the 30-second scrape, the 30-second latency offset,
+and the one-minute evaluation interval) vmalert stops seeing the series, sends
+the resolution to Alertmanager, and `GET /api/v2/alerts` no longer lists
+`TallyCloudEventsSilent`. `GET /api/v1/alerts` on the vmalert hostname drops it
+at the same evaluation.
+
+## What else the run shows
+
+The two `TallyScrapeTargetDown` alerts for `openstack-db-exporter` and
+`ceilometer` are firing throughout and are expected. Both jobs are static
+targets for exporters that run beside an OpenStack control plane rather than in
+this cluster, which is the designed dev state of
+[`../openstack-metrics.md`](../openstack-metrics.md#replacing-the-placeholders).
+
+The seed call without its `Authorization` header answers 401 and moves no
+counter, which is the check that ingest is not open to whoever resolves the
+hostname.
+
+A query that comes back empty within 30 seconds of a post has lost nothing.
+VictoriaMetrics evaluates queries behind wall clock by `-search.latencyOffset`,
+30 seconds by default, so a query over a window still being written answers
+empty; repeat it after the offset before treating it as a failure. The full
+explanation is in the
+[acceptance drill](../openstack-metrics.md#acceptance-drill) of the metrics
+pipeline.
+
+Two costs of the run, both accepted:
+
+- The seed events stay in the reporting database and their series stay in the
+  dev store for the 13-month retention VictoriaMetrics runs with. `make down`
+  deletes the cluster and its volumes, and that is the shorter way out.
+- The drill is for dev clusters. It books an instance in a cloud and a project
+  that do not exist, so running it against a store any invoice is derived from
+  puts invented usage into the billing record.

--- a/docs/openstack-metrics.md
+++ b/docs/openstack-metrics.md
@@ -671,5 +671,7 @@ the first symptom is an invoice that comes up short. A deployment that replaces
 this file therefore alerts on `up == 0` for both jobs — they are static targets,
 so their `up` series exists whatever the exporter is doing. The two discovered
 jobs need the second rule as well, on `absent(up{job="..."})`, for the reason
-above. Nothing in this tree alerts yet, because the tree carries no alerting
-component.
+above. `TallyScrapeTargetDown` and `TallyScrapeJobMissing` in
+[`deploy/kubernetes/base/vmalert/rules.yaml`](../deploy/kubernetes/base/vmalert/rules.yaml)
+are those two rules; [`alerting.md`](alerting.md) describes them and the eight
+others the tree ships.

--- a/docs/runbooks/TallyCloudEventsSilent.md
+++ b/docs/runbooks/TallyCloudEventsSilent.md
@@ -1,0 +1,40 @@
+# TallyCloudEventsSilent
+
+`sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[1h])) == 0 and sum by (cloud) (increase(tally_events_ingested_total{source="collector"}[24h])) > 0`, `for: 15m`.
+
+## Symptom
+
+A cloud that ingested collector events at some point in the last 24 hours has
+ingested none for more than an hour. The second half of the expression is what
+keeps a cloud that is idle by design, or one that has been decommissioned, from
+firing this alert forever.
+
+## Impact on billing
+
+Every create, delete, and resize the cloud performed inside the gap is unbilled
+or overbilled until a reconciliation run turns the difference into synthetic
+events. A resource that is created and deleted inside the gap is invisible for
+good: no run ever observes it, so nothing books it, and no later repair
+recovers it. That is the accepted limitation of the event-driven design, listed
+under [Reconciliation](../../README.md#reconciliation) in the concept.
+
+## First checks
+
+1. The collector process beside the broker: `/healthz` and `/readyz` on
+   `TALLY_OSC_HTTP_PORT`, the gauges `tally_collector_buffer_depth` and
+   `tally_collector_oldest_buffered_seconds`, and the counter
+   `tally_collector_delivery_errors_total`. A buffer that grows says the
+   collector still consumes and cannot deliver; a readiness that fails names
+   its reason in the log
+   ([`openstack-collector.md`](../openstack-collector.md)).
+2. The broker connection. `--dump` prints one line per delivery and reads
+   nothing but the AMQP variables, so it says whether the bus carries
+   notifications at all. It consumes through a queue of its own and takes no
+   delivery away from a running collector.
+3. The Reporting API as the collector reaches it: the base URL in
+   `TALLY_OSC_REPORTING_URL`, and an ingest credential whose scope matches
+   `TALLY_OSC_CLOUD`. An event outside that scope is refused with the reason
+   `scope` and is never resent.
+4. Whether reconciliation still runs for the cloud
+   (`tally_sync_runs_total{status="completed"}`). It is what heals the gap, so
+   a silent collector and a stale sync together cost more than either alone.

--- a/docs/runbooks/TallyExporterServiceSilent.md
+++ b/docs/runbooks/TallyExporterServiceSilent.md
@@ -1,0 +1,32 @@
+# TallyExporterServiceSilent
+
+`(up{job="openstack-db-exporter"} == 1) unless on (cloud) <series>`, joined by `or` over `openstack_nova_total_vms`, `openstack_cinder_volumes`, `openstack_neutron_floating_ips`, `openstack_glance_images`, and `openstack_loadbalancer_total_loadbalancers`, `for: 15m`.
+
+## Symptom
+
+The exporter target is up while one of the five billed services emits no series
+for a cloud. The exporter answers 200, the scrape duration stays normal, and the
+match on `cloud` keeps a healthy cloud from covering for another. At a 300
+second scrape interval, `for: 15m` wants three short scrapes in a row.
+
+## Impact on billing
+
+That service is unmetered for the cloud while every scrape-health signal stays
+green. Nothing on `/targets` and no `up` series shows it, so the gap surfaces
+when the invoice comes up short.
+
+## First checks
+
+1. Which of the five series is missing for which cloud: one instant query per
+   series against the store.
+2. The exporter log for database errors of that service. A connection pool that
+   loses the race gets `ERROR 1226`, its collectors emit nothing, and the scrape
+   still answers 200.
+3. The connection cap on the exporter's database account
+   ([`openstack-metrics.md`](../openstack-metrics.md#the-read-only-database-user)).
+   The exporter opens one pool per DSN, eight of them, and gathers the
+   collectors in parallel, so a `MAX_USER_CONNECTIONS` at or below eight
+   truncates every scrape by a different set of services.
+4. The scrape duration on `/targets`. One near the job's 60 second
+   `scrape_timeout` points at the queries, while a normal one with series
+   missing points at the cap.

--- a/docs/runbooks/TallyScrapeJobMissing.md
+++ b/docs/runbooks/TallyScrapeJobMissing.md
@@ -1,0 +1,31 @@
+# TallyScrapeJobMissing
+
+`absent(up{job="reporting-api"}) or absent(up{job="otel-collector"})`, `for: 5m`.
+
+## Symptom
+
+One of the two discovered jobs resolves to no target at all. `up` is a
+per-target series, so zero targets produce no `up` series rather than `up == 0`:
+the job disappears from `/targets` instead of turning red, and
+TallyScrapeTargetDown stays silent.
+
+## Impact on billing
+
+The same as the job's targets being down, described in
+[TallyScrapeTargetDown](TallyScrapeTargetDown.md), without a red target to see
+it by.
+
+## First checks
+
+1. The Deployment's replica count. A Deployment scaled to zero takes its job
+   off the page.
+2. The Service name and the port name the relabel rule keeps, `reporting-api;http`
+   and `otel-collector;metrics` in
+   [`scrape.yaml`](../../deploy/kubernetes/base/victoriametrics/scrape.yaml). A
+   rename on either side drops every endpoint of the job.
+3. The `victoriametrics-scrape` RoleBinding in
+   [`victoriametrics.yaml`](../../deploy/kubernetes/base/victoriametrics/victoriametrics.yaml).
+   Without it the endpointslice discovery is refused and the job has nothing to
+   keep.
+4. The VictoriaMetrics log for discovery errors, an unreachable API server
+   among them.

--- a/docs/runbooks/TallyScrapeTargetDown.md
+++ b/docs/runbooks/TallyScrapeTargetDown.md
@@ -1,0 +1,39 @@
+# TallyScrapeTargetDown
+
+`up{job=~"reporting-api|openstack-db-exporter|ceilometer|otel-collector"} == 0`, `for: 5m`.
+
+## Symptom
+
+A configured scrape target has answered nothing for five minutes. The `job` and
+`instance` labels of the firing series name which one.
+
+## Impact on billing
+
+It depends on the job:
+
+- `reporting-api`: every service metric is gone, and with it every rule that
+  reads one, so the ingestion and reconciliation alerts go blind at the same
+  time. The API may also be refusing ingest, in which case the collectors are
+  filling their buffers.
+- `otel-collector`: the pushed series are lost at the receiver, the collector
+  gauges and Ceilometer's OTLP path among them. Nothing buffers them on the way
+  in.
+- `openstack-db-exporter` and `ceilometer`: a metering source runs empty. The
+  inventory Tally bills from stops being observed for the cloud the job carries
+  in its static labels.
+
+## First checks
+
+1. `/targets` on the VictoriaMetrics hostname, which names the error per
+   target. On a dev cluster that is
+   `https://vm.tally.127-0-0-1.nip.io:8443/targets`.
+2. Pod status and log of the workload behind the target, and the Service and
+   port names it is reached through.
+3. For `openstack-db-exporter`, the limits on its database account
+   ([`openstack-metrics.md`](../openstack-metrics.md#the-read-only-database-user)).
+   A statement cap that ends the queries fails the scrape, while a connection
+   cap that is too low leaves the target up and the scrape short, which is
+   TallyExporterServiceSilent rather than this alert.
+4. Whether this is a dev cluster. Both static jobs, `openstack-db-exporter` and
+   `ceilometer`, are down there by design: neither target exists in that
+   cluster.

--- a/docs/runbooks/TallySyncStale.md
+++ b/docs/runbooks/TallySyncStale.md
@@ -1,0 +1,34 @@
+# TallySyncStale
+
+`sum by (cloud) (increase(tally_sync_runs_total{status="completed"}[30m])) == 0`, with no `for`, so it fires on the first evaluation that finds the window empty.
+
+## Symptom
+
+No reconciliation run of this cloud reached `completed` in the last 30 minutes.
+The expected cadence is one run every 10 minutes, so the window covers three of
+them and a single missed run does not fire the alert.
+
+## Impact on billing
+
+Drift stops being corrected: a resource the projection holds and the cloud no
+longer has keeps accruing charges, and one the cloud holds and the projection
+never learned of stays unbilled. Every event the collector lost stays lost for
+as long as this holds, because a completed run is what books it.
+
+## First checks
+
+1. The Reporting API log for the sync runs of the cloud, and whatever calls
+   `POST /internal/sync/{cloud}` on the schedule. A run that never starts and a
+   run that starts and fails both leave this counter flat.
+2. `tally_sync_errors_total` for the cloud and the `sync_runs` row of the last
+   run. A run that recorded any error at all ends `failed`, is answered 500,
+   and holds the reasons in that row.
+3. The cloud's `adapter_config` entry, the clouds.yaml the pod reads, and
+   whether Keystone and the service APIs answer. A failure that names no single
+   resource type ends the whole run before a type is observed.
+4. The 45 second budget a run is bounded at. A cloud whose enumeration outgrows
+   it never completes a run, so every call is answered while the counter stays
+   flat.
+
+The adapter, its runs, and what a partial outage does to one are described in
+[`openstack-reconciliation.md`](../openstack-reconciliation.md).


### PR DESCRIPTION
Closes #29

Adds the WP 2.4 alerting stack to the kustomize base: vmalert evaluates the alerting rules against VictoriaMetrics and posts what fires to Alertmanager (decision D2 — no Prometheus server exists). Both are base components with read-only UIs published on the existing Gateway, both are validated in CI against the pinned images they run in the cluster.

## The change set, in commit order

**`7696c36` Add the Alertmanager base component** — `deploy/kubernetes/base/alertmanager/` with `config.yaml` (route tree, `group_by: [alertname, cloud]`, `repeat_interval: 4h` with a `severity="critical"` sub-route at `1h`, one receiver `default` with no integration), a `configMapGenerator` so an edit re-rolls the pod, and `alertmanager.yaml` with the Deployment, Service and HTTPRoute on the placeholder host `alertmanager.tally.example.com`. Port 9093 answers reads and writes on one API, so the route refuses the write paths with the `HTTPRouteFilter`/`directResponse` 403 pattern `grafana.yaml` already uses and forwards the rest: the UI renders and its read API answers, while silences are created from inside the cluster with `amtool`.

**`effb271` Add runbook stubs for the five critical alerts** — one file per critical alert under `docs/runbooks/`, referenced from the rules' `runbook` annotation. Each recaps its expression and then answers three questions in a fixed order: what the alert says, what it costs in billing terms, and what to look at first — the collector's health endpoints and buffer gauges, the sync run counter, the relabel rules in `scrape.yaml`, and the connection cap on the exporter's database account.

**`2482e46` Add the vmalert base component with its alerting rules** — `rules.yaml` plus the Deployment/Service/HTTPRoute, evaluating once a minute against the store. The route publishes `/vmalert`, `/api/v1/rules` and `/api/v1/alerts` rather than the host, so `/-/reload`, `/flags`, `/metrics` and `/debug/pprof` — answered at the root alone — are not reachable through the Gateway. `-remoteWrite.url` and `-remoteRead.url` keep `ALERTS` and `ALERTS_FOR_STATE` in the store, so editing `rules.yaml` (which re-rolls the pod through the generated ConfigMap name) does not restart every pending `for`. `rules_test.go` and `manifest_test.go` pin the rule names and order, the severities, the runbook links and the sections those pages carry, that both scrape rules name every job of `scrape.yaml`, and that the route withholds the root.

**`34aadf6` Publish vmalert and Alertmanager on the dev overlay** — the overlay replaces both placeholder hostnames with their nip.io form (already covered by the wildcard Certificate patch) and patches both external URLs to the same host-port form the Grafana root URL uses. kind publishes https on 8443, so a link rendered without the port sends the browser to a closed port. vmalert's external URL becomes the `generatorURL` of every alert it sends — the "Source" link in the Alertmanager UI — and Alertmanager builds its own rendered links from its.

**`e0c38c7` Validate the alerting configs in CI and publish their URLs** — `make check-alerting` loads `rules.yaml` into the vmalert binary with `-dryRun` and runs `config.yaml` through `amtool check-config`. Both image references are read out of the manifests, so the check always uses the versions the cluster runs. CI calls the target as a fourth step. `make up` waits for both new Deployments and prints their URLs; Tilt links them beside the other infrastructure resources. The vmalert URL carries the `/vmalert/` prefix because the route does not publish the root.

**`0da8c06` Document the alerting stack and the phase 2 acceptance drill** — `docs/alerting.md` covers what both components are deployed with flag by flag, the rules with their severities and runbooks, how editing `rules.yaml` or `config.yaml` re-rolls the pod, how an overlay replaces the generated Alertmanager config to add a receiver, and what a fresh dev cluster shows. `docs/drills/phase2.md` scripts the `TallyCloudEventsSilent` drill end to end: seed one collector event, wait the hour out, read the alert pending and then firing, confirm a vmalert restart restores the timer through `-remoteRead.url`, and resolve it with a second event. `docs/openstack-metrics.md` closed by saying the tree carries no alerting component; it does now, so that sentence names the two scrape rules and points at the new document.

## Divergence from the issue

The issue specifies ten alerting rules. The branch ships **eleven alerts and one recording rule**:

- `tally:current_resources:sum` records `sum by (cloud, resource_type) (tally_current_resources)`, and `TallyResourceCountAnomaly` reads that recorded series on both sides of its comparison instead of aggregating the raw one inside its own baseline. The issue's expression would have made the store repeat that aggregation once per step of the seven-day window on every minute evaluation.
- That put the anomaly rule behind vmalert's `-remoteWrite.url`, so `TallyRecordedSeriesMissing` was added to report a stalled write path. Without it, a queue that overflows leaves a hole in the recorded series and the anomaly rule stops evaluating with no timer, no notification and no log line to say so. Its second clause keeps it quiet on a cluster that has not reconciled yet.

The three deviations from the roadmap that the issue itself surfaces (the drill not scaling a collector that the dev cluster does not run; `ceilometer` as a fourth job in `TallyScrapeTargetDown`; the receiver shipping without env-substituted endpoints) are implemented as the issue describes them.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
