### PR TITLE
Add counter metrics from configurable sources

### DIFF
--- a/cmd/tally-engine/.env.example
+++ b/cmd/tally-engine/.env.example
@@ -35,8 +35,14 @@ TALLY_ENGINE_DB_URL=
 # TALLY_ENGINE_REPORTING_DB_URL=postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable
 TALLY_ENGINE_REPORTING_DB_URL=
 
-# Base URL of the VictoriaMetrics instance the counter metrics are queried
-# from. No default, because the endpoint differs per deployment.
+# Base URL of the VictoriaMetrics instance the metricsql counter sources are
+# queried against. Needed only when the counter sources file declares
+# metricsql sources; no default, because the endpoint differs per deployment.
+#
+# In the dev cluster the engine reaches VictoriaMetrics directly:
+# TALLY_ENGINE_VM_URL=http://victoriametrics:8428
+# The Gateway's https://vm.tally.127-0-0-1.nip.io:8443 works from outside the
+# cluster only with the dev CA trusted by the process.
 TALLY_ENGINE_VM_URL=
 
 # Hours a run waits after its billing period has ended before it executes, so
@@ -53,5 +59,8 @@ TALLY_ENGINE_AUTO_FINALIZE=false
 TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES=infrastructure_tenant
 
 # Path to the counter sources YAML, the file that declares which counters exist
-# and how each one is measured.
+# and how each one is measured; counter-sources.example.yaml beside this file
+# shows the format. The explicitly empty value means no counter sources. A path
+# to a file that does not exist is an error when the file is read, not a run
+# without counters.
 TALLY_ENGINE_COUNTER_SOURCES=/etc/tally/counter-sources.yaml

--- a/cmd/tally-engine/counter-sources.example.yaml
+++ b/cmd/tally-engine/counter-sources.example.yaml
@@ -1,0 +1,56 @@
+# Counter sources of the metering engine, read from the path
+# TALLY_ENGINE_COUNTER_SOURCES names (default
+# /etc/tally/counter-sources.yaml). A counter is measured per usage interval of
+# a resource, so a counter is sliced wherever metering split that resource.
+#
+# An events source counts the events of its event_type the resource recorded
+# inside the interval, read from the reporting database. A metricsql source
+# runs its query as an instant query against VictoriaMetrics
+# (TALLY_ENGINE_VM_URL, needed only when a metricsql source exists) at the
+# interval's end; an empty result is 0 and the query has to aggregate to a
+# single series. Either way the value is billed at four decimal places, so a
+# metric measured one way and later the other keeps one shape.
+#
+# A query may use four placeholders: {cloud}, {resource_id}, {project_id} (the
+# project of the interval) and {window} (the interval's length, rendered like
+# 360h, 90m or 61s; an interval shorter than a second is measured over 1s). The
+# three identity values come from ingested event data and are substituted as
+# they are rather than escaped into the query, so one holding a character
+# MetricsQL reads as syntax -- a quote, a backtick, a space, a brace -- is
+# refused. That refusal fails a required source like any other failure, because
+# a resource id is not what may decide whether a billed counter is measured; an
+# optional source is warned under counter_identity_not_queryable instead, which
+# is its own code because no rerun clears it. The values are inert as a literal
+# only: a query may not match one with =~ or !~, where the value is read as a
+# pattern and the dot an id may hold matches any character, and it may not call
+# label_replace, label_transform, label_match or label_mismatch, whose pattern
+# argument reads it the same way without a matcher to mark it.
+#
+# required applies to metricsql sources only and defaults to true: a failing
+# required source fails the run. required: false turns that failure into a
+# counter_source_failed warning and leaves the metric out of that interval,
+# which is what a metric that is only reported wants.
+#
+# The keys of an entry are platform, resource_type, metric and kind, plus
+# event_type for an events source and query (with optional required) for a
+# metricsql source. Any other key is refused. The metric names minutes and
+# count are reserved by the engine, and one (platform, resource_type, metric)
+# may appear once.
+#
+# The series name in the first entry is the roadmap's illustration. A
+# deployment queries the series name its own Ceilometer pipeline stores; see
+# docs/openstack-metrics.md.
+
+sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: >
+      sum(increase(ceilometer_network_outgoing_bytes{cloud="{cloud}",
+          resource_id="{resource_id}"}[{window}])) / 1e9
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull

--- a/cmd/tally-engine/main_test.go
+++ b/cmd/tally-engine/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/b42labs/tally/internal/engine/config"
+	"github.com/b42labs/tally/internal/engine/counters"
 	"github.com/b42labs/tally/internal/engine/store/storetest"
 	enginemigrations "github.com/b42labs/tally/migrations/engine"
 )
@@ -450,6 +451,65 @@ func TestEnvExampleListsEveryVariable(t *testing.T) {
 		if !strings.Contains(string(example), name) {
 			t.Errorf(".env.example does not mention %s", name)
 		}
+	}
+}
+
+// TestCounterSourcesExampleLoads keeps the example sources file loadable: a
+// format change that is not mirrored there would leave an operator with an
+// example the engine refuses.
+func TestCounterSourcesExampleLoads(t *testing.T) {
+	cfg, err := counters.Load("counter-sources.example.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+	if len(cfg.Sources) != 2 {
+		t.Fatalf("len(cfg.Sources) = %d, want 2", len(cfg.Sources))
+	}
+
+	egress := cfg.Sources[0]
+	if egress.Platform != "openstack" {
+		t.Errorf("sources[0].Platform = %q, want %q", egress.Platform, "openstack")
+	}
+	if egress.ResourceType != "instance" {
+		t.Errorf("sources[0].ResourceType = %q, want %q", egress.ResourceType, "instance")
+	}
+	if egress.Metric != "egress_gb" {
+		t.Errorf("sources[0].Metric = %q, want %q", egress.Metric, "egress_gb")
+	}
+	if egress.Kind != counters.KindMetricsQL {
+		t.Errorf("sources[0].Kind = %q, want %q", egress.Kind, counters.KindMetricsQL)
+	}
+	if !egress.Required {
+		t.Error("sources[0].Required = false, want true")
+	}
+	for _, placeholder := range []string{"{cloud}", "{resource_id}", "{window}"} {
+		if !strings.Contains(egress.Query, placeholder) {
+			t.Errorf("sources[0].Query = %q, want it to contain %s", egress.Query, placeholder)
+		}
+	}
+
+	pulls := cfg.Sources[1]
+	if pulls.Platform != "harbor" {
+		t.Errorf("sources[1].Platform = %q, want %q", pulls.Platform, "harbor")
+	}
+	if pulls.ResourceType != "repository" {
+		t.Errorf("sources[1].ResourceType = %q, want %q", pulls.ResourceType, "repository")
+	}
+	if pulls.Metric != "pulls" {
+		t.Errorf("sources[1].Metric = %q, want %q", pulls.Metric, "pulls")
+	}
+	if pulls.Kind != counters.KindEvents {
+		t.Errorf("sources[1].Kind = %q, want %q", pulls.Kind, counters.KindEvents)
+	}
+	if pulls.EventType != "repository.pull" {
+		t.Errorf("sources[1].EventType = %q, want %q", pulls.EventType, "repository.pull")
+	}
+	if !pulls.Required {
+		t.Error("sources[1].Required = false, want true")
+	}
+
+	if !cfg.HasMetricsQL() {
+		t.Error("cfg.HasMetricsQL() = false, want true")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud/v2 v2.13.0
+	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/oapi-codegen/nethttp-middleware v1.2.0
@@ -50,6 +51,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/getkin/kin-openapi v0.146.0 h1:RA/1RdxrSJW4oc1+6IfnYB6AO9CaGy8GTKPh0k4Ordo=
@@ -74,6 +76,12 @@ github.com/gophercloud/gophercloud/v2 v2.13.0 h1:yEyJG+kABd8x2ttTqLsomihU6Kg2Yhe
 github.com/gophercloud/gophercloud/v2 v2.13.0/go.mod h1:KZRLVs6gcoy/pEFdkZqFjdYqnS0emMHv66UqdM5lMjU=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -99,6 +107,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/core/money/money.go
+++ b/internal/core/money/money.go
@@ -12,8 +12,9 @@ import (
 const (
 	// moneyPlaces is the scale every monetary value is rounded and rendered at.
 	moneyPlaces = 2
-	// minutePlaces is the scale derived minute quantities are rounded at.
-	minutePlaces = 4
+	// quantityPlaces is the scale usage quantities, minutes and counters alike,
+	// are rounded and rendered at.
+	quantityPlaces = 4
 	// divisionScale is the working precision every division runs at, set
 	// explicitly so no result depends on decimal.DivisionPrecision.
 	divisionScale = 28
@@ -31,7 +32,14 @@ func Round2(d decimal.Decimal) decimal.Decimal {
 // decimal places. Interval arithmetic is done in integer seconds; this is where
 // it becomes a billable quantity.
 func Minutes(seconds int64) decimal.Decimal {
-	return Div(decimal.NewFromInt(seconds), decimal.NewFromInt(60)).Round(minutePlaces)
+	return Div(decimal.NewFromInt(seconds), decimal.NewFromInt(60)).Round(quantityPlaces)
+}
+
+// RoundQuantity rounds a usage quantity to four decimal places, half away from
+// zero, the way Round2 rounds money. It is the rounding a counter value read
+// from a metrics store goes through before it is carried as a Quantity.
+func RoundQuantity(d decimal.Decimal) decimal.Decimal {
+	return d.Round(quantityPlaces)
 }
 
 // Div divides at an explicit working precision. Dividing by zero panics, as it
@@ -59,20 +67,21 @@ func (a Amount) MarshalJSON() ([]byte, error) {
 	return []byte(a.StringFixed(moneyPlaces)), nil
 }
 
-// Quantity is a usage quantity that serializes at the four-place scale derived
-// minute quantities are rounded at. A bare decimal renders 21600.0000 as 21600,
-// which hides the scale the quantity carries into JSONB.
+// Quantity is a usage quantity that serializes at the four-place scale Minutes
+// and RoundQuantity round to. A bare decimal renders 21600.0000 as 21600, which
+// hides the scale the quantity carries into JSONB.
 type Quantity struct {
 	decimal.Decimal
 }
 
 // NewQuantity wraps a decimal for serialization. It does not round: derive the
-// value with Minutes, which rounds to four places.
+// value with Minutes, or round it with RoundQuantity, which both round to four
+// places.
 func NewQuantity(d decimal.Decimal) Quantity {
 	return Quantity{Decimal: d}
 }
 
 // MarshalJSON renders the quantity as a JSON number with exactly four decimal places.
 func (q Quantity) MarshalJSON() ([]byte, error) {
-	return []byte(q.StringFixed(minutePlaces)), nil
+	return []byte(q.StringFixed(quantityPlaces)), nil
 }

--- a/internal/core/money/money_test.go
+++ b/internal/core/money/money_test.go
@@ -68,6 +68,33 @@ func TestMinutes(t *testing.T) {
 	}
 }
 
+func TestRoundQuantity(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		want      string
+		wantFixed string
+	}{
+		{name: "half up at the fifth place", in: "22.49995", want: "22.5", wantFixed: "22.5000"},
+		{name: "smallest value that rounds up", in: "0.00005", want: "0.0001", wantFixed: "0.0001"},
+		{name: "largest value that rounds down", in: "0.00004", want: "0", wantFixed: "0.0000"},
+		{name: "half away from zero on the negative side", in: "-1.23455", want: "-1.2346", wantFixed: "-1.2346"},
+		{name: "counter value left unchanged", in: "812", want: "812", wantFixed: "812.0000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := money.RoundQuantity(dec(t, tc.in))
+			if !got.Equal(dec(t, tc.want)) {
+				t.Errorf("RoundQuantity(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+			if fixed := got.StringFixed(4); fixed != tc.wantFixed {
+				t.Errorf("RoundQuantity(%s).StringFixed(4) = %s, want %s", tc.in, fixed, tc.wantFixed)
+			}
+		})
+	}
+}
+
 func TestDivPrecision(t *testing.T) {
 	// One third at the working precision: 28 digits after the point, and the
 	// last one rounded up rather than truncated.

--- a/internal/engine/config/config.go
+++ b/internal/engine/config/config.go
@@ -73,9 +73,10 @@ type Config struct {
 	// is a member of it. Supports the *_FILE convention.
 	ReportingDBURL string `env:"TALLY_ENGINE_REPORTING_DB_URL"`
 	// VMURL is the base URL of the VictoriaMetrics instance the metricsql
-	// counter sources are queried against. It has no default because the
-	// endpoint differs per deployment, and no gate here: the package that
-	// queries VictoriaMetrics adds its own.
+	// counter sources are queried against. It is needed only when the counter
+	// sources file declares metricsql sources. It has no default because the
+	// endpoint differs per deployment, and no gate here: the first subcommand
+	// that queries VictoriaMetrics adds its own.
 	VMURL string `env:"TALLY_ENGINE_VM_URL"`
 	// GraceHours is how long a run waits after its billing period ends before it
 	// executes, so events that arrive late still reach the run that bills them.
@@ -91,10 +92,14 @@ type Config struct {
 	// its own. Setting the variable to the empty string yields that empty list.
 	AttributingRelationTypes []string `env:"TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES" envDefault:"infrastructure_tenant"`
 	// CounterSourcesPath is the path to the counter sources YAML, the file that
-	// declares which counters exist and how each one is measured. It has no
-	// *_FILE companion because the value is a path already, not a secret.
-	// Whether the file exists and parses is checked by the package that reads
-	// it, not here.
+	// declares which counters exist and how each one is measured;
+	// cmd/tally-engine/counter-sources.example.yaml shows the format. Setting
+	// the variable to the empty string means no counter sources, which
+	// counters.Load reads as the zero configuration; a path to a file that does
+	// not exist is an error when the file is read, not a run without counters.
+	// It has no *_FILE companion because the value is a path already, not a
+	// secret. Whether the file parses is checked by the package that reads it,
+	// not here.
 	CounterSourcesPath string `env:"TALLY_ENGINE_COUNTER_SOURCES" envDefault:"/etc/tally/counter-sources.yaml"`
 }
 
@@ -134,6 +139,12 @@ func Load() (Config, error) {
 	}
 	if slices.Contains(cfg.AttributingRelationTypes, "") {
 		return Config{}, fmt.Errorf("%s: %q must not contain an empty relation type", envAttributingTypes, raw)
+	}
+	// The counter sources path is read the same way: only the explicit empty
+	// value means no counter sources, which counters.Load honors by reading
+	// nothing, while an unset variable keeps the default path.
+	if raw, isSet := os.LookupEnv(envCounterSources); isSet && raw == "" {
+		cfg.CounterSourcesPath = ""
 	}
 
 	return cfg, nil

--- a/internal/engine/config/config_test.go
+++ b/internal/engine/config/config_test.go
@@ -192,6 +192,35 @@ func TestAttributingTypesExplicitEmpty(t *testing.T) {
 	})
 }
 
+func TestCounterSourcesExplicitEmpty(t *testing.T) {
+	t.Run("an explicitly empty value configures no counter sources", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_ENGINE_DB_URL":          "postgres://tally@localhost/engine",
+			"TALLY_ENGINE_COUNTER_SOURCES": "",
+		})
+
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if cfg.CounterSourcesPath != "" {
+			t.Errorf("CounterSourcesPath = %q, want the empty path", cfg.CounterSourcesPath)
+		}
+	})
+
+	t.Run("an unset variable keeps the default path", func(t *testing.T) {
+		setEnv(t, nil)
+
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if want := "/etc/tally/counter-sources.yaml"; cfg.CounterSourcesPath != want {
+			t.Errorf("CounterSourcesPath = %q, want %q", cfg.CounterSourcesPath, want)
+		}
+	})
+}
+
 func TestLogLevelRejected(t *testing.T) {
 	setEnv(t, map[string]string{
 		"TALLY_ENGINE_DB_URL": "postgres://tally@localhost/engine",

--- a/internal/engine/counters/counters.go
+++ b/internal/engine/counters/counters.go
@@ -11,9 +11,13 @@
 // length.
 //
 // A metricsql source is required unless the file says required: false. A failed
-// query of a required source fails the pass, because billing data must not
-// silently omit a revenue-relevant counter. A failed query of an optional
-// source leaves the metric out of that draft and yields a warning.
+// query of a required source fails the pass, whatever failed it, because
+// billing data must not silently omit a revenue-relevant counter: an identity
+// no MetricsQL query may carry would otherwise leave that omission to whoever
+// writes an event. A failed query of an optional source leaves the metric out
+// of that draft and yields a warning. So does an identity no query may carry,
+// under its own code, because unlike a failed query it does not clear on a
+// rerun.
 //
 // This package persists nothing.
 //
@@ -23,14 +27,21 @@ package counters
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"slices"
+	"time"
 
+	"github.com/shopspring/decimal"
 	"gopkg.in/yaml.v3"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/metering"
+	"github.com/b42labs/tally/internal/engine/source"
 )
 
 // Kind is how a counter source measures its metric.
@@ -284,4 +295,292 @@ func validate(sources []Source) error {
 	}
 
 	return nil
+}
+
+// EventCounter counts the events of one type inside an interval. It is the seam
+// an events source is measured through, implemented by *source.Snapshot; the
+// unit tests here and the engine's golden suite substitute their own.
+type EventCounter interface {
+	CountEvents(ctx context.Context, r source.Resource, eventType string, from, to time.Time) (int64, error)
+}
+
+var _ EventCounter = (*source.Snapshot)(nil)
+
+// Querier runs an instant query and returns its single value. It is the seam a
+// metricsql source is measured through, implemented by *VMClient; the unit tests
+// here and the engine's golden suite substitute their own.
+type Querier interface {
+	Query(ctx context.Context, expr string, at time.Time) (decimal.Decimal, error)
+}
+
+var _ Querier = (*VMClient)(nil)
+
+// WarningCounterSourceFailed marks a metricsql source declared required: false
+// whose query failed for one draft. The metric is left out of that draft.
+const WarningCounterSourceFailed = "counter_source_failed"
+
+// WarningCounterIdentityNotQueryable marks a resource whose identity a
+// MetricsQL query may not carry, for a source declared required: false. It is a
+// second code rather than the one above because it does not clear on a rerun:
+// the metric stays missing from that resource's drafts until the identity
+// changes, which is a different thing to alert on than a store that was down.
+const WarningCounterIdentityNotQueryable = "counter_identity_not_queryable"
+
+// Warning names a metric that is missing from one draft and why. It is a second
+// warning type beside metering.Warning because it names a metric and an
+// interval, which a metering warning has no field for; the run writes both lists
+// to its stats. Detail is the failed source's error text.
+type Warning struct {
+	Cloud        string    `json:"cloud"`
+	ResourceType string    `json:"resource_type"`
+	ResourceID   string    `json:"resource_id"`
+	Metric       string    `json:"metric"`
+	FromTS       time.Time `json:"from_ts"`
+	ToTS         time.Time `json:"to_ts"`
+	Code         string    `json:"code"`
+	Detail       string    `json:"detail"`
+}
+
+// maxSourceFailures is how many drafts in a row one optional metricsql source
+// may fail before Apply stops querying it. A store that is down fails every
+// draft the same way and each failure costs the client's whole retry ladder, so
+// querying it again for every remaining draft would stretch the pass by minutes
+// per draft while the reporting snapshot stays open.
+const maxSourceFailures = 5
+
+// probeEvery is how often a source past maxSourceFailures is queried again
+// anyway: on every probeEvery-th draft it is left out of. A store that came
+// back mid-pass is found before the pass ends rather than only at the next
+// run, without paying the retry ladder for the drafts between.
+const probeEvery = 50
+
+// errNotQueryable marks the failure of a metricsql source that is a property of
+// the resource rather than of its answer or of the store: an identity
+// RenderQuery refuses to substitute. Apply warns an optional source under its
+// own code for it, because no rerun renders it differently.
+var errNotQueryable = errors.New("the resource cannot be queried")
+
+// Measurer measures the counter metrics of a configuration into usage drafts.
+type Measurer struct {
+	events EventCounter
+	vm     Querier
+	// byType is the sources of each platform and resource type, in file order.
+	byType map[resourceTypeKey][]Source
+}
+
+// resourceTypeKey is the platform and resource type a set of sources measures.
+type resourceTypeKey struct{ platform, resourceType string }
+
+// New checks cfg the way a loaded file is checked and indexes its sources by the
+// resource type they measure, so a hand-built configuration is held to the same
+// rules as one Load returned.
+//
+// A kind configured without the seam it is measured through is an error rather
+// than a run that leaves those metrics out of every draft. A configuration
+// without sources needs neither seam.
+func New(cfg Config, events EventCounter, vm Querier) (*Measurer, error) {
+	if err := validate(cfg.Sources); err != nil {
+		return nil, err
+	}
+
+	var eventSources, metricsQLSources int
+	byType := make(map[resourceTypeKey][]Source)
+	for _, s := range cfg.Sources {
+		// validate leaves no third kind, so anything but an events source is
+		// measured with a query.
+		if s.Kind == KindEvents {
+			eventSources++
+		} else {
+			metricsQLSources++
+		}
+		k := resourceTypeKey{platform: s.Platform, resourceType: s.ResourceType}
+		byType[k] = append(byType[k], s)
+	}
+
+	if eventSources > 0 && events == nil {
+		return nil, fmt.Errorf("%d events sources are configured but no event counter was given", eventSources)
+	}
+	if metricsQLSources > 0 && vm == nil {
+		return nil, fmt.Errorf("%d metricsql sources are configured but no VictoriaMetrics querier was given",
+			metricsQLSources)
+	}
+
+	return &Measurer{events: events, vm: vm, byType: byType}, nil
+}
+
+// Apply measures the counter metrics of every resource it holds sources for into
+// that resource's drafts. It runs over the resources of a metering pass, after
+// metering.Meter and before anything is persisted, while the reporting snapshot
+// is still open.
+//
+// The values are written into each draft's usage object in place. That map is
+// the one metering built and every copy of the draft shares it, so the caller's
+// metering.Result carries the counters once Apply returns.
+//
+// A source that fails where its metric may not be missing ends the pass. The
+// drafts measured before it keep the values they were given, which is why a
+// caller discards the whole result on an error instead of persisting what came
+// back. A failed optional metricsql source yields a warning instead, and its
+// metric is left out of that one draft; once it has failed maxSourceFailures
+// drafts in a row it is left out of the remaining ones without being queried
+// again, each of them still named by its own warning, and every probeEvery-th
+// of those drafts queries it once more so that a store which came back is found
+// while the pass still runs.
+//
+// A resource whose identity a MetricsQL query may not carry fails a required
+// source like any other failure: the identity comes from ingested event data,
+// so warning over it instead would hand whoever writes an event the decision
+// whether a billed counter is measured. An optional source is warned under
+// WarningCounterIdentityNotQueryable, which unlike a failed query does not
+// clear on a rerun. Neither that refusal nor an answer this one resource shaped
+// is counted against the source: only a store that is down says anything about
+// the next draft, so the resources whose own answers are fine keep the metric.
+func (m *Measurer) Apply(ctx context.Context, resources []metering.ResourceUsage) ([]Warning, error) {
+	var warnings []Warning
+	// The drafts each optional metricsql source has been left out of in a
+	// row, the ones it failed and the ones it was no longer queried for, reset
+	// wherever one succeeds.
+	failures := make(map[Source]int)
+
+	for i := range resources {
+		ru := &resources[i]
+		sources := m.byType[resourceTypeKey{platform: ru.Resource.Platform, resourceType: ru.Resource.ResourceType}]
+		// A resource no source measures is left as metering folded it, and
+		// neither seam is called for it.
+		if len(sources) == 0 {
+			continue
+		}
+
+		for j := range ru.Drafts {
+			d := &ru.Drafts[j]
+			// Every draft metering builds carries a usage object; one built by
+			// hand may not.
+			if d.Usage == nil {
+				d.Usage = make(map[string]any, len(sources))
+			}
+
+			for _, s := range sources {
+				// A metric that would replace a size field the provider
+				// reported is a configuration conflict one rename fixes,
+				// whatever required says, so it fails the pass rather than
+				// billing whichever value was written last.
+				if _, taken := d.Usage[s.Metric]; taken {
+					return nil, fmt.Errorf(
+						"the usage of %s/%s/%s over [%s, %s) already carries %q, which the counter source for %s/%s would overwrite",
+						ru.Resource.Cloud, ru.Resource.ResourceType, ru.Resource.ResourceID,
+						d.FromTS.Format(time.RFC3339Nano), d.ToTS.Format(time.RFC3339Nano),
+						s.Metric, s.Platform, s.ResourceType)
+				}
+
+				// A source that has failed the last drafts in a row is left
+				// out of the remaining ones rather than queried for each of
+				// them: what fails them is the store, not the draft. Every
+				// probeEvery-th of them is queried anyway, so a store that
+				// came back is found while the pass still runs.
+				if n := failures[s]; n >= maxSourceFailures && n%probeEvery != 0 {
+					failures[s] = n + 1
+					warnings = append(warnings, warningOf(ru.Resource, d, s.Metric,
+						WarningCounterSourceFailed, fmt.Sprintf(
+							"%s: the source failed %d drafts in a row, so it is queried again only every %d drafts",
+							measuring(ru.Resource, d, s.Metric), maxSourceFailures, probeEvery)))
+					continue
+				}
+
+				value, err := m.measure(ctx, ru.Resource, d, s)
+				if err != nil {
+					wrapped := fmt.Errorf("%s: %w", measuring(ru.Resource, d, s.Metric), err)
+
+					// A failed count aborts the snapshot's transaction, so
+					// nothing after it could be read anyway; a required metric
+					// may not be missing from a draft, whatever failed it; and
+					// a canceled run must not complete with warnings over the
+					// reads it never made.
+					if s.Kind == KindEvents || s.Required || ctx.Err() != nil {
+						return nil, wrapped
+					}
+
+					// An identity the query may not carry is refused the same
+					// way however often the pass is rerun, which is what its
+					// own warning code says: it names a resource to fix rather
+					// than a store to wait for.
+					notQueryable := errors.Is(err, errNotQueryable)
+
+					// Only a failure of the store says anything about the next
+					// draft. Counting a refusal, or an answer this one resource
+					// shaped, would leave the metric out of the resources whose
+					// own answers are fine.
+					if !notQueryable && !errors.Is(err, ErrAnswerShape) {
+						failures[s]++
+					}
+					code := WarningCounterSourceFailed
+					if notQueryable {
+						code = WarningCounterIdentityNotQueryable
+					}
+					warnings = append(warnings, warningOf(ru.Resource, d, s.Metric, code, wrapped.Error()))
+					continue
+				}
+				delete(failures, s)
+
+				// The write is in place, into the map metering built: every
+				// copy of the draft shares it, so the caller's result carries
+				// the counter without anything being handed back.
+				d.Usage[s.Metric] = value
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
+// measuring names what an error or a warning of the pass is about: the metric,
+// the resource it is measured for, and the interval it is measured over.
+func measuring(r source.Resource, d *metering.UsageDraft, metric string) string {
+	return fmt.Sprintf("measuring %s of %s/%s/%s over [%s, %s)",
+		metric, r.Cloud, r.ResourceType, r.ResourceID,
+		d.FromTS.Format(time.RFC3339Nano), d.ToTS.Format(time.RFC3339Nano))
+}
+
+// warningOf names the metric one draft is billed without, and why.
+func warningOf(r source.Resource, d *metering.UsageDraft, metric, code, detail string) Warning {
+	return Warning{
+		Cloud:        r.Cloud,
+		ResourceType: r.ResourceType,
+		ResourceID:   r.ResourceID,
+		Metric:       metric,
+		FromTS:       d.FromTS,
+		ToTS:         d.ToTS,
+		Code:         code,
+		Detail:       detail,
+	}
+}
+
+// measure reads one source's value for one draft: an events source counts the
+// events of its type inside the draft's interval, a metricsql source queries the
+// draft's own window at its end.
+//
+// Both are carried as the quantity every usage value is rendered at, four
+// decimal places, whatever measured them. A count written as the bare integer it
+// is would render as 5 where a query result renders as 5.0000, and a metric
+// moved from one kind to the other would split its own history into two jsonb
+// numbers under one name, in records no later run may rewrite.
+func (m *Measurer) measure(
+	ctx context.Context, r source.Resource, d *metering.UsageDraft, s Source,
+) (money.Quantity, error) {
+	if s.Kind == KindEvents {
+		count, err := m.events.CountEvents(ctx, r, s.EventType, d.FromTS, d.ToTS)
+		if err != nil {
+			return money.Quantity{}, err
+		}
+		return money.NewQuantity(decimal.NewFromInt(count)), nil
+	}
+
+	expr, err := RenderQuery(s.Query, r.Cloud, r.ResourceID, d.ProjectID, d.Seconds)
+	if err != nil {
+		return money.Quantity{}, fmt.Errorf("%w: %w", errNotQueryable, err)
+	}
+	value, err := m.vm.Query(ctx, expr, d.ToTS)
+	if err != nil {
+		return money.Quantity{}, err
+	}
+	return money.NewQuantity(money.RoundQuantity(value)), nil
 }

--- a/internal/engine/counters/counters.go
+++ b/internal/engine/counters/counters.go
@@ -1,0 +1,287 @@
+// Package counters measures the counter metrics of a deployment per usage
+// draft, from the counter sources file the deployment configures. The pass sits
+// after metering.Meter and before anything is persisted, while the reporting
+// snapshot is still open: the events reads go through the same snapshot as the
+// history the drafts were folded from, so a counter and the drafts it slices
+// into see the same data.
+//
+// A source measures its metric in one of two ways. An events source counts the
+// events of one type inside the draft's interval. A metricsql source runs an
+// instant query against VictoriaMetrics at the draft's end, over the draft's
+// length.
+//
+// A metricsql source is required unless the file says required: false. A failed
+// query of a required source fails the pass, because billing data must not
+// silently omit a revenue-relevant counter. A failed query of an optional
+// source leaves the metric out of that draft and yields a warning.
+//
+// This package persists nothing.
+//
+// The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.4
+// and decision D7.
+package counters
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Kind is how a counter source measures its metric.
+type Kind string
+
+const (
+	// KindEvents counts the events of one type inside the draft's interval.
+	KindEvents Kind = "events"
+	// KindMetricsQL runs an instant MetricsQL query against VictoriaMetrics at
+	// the draft's end.
+	KindMetricsQL Kind = "metricsql"
+)
+
+// The two usage keys the engine derives itself, held by usageMinutes and
+// usageCount in internal/engine/metering/metering.go. A counter may not claim
+// them: its value would replace a quantity the drafts already carry.
+var reservedMetrics = []string{"minutes", "count"}
+
+// The placeholders a metricsql query may use, and the pattern that finds them.
+// A label selector such as {cloud="{cloud}"} does not match the pattern; only
+// the placeholder inside it does.
+//
+// identityPlaceholder finds the three placeholders whose value a query may not
+// read as a pattern. regexMatchedIdentity finds a label matcher that reads its
+// value as one: =~ or !~ and the whole string literal behind it, in each of the
+// three forms MetricsQL writes a literal in. The literal is matched whole
+// rather than up to the placeholder, so a quantifier such as [0-9]{1,3} before
+// it cannot hide it behind a brace. regexArgumentFunc finds the MetricsQL
+// functions that read a bare string argument as a pattern, which carry no =~
+// for the matcher pattern to find.
+var (
+	placeholderPattern   = regexp.MustCompile(`\{([a-z_]+)\}`)
+	knownPlaceholders    = []string{"cloud", "resource_id", "project_id", "window"}
+	identityPlaceholder  = regexp.MustCompile(`\{(cloud|resource_id|project_id)\}`)
+	regexMatchedIdentity = regexp.MustCompile(
+		"[=!]~\\s*(?:\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*'|`[^`]*`)")
+	regexArgumentFunc = regexp.MustCompile(
+		`\b(label_replace|label_transform|label_match|label_mismatch)\s*\(`)
+)
+
+// Source is one resolved entry of the counter sources file: which metric of
+// which platform and resource type it measures, and how. EventType is set for
+// events sources and Query for metricsql sources. Required is true unless the
+// file said required: false, and it applies to metricsql sources only.
+type Source struct {
+	Platform, ResourceType, Metric string
+	Kind                           Kind
+	EventType                      string
+	Query                          string
+	Required                       bool
+}
+
+// Config is the counter sources of a deployment, in file order.
+type Config struct {
+	Sources []Source
+}
+
+// HasMetricsQL reports whether any source is a metricsql source, which is how
+// a caller knows whether it needs a VictoriaMetrics client at all.
+func (c Config) HasMetricsQL() bool {
+	for _, s := range c.Sources {
+		if s.Kind == KindMetricsQL {
+			return true
+		}
+	}
+	return false
+}
+
+// sourcesFile is the counter sources file as it is written.
+type sourcesFile struct {
+	Sources []sourceFile `yaml:"sources"`
+}
+
+// sourceFile is one entry of that file. Required is a pointer so that an absent
+// key can be told from required: false.
+type sourceFile struct {
+	Platform     string `yaml:"platform"`
+	ResourceType string `yaml:"resource_type"`
+	Metric       string `yaml:"metric"`
+	Kind         string `yaml:"kind"`
+	EventType    string `yaml:"event_type"`
+	Query        string `yaml:"query"`
+	Required     *bool  `yaml:"required"`
+}
+
+// Load reads the counter sources at path. An empty path yields the zero Config
+// and no error, which is what a deployment that measures no counter metric
+// configures.
+//
+// A path that cannot be read is an error rather than a run without counters: a
+// misconfigured path would otherwise drop a billed metric from every draft of
+// the period without anything saying so.
+func Load(path string) (Config, error) {
+	if path == "" {
+		return Config{}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("reading the counter sources %s: %w", path, err)
+	}
+
+	cfg, err := Parse(data)
+	if err != nil {
+		return Config{}, fmt.Errorf("%s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// Parse decodes the counter sources and checks every entry. An empty document,
+// one that holds only comments, and one without sources each yield the zero
+// Config and no error.
+//
+// A key the file form does not know is an error naming it, so that a misspelled
+// event_typ fails the run instead of leaving the source measuring nothing.
+func Parse(data []byte) (Config, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var file sourcesFile
+	if err := dec.Decode(&file); err != nil {
+		// A document with no content at all yields no value to decode into.
+		if errors.Is(err, io.EOF) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("parsing the counter sources: %w", err)
+	}
+
+	// Only the first document is decoded. A second one, appended to add another
+	// team's counters, would otherwise leave its sources out of every draft of
+	// the period without anything saying so.
+	var extra sourcesFile
+	switch err := dec.Decode(&extra); {
+	case errors.Is(err, io.EOF):
+	case err != nil:
+		return Config{}, fmt.Errorf("parsing the counter sources: %w", err)
+	default:
+		return Config{}, errors.New(
+			"parsing the counter sources: the file holds more than one document, every source belongs in the first")
+	}
+
+	var sources []Source
+	for _, entry := range file.Sources {
+		sources = append(sources, Source{
+			Platform:     entry.Platform,
+			ResourceType: entry.ResourceType,
+			Metric:       entry.Metric,
+			Kind:         Kind(entry.Kind),
+			EventType:    entry.EventType,
+			Query:        entry.Query,
+			Required:     entry.Required == nil || *entry.Required,
+		})
+	}
+
+	if err := validate(sources); err != nil {
+		return Config{}, err
+	}
+
+	// Only the file form tells required: false from an absent key, so the rule
+	// about the key's presence is checked here rather than in validate.
+	for i, entry := range file.Sources {
+		if Kind(entry.Kind) == KindEvents && entry.Required != nil {
+			return Config{}, fmt.Errorf("sources[%d]: required applies to metricsql sources only", i)
+		}
+	}
+
+	return Config{Sources: sources}, nil
+}
+
+// validate reports the first source that does not hold, named by its position
+// in the file. It takes the sources rather than a Config so that a hand-built
+// configuration is checked the same way a loaded one is.
+func validate(sources []Source) error {
+	type key struct {
+		platform, resourceType, metric string
+	}
+	seen := make(map[key]bool, len(sources))
+
+	for i, s := range sources {
+		entry := fmt.Sprintf("sources[%d]", i)
+
+		if s.Platform == "" {
+			return fmt.Errorf("%s: platform must be set", entry)
+		}
+		if s.ResourceType == "" {
+			return fmt.Errorf("%s: resource_type must be set", entry)
+		}
+		if s.Metric == "" {
+			return fmt.Errorf("%s: metric must be set", entry)
+		}
+		if slices.Contains(reservedMetrics, s.Metric) {
+			return fmt.Errorf("%s: metric %q is reserved by the engine", entry, s.Metric)
+		}
+
+		switch s.Kind {
+		case KindEvents:
+			if s.EventType == "" {
+				return fmt.Errorf("%s: event_type must be set", entry)
+			}
+			if s.Query != "" {
+				return fmt.Errorf("%s: query applies to metricsql sources only", entry)
+			}
+		case KindMetricsQL:
+			if s.Query == "" {
+				return fmt.Errorf("%s: query must be set", entry)
+			}
+			if s.EventType != "" {
+				return fmt.Errorf("%s: event_type applies to events sources only", entry)
+			}
+			for _, match := range placeholderPattern.FindAllStringSubmatch(s.Query, -1) {
+				if !slices.Contains(knownPlaceholders, match[1]) {
+					return fmt.Errorf("%s: query uses the unknown placeholder {%s}", entry, match[1])
+				}
+			}
+			// An identity value is inert as a literal, not as a pattern: a
+			// regex matcher reads the dot such a value may hold as a wildcard,
+			// so the matcher would select the series of the resources beside
+			// the one it names and an aggregate over them would bill this
+			// resource for theirs. Every matcher of the query is looked at, not
+			// only the first: one that reads its own literal is no reason to
+			// stop before the one that reads an identity.
+			for _, matcher := range regexMatchedIdentity.FindAllString(s.Query, -1) {
+				if id := identityPlaceholder.FindStringSubmatch(matcher); id != nil {
+					return fmt.Errorf(
+						"%s: query matches {%s} with =~ or !~, which reads the substituted value as a pattern; "+
+							"an identity is matched with = or !=", entry, id[1])
+				}
+			}
+			// The same hazard without a matcher to mark it: these functions
+			// read one of their string arguments as a pattern. Which argument a
+			// placeholder sits in cannot be told apart from here without
+			// parsing MetricsQL, so a query that calls one of them and
+			// substitutes an identity anywhere is refused.
+			if fn := regexArgumentFunc.FindStringSubmatch(s.Query); fn != nil &&
+				identityPlaceholder.MatchString(s.Query) {
+				return fmt.Errorf(
+					"%s: query calls %s, whose pattern argument would read a substituted identity as a pattern",
+					entry, fn[1])
+			}
+		default:
+			return fmt.Errorf("%s: kind %q must be events or metricsql", entry, s.Kind)
+		}
+
+		// Two entries for one metric of one resource type would write the same
+		// usage key twice, and the second value would be the one billed.
+		k := key{platform: s.Platform, resourceType: s.ResourceType, metric: s.Metric}
+		if seen[k] {
+			return fmt.Errorf("%s: %s of %s/%s is configured twice", entry, s.Metric, s.Platform, s.ResourceType)
+		}
+		seen[k] = true
+	}
+
+	return nil
+}

--- a/internal/engine/counters/counters_test.go
+++ b/internal/engine/counters/counters_test.go
@@ -623,3 +623,220 @@ func TestHasMetricsQL(t *testing.T) {
 		})
 	}
 }
+
+func TestWindow(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int64
+		want    string
+	}{
+		{name: "a month of 30 days is whole hours", seconds: 1296000, want: "360h"},
+		{name: "an hour and a half is whole minutes", seconds: 5400, want: "90m"},
+		{name: "a minute and a second is neither", seconds: 61, want: "61s"},
+		{name: "one hour", seconds: 3600, want: "1h"},
+		{name: "one minute", seconds: 60, want: "1m"},
+		// A draft shorter than a second still needs a window MetricsQL
+		// measures over, and [0s] is not one.
+		{name: "a draft shorter than a second", seconds: 0, want: "1s"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := counters.Window(tc.seconds); got != tc.want {
+				t.Errorf("Window(%d) = %q, want %q", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderQuery(t *testing.T) {
+	t.Run("a query is rendered for the draft it measures", func(t *testing.T) {
+		tests := []struct {
+			name                         string
+			query                        string
+			cloud, resourceID, projectID string
+			want                         string
+		}{
+			{
+				name:  "the roadmap's query",
+				query: `sum(increase(ceilometer_network_outgoing_bytes{cloud="{cloud}", resource_id="{resource_id}"}[{window}])) / 1e9`,
+				want:  `sum(increase(ceilometer_network_outgoing_bytes{cloud="os-prod-eu1", resource_id="abc-123"}[360h])) / 1e9`,
+			},
+			{
+				name:  "a query selecting the project",
+				query: `sum(metric{cloud="{cloud}", project="{project_id}"})`,
+				want:  `sum(metric{cloud="os-prod-eu1", project="proj-456"})`,
+			},
+			{
+				name:       "a repository id, which carries a slash",
+				query:      `sum(metric{repository="{resource_id}"})`,
+				resourceID: "team-alpha/app",
+				want:       `sum(metric{repository="team-alpha/app"})`,
+			},
+			{
+				name:  "an empty query",
+				query: "",
+				want:  "",
+			},
+			{
+				name:  "a query without placeholders",
+				query: "sum(metric)",
+				want:  "sum(metric)",
+			},
+			{
+				// The placeholder the value would be refused for is not in
+				// this query, so the value never reaches it.
+				name:       "a value a query does not substitute",
+				query:      `sum(metric{cloud="{cloud}"})`,
+				resourceID: `x"} or vector(1e12) #`,
+				want:       `sum(metric{cloud="os-prod-eu1"})`,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				cloud, resourceID, projectID := tc.cloud, tc.resourceID, tc.projectID
+				if cloud == "" {
+					cloud = "os-prod-eu1"
+				}
+				if resourceID == "" {
+					resourceID = "abc-123"
+				}
+				if projectID == "" {
+					projectID = "proj-456"
+				}
+
+				got, err := counters.RenderQuery(tc.query, cloud, resourceID, projectID, 1296000)
+				if err != nil {
+					t.Fatalf("RenderQuery() error = %v, want nil", err)
+				}
+				if got != tc.want {
+					t.Errorf("RenderQuery() = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	// The identity values reach the engine from ingested event data, and the
+	// query around them is text an operator wrote. Nothing here can tell which
+	// of MetricsQL's three string literal forms a placeholder sits in, or
+	// whether it sits in one at all, so a value that is not inert is refused
+	// rather than escaped for one of them.
+	t.Run("an identity a query may not carry is refused", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			query   string
+			value   string
+			wantErr string
+		}{
+			{
+				name:    "a resource id ending the double-quoted matcher it sits in",
+				query:   `sum(increase(metric{resource_id="{resource_id}"}[{window}]))`,
+				value:   `x"}[1s])) or vector(1e12) #`,
+				wantErr: `the resource_id "x\"}[1s])) or vector(1e12) #" holds a character`,
+			},
+			{
+				name:    "a resource id ending a single-quoted matcher",
+				query:   `sum(metric{resource_id='{resource_id}'})`,
+				value:   `x'} or vector(1e12) or metric{a='`,
+				wantErr: "the resource_id",
+			},
+			{
+				name:    "a resource id ending a backquoted matcher",
+				query:   "sum(metric{resource_id=`{resource_id}`})",
+				value:   "x`} or vector(1e12) or metric{a=`",
+				wantErr: "the resource_id",
+			},
+			{
+				name:    "a resource id holding a backslash",
+				query:   `sum(metric{resource_id="{resource_id}"})`,
+				value:   `a\b`,
+				wantErr: "the resource_id",
+			},
+			{
+				name:    "a resource id holding a line break, which no literal carries",
+				query:   `sum(metric{resource_id="{resource_id}"})`,
+				value:   "a\nb",
+				wantErr: "the resource_id",
+			},
+			{
+				// A regex matcher needs no quote at all to be subverted.
+				name:    "a resource id that is a regex matching everything",
+				query:   `sum(metric{resource_id=~"{resource_id}"})`,
+				value:   ".*",
+				wantErr: "the resource_id",
+			},
+			{
+				name:    "a placeholder written outside a literal",
+				query:   "sum(metric{resource_id={resource_id}})",
+				value:   "x} or vector(1e12) or metric{a=b",
+				wantErr: "the resource_id",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := counters.RenderQuery(tc.query, "os-prod-eu1", tc.value, "proj-456", 1296000)
+				if err == nil {
+					t.Fatalf("RenderQuery() error = nil, want %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("RenderQuery() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+			})
+		}
+	})
+
+	// The cloud and the project id come from ingested event data the same way
+	// the resource id does, and they land in the same matcher.
+	t.Run("every substituted identity is checked, not only the resource id", func(t *testing.T) {
+		tests := []struct {
+			name                         string
+			query                        string
+			cloud, resourceID, projectID string
+			wantErr                      string
+		}{
+			{
+				name:    "a cloud holding a quote",
+				query:   `sum(metric{cloud="{cloud}"})`,
+				cloud:   `a"b`,
+				wantErr: `the cloud "a\"b" holds a character`,
+			},
+			{
+				name:      "a project id holding a quote",
+				query:     `sum(metric{project="{project_id}"})`,
+				projectID: `c"d`,
+				wantErr:   `the project_id "c\"d" holds a character`,
+			},
+			{
+				name:       "a resource id holding a quote",
+				query:      `sum(metric{resource_id="{resource_id}"})`,
+				resourceID: `e"f`,
+				wantErr:    `the resource_id "e\"f" holds a character`,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				cloud, resourceID, projectID := tc.cloud, tc.resourceID, tc.projectID
+				if cloud == "" {
+					cloud = "os-prod-eu1"
+				}
+				if resourceID == "" {
+					resourceID = "abc-123"
+				}
+				if projectID == "" {
+					projectID = "proj-456"
+				}
+
+				_, err := counters.RenderQuery(tc.query, cloud, resourceID, projectID, 1296000)
+				if err == nil {
+					t.Fatalf("RenderQuery() error = nil, want %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("RenderQuery() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+			})
+		}
+	})
+}

--- a/internal/engine/counters/counters_test.go
+++ b/internal/engine/counters/counters_test.go
@@ -1,14 +1,26 @@
 package counters_test
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/money"
 	"github.com/b42labs/tally/internal/engine/counters"
+	"github.com/b42labs/tally/internal/engine/metering"
+	"github.com/b42labs/tally/internal/engine/source"
 )
 
 // roadmapSources is the file the roadmap gives as the example of both kinds:
@@ -837,6 +849,1053 @@ func TestRenderQuery(t *testing.T) {
 					t.Errorf("RenderQuery() error = %q, want it to contain %q", err, tc.wantErr)
 				}
 			})
+		}
+	})
+}
+
+// The billing period the merge cases below are measured over: March 2026.
+var (
+	periodFrom = utc(time.March, 1)
+	periodTo   = utc(time.April, 1)
+)
+
+// The two resources the merge cases measure.
+var (
+	repository = source.Resource{
+		Cloud: "harbor-prod", Platform: "harbor",
+		ResourceType: "repository", ResourceID: "team-alpha/app",
+	}
+	instance = source.Resource{
+		Cloud: "os-prod-eu1", Platform: "openstack",
+		ResourceType: "instance", ResourceID: "abc-123",
+	}
+)
+
+// The queries the merge cases run: the roadmap's egress query for an instance,
+// and the same shape over a repository.
+const (
+	instanceEgress   = `sum(increase(ceilometer_network_outgoing_bytes{cloud="{cloud}", resource_id="{resource_id}"}[{window}])) / 1e9`
+	repositoryEgress = `sum(increase(harbor_egress_bytes{cloud="{cloud}", repository="{resource_id}"}[{window}])) / 1e9`
+)
+
+// utc is a day of 2026 at midnight UTC.
+func utc(month time.Month, day int) time.Time {
+	return time.Date(2026, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+type option func(*event.Stored)
+
+func withState(state string) option {
+	return func(s *event.Stored) { s.Payload.State = &state }
+}
+
+func withSize(size map[string]any) option {
+	return func(s *event.Stored) { s.Payload.Size = size }
+}
+
+func withProject(id string) option {
+	return func(s *event.Stored) { s.ProjectID = id }
+}
+
+func withResource(resourceType, resourceID string) option {
+	return func(s *event.Stored) { s.ResourceType, s.ResourceID = resourceType, resourceID }
+}
+
+func withPlatform(platform string) option {
+	return func(s *event.Stored) { s.Platform = platform }
+}
+
+func withCloud(cloud string) option {
+	return func(s *event.Stored) { s.Cloud = cloud }
+}
+
+// ev builds a stored event, the way the metering tests build one. Defaults keep
+// each case to the dimension it exercises: one OpenStack instance of one
+// project, received when it happened.
+func ev(id, eventType string, ts time.Time, opts ...option) event.Stored {
+	s := event.Stored{
+		Event: event.Event{
+			EventID:      id,
+			Timestamp:    ts,
+			EventType:    eventType,
+			Platform:     "openstack",
+			Cloud:        "os-prod-eu1",
+			ResourceType: "instance",
+			ResourceID:   "i-1",
+			ProjectID:    "p-1",
+			Source:       event.SourceCollector,
+		},
+		ReceivedAt: ts,
+	}
+	for _, opt := range opts {
+		opt(&s)
+	}
+	return s
+}
+
+// size decodes a size object through the path source.History decodes the payload
+// column through, so its numbers are the float64 values a draft copies verbatim.
+func size(t *testing.T, object string) map[string]any {
+	t.Helper()
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(object), &decoded); err != nil {
+		t.Fatalf("decoding the size %s: %v", object, err)
+	}
+	return decoded
+}
+
+// meterResource folds a history into the drafts the merge is measured into.
+func meterResource(t *testing.T, history []event.Stored, from, to time.Time) []metering.UsageDraft {
+	t.Helper()
+
+	drafts, err := metering.MeterResource(history, from, to)
+	if err != nil {
+		t.Fatalf("MeterResource() error = %v, want nil", err)
+	}
+	return drafts
+}
+
+// draft is one usage draft as metering hands it out, for the cases that need a
+// single interval rather than a whole history.
+func draft(from, to time.Time, usage map[string]any) metering.UsageDraft {
+	return metering.UsageDraft{
+		State:     "active",
+		ProjectID: "proj-456",
+		FromTS:    from,
+		ToTS:      to,
+		Seconds:   int64(to.Sub(from) / time.Second),
+		Usage:     usage,
+	}
+}
+
+// egressSource is the metricsql source of the instance cases.
+func egressSource(required bool) counters.Source {
+	return counters.Source{
+		Platform: "openstack", ResourceType: "instance", Metric: "egress_gb",
+		Kind: counters.KindMetricsQL, Query: instanceEgress, Required: required,
+	}
+}
+
+// pullsSource is the events source of the repository cases. It is not required,
+// a flag the merge ignores on an events source.
+func pullsSource() counters.Source {
+	return counters.Source{
+		Platform: "harbor", ResourceType: "repository", Metric: "pulls",
+		Kind: counters.KindEvents, EventType: "repository.pull",
+	}
+}
+
+// rendered is the expression a repository draft of the given length is queried
+// with.
+func rendered(t *testing.T, query string, seconds int64) string {
+	t.Helper()
+
+	expr, err := counters.RenderQuery(query, "harbor-prod", "team-alpha/app", "harbor-team-alpha", seconds)
+	if err != nil {
+		t.Fatalf("RenderQuery() error = %v, want nil", err)
+	}
+	return expr
+}
+
+// newMeasurer builds the measurer of one case over the sources it measures.
+func newMeasurer(t *testing.T, events counters.EventCounter, vm counters.Querier, sources ...counters.Source) *counters.Measurer {
+	t.Helper()
+
+	m, err := counters.New(counters.Config{Sources: sources}, events, vm)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	return m
+}
+
+// countKey is the table entry the fake counter answers a call from.
+type countKey struct {
+	eventType string
+	from      time.Time
+}
+
+// countCall is a call the fake counter saw.
+type countCall struct {
+	resource  source.Resource
+	eventType string
+	from, to  time.Time
+}
+
+// fakeCounter answers from a table keyed by event type and interval start, and
+// records every call in order. An interval the table does not name counts zero,
+// and err fails every call.
+type fakeCounter struct {
+	counts map[countKey]int64
+	err    error
+	calls  []countCall
+}
+
+func (f *fakeCounter) CountEvents(_ context.Context, r source.Resource, eventType string, from, to time.Time) (int64, error) {
+	f.calls = append(f.calls, countCall{resource: r, eventType: eventType, from: from, to: to})
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.counts[countKey{eventType: eventType, from: from}], nil
+}
+
+// queryCall is a call the fake querier saw.
+type queryCall struct {
+	expr string
+	at   time.Time
+}
+
+// fakeQuerier answers from a table of decimal literals keyed by the instant it
+// is queried at, and records every call in order. err fails every call, or only
+// the call at failAt where that is set. A canceled context fails before either,
+// the way the real client's request does.
+type fakeQuerier struct {
+	values map[time.Time]string
+	err    error
+	failAt *time.Time
+	calls  []queryCall
+}
+
+func (f *fakeQuerier) Query(ctx context.Context, expr string, at time.Time) (decimal.Decimal, error) {
+	f.calls = append(f.calls, queryCall{expr: expr, at: at})
+	if err := ctx.Err(); err != nil {
+		return decimal.Zero, err
+	}
+	if f.err != nil && (f.failAt == nil || f.failAt.Equal(at)) {
+		return decimal.Zero, f.err
+	}
+
+	value, ok := f.values[at]
+	if !ok {
+		return decimal.Zero, fmt.Errorf("the fake querier has no value at %s", at.Format(time.RFC3339Nano))
+	}
+	return decimal.NewFromString(value)
+}
+
+// quantityOf is the value a draft carries for a counter metric, rendered at the
+// four places it reaches JSONB at. Both kinds are read through it: a count and a
+// query result reach a usage object as the same quantity.
+func quantityOf(t *testing.T, d metering.UsageDraft, metric string) string {
+	t.Helper()
+
+	quantity, ok := d.Usage[metric].(money.Quantity)
+	if !ok {
+		t.Fatalf("Usage[%s] = %#v, want a money.Quantity", metric, d.Usage[metric])
+	}
+	return quantity.StringFixed(4)
+}
+
+func TestNew(t *testing.T) {
+	pushesSource := counters.Source{
+		Platform: "harbor", ResourceType: "repository", Metric: "pushes",
+		Kind: counters.KindEvents, EventType: "repository.push",
+	}
+
+	t.Run("events sources without an event counter", func(t *testing.T) {
+		cfg := counters.Config{Sources: []counters.Source{pullsSource(), pushesSource}}
+
+		_, err := counters.New(cfg, nil, &fakeQuerier{})
+		if err == nil {
+			t.Fatal("New() error = nil, want an error")
+		}
+		want := "2 events sources are configured but no event counter was given"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("New() error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("a metricsql source without a querier", func(t *testing.T) {
+		cfg := counters.Config{Sources: []counters.Source{egressSource(true)}}
+
+		_, err := counters.New(cfg, &fakeCounter{}, nil)
+		if err == nil {
+			t.Fatal("New() error = nil, want an error")
+		}
+		want := "1 metricsql sources are configured but no VictoriaMetrics querier was given"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("New() error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("a hand-built source the file form would be refused for", func(t *testing.T) {
+		cfg := counters.Config{Sources: []counters.Source{
+			{Platform: "harbor", ResourceType: "repository", Metric: "pulls"},
+		}}
+
+		_, err := counters.New(cfg, &fakeCounter{}, &fakeQuerier{})
+		if err == nil {
+			t.Fatal("New() error = nil, want an error")
+		}
+		want := `sources[0]: kind "" must be events or metricsql`
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("New() error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("no source at all needs neither seam", func(t *testing.T) {
+		m, err := counters.New(counters.Config{}, nil, nil)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		if m == nil {
+			t.Error("New() = nil, want a measurer")
+		}
+	})
+}
+
+func TestApply(t *testing.T) {
+	t.Run("example 5: two counts and a query over each draft", func(t *testing.T) {
+		identity := []option{
+			withPlatform("harbor"), withCloud("harbor-prod"),
+			withResource("repository", "team-alpha/app"), withProject("harbor-team-alpha"),
+		}
+		drafts := meterResource(t, []event.Stored{
+			ev("e1", "repository.create", utc(time.February, 14), append(identity,
+				withState("active"), withSize(size(t, `{"storage_gb":10}`)))...),
+			ev("e2", "repository.push", utc(time.March, 18), append(identity,
+				withState("active"), withSize(size(t, `{"storage_gb":15}`)))...),
+		}, periodFrom, periodTo)
+		if len(drafts) != 2 {
+			t.Fatalf("MeterResource() = %d drafts, want 2", len(drafts))
+		}
+		metered := []map[string]any{maps.Clone(drafts[0].Usage), maps.Clone(drafts[1].Usage)}
+
+		counter := &fakeCounter{counts: map[countKey]int64{
+			{eventType: "repository.pull", from: periodFrom}:          812,
+			{eventType: "repository.pull", from: utc(time.March, 18)}: 711,
+			{eventType: "repository.push", from: periodFrom}:          47,
+			{eventType: "repository.push", from: utc(time.March, 18)}: 23,
+		}}
+		querier := &fakeQuerier{values: map[time.Time]string{
+			utc(time.March, 18): "38.5",
+			periodTo:            "31.2",
+		}}
+		m := newMeasurer(t, counter, querier,
+			pullsSource(),
+			counters.Source{
+				Platform: "harbor", ResourceType: "repository", Metric: "pushes",
+				Kind: counters.KindEvents, EventType: "repository.push",
+			},
+			counters.Source{
+				Platform: "harbor", ResourceType: "repository", Metric: "egress_gb",
+				Kind: counters.KindMetricsQL, Query: repositoryEgress, Required: true,
+			},
+		)
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: repository, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+
+		want := []struct {
+			pulls, pushes, egress string
+		}{
+			{pulls: "812.0000", pushes: "47.0000", egress: "38.5000"},
+			{pulls: "711.0000", pushes: "23.0000", egress: "31.2000"},
+		}
+		for i, d := range drafts {
+			if got := quantityOf(t, d, "pulls"); got != want[i].pulls {
+				t.Errorf("draft %d Usage[pulls] = %s, want %s", i, got, want[i].pulls)
+			}
+			if got := quantityOf(t, d, "pushes"); got != want[i].pushes {
+				t.Errorf("draft %d Usage[pushes] = %s, want %s", i, got, want[i].pushes)
+			}
+			if got := quantityOf(t, d, "egress_gb"); got != want[i].egress {
+				t.Errorf("draft %d Usage[egress_gb] = %s, want %s", i, got, want[i].egress)
+			}
+			// What metering derived is left as it was.
+			for _, metric := range []string{"storage_gb", "minutes", "count"} {
+				if got := d.Usage[metric]; got != metered[i][metric] {
+					t.Errorf("draft %d Usage[%s] = %#v, want %#v", i, metric, got, metered[i][metric])
+				}
+			}
+		}
+
+		wantCounts := []countCall{
+			{resource: repository, eventType: "repository.pull", from: drafts[0].FromTS, to: drafts[0].ToTS},
+			{resource: repository, eventType: "repository.push", from: drafts[0].FromTS, to: drafts[0].ToTS},
+			{resource: repository, eventType: "repository.pull", from: drafts[1].FromTS, to: drafts[1].ToTS},
+			{resource: repository, eventType: "repository.push", from: drafts[1].FromTS, to: drafts[1].ToTS},
+		}
+		if !reflect.DeepEqual(counter.calls, wantCounts) {
+			t.Errorf("the counter saw %+v, want %+v", counter.calls, wantCounts)
+		}
+
+		wantQueries := []queryCall{
+			{expr: rendered(t, repositoryEgress, drafts[0].Seconds), at: drafts[0].ToTS},
+			{expr: rendered(t, repositoryEgress, drafts[1].Seconds), at: drafts[1].ToTS},
+		}
+		if !reflect.DeepEqual(querier.calls, wantQueries) {
+			t.Errorf("the querier saw %+v, want %+v", querier.calls, wantQueries)
+		}
+
+		encoded, err := json.Marshal(drafts[0].Usage)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+		// Every counter renders at the four places a usage quantity carries,
+		// whichever kind measured it: count is the engine's own key, not a
+		// counter.
+		wantJSON := `{"count":1,"egress_gb":38.5000,"minutes":24480.0000,` +
+			`"pulls":812.0000,"pushes":47.0000,"storage_gb":10}`
+		if string(encoded) != wantJSON {
+			t.Errorf("Marshal(Usage) = %s, want %s", encoded, wantJSON)
+		}
+	})
+
+	t.Run("the end-to-end example: one query per power cycle draft", func(t *testing.T) {
+		powered := `{"vcpus":4,"ram_gb":8,"disk_gb":80}`
+		identity := []option{withResource("instance", "abc-123"), withProject("proj-456")}
+		drafts := meterResource(t, []event.Stored{
+			ev("e1", "compute.instance.create.end", utc(time.February, 2), append(identity,
+				withState("active"), withSize(size(t, powered)))...),
+			ev("e2", "compute.instance.power_off.end", utc(time.March, 11), append(identity,
+				withState("shutoff"))...),
+			ev("e3", "compute.instance.power_on.end", utc(time.March, 21), append(identity,
+				withState("active"))...),
+		}, periodFrom, periodTo)
+		if len(drafts) != 3 {
+			t.Fatalf("MeterResource() = %d drafts, want 3", len(drafts))
+		}
+
+		querier := &fakeQuerier{values: map[time.Time]string{
+			utc(time.March, 11): "18.0",
+			utc(time.March, 21): "0",
+			periodTo:            "22.5",
+		}}
+		m := newMeasurer(t, nil, querier, egressSource(true))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+
+		wantEgress := []string{"18.0000", "0.0000", "22.5000"}
+		for i, d := range drafts {
+			if got := quantityOf(t, d, "egress_gb"); got != wantEgress[i] {
+				t.Errorf("draft %d Usage[egress_gb] = %s, want %s", i, got, wantEgress[i])
+			}
+		}
+
+		// Each draft is queried over its own length, at its own end.
+		wantQueries := []queryCall{
+			{
+				expr: `sum(increase(ceilometer_network_outgoing_bytes{cloud="os-prod-eu1", resource_id="abc-123"}[240h])) / 1e9`,
+				at:   utc(time.March, 11),
+			},
+			{
+				expr: `sum(increase(ceilometer_network_outgoing_bytes{cloud="os-prod-eu1", resource_id="abc-123"}[240h])) / 1e9`,
+				at:   utc(time.March, 21),
+			},
+			{
+				expr: `sum(increase(ceilometer_network_outgoing_bytes{cloud="os-prod-eu1", resource_id="abc-123"}[264h])) / 1e9`,
+				at:   periodTo,
+			},
+		}
+		if !reflect.DeepEqual(querier.calls, wantQueries) {
+			t.Errorf("the querier saw %+v, want %+v", querier.calls, wantQueries)
+		}
+	})
+
+	t.Run("an empty result is zero and a value is rounded to four places", func(t *testing.T) {
+		tests := []struct {
+			name, value, want string
+		}{
+			{name: "a resource that reported no sample", value: "0", want: "0.0000"},
+			{name: "a fifth place rounded half away from zero", value: "22.49995", want: "22.5000"},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				drafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+				querier := &fakeQuerier{values: map[time.Time]string{periodTo: tc.value}}
+				m := newMeasurer(t, nil, querier, egressSource(true))
+
+				if _, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}}); err != nil {
+					t.Fatalf("Apply() error = %v, want nil", err)
+				}
+				if got := quantityOf(t, drafts[0], "egress_gb"); got != tc.want {
+					t.Errorf("Usage[egress_gb] = %s, want %s", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("a resource no source measures is untouched", func(t *testing.T) {
+		usage := map[string]any{
+			"minutes":    money.NewQuantity(money.Minutes(2678400)),
+			"count":      1,
+			"storage_gb": 10.0,
+		}
+		metered := maps.Clone(usage)
+		counter := &fakeCounter{}
+		querier := &fakeQuerier{}
+		m := newMeasurer(t, counter, querier, egressSource(true))
+
+		resources := []metering.ResourceUsage{
+			{Resource: repository, Drafts: []metering.UsageDraft{draft(periodFrom, periodTo, usage)}},
+		}
+		warnings, err := m.Apply(t.Context(), resources)
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+		if !reflect.DeepEqual(usage, metered) {
+			t.Errorf("Usage = %#v, want %#v", usage, metered)
+		}
+		if len(counter.calls) != 0 || len(querier.calls) != 0 {
+			t.Errorf("the seams saw %+v and %+v, want no call", counter.calls, querier.calls)
+		}
+	})
+
+	t.Run("nothing to measure calls neither seam", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			resources []metering.ResourceUsage
+		}{
+			{name: "no resources at all"},
+			{name: "an empty resource list", resources: []metering.ResourceUsage{}},
+			{name: "a resource without drafts", resources: []metering.ResourceUsage{{Resource: instance}}},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				counter := &fakeCounter{}
+				querier := &fakeQuerier{}
+				m := newMeasurer(t, counter, querier, egressSource(true))
+
+				warnings, err := m.Apply(t.Context(), tc.resources)
+				if err != nil {
+					t.Fatalf("Apply() error = %v, want nil", err)
+				}
+				if warnings != nil {
+					t.Errorf("Apply() warnings = %#v, want none", warnings)
+				}
+				if len(counter.calls) != 0 || len(querier.calls) != 0 {
+					t.Errorf("the seams saw %+v and %+v, want no call", counter.calls, querier.calls)
+				}
+			})
+		}
+	})
+
+	t.Run("a draft without a usage object gets one", func(t *testing.T) {
+		counter := &fakeCounter{counts: map[countKey]int64{
+			{eventType: "repository.pull", from: periodFrom}: 5,
+		}}
+		m := newMeasurer(t, counter, nil, pullsSource())
+
+		resources := []metering.ResourceUsage{
+			{Resource: repository, Drafts: []metering.UsageDraft{draft(periodFrom, periodTo, nil)}},
+		}
+		if _, err := m.Apply(t.Context(), resources); err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if got := quantityOf(t, resources[0].Drafts[0], "pulls"); got != "5.0000" {
+			t.Errorf("Usage[pulls] = %s, want 5.0000", got)
+		}
+	})
+
+	t.Run("a metric colliding with a size field fails the pass", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			required bool
+		}{
+			{name: "a required source", required: true},
+			{name: "an optional source", required: false},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				drafts := []metering.UsageDraft{
+					draft(periodFrom, utc(time.March, 11), map[string]any{"egress_gb": 3.0}),
+					draft(utc(time.March, 11), periodTo, map[string]any{}),
+				}
+				querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+				m := newMeasurer(t, nil, querier, egressSource(tc.required))
+
+				warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+				if err == nil {
+					t.Fatal("Apply() error = nil, want an error")
+				}
+				want := `already carries "egress_gb", which the counter source for openstack/instance would overwrite`
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Apply() error = %q, want it to contain %q", err, want)
+				}
+				if warnings != nil {
+					t.Errorf("Apply() warnings = %#v, want none", warnings)
+				}
+				// The collision is found before the first draft is queried, and
+				// the pass ends there, so the second draft is not measured.
+				if len(querier.calls) != 0 {
+					t.Errorf("the querier saw %+v, want no call", querier.calls)
+				}
+			})
+		}
+	})
+
+	t.Run("a required metricsql source that fails ends the pass", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		drafts := []metering.UsageDraft{
+			draft(periodFrom, utc(time.March, 11), map[string]any{}),
+			draft(utc(time.March, 11), periodTo, map[string]any{}),
+		}
+		querier := &fakeQuerier{err: sentinel}
+		m := newMeasurer(t, nil, querier, egressSource(true))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err == nil {
+			t.Fatal("Apply() error = nil, want an error")
+		}
+		want := "measuring egress_gb of os-prod-eu1/instance/abc-123 over " +
+			"[2026-03-01T00:00:00Z, 2026-03-11T00:00:00Z):"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Apply() error = %q, want it to contain %q", err, want)
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("Apply() error = %v, want it to wrap the querier's error", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+	})
+
+	t.Run("an optional metricsql source that fails is a warning", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		drafts := []metering.UsageDraft{
+			draft(periodFrom, utc(time.March, 11), map[string]any{}),
+			draft(utc(time.March, 11), periodTo, map[string]any{}),
+		}
+		failAt := utc(time.March, 11)
+		querier := &fakeQuerier{
+			values: map[time.Time]string{periodTo: "22.5"},
+			err:    sentinel,
+			failAt: &failAt,
+		}
+		m := newMeasurer(t, nil, querier, egressSource(false))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if len(warnings) != 1 {
+			t.Fatalf("Apply() = %d warnings, want 1", len(warnings))
+		}
+
+		got := warnings[0]
+		named := got
+		named.Detail = ""
+		want := counters.Warning{
+			Cloud: "os-prod-eu1", ResourceType: "instance", ResourceID: "abc-123",
+			Metric: "egress_gb", FromTS: drafts[0].FromTS, ToTS: drafts[0].ToTS,
+			Code: "counter_source_failed",
+		}
+		if named != want {
+			t.Errorf("Apply() warning = %+v, want %+v", named, want)
+		}
+		for _, part := range []string{"measuring egress_gb of", "boom"} {
+			if !strings.Contains(got.Detail, part) {
+				t.Errorf("Detail = %q, want it to contain %q", got.Detail, part)
+			}
+		}
+
+		// The draft the query failed for is billed without the metric, the one
+		// after it carries its value.
+		if _, taken := drafts[0].Usage["egress_gb"]; taken {
+			t.Errorf("draft 0 Usage[egress_gb] = %#v, want it absent", drafts[0].Usage["egress_gb"])
+		}
+		if got := quantityOf(t, drafts[1], "egress_gb"); got != "22.5000" {
+			t.Errorf("draft 1 Usage[egress_gb] = %s, want 22.5000", got)
+		}
+
+		encoded, err := json.Marshal(warnings[0])
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+		for _, key := range []string{
+			`"cloud":`, `"resource_type":`, `"resource_id":`, `"metric":`,
+			`"from_ts":`, `"to_ts":`, `"code":`, `"detail":`,
+		} {
+			if !strings.Contains(string(encoded), key) {
+				t.Errorf("Marshal(warning) = %s, want it to hold %s", encoded, key)
+			}
+		}
+	})
+
+	t.Run("a count that fails ends the pass", func(t *testing.T) {
+		sentinel := errors.New("tx aborted")
+		drafts := []metering.UsageDraft{draft(periodFrom, utc(time.March, 18), map[string]any{})}
+		counter := &fakeCounter{err: sentinel}
+		// The source is not required and the pass ends anyway: a failed
+		// statement leaves the snapshot's transaction aborted.
+		m := newMeasurer(t, counter, nil, pullsSource())
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: repository, Drafts: drafts}})
+		if err == nil {
+			t.Fatal("Apply() error = nil, want an error")
+		}
+		want := "measuring pulls of harbor-prod/repository/team-alpha/app over " +
+			"[2026-03-01T00:00:00Z, 2026-03-18T00:00:00Z):"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Apply() error = %q, want it to contain %q", err, want)
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("Apply() error = %v, want it to wrap the counter's error", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+	})
+
+	// The sources of a resource are looked up by the platform and the resource
+	// type together, so a second resource type of the same platform is measured
+	// with its own sources or with none.
+	t.Run("a second resource type of the same platform is not measured with the first's sources",
+		func(t *testing.T) {
+			volume := source.Resource{
+				Cloud: "os-prod-eu1", Platform: "openstack",
+				ResourceType: "volume", ResourceID: "vol-9",
+			}
+			instanceDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+			volumeDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+
+			querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+			m := newMeasurer(t, nil, querier, egressSource(true))
+
+			warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{
+				{Resource: instance, Drafts: instanceDrafts},
+				{Resource: volume, Drafts: volumeDrafts},
+			})
+			if err != nil {
+				t.Fatalf("Apply() error = %v, want nil", err)
+			}
+			if warnings != nil {
+				t.Errorf("Apply() warnings = %#v, want none", warnings)
+			}
+
+			if got := quantityOf(t, instanceDrafts[0], "egress_gb"); got != "22.5000" {
+				t.Errorf("the instance draft Usage[egress_gb] = %s, want 22.5000", got)
+			}
+			if len(volumeDrafts[0].Usage) != 0 {
+				t.Errorf("the volume draft Usage = %#v, want it untouched", volumeDrafts[0].Usage)
+			}
+
+			// One call, for the instance: the volume's drafts are never
+			// measured with the instance's query.
+			wantQueries := []queryCall{{
+				expr: `sum(increase(ceilometer_network_outgoing_bytes{cloud="os-prod-eu1", ` +
+					`resource_id="abc-123"}[744h])) / 1e9`,
+				at: periodTo,
+			}}
+			if !reflect.DeepEqual(querier.calls, wantQueries) {
+				t.Errorf("the querier saw %+v, want %+v", querier.calls, wantQueries)
+			}
+		})
+
+	// A store that is down fails every draft the same way, and each failure
+	// costs the client's whole retry ladder. The pass stops querying such a
+	// source rather than paying that ladder once per draft.
+	t.Run("an optional source that keeps failing is not queried for every draft", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		drafts := make([]metering.UsageDraft, 0, 9)
+		for day := 1; day <= 9; day++ {
+			drafts = append(drafts, draft(utc(time.March, day), utc(time.March, day+1), map[string]any{}))
+		}
+		querier := &fakeQuerier{err: sentinel}
+		m := newMeasurer(t, nil, querier, egressSource(false))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+
+		// Every draft is billed without the metric and says so, but only the
+		// first five reached the store.
+		if len(warnings) != len(drafts) {
+			t.Fatalf("Apply() = %d warnings, want %d", len(warnings), len(drafts))
+		}
+		if len(querier.calls) != 5 {
+			t.Errorf("the querier saw %d calls, want 5", len(querier.calls))
+		}
+		for i, w := range warnings {
+			if w.Code != "counter_source_failed" || w.Metric != "egress_gb" {
+				t.Errorf("warning %d = %+v, want a counter_source_failed of egress_gb", i, w)
+			}
+			if !w.FromTS.Equal(drafts[i].FromTS) {
+				t.Errorf("warning %d FromTS = %s, want %s", i, w.FromTS, drafts[i].FromTS)
+			}
+		}
+		want := "the source failed 5 drafts in a row, so it is queried again only every 50 drafts"
+		if !strings.Contains(warnings[5].Detail, want) {
+			t.Errorf("warning 5 Detail = %q, want it to contain %q", warnings[5].Detail, want)
+		}
+		for _, d := range drafts {
+			if _, taken := d.Usage["egress_gb"]; taken {
+				t.Errorf("Usage[egress_gb] = %#v, want it absent", d.Usage["egress_gb"])
+			}
+		}
+	})
+
+	// Idle resources are ordinary in a billing period, and a source computing a
+	// ratio divides by zero for each of them: MetricsQL prints NaN, which does
+	// not parse. Counting those against the source would back it off, and the
+	// active resources metered after them would lose the billed metric to a
+	// store that is healthy and answering.
+	t.Run("an answer one resource shaped does not stop the source for the drafts after it",
+		func(t *testing.T) {
+			drafts := make([]metering.UsageDraft, 0, 9)
+			for day := 1; day <= 9; day++ {
+				drafts = append(drafts, draft(utc(time.March, day), utc(time.March, day+1), map[string]any{}))
+			}
+			querier := &fakeQuerier{
+				err: fmt.Errorf("%w: parsing the VictoriaMetrics value %q: boom",
+					counters.ErrAnswerShape, "NaN"),
+			}
+			m := newMeasurer(t, nil, querier, egressSource(false))
+
+			warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+			if err != nil {
+				t.Fatalf("Apply() error = %v, want nil", err)
+			}
+
+			// Every draft is billed without the metric, and every one of them
+			// reached the store: none of these failures was the store's.
+			if len(warnings) != len(drafts) {
+				t.Fatalf("Apply() = %d warnings, want %d", len(warnings), len(drafts))
+			}
+			if len(querier.calls) != len(drafts) {
+				t.Errorf("the querier saw %d calls, want %d", len(querier.calls), len(drafts))
+			}
+			for i, w := range warnings {
+				if w.Code != "counter_source_failed" {
+					t.Errorf("warning %d Code = %q, want counter_source_failed", i, w.Code)
+				}
+				if part := "the source failed"; strings.Contains(w.Detail, part) {
+					t.Errorf("warning %d Detail = %q, want it not to blame the store", i, w.Detail)
+				}
+			}
+		})
+
+	t.Run("a draft the store answers again resets the count of failures", func(t *testing.T) {
+		drafts := make([]metering.UsageDraft, 0, 10)
+		for day := 1; day <= 10; day++ {
+			drafts = append(drafts, draft(utc(time.March, day), utc(time.March, day+1), map[string]any{}))
+		}
+		// The querier answers the fifth draft and fails every other, so the
+		// four failures before it do not add up with the five after it and
+		// every draft is queried.
+		querier := &fakeQuerier{values: map[time.Time]string{drafts[4].ToTS: "22.5"}}
+		m := newMeasurer(t, nil, querier, egressSource(false))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		if len(warnings) != 9 {
+			t.Fatalf("Apply() = %d warnings, want 9", len(warnings))
+		}
+		if len(querier.calls) != len(drafts) {
+			t.Errorf("the querier saw %d calls, want %d", len(querier.calls), len(drafts))
+		}
+		if got := quantityOf(t, drafts[4], "egress_gb"); got != "22.5000" {
+			t.Errorf("draft 4 Usage[egress_gb] = %s, want 22.5000", got)
+		}
+	})
+
+	// A store that is down for part of the pass comes back during it, and the
+	// source has to be queried again to be found: the drafts after the outage
+	// are billed with the metric rather than warned to the end of the pass.
+	t.Run("a source the store stopped answering is queried again later in the pass", func(t *testing.T) {
+		const drafted = 55
+		drafts := make([]metering.UsageDraft, 0, drafted)
+		for h := range drafted {
+			from := periodFrom.Add(time.Duration(h) * time.Hour)
+			drafts = append(drafts, draft(from, from.Add(time.Hour), map[string]any{}))
+		}
+		// The store answers from the 51st draft on, which is the one the probe
+		// falls on: the five failures before it stop the queries and the 45
+		// drafts between are left out without one.
+		values := make(map[time.Time]string, drafted-50)
+		for _, d := range drafts[50:] {
+			values[d.ToTS] = "22.5"
+		}
+		querier := &fakeQuerier{values: values}
+		m := newMeasurer(t, nil, querier, egressSource(false))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err != nil {
+			t.Fatalf("Apply() error = %v, want nil", err)
+		}
+		// The five drafts the store failed and the 45 it was not asked about.
+		if len(warnings) != 50 {
+			t.Fatalf("Apply() = %d warnings, want 50", len(warnings))
+		}
+		// Those five queries, the probe, and every draft after it.
+		if len(querier.calls) != 10 {
+			t.Errorf("the querier saw %d calls, want 10", len(querier.calls))
+		}
+		for i, d := range drafts[50:] {
+			if got := quantityOf(t, d, "egress_gb"); got != "22.5000" {
+				t.Errorf("draft %d Usage[egress_gb] = %s, want 22.5000", 50+i, got)
+			}
+		}
+	})
+
+	// The identity values come from ingested event data, so a value that would
+	// compose a query of its own is refused rather than escaped into the
+	// matcher. Nothing upstream bounds the characters such a value may hold,
+	// and the refusal is the same however often the pass is rerun, so failing
+	// the pass over it would leave the period unclosable.
+	// The identity comes from ingested event data, so warning over it for a
+	// required source would let whoever writes an event decide whether a
+	// revenue-relevant counter is measured: a create event whose resource_id
+	// holds a space passes event.Validate and closes the period unmeasured.
+	t.Run("an identity a query may not carry ends the pass for a required source", func(t *testing.T) {
+		injected := source.Resource{
+			Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+			ResourceID: "vm münchen 01",
+		}
+		injectedDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+		querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+		m := newMeasurer(t, nil, querier, egressSource(true))
+
+		warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{
+			{Resource: injected, Drafts: injectedDrafts},
+		})
+		if err == nil {
+			t.Fatal("Apply() error = nil, want an error")
+		}
+		for _, part := range []string{
+			"measuring egress_gb of os-prod-eu1/instance/vm münchen 01",
+			"holds a character a MetricsQL query may not carry",
+		} {
+			if !strings.Contains(err.Error(), part) {
+				t.Errorf("Apply() error = %q, want it to contain %q", err, part)
+			}
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
+		}
+		if len(querier.calls) != 0 {
+			t.Errorf("the querier saw %+v, want no call", querier.calls)
+		}
+	})
+
+	t.Run("an identity a query may not carry warns an optional source under its own code",
+		func(t *testing.T) {
+			injected := source.Resource{
+				Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+				ResourceID: `x"}[1s])) or vector(1e12) #`,
+			}
+			injectedDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+			cleanDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+			querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+			m := newMeasurer(t, nil, querier, egressSource(false))
+
+			warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{
+				{Resource: injected, Drafts: injectedDrafts},
+				{Resource: instance, Drafts: cleanDrafts},
+			})
+			if err != nil {
+				t.Fatalf("Apply() error = %v, want nil", err)
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("Apply() = %d warnings, want 1", len(warnings))
+			}
+
+			got := warnings[0]
+			named := got
+			named.Detail = ""
+			// The code is not the one a store that was down yields: this
+			// warning names a resource to fix, and no rerun clears it.
+			want := counters.Warning{
+				Cloud: "os-prod-eu1", ResourceType: "instance", ResourceID: injected.ResourceID,
+				Metric: "egress_gb", FromTS: periodFrom, ToTS: periodTo,
+				Code: "counter_identity_not_queryable",
+			}
+			if named != want {
+				t.Errorf("Apply() warning = %+v, want %+v", named, want)
+			}
+			if part := "holds a character a MetricsQL query may not carry"; !strings.Contains(got.Detail, part) {
+				t.Errorf("Detail = %q, want it to contain %q", got.Detail, part)
+			}
+			if _, taken := injectedDrafts[0].Usage["egress_gb"]; taken {
+				t.Errorf("the refused draft Usage[egress_gb] = %#v, want it absent",
+					injectedDrafts[0].Usage["egress_gb"])
+			}
+
+			// The resource whose identity renders is billed, and it is the only
+			// one the store is asked about.
+			if got := quantityOf(t, cleanDrafts[0], "egress_gb"); got != "22.5000" {
+				t.Errorf("the instance draft Usage[egress_gb] = %s, want 22.5000", got)
+			}
+			if len(querier.calls) != 1 {
+				t.Errorf("the querier saw %+v, want one call", querier.calls)
+			}
+		})
+
+	// A refusal is not a failure of the store: counting it against the source
+	// would leave the metric out of every resource measured after a handful of
+	// them, which is a resource id away from dropping a billed metric from the
+	// whole deployment.
+	t.Run("an identity a query may not carry does not stop the source for the next resource",
+		func(t *testing.T) {
+			injected := source.Resource{
+				Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance",
+				ResourceID: "vm münchen 01",
+			}
+			injectedDrafts := make([]metering.UsageDraft, 0, 6)
+			for day := 1; day <= 6; day++ {
+				injectedDrafts = append(injectedDrafts,
+					draft(utc(time.March, day), utc(time.March, day+1), map[string]any{}))
+			}
+			cleanDrafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+			querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+			m := newMeasurer(t, nil, querier, egressSource(false))
+
+			warnings, err := m.Apply(t.Context(), []metering.ResourceUsage{
+				{Resource: injected, Drafts: injectedDrafts},
+				{Resource: instance, Drafts: cleanDrafts},
+			})
+			if err != nil {
+				t.Fatalf("Apply() error = %v, want nil", err)
+			}
+			// One per refused draft, and none for the resource after them.
+			if len(warnings) != len(injectedDrafts) {
+				t.Fatalf("Apply() = %d warnings, want %d", len(warnings), len(injectedDrafts))
+			}
+			if got := quantityOf(t, cleanDrafts[0], "egress_gb"); got != "22.5000" {
+				t.Errorf("the instance draft Usage[egress_gb] = %s, want 22.5000", got)
+			}
+			if len(querier.calls) != 1 {
+				t.Errorf("the querier saw %+v, want one call", querier.calls)
+			}
+		})
+
+	t.Run("a canceled run fails even an optional source", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		drafts := []metering.UsageDraft{draft(periodFrom, periodTo, map[string]any{})}
+		querier := &fakeQuerier{values: map[time.Time]string{periodTo: "22.5"}}
+		m := newMeasurer(t, nil, querier, egressSource(false))
+
+		warnings, err := m.Apply(ctx, []metering.ResourceUsage{{Resource: instance, Drafts: drafts}})
+		if err == nil {
+			t.Fatal("Apply() error = nil, want an error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Apply() error = %v, want it to wrap context.Canceled", err)
+		}
+		if warnings != nil {
+			t.Errorf("Apply() warnings = %#v, want none", warnings)
 		}
 	})
 }

--- a/internal/engine/counters/counters_test.go
+++ b/internal/engine/counters/counters_test.go
@@ -1,0 +1,625 @@
+package counters_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/b42labs/tally/internal/engine/counters"
+)
+
+// roadmapSources is the file the roadmap gives as the example of both kinds:
+// one metricsql source with every placeholder a query may use, and one events
+// source.
+const roadmapSources = `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: >
+      sum(increase(ceilometer_network_outgoing_bytes{cloud="{cloud}",
+          resource_id="{resource_id}"}[{window}])) / 1e9
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+`
+
+// writeSources writes a counter sources file and returns its path.
+func writeSources(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "counter-sources.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestLoad(t *testing.T) {
+	t.Run("an empty path configures no counter source", func(t *testing.T) {
+		cfg, err := counters.Load("")
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if len(cfg.Sources) != 0 {
+			t.Errorf("Sources = %#v, want none", cfg.Sources)
+		}
+	})
+
+	t.Run("a path that does not exist is an error, not a run without counters", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+
+		_, err := counters.Load(path)
+		if err == nil {
+			t.Fatal("Load() error = nil, want an error")
+		}
+		if want := "reading the counter sources " + path + ":"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Load() error = %q, want it to contain %q", err, want)
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Load() error = %v, want it to wrap fs.ErrNotExist", err)
+		}
+	})
+
+	t.Run("the roadmap's file yields both kinds in file order", func(t *testing.T) {
+		cfg, err := counters.Load(writeSources(t, roadmapSources))
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if len(cfg.Sources) != 2 {
+			t.Fatalf("Sources = %d entries, want 2", len(cfg.Sources))
+		}
+
+		egress := cfg.Sources[0]
+		if egress.Platform != "openstack" || egress.ResourceType != "instance" || egress.Metric != "egress_gb" {
+			t.Errorf("Sources[0] measures %s of %s/%s, want egress_gb of openstack/instance",
+				egress.Metric, egress.Platform, egress.ResourceType)
+		}
+		if egress.Kind != counters.KindMetricsQL {
+			t.Errorf("Sources[0].Kind = %q, want %q", egress.Kind, counters.KindMetricsQL)
+		}
+		for _, placeholder := range []string{"{cloud}", "{resource_id}", "{window}"} {
+			if !strings.Contains(egress.Query, placeholder) {
+				t.Errorf("Sources[0].Query = %q, want it to contain %q", egress.Query, placeholder)
+			}
+		}
+		if egress.EventType != "" {
+			t.Errorf("Sources[0].EventType = %q, want it empty", egress.EventType)
+		}
+		// The file says nothing about required, so the source is required.
+		if !egress.Required {
+			t.Error("Sources[0].Required = false, want true")
+		}
+
+		pulls := cfg.Sources[1]
+		if pulls.Platform != "harbor" || pulls.ResourceType != "repository" || pulls.Metric != "pulls" {
+			t.Errorf("Sources[1] measures %s of %s/%s, want pulls of harbor/repository",
+				pulls.Metric, pulls.Platform, pulls.ResourceType)
+		}
+		if pulls.Kind != counters.KindEvents {
+			t.Errorf("Sources[1].Kind = %q, want %q", pulls.Kind, counters.KindEvents)
+		}
+		if pulls.EventType != "repository.pull" {
+			t.Errorf("Sources[1].EventType = %q, want %q", pulls.EventType, "repository.pull")
+		}
+		if pulls.Query != "" {
+			t.Errorf("Sources[1].Query = %q, want it empty", pulls.Query)
+		}
+
+		if !cfg.HasMetricsQL() {
+			t.Error("HasMetricsQL() = false, want true")
+		}
+	})
+
+	t.Run("a file that does not parse is reported by its path", func(t *testing.T) {
+		path := writeSources(t, "sources: [\n")
+
+		_, err := counters.Load(path)
+		if err == nil {
+			t.Fatal("Load() error = nil, want an error")
+		}
+		if prefix := path + ": "; !strings.HasPrefix(err.Error(), prefix) {
+			t.Errorf("Load() error = %q, want it to start with %q", err, prefix)
+		}
+		if want := "parsing the counter sources:"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Load() error = %q, want it to contain %q", err, want)
+		}
+	})
+}
+
+func TestParseAcceptsDocumentsWithoutSources(t *testing.T) {
+	documents := map[string]string{
+		"an empty document":        "",
+		"only a comment":           "# only a comment\n",
+		"an empty mapping":         "{}\n",
+		"a bare document marker":   "---\n",
+		"an empty list of sources": "sources: []\n",
+	}
+
+	for name, document := range documents {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := counters.Parse([]byte(document))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+			if len(cfg.Sources) != 0 {
+				t.Errorf("Sources = %#v, want none", cfg.Sources)
+			}
+		})
+	}
+
+	t.Run("no content at all", func(t *testing.T) {
+		cfg, err := counters.Parse(nil)
+		if err != nil {
+			t.Fatalf("Parse() error = %v, want nil", err)
+		}
+		if len(cfg.Sources) != 0 {
+			t.Errorf("Sources = %#v, want none", cfg.Sources)
+		}
+	})
+}
+
+func TestParseRejectsAMalformedDocument(t *testing.T) {
+	t.Run("content that is not YAML", func(t *testing.T) {
+		_, err := counters.Parse([]byte("sources: [\n"))
+		if err == nil {
+			t.Fatal("Parse() error = nil, want an error")
+		}
+		if want := "parsing the counter sources:"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Parse() error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("a misspelled key is named rather than ignored", func(t *testing.T) {
+		_, err := counters.Parse([]byte(`sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_typ: repository.pull
+`))
+		if err == nil {
+			t.Fatal("Parse() error = nil, want an error")
+		}
+		if want := "parsing the counter sources:"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Parse() error = %q, want it to contain %q", err, want)
+		}
+		if want := "event_typ"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Parse() error = %q, want it to name %q", err, want)
+		}
+	})
+
+	// Only the first document is decoded. A second one, appended to add
+	// another team's counters, would otherwise leave its sources out of every
+	// draft of the period without anything saying so.
+	t.Run("a second document is refused rather than dropped", func(t *testing.T) {
+		_, err := counters.Parse([]byte(`sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+---
+sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pushes
+    kind: events
+    event_type: repository.push
+`))
+		if err == nil {
+			t.Fatal("Parse() error = nil, want an error")
+		}
+		want := "the file holds more than one document, every source belongs in the first"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Parse() error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("a second document that is not YAML is named too", func(t *testing.T) {
+		_, err := counters.Parse([]byte("sources: []\n---\nsources: [\n"))
+		if err == nil {
+			t.Fatal("Parse() error = nil, want an error")
+		}
+		if want := "parsing the counter sources:"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Parse() error = %q, want it to contain %q", err, want)
+		}
+	})
+}
+
+func TestParseRejectsInvalidSources(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "an entry without a platform",
+			content: `sources:
+  - resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+`,
+			wantErr: "sources[0]: platform must be set",
+		},
+		{
+			name: "an entry without a resource type",
+			content: `sources:
+  - platform: harbor
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+`,
+			wantErr: "sources[0]: resource_type must be set",
+		},
+		{
+			name: "an entry without a metric",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    kind: events
+    event_type: repository.pull
+`,
+			wantErr: "sources[0]: metric must be set",
+		},
+		{
+			name: "a counter claiming the minutes the engine derives",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: minutes
+    kind: events
+    event_type: repository.pull
+`,
+			wantErr: `sources[0]: metric "minutes" is reserved by the engine`,
+		},
+		{
+			name: "a counter claiming the count the engine derives",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: count
+    kind: events
+    event_type: repository.pull
+`,
+			wantErr: `sources[0]: metric "count" is reserved by the engine`,
+		},
+		{
+			name: "a kind the engine cannot measure",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: gauge
+    event_type: repository.pull
+`,
+			wantErr: `sources[0]: kind "gauge" must be events or metricsql`,
+		},
+		{
+			name: "an entry without a kind",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    event_type: repository.pull
+`,
+			wantErr: `sources[0]: kind "" must be events or metricsql`,
+		},
+		{
+			name: "an events source without an event type",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+`,
+			wantErr: "sources[0]: event_type must be set",
+		},
+		{
+			name: "an events source carrying a query",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+    query: 'sum(pulls)'
+`,
+			wantErr: "sources[0]: query applies to metricsql sources only",
+		},
+		{
+			name: "an events source declared required",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+    required: true
+`,
+			wantErr: "sources[0]: required applies to metricsql sources only",
+		},
+		{
+			name: "an events source opting out of being required",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+    required: false
+`,
+			wantErr: "sources[0]: required applies to metricsql sources only",
+		},
+		{
+			name: "a metricsql source without a query",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+`,
+			wantErr: "sources[0]: query must be set",
+		},
+		{
+			name: "a metricsql source carrying an event type",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(egress)'
+    event_type: instance.egress
+`,
+			wantErr: "sources[0]: event_type applies to events sources only",
+		},
+		{
+			name: "a query using a placeholder the engine does not render",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(egress{tenant="{tenant}"})'
+`,
+			wantErr: "sources[0]: query uses the unknown placeholder {tenant}",
+		},
+		{
+			name: "a query matching a resource id with a regex matcher",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(metric{repository=~"{resource_id}"})'
+`,
+			wantErr: "sources[0]: query matches {resource_id} with =~ or !~, which reads the substituted " +
+				"value as a pattern; an identity is matched with = or !=",
+		},
+		{
+			name: "a query matching a cloud with a negated regex matcher",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(metric{cloud!~"prefix-{cloud}"})'
+`,
+			wantErr: "sources[0]: query matches {cloud} with =~ or !~, which reads the substituted " +
+				"value as a pattern; an identity is matched with = or !=",
+		},
+		{
+			// A quantifier is written with the braces and the comma the guard
+			// once stopped at, so the placeholder behind it stayed unseen.
+			name: "a resource id behind a quantifier in a regex matcher",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(rate(cpu{instance=~"node-[0-9]{1,3}-{resource_id}"}[{window}]))'
+`,
+			wantErr: "sources[0]: query matches {resource_id} with =~ or !~, which reads the substituted " +
+				"value as a pattern; an identity is matched with = or !=",
+		},
+		{
+			name: "a resource id behind a quantifier in a negated regex matcher",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(rate(cpu{pod!~"sys-.{0,8}-{resource_id}"}[{window}]))'
+`,
+			wantErr: "sources[0]: query matches {resource_id} with =~ or !~, which reads the substituted " +
+				"value as a pattern; an identity is matched with = or !=",
+		},
+		{
+			// The same hazard with no =~ anywhere: the pattern is an argument.
+			name: "an identity in the pattern argument of label_replace",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(label_replace(cpu, "d", "$1", "instance", "{resource_id}.*"))'
+`,
+			wantErr: "sources[0]: query calls label_replace, whose pattern argument would read a " +
+				"substituted identity as a pattern",
+		},
+		{
+			name: "an identity in the pattern argument of label_match",
+			content: `sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(label_match(cpu, "instance", "{cloud}"))'
+`,
+			wantErr: "sources[0]: query calls label_match, whose pattern argument would read a " +
+				"substituted identity as a pattern",
+		},
+		{
+			name: "one metric of one resource type configured twice",
+			content: `sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull.v2
+`,
+			wantErr: "sources[1]: pulls of harbor/repository is configured twice",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := counters.Parse([]byte(tc.content))
+			if err == nil {
+				t.Fatalf("Parse() error = nil, want %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Errorf("Parse() error = %q, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseAcceptsQueriesWithLabelSelectors(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "selectors holding every placeholder a query may use",
+			query: `metric{cloud="{cloud}",resource_id="{resource_id}"}[{window}]`,
+		},
+		{
+			name:  "the project placeholder",
+			query: `sum(metric{project="{project_id}"})`,
+		},
+		{
+			name:  "an empty selector, which holds no placeholder",
+			query: `metric{}`,
+		},
+		{
+			// The regex matcher reads a value the file wrote itself, and the
+			// identity beside it is matched as the literal it is inert as.
+			name:  "a regex matcher over a label no identity is substituted into",
+			query: `sum(metric{job=~"vm.*",resource_id="{resource_id}"})`,
+		},
+		{
+			// The braces of a quantifier belong to the matcher's own pattern,
+			// not to a placeholder, and neither ends the literal the guard
+			// reads.
+			name:  "a quantifier in a regex matcher over a label no identity reaches",
+			query: `sum(rate(cpu{instance=~"node-[0-9]{1,3}",resource_id="{resource_id}"}[{window}]))`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := counters.Parse([]byte(`sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: '` + tc.query + `'
+`))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+			if len(cfg.Sources) != 1 {
+				t.Fatalf("Sources = %d entries, want 1", len(cfg.Sources))
+			}
+			if cfg.Sources[0].Query != tc.query {
+				t.Errorf("Sources[0].Query = %q, want %q", cfg.Sources[0].Query, tc.query)
+			}
+		})
+	}
+}
+
+func TestParseResolvesRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		required string
+		want     bool
+	}{
+		{name: "a metricsql source is required unless the file says otherwise", required: "", want: true},
+		{name: "a metricsql source can opt out of being required", required: "    required: false\n", want: false},
+		{name: "a metricsql source can say so explicitly", required: "    required: true\n", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := counters.Parse([]byte(`sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'sum(egress)'
+` + tc.required))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+			if len(cfg.Sources) != 1 {
+				t.Fatalf("Sources = %d entries, want 1", len(cfg.Sources))
+			}
+			if got := cfg.Sources[0].Required; got != tc.want {
+				t.Errorf("Sources[0].Required = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasMetricsQL(t *testing.T) {
+	events := counters.Source{
+		Platform: "harbor", ResourceType: "repository", Metric: "pulls",
+		Kind: counters.KindEvents, EventType: "repository.pull", Required: true,
+	}
+	metricsQL := counters.Source{
+		Platform: "openstack", ResourceType: "instance", Metric: "egress_gb",
+		Kind: counters.KindMetricsQL, Query: "sum(egress)", Required: true,
+	}
+
+	tests := []struct {
+		name string
+		cfg  counters.Config
+		want bool
+	}{
+		{
+			name: "one metricsql source among events sources needs a client",
+			cfg:  counters.Config{Sources: []counters.Source{events, metricsQL, events}},
+			want: true,
+		},
+		{
+			name: "events sources alone need no client",
+			cfg:  counters.Config{Sources: []counters.Source{events}},
+			want: false,
+		},
+		{
+			name: "no source at all needs no client",
+			cfg:  counters.Config{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.HasMetricsQL(); got != tc.want {
+				t.Errorf("HasMetricsQL() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/engine/counters/vm.go
+++ b/internal/engine/counters/vm.go
@@ -1,0 +1,264 @@
+package counters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/shopspring/decimal"
+)
+
+// queryTimeout bounds one attempt of an instant query. Retries happen below
+// http.Client.Do, so the bound is per attempt rather than per query.
+const queryTimeout = 30 * time.Second
+
+// bodyExcerpt is how much of a body that is not a VictoriaMetrics error
+// document an error message quotes, so that an HTML error page from something
+// in front of VictoriaMetrics does not end up in the log line whole.
+const bodyExcerpt = 200
+
+// maxBodyBytes bounds what one answer reads into memory. The single-series
+// check below rejects a query that does not aggregate, but only once the whole
+// body is read and decoded, which is too late for the vector of a hundred
+// thousand series such a query returns.
+const maxBodyBytes = 1 << 20
+
+// ErrAnswerShape marks the failures of a query that are a property of the one
+// answer it got rather than of the store: a vector that did not aggregate, a
+// value MetricsQL printed as NaN or Inf, a result of the wrong type. A Querier
+// wraps it so that a caller can tell them apart from an outage, because the
+// next resource's answer says nothing about them and the retry ladder an outage
+// costs was never paid for them.
+var ErrAnswerShape = errors.New("the answer cannot be billed")
+
+// VMClient is the instant-query client over the VictoriaMetrics read endpoint
+// /api/v1/query.
+type VMClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewVMClient checks baseURL and returns the client that queries it. The url is
+// the read endpoint's base, with or without a trailing slash and with or
+// without a path prefix, such as http://victoriametrics:8428.
+//
+// A nil httpClient selects the package default, which retries connection
+// errors, 429, and 5xx below http.Client.Do and bounds one attempt by
+// queryTimeout. Tests pass their own client.
+func NewVMClient(baseURL string, httpClient *http.Client) (*VMClient, error) {
+	if baseURL == "" {
+		return nil, errors.New("the VictoriaMetrics url is empty")
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing the VictoriaMetrics url: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, fmt.Errorf("the VictoriaMetrics url %q must be http or https with a host", baseURL)
+	}
+
+	if httpClient == nil {
+		httpClient = defaultHTTPClient()
+	}
+	return &VMClient{baseURL: baseURL, httpClient: httpClient}, nil
+}
+
+// defaultHTTPClient is the client a caller gets when it passes none. The
+// retrying transport sits below http.Client.Do, so Query makes one call and
+// sees one result however many attempts it took.
+func defaultHTTPClient() *http.Client {
+	rc := retryablehttp.NewClient()
+	// The default logger writes every retry to stderr, past the engine's
+	// handler.
+	rc.Logger = nil
+	// Without a passthrough handler an exhausted retry on a 5xx returns a bare
+	// "giving up after N attempt(s)" error and drops the response. With it the
+	// last response comes back and Query reports its status.
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	rc.HTTPClient.Timeout = queryTimeout
+	// RetryMax stays at its default of four. DefaultRetryPolicy retries
+	// connection errors, 429, and 5xx except 501; a 4xx such as the 422
+	// VictoriaMetrics answers for an invalid query is returned at once.
+	return rc.StandardClient()
+}
+
+// vmResponse is the part of an /api/v1/query answer this package reads. A
+// series carries its value as a two-element array of the sample's timestamp and
+// its value, and the value is a string rather than a JSON number so that it
+// arrives with the precision VictoriaMetrics printed it at.
+type vmResponse struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	Data      struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Value [2]json.RawMessage `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// Query runs expr as an instant query at at, which is a draft's end, and
+// returns the single value it selects. The value comes back unrounded, because
+// the quantity a counter contributes is rounded where it is merged into the
+// draft.
+//
+// An empty result is zero: a resource that reported no sample over the query's
+// window used none of the metric. More than one series is an error rather than
+// a sum or a pick of the first, because both would bill a number nobody
+// configured; such a query has to aggregate to a single series.
+func (c *VMClient) Query(ctx context.Context, expr string, at time.Time) (decimal.Decimal, error) {
+	u := strings.TrimRight(c.baseURL, "/") + "/api/v1/query?" + url.Values{
+		"query": {expr},
+		"time":  {at.UTC().Format(time.RFC3339Nano)},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("querying VictoriaMetrics: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("querying VictoriaMetrics: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("querying VictoriaMetrics: %w", err)
+	}
+
+	var r vmResponse
+	decodeErr := json.Unmarshal(body, &r)
+
+	// VictoriaMetrics reports a rejected query as an error document, but what
+	// sits in front of it answers in whatever form it likes, so a body that
+	// does not decode is quoted instead of dropped.
+	if resp.StatusCode != http.StatusOK {
+		if decodeErr != nil {
+			excerpt := body
+			if len(excerpt) > bodyExcerpt {
+				excerpt = excerpt[:bodyExcerpt]
+			}
+			return decimal.Zero, fmt.Errorf("VictoriaMetrics answered status %d: %s", resp.StatusCode, excerpt)
+		}
+		return decimal.Zero, fmt.Errorf("VictoriaMetrics answered status %d %s: %s", resp.StatusCode, r.ErrorType, r.Error)
+	}
+
+	// The bound is about the vector a query that does not aggregate returns, so
+	// it is read as that only once the answer is one: an error page from in
+	// front of VictoriaMetrics is as large as it likes and is reported by its
+	// status above.
+	if len(body) > maxBodyBytes {
+		return decimal.Zero, fmt.Errorf(
+			"%w: the VictoriaMetrics answer is larger than %d bytes: the query must aggregate to a single series",
+			ErrAnswerShape, maxBodyBytes)
+	}
+
+	if decodeErr != nil {
+		return decimal.Zero, fmt.Errorf("decoding the VictoriaMetrics response: %w", decodeErr)
+	}
+	if r.Status != "success" {
+		return decimal.Zero, fmt.Errorf("VictoriaMetrics answered status 200 %s: %s", r.ErrorType, r.Error)
+	}
+	if r.Data.ResultType != "vector" {
+		return decimal.Zero, fmt.Errorf("%w: VictoriaMetrics returned a %s result, want a vector",
+			ErrAnswerShape, r.Data.ResultType)
+	}
+
+	switch len(r.Data.Result) {
+	case 0:
+		return decimal.Zero, nil
+	case 1:
+	default:
+		return decimal.Zero, fmt.Errorf(
+			"%w: VictoriaMetrics returned %d series, want at most one: the query must aggregate to a single series",
+			ErrAnswerShape, len(r.Data.Result))
+	}
+
+	var s string
+	if err := json.Unmarshal(r.Data.Result[0].Value[1], &s); err != nil {
+		return decimal.Zero, fmt.Errorf("decoding the VictoriaMetrics response: %w", err)
+	}
+	// NaN, +Inf and -Inf, which MetricsQL prints for a division by zero and for
+	// an overflow, do not parse and are reported rather than billed.
+	value, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("%w: parsing the VictoriaMetrics value %q: %w", ErrAnswerShape, s, err)
+	}
+	return value, nil
+}
+
+// Window renders the {window} placeholder from a draft's Seconds, which are
+// whole seconds. The unit is the coarsest one that divides them, so a draft
+// covering a month of 30 days is 360h rather than 1296000s.
+func Window(seconds int64) string {
+	switch {
+	// Two state transitions inside one second leave a draft shorter than a
+	// second, and it still has to be measured over a window MetricsQL accepts:
+	// a second is the shortest lookbehind there is, while [0s] is either
+	// rejected, which would fail the run, or answered with something nobody
+	// chose.
+	case seconds < 1:
+		return "1s"
+	case seconds%3600 == 0:
+		return fmt.Sprintf("%dh", seconds/3600)
+	case seconds%60 == 0:
+		return fmt.Sprintf("%dm", seconds/60)
+	default:
+		return fmt.Sprintf("%ds", seconds)
+	}
+}
+
+// inertIdentity is what a substituted identity value may hold. MetricsQL writes
+// string literals in double quotes, single quotes and backticks, and a
+// placeholder may sit outside a literal altogether, so escaping for one of
+// those forms would leave the others open. These characters carry no meaning in
+// any of them: they can neither end a literal nor start an expression.
+//
+// They are inert as a literal, not as a pattern: a dot is a wildcard where a
+// value is read as a regular expression, so validate keeps a substituted
+// identity out of a =~ or !~ matcher.
+var inertIdentity = regexp.MustCompile(`^[A-Za-z0-9._:/@-]*$`)
+
+// RenderQuery substitutes a metricsql source's placeholders with the draft they
+// are measured for: {cloud}, {resource_id} and {project_id} with the draft's
+// identity, {window} with its length.
+//
+// The three identity values reach the engine from ingested event data, while
+// the query around them is text an operator wrote. A value that is not inert in
+// MetricsQL is therefore refused rather than escaped: nothing here can tell
+// which of MetricsQL's string literal forms a placeholder sits in, or whether
+// it sits in one at all, so an escaper for any single form would let such a
+// value compose a query of its own. Only the placeholders the query uses are
+// checked. The window is rendered from a count of seconds and needs no check.
+func RenderQuery(query, cloud, resourceID, projectID string, seconds int64) (string, error) {
+	for _, identity := range []struct{ name, value string }{
+		{"cloud", cloud}, {"resource_id", resourceID}, {"project_id", projectID},
+	} {
+		if !strings.Contains(query, "{"+identity.name+"}") {
+			continue
+		}
+		if !inertIdentity.MatchString(identity.value) {
+			return "", fmt.Errorf("the %s %q holds a character a MetricsQL query may not carry",
+				identity.name, identity.value)
+		}
+	}
+
+	return strings.NewReplacer(
+		"{cloud}", cloud,
+		"{resource_id}", resourceID,
+		"{project_id}", projectID,
+		"{window}", Window(seconds),
+	).Replace(query), nil
+}

--- a/internal/engine/counters/vm_internal_test.go
+++ b/internal/engine/counters/vm_internal_test.go
@@ -1,0 +1,120 @@
+package counters
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// defaultVectorBody is what VictoriaMetrics answers the queries below with: an
+// instant vector of one series.
+const defaultVectorBody = `{"status":"success","data":{"resultType":"vector","result":[{"value":[1773792000,"38.5"]}]}}`
+
+// impatient is the client a caller gets when it passes none, with its waits cut
+// to a millisecond and its retries to retryMax. Nothing else about it is
+// changed, so what the cases below run is the configuration of a deployment
+// rather than one a test rebuilt beside it.
+func impatient(t *testing.T, retryMax int) *http.Client {
+	t.Helper()
+
+	c := defaultHTTPClient()
+	rt, ok := c.Transport.(*retryablehttp.RoundTripper)
+	if !ok {
+		t.Fatalf("Transport = %T, want a *retryablehttp.RoundTripper", c.Transport)
+	}
+	rt.Client.RetryWaitMin = time.Millisecond
+	rt.Client.RetryWaitMax = time.Millisecond
+	rt.Client.RetryMax = retryMax
+	return c
+}
+
+// TestDefaultHTTPClient runs the client a caller gets when it passes none. The
+// query cases elsewhere build their own retry policy beside it, so without this
+// one nothing exercises the package default: dropping its passthrough handler
+// would replace the status Query reports with a bare "giving up after N
+// attempt(s)", and dropping its nil logger would write every retry to stderr,
+// past the engine's handler.
+func TestDefaultHTTPClient(t *testing.T) {
+	t.Run("one attempt is bounded and four retries are left to the policy", func(t *testing.T) {
+		c := defaultHTTPClient()
+		rt, ok := c.Transport.(*retryablehttp.RoundTripper)
+		if !ok {
+			t.Fatalf("Transport = %T, want a *retryablehttp.RoundTripper", c.Transport)
+		}
+
+		// The bound sits on the client each attempt goes through, below the
+		// retrying transport, so it is per attempt rather than per query.
+		if got := rt.Client.HTTPClient.Timeout; got != queryTimeout {
+			t.Errorf("HTTPClient.Timeout = %s, want %s", got, queryTimeout)
+		}
+		if rt.Client.RetryMax != 4 {
+			t.Errorf("RetryMax = %d, want 4", rt.Client.RetryMax)
+		}
+		if rt.Client.Logger != nil {
+			t.Errorf("Logger = %#v, want nil, which is what keeps a retry line out of stderr", rt.Client.Logger)
+		}
+	})
+
+	t.Run("a store that is unavailable once is queried again", func(t *testing.T) {
+		var attempts atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if attempts.Add(1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = io.WriteString(w, defaultVectorBody)
+		}))
+		t.Cleanup(srv.Close)
+
+		c, err := NewVMClient(srv.URL, impatient(t, 2))
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+
+		got, err := c.Query(t.Context(), "up", time.Now().UTC())
+		if err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+		if want := "38.5"; got.String() != want {
+			t.Errorf("Query() = %s, want %s", got, want)
+		}
+		if attempts.Load() != 2 {
+			t.Errorf("the store saw %d attempts, want 2", attempts.Load())
+		}
+	})
+
+	t.Run("an exhausted retry reports the store's answer, not the attempts", func(t *testing.T) {
+		var attempts atomic.Int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "internal error")
+		}))
+		t.Cleanup(srv.Close)
+
+		c, err := NewVMClient(srv.URL, impatient(t, 2))
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+
+		_, err = c.Query(t.Context(), "up", time.Now().UTC())
+		if err == nil {
+			t.Fatal("Query() error = nil, want an error")
+		}
+		if want := "answered status 500: internal error"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Query() error = %q, want it to contain %q", err, want)
+		}
+		if want := "giving up after"; strings.Contains(err.Error(), want) {
+			t.Errorf("Query() error = %q, want it not to contain %q", err, want)
+		}
+		if attempts.Load() != 3 {
+			t.Errorf("the store saw %d attempts, want 3", attempts.Load())
+		}
+	})
+}

--- a/internal/engine/counters/vm_test.go
+++ b/internal/engine/counters/vm_test.go
@@ -1,0 +1,463 @@
+package counters_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/engine/counters"
+)
+
+// vectorBody is what VictoriaMetrics answers for a query that selects one
+// series: an instant vector of one sample, its value a string.
+const vectorBody = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1773792000,"38.5"]}]}}`
+
+// draftEnd is the instant the queries of these tests are run at.
+var draftEnd = time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC)
+
+// testClient builds the client the tests query through: the retry policy the
+// package default uses, with the waits cut to a millisecond and the number of
+// retries set per test.
+func testClient(retryMax int) *http.Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = nil
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	rc.RetryWaitMin = time.Millisecond
+	rc.RetryWaitMax = time.Millisecond
+	rc.RetryMax = retryMax
+	return rc.StandardClient()
+}
+
+// recordedRequest is what a test server saw of one request.
+type recordedRequest struct {
+	method string
+	path   string
+	query  url.Values
+}
+
+// recorder collects the requests a test server saw. A retried query reaches the
+// handler from the client's goroutine and the test reads the requests from its
+// own, so the slice is guarded.
+type recorder struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func (r *recorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.requests = append(r.requests, recordedRequest{
+		method: req.Method,
+		path:   req.URL.Path,
+		query:  req.URL.Query(),
+	})
+}
+
+func (r *recorder) seen() []recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.requests)
+}
+
+// newTestServer starts a server that records every request before handler
+// answers it.
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *recorder) {
+	t.Helper()
+
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// answer writes status and body, which is what most of these servers do.
+func answer(status int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+// newQueryClient starts a server answering status and body and returns the
+// client that queries it.
+func newQueryClient(t *testing.T, retryMax, status int, body string) (*counters.VMClient, *recorder) {
+	t.Helper()
+
+	srv, rec := newTestServer(t, answer(status, body))
+	c, err := counters.NewVMClient(srv.URL, testClient(retryMax))
+	if err != nil {
+		t.Fatalf("NewVMClient() error = %v, want nil", err)
+	}
+	return c, rec
+}
+
+func TestNewVMClient(t *testing.T) {
+	t.Run("a url the engine cannot query is refused", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			baseURL string
+			wantErr string
+		}{
+			{
+				name:    "an unset url",
+				baseURL: "",
+				wantErr: "the VictoriaMetrics url is empty",
+			},
+			{
+				name:    "a url that does not parse",
+				baseURL: "://bad",
+				wantErr: "parsing the VictoriaMetrics url:",
+			},
+			{
+				name:    "a scheme that is not HTTP",
+				baseURL: "ftp://vm:8428",
+				wantErr: "must be http or https with a host",
+			},
+			{
+				name:    "a url without a host",
+				baseURL: "http://",
+				wantErr: "must be http or https with a host",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := counters.NewVMClient(tc.baseURL, nil)
+				if err == nil {
+					t.Fatalf("NewVMClient(%q) error = nil, want %q", tc.baseURL, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("NewVMClient(%q) error = %q, want it to contain %q", tc.baseURL, err, tc.wantErr)
+				}
+			})
+		}
+	})
+
+	// What that default does is run in TestDefaultHTTPClient, which reaches it
+	// without going through a url.
+	t.Run("a caller may pass no client and gets the package default", func(t *testing.T) {
+		c, err := counters.NewVMClient("http://vm:8428", nil)
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+		if c == nil {
+			t.Fatal("NewVMClient() client = nil, want a client")
+		}
+	})
+}
+
+func TestVMClientQuery(t *testing.T) {
+	t.Run("the request carries the expression and the draft's end", func(t *testing.T) {
+		const expr = `sum(increase(x{cloud="os-prod-eu1"}[360h])) / 1e9`
+
+		// The base url keeps its path prefix, whether or not it ends in a
+		// slash, because vmauth publishes VictoriaMetrics under one.
+		for _, base := range []string{"/vm", "/vm/"} {
+			t.Run("a base url "+base, func(t *testing.T) {
+				srv, rec := newTestServer(t, answer(http.StatusOK, vectorBody))
+				c, err := counters.NewVMClient(srv.URL+base, testClient(0))
+				if err != nil {
+					t.Fatalf("NewVMClient() error = %v, want nil", err)
+				}
+
+				if _, err := c.Query(t.Context(), expr, draftEnd); err != nil {
+					t.Fatalf("Query() error = %v, want nil", err)
+				}
+
+				seen := rec.seen()
+				if len(seen) != 1 {
+					t.Fatalf("saw %d requests, want 1", len(seen))
+				}
+				if seen[0].method != http.MethodGet {
+					t.Errorf("method = %q, want %q", seen[0].method, http.MethodGet)
+				}
+				if want := "/vm/api/v1/query"; seen[0].path != want {
+					t.Errorf("path = %q, want %q", seen[0].path, want)
+				}
+				if got := seen[0].query.Get("query"); got != expr {
+					t.Errorf("query = %q, want %q", got, expr)
+				}
+				if got, want := seen[0].query.Get("time"), "2026-03-11T00:00:00Z"; got != want {
+					t.Errorf("time = %q, want %q", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("a draft ending between two seconds keeps its fraction", func(t *testing.T) {
+		srv, rec := newTestServer(t, answer(http.StatusOK, vectorBody))
+		c, err := counters.NewVMClient(srv.URL, testClient(0))
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+
+		at := time.Date(2026, 3, 16, 0, 0, 0, 500_000_000, time.UTC)
+		if _, err := c.Query(t.Context(), "up", at); err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+
+		seen := rec.seen()
+		if len(seen) != 1 {
+			t.Fatalf("saw %d requests, want 1", len(seen))
+		}
+		if got, want := seen[0].query.Get("time"), "2026-03-16T00:00:00.5Z"; got != want {
+			t.Errorf("time = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a vector of one series is its value", func(t *testing.T) {
+		c, _ := newQueryClient(t, 0, http.StatusOK, vectorBody)
+
+		got, err := c.Query(t.Context(), "up", draftEnd)
+		if err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+		want, err := decimal.NewFromString("38.5")
+		if err != nil {
+			t.Fatalf("NewFromString() error = %v, want nil", err)
+		}
+		if !got.Equal(want) {
+			t.Errorf("Query() = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("an empty result is zero rather than an error", func(t *testing.T) {
+		c, _ := newQueryClient(t, 0, http.StatusOK,
+			`{"status":"success","data":{"resultType":"vector","result":[]}}`)
+
+		got, err := c.Query(t.Context(), "up", draftEnd)
+		if err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+		if !got.IsZero() {
+			t.Errorf("Query() = %s, want 0", got)
+		}
+	})
+
+	t.Run("a result the engine cannot bill is an error", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			retryMax int
+			status   int
+			body     string
+			wantErr  string
+			// wantRequests is how often the query reached the server, which is
+			// what says whether the status was retried.
+			wantRequests int
+			// wantAnswerShape is whether the failure is a property of this one
+			// answer rather than of the store, which is what says whether a
+			// caller may hold it against the next query.
+			wantAnswerShape bool
+		}{
+			{
+				name:            "more than one series, which no rule picks from",
+				status:          http.StatusOK,
+				body:            `{"status":"success","data":{"resultType":"vector","result":[{"value":[1773792000,"1"]},{"value":[1773792000,"2"]}]}}`,
+				wantErr:         "returned 2 series, want at most one",
+				wantRequests:    1,
+				wantAnswerShape: true,
+			},
+			{
+				name:            "a result that is not a vector",
+				status:          http.StatusOK,
+				body:            `{"status":"success","data":{"resultType":"scalar","result":[{"value":[1773792000,"1"]}]}}`,
+				wantErr:         "returned a scalar result, want a vector",
+				wantRequests:    1,
+				wantAnswerShape: true,
+			},
+			{
+				name:            "a value that is not a number",
+				status:          http.StatusOK,
+				body:            `{"status":"success","data":{"resultType":"vector","result":[{"value":[1773792000,"NaN"]}]}}`,
+				wantErr:         `parsing the VictoriaMetrics value "NaN":`,
+				wantRequests:    1,
+				wantAnswerShape: true,
+			},
+			{
+				// The single-series check below runs on a decoded body, which
+				// is too late for the vector such a query returns.
+				name:   "an answer too large to hold, from a query that did not aggregate",
+				status: http.StatusOK,
+				body: `{"status":"success","data":{"resultType":"vector","result":[` +
+					strings.Repeat(`{"metric":{"resource_id":"abc-123"},"value":[1773792000,"1"]},`, 20000) +
+					`{"metric":{},"value":[1773792000,"1"]}]}}`,
+				wantErr:         "the VictoriaMetrics answer is larger than 1048576 bytes",
+				wantRequests:    1,
+				wantAnswerShape: true,
+			},
+			{
+				// Whatever sits in front of VictoriaMetrics answers in
+				// whatever form it likes, and none of it belongs in the log
+				// line whole.
+				name:         "an error page from in front of the store is quoted, not logged whole",
+				status:       http.StatusBadGateway,
+				body:         "<html>" + strings.Repeat("x", 500) + "</html>",
+				wantErr:      "answered status 502: <html>" + strings.Repeat("x", 194),
+				wantRequests: 1,
+			},
+			{
+				// The bound is about the vector a query that does not
+				// aggregate returns. An error page is as large as it likes,
+				// and reporting it as a query that has to aggregate would send
+				// oncall after a query that is correct.
+				name:         "an error page larger than the bound on an answer",
+				status:       http.StatusBadGateway,
+				body:         "<html>" + strings.Repeat("x", 1<<20) + "</html>",
+				wantErr:      "answered status 502: <html>" + strings.Repeat("x", 194),
+				wantRequests: 1,
+			},
+			{
+				name:         "a value serialized as a number rather than a string",
+				status:       http.StatusOK,
+				body:         `{"status":"success","data":{"resultType":"vector","result":[{"value":[1773792000,38.5]}]}}`,
+				wantErr:      "decoding the VictoriaMetrics response:",
+				wantRequests: 1,
+			},
+			{
+				name:         "a series without a sample",
+				status:       http.StatusOK,
+				body:         `{"status":"success","data":{"resultType":"vector","result":[{"metric":{}}]}}`,
+				wantErr:      "decoding the VictoriaMetrics response:",
+				wantRequests: 1,
+			},
+			{
+				name:         "a body that is not JSON",
+				status:       http.StatusOK,
+				body:         "not json",
+				wantErr:      "decoding the VictoriaMetrics response:",
+				wantRequests: 1,
+			},
+			{
+				name:         "an error reported with status 200",
+				status:       http.StatusOK,
+				body:         `{"status":"error","errorType":"execution","error":"boom"}`,
+				wantErr:      "answered status 200 execution: boom",
+				wantRequests: 1,
+			},
+			{
+				name:         "an invalid query, which is not retried",
+				retryMax:     2,
+				status:       http.StatusUnprocessableEntity,
+				body:         `{"status":"error","errorType":"422","error":"unexpected token"}`,
+				wantErr:      "answered status 422 422: unexpected token",
+				wantRequests: 1,
+			},
+			{
+				name:         "a server error whose body is not an error document",
+				retryMax:     2,
+				status:       http.StatusInternalServerError,
+				body:         "internal error",
+				wantErr:      "answered status 500: internal error",
+				wantRequests: 3,
+			},
+			{
+				name:         "a store that stays unavailable",
+				retryMax:     2,
+				status:       http.StatusServiceUnavailable,
+				body:         `{"status":"error","errorType":"503","error":"too many concurrent requests"}`,
+				wantErr:      "answered status 503",
+				wantRequests: 3,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				c, rec := newQueryClient(t, tc.retryMax, tc.status, tc.body)
+
+				_, err := c.Query(t.Context(), "up", draftEnd)
+				if err == nil {
+					t.Fatalf("Query() error = nil, want %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Query() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				if got := len(rec.seen()); got != tc.wantRequests {
+					t.Errorf("saw %d requests, want %d", got, tc.wantRequests)
+				}
+				// A store that is down fails the next query the same way and is
+				// worth backing off from; an answer only this query got is not.
+				if got := errors.Is(err, counters.ErrAnswerShape); got != tc.wantAnswerShape {
+					t.Errorf("errors.Is(err, ErrAnswerShape) = %t, want %t", got, tc.wantAnswerShape)
+				}
+			})
+		}
+	})
+
+	t.Run("a store that is unavailable once is queried again", func(t *testing.T) {
+		var attempts atomic.Int64
+		srv, rec := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			answer(http.StatusOK, vectorBody)(w, r)
+		})
+		c, err := counters.NewVMClient(srv.URL, testClient(2))
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+
+		got, err := c.Query(t.Context(), "up", draftEnd)
+		if err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+		want, err := decimal.NewFromString("38.5")
+		if err != nil {
+			t.Fatalf("NewFromString() error = %v, want nil", err)
+		}
+		if !got.Equal(want) {
+			t.Errorf("Query() = %s, want %s", got, want)
+		}
+		if seen := len(rec.seen()); seen != 2 {
+			t.Errorf("saw %d requests, want 2", seen)
+		}
+	})
+
+	t.Run("a canceled run stops the query", func(t *testing.T) {
+		var once sync.Once
+		started := make(chan struct{})
+		srv, _ := newTestServer(t, func(_ http.ResponseWriter, r *http.Request) {
+			once.Do(func() { close(started) })
+			<-r.Context().Done()
+		})
+		c, err := counters.NewVMClient(srv.URL, testClient(2))
+		if err != nil {
+			t.Fatalf("NewVMClient() error = %v, want nil", err)
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() {
+			<-started
+			cancel()
+		}()
+
+		_, err = c.Query(ctx, "up", draftEnd)
+		if err == nil {
+			t.Fatal("Query() error = nil, want an error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Query() error = %v, want it to wrap context.Canceled", err)
+		}
+		if want := "querying VictoriaMetrics:"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Query() error = %q, want it to contain %q", err, want)
+		}
+	})
+}

--- a/internal/engine/source/queries.sql
+++ b/internal/engine/source/queries.sql
@@ -47,3 +47,19 @@ WHERE relation_type = ANY(sqlc.arg('relation_types')::text[])
   AND valid_from < sqlc.arg('period_to')::timestamptz
   AND (valid_to IS NULL OR valid_to > sqlc.arg('period_from')::timestamptz)
 ORDER BY id;
+
+-- The events of one type a counter measures inside one usage interval. The
+-- interval is half-open, [from_ts, to_ts), the same bound the interval itself
+-- has, and the key carries the cloud and the resource type beside the id
+-- because an id is unique only within both. idx_events_resource serves the
+-- predicate on uncompressed chunks; a chunk past the 90-day compression policy
+-- is segmented by (cloud, resource_type) alone, so the resource id and the
+-- event type are filtered after decompression, which is what a correction of an
+-- older period pays.
+-- name: CountEvents :one
+SELECT count(*)
+FROM events
+WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+  AND event_type = sqlc.arg('event_type')
+  AND timestamp >= sqlc.arg('from_ts')::timestamptz
+  AND timestamp < sqlc.arg('to_ts')::timestamptz;

--- a/internal/engine/source/source.go
+++ b/internal/engine/source/source.go
@@ -5,11 +5,11 @@
 // through the tally_engine_reader role, and this package writes nothing, here
 // or anywhere else.
 //
-// Every reporting read of the engine is a method on Snapshot. The transaction
-// itself stays unexported, so a later package that needs another query, such as
-// the event count a counter measures, adds a method here rather than taking a
-// handle on the transaction and running its own statements outside the
-// snapshot.
+// Every reporting read of the engine is a method on Snapshot, the event count a
+// counter measures included (CountEvents). The transaction itself stays
+// unexported, so a later package that needs another query adds a method here
+// rather than taking a handle on the transaction and running its own statements
+// outside the snapshot.
 //
 // A snapshot holds one connection for its lifetime and pins the reporting
 // database's vacuum horizon while it is open, which keeps dead tuples from
@@ -208,6 +208,27 @@ func (s *Snapshot) History(ctx context.Context, r Resource, periodTo time.Time) 
 		events = append(events, stored)
 	}
 	return events, nil
+}
+
+// CountEvents counts the events of one type of r whose timestamp lies in the
+// half-open interval [from, to). It is the count an events-kind counter source
+// measures per usage interval, and it runs inside the snapshot transaction, so
+// the count and the history the interval was folded from see the same data. A
+// resource with no matching events counts as 0 and no error.
+func (s *Snapshot) CountEvents(ctx context.Context, r Resource, eventType string, from, to time.Time) (int64, error) {
+	count, err := s.queries.CountEvents(ctx, sqlcgen.CountEventsParams{
+		Cloud:        r.Cloud,
+		ResourceType: r.ResourceType,
+		ResourceID:   r.ResourceID,
+		EventType:    eventType,
+		FromTs:       timestamptz(from),
+		ToTs:         timestamptz(to),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("counting the %s events of %s/%s/%s: %w",
+			eventType, r.Cloud, r.ResourceType, r.ResourceID, err)
+	}
+	return count, nil
 }
 
 // Project is one entry of the project registry.

--- a/internal/engine/source/source_test.go
+++ b/internal/engine/source/source_test.go
@@ -272,6 +272,78 @@ func TestHistory(t *testing.T) {
 	})
 }
 
+// TestCountEvents pins what an events-kind counter is handed: the events of
+// one type inside the half-open interval, keyed by the cloud and the resource
+// type beside the id rather than by the id alone.
+func TestCountEvents(t *testing.T) {
+	db := storetest.NewDB(t)
+	pool := db.Store.Pool()
+
+	repo := source.Resource{
+		Cloud: "harbor-prod", Platform: "harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+	}
+	// A sibling of the same cloud and type, the same repository in another
+	// cloud, and repo's own id under another type of the same cloud. An id is
+	// unique only within the cloud and the resource type, so none of them is
+	// repo.
+	other := source.Resource{
+		Cloud: "harbor-prod", Platform: "harbor", ResourceType: "repository", ResourceID: "team-alpha/other",
+	}
+	staged := source.Resource{
+		Cloud: "harbor-stage", Platform: "harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+	}
+	otherType := source.Resource{
+		Cloud: "harbor-prod", Platform: "harbor", ResourceType: "project", ResourceID: "team-alpha/app",
+	}
+
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 18, 0, 0, 0, 0, time.UTC)
+	pulled := time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC)
+	justBefore := time.Date(2026, 2, 28, 23, 59, 59, 0, time.UTC)
+	elsewhere := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+
+	// The interval is half-open, so the pull at its first instant counts and
+	// the one at its last belongs to the next interval.
+	seedEvent(t, pool, repo, "count-at-from", "repository.pull", from, from, nil)
+	seedEvent(t, pool, repo, "count-inside", "repository.pull", pulled, pulled, nil)
+	seedEvent(t, pool, repo, "count-at-to", "repository.pull", to, to, nil)
+	seedEvent(t, pool, repo, "count-before", "repository.pull", justBefore, justBefore, nil)
+	// Inside the interval, but not what this counter counts: another event type
+	// of repo, and the pull of a resource repo shares only part of its key
+	// with — the id, the cloud, or the resource type.
+	seedEvent(t, pool, repo, "count-push", "repository.push", elsewhere, elsewhere, nil)
+	seedEvent(t, pool, other, "count-other-id", "repository.pull", elsewhere, elsewhere, nil)
+	seedEvent(t, pool, staged, "count-other-cloud", "repository.pull", elsewhere, elsewhere, nil)
+	seedEvent(t, pool, otherType, "count-other-type", "repository.pull", elsewhere, elsewhere, nil)
+
+	t.Run("counts the events of the type inside the half-open interval", func(t *testing.T) {
+		snap := openSnapshot(t, db.URL)
+
+		got, err := snap.CountEvents(t.Context(), repo, "repository.pull", from, to)
+		if err != nil {
+			t.Fatalf("CountEvents() error = %v, want nil", err)
+		}
+		if want := int64(2); got != want {
+			t.Errorf("CountEvents() = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("a resource without events counts zero", func(t *testing.T) {
+		snap := openSnapshot(t, db.URL)
+
+		empty := source.Resource{
+			Cloud: "harbor-prod", Platform: "harbor", ResourceType: "repository", ResourceID: "team-alpha/empty",
+		}
+		got, err := snap.CountEvents(t.Context(), empty, "repository.pull", from, to)
+		if err != nil {
+			t.Fatalf("CountEvents() error = %v, want nil", err)
+		}
+		if got != 0 {
+			t.Errorf("CountEvents() = %d, want 0", got)
+		}
+	})
+}
+
 // TestSnapshot pins what makes the transaction a snapshot: a run reads one
 // version of the reporting data however long it takes, and it knows which
 // version that was.
@@ -546,6 +618,16 @@ func TestReaderRole(t *testing.T) {
 		if want := []source.Relation{relation}; !reflect.DeepEqual(relations, want) {
 			t.Errorf("Relations() = %+v, want %+v", relations, want)
 		}
+
+		// The same grant on the events hypertable, exercised through an
+		// aggregate rather than through the rows themselves.
+		events, err := snap.CountEvents(t.Context(), metered, "instance.create", periodFrom, periodTo)
+		if err != nil {
+			t.Fatalf("CountEvents() error = %v, want nil", err)
+		}
+		if events != 1 {
+			t.Errorf("CountEvents() = %d, want 1", events)
+		}
 	})
 
 	t.Run("writes nothing and reads no credentials", func(t *testing.T) {
@@ -629,6 +711,13 @@ func TestReadsReportTheQueryThatFailed(t *testing.T) {
 				return err
 			},
 			want: "listing the project relations:",
+		},
+		"CountEvents": {
+			read: func() error {
+				_, err := snap.CountEvents(t.Context(), metered, "instance.create", periodFrom, periodTo)
+				return err
+			},
+			want: "counting the instance.create events of " + cloud + "/instance/i-1:",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/engine/source/sqlcgen/queries.sql.go
+++ b/internal/engine/source/sqlcgen/queries.sql.go
@@ -12,6 +12,46 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countEvents = `-- name: CountEvents :one
+SELECT count(*)
+FROM events
+WHERE cloud = $1 AND resource_type = $2 AND resource_id = $3
+  AND event_type = $4
+  AND timestamp >= $5::timestamptz
+  AND timestamp < $6::timestamptz
+`
+
+type CountEventsParams struct {
+	Cloud        string
+	ResourceType string
+	ResourceID   string
+	EventType    string
+	FromTs       pgtype.Timestamptz
+	ToTs         pgtype.Timestamptz
+}
+
+// The events of one type a counter measures inside one usage interval. The
+// interval is half-open, [from_ts, to_ts), the same bound the interval itself
+// has, and the key carries the cloud and the resource type beside the id
+// because an id is unique only within both. idx_events_resource serves the
+// predicate on uncompressed chunks; a chunk past the 90-day compression policy
+// is segmented by (cloud, resource_type) alone, so the resource id and the
+// event type are filtered after decompression, which is what a correction of an
+// older period pays.
+func (q *Queries) CountEvents(ctx context.Context, arg CountEventsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countEvents,
+		arg.Cloud,
+		arg.ResourceType,
+		arg.ResourceID,
+		arg.EventType,
+		arg.FromTs,
+		arg.ToTs,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const listCandidates = `-- name: ListCandidates :many
 SELECT cloud, platform, resource_type, resource_id
 FROM current_resources


### PR DESCRIPTION
## What this does

Implements WP 3.4 of `roadmap/03-phase-3-metering-rating.md` and decision D7: counter metrics measured **per usage interval** from a configurable `counter-sources.yaml`, with two source kinds — the count of one event type inside the interval (`kind: events`) and an instant MetricsQL query against VictoriaMetrics at the interval's end (`kind: metricsql`).

Nothing is persisted here. `tally-engine run` stays the stub #34 left; #39 chains `metering.Meter`, this package, rating, and attribution into a recorded run and writes the warnings this package returns into `runs.stats`.

Closes #36

## The commits, in order

1. **`53999a1` Add `money.RoundQuantity` and rename the four-place scale constant**
   `minutePlaces` becomes `quantityPlaces` ("minutes and counters alike") and `RoundQuantity(decimal.Decimal) decimal.Decimal` joins `Round2` as the four-place, half-away-from-zero entry point. `roadmap/00-conventions.md` section 6 makes this package the only place rounding happens, so a counter value parsed from a metrics store rounds here rather than at the call site. `Minutes` and `Quantity.MarshalJSON` are unchanged in behaviour.

2. **`1b43bce` Add `Snapshot.CountEvents` counting one event type per interval**
   `CountEvents :one` in `queries.sql` (regenerated into `sqlcgen/`) plus `(*Snapshot).CountEvents(ctx, r, eventType, from, to) (int64, error)`. It runs inside the run's snapshot transaction, so the count and the drafts it slices into see one version of the `events` table. The interval is half-open `[from, to)` — the bound the usage interval itself carries — and the key is `(cloud, resource_type, resource_id, event_type)`, which `idx_events_resource` serves. `TestReaderRole` and `TestReadsReportTheQueryThatFailed` gain the new read.

3. **`236cc17` Add the `counters` package loading and validating counter sources**
   `Kind`/`Source`/`Config`/`Config.HasMetricsQL`, `Load(path)` and `Parse(data)`. YAML decodes with `KnownFields(true)`, so `event_typ` is an error naming the key rather than a silently dropped field, and every entry is checked by index: required fields set, `minutes`/`count` refused as reserved metric names, kind restricted to the two, `event_type`/`query`/`required` restricted to the kind they belong to, unknown `{placeholder}`s in a query refused, and a duplicate `(platform, resource_type, metric)` refused. An empty path is the zero `Config`; a path that cannot be read is an error, so a misconfigured path never silently drops a billed metric.

4. **`4b8a3af` Add the VictoriaMetrics instant-query client with retries**
   `VMClient`/`NewVMClient`/`Query`, plus `Window(seconds)` and `RenderQuery(...)` for the `{cloud}`, `{resource_id}`, `{project_id}`, `{window}` placeholders. Built on `hashicorp/go-retryablehttp` — the client `roadmap/00-conventions.md` names for VM queries — so connection errors, 429 and 5xx retry below `http.Client.Do` while a 4xx (the 422 for an invalid query) is reported at once, and an exhausted retry reports the last response by status instead of dropping it. An empty result is `decimal.Zero`; **more than one series is refused** rather than summed or picked from, because either would bill a number nobody configured.

5. **`64c18a7` Add `counters.Measurer` merging counter values into usage drafts**
   `New(cfg, events, vm)` and `Apply(ctx, resources)`. The pass runs after `metering.Meter` and before anything is persisted, with the reporting snapshot still open, and writes into each draft's `Usage` map in place. An `events` value is carried as the `int64` it is; a `metricsql` value is rounded with `money.RoundQuantity` and carried as a `money.Quantity`. A failed count, a failed **required** `metricsql` source, a metric colliding with a size field, or a canceled context ends the pass; a failed **optional** `metricsql` source becomes a `counter_source_failed` warning and the metric is left out of that one draft. `EventCounter` and `Querier` are the two seams the tests and #42's golden suite substitute.

6. **`5c57379` Read an explicitly empty `TALLY_ENGINE_COUNTER_SOURCES` as no sources**
   The `env` package applies the default to an empty-string variable exactly as to an unset one, so `config.Load` consults `os.LookupEnv` to tell them apart — the same pattern `TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES` already uses. The explicit empty value is what a deployment without counter metrics configures; a path to a missing file stays an error when the file is read.

7. **`c005822` Ship the counter sources example file beside `.env.example`**
   `cmd/tally-engine/counter-sources.example.yaml` carries the roadmap's two entries (one `metricsql`, one `events`) under a header stating where the engine reads the file from, what each kind measures, which placeholders a query may use, and what `required: false` does — the format a deployment's ConfigMap will carry. `TestCounterSourcesExampleLoads` loads it through `counters.Load`, so a format change that is not mirrored here fails the build instead of reaching an operator.

## Where the diff diverges from the issue

Three deliberate departures, all in the merge and the query rendering:

- **`RenderQuery` refuses an unusable identity instead of escaping it.** The issue specified escaping `\` and `"` in `cloud`, `resource_id`, and `project_id` before substitution. The implementation validates each identity a query actually references against an inert-character pattern and returns an error otherwise. Escaping still lets a hostile or malformed identifier reshape the label matcher; refusing cannot. `RenderQuery` therefore returns `(string, error)` rather than a bare `string`.
- **A second warning code, `counter_identity_not_queryable`.** A resource whose identity a query may not carry does not clear on a rerun — the metric stays missing until the identity changes — which is a different thing for an operator to act on than a store that was down. A **required** source still fails the pass on it: the identity comes from ingested event data, so warning instead would hand whoever writes an event the decision whether a billed counter gets measured.
- **A failure budget for optional `metricsql` sources.** After `maxSourceFailures` (5) consecutive drafts, an optional source is left out of the remaining drafts without being queried — each still named by its own warning — and re-probed every `probeEvery` (50) drafts. A store that is down fails every draft identically and each failure costs the whole retry ladder, which would stretch the pass by minutes per draft while the reporting snapshot stays open. Neither an identity refusal nor an `ErrAnswerShape` answer counts against the budget: only a store failure says anything about the next draft.

## Testing

`counters_test.go` covers every `Parse`/`Load` rule, `Window`, `RenderQuery` including the refusals, the nil-seam cases of `New`, and `Apply` against recording in-memory seams reproducing concept example 5 (`pulls` 812/711, `pushes` 47/23) and the end-to-end example's egress 18.0/0/22.5 across three drafts. `vm_test.go` drives `VMClient` against `httptest` servers for the request shape, each response path, the retry ladder, and a canceled context. `source_test.go` covers `CountEvents` on the `storetest` container with two event types, two resources, and two clouds around the interval's edges.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
