### PR TITLE
Import versioned pricing models and rate metered usage

### DIFF
--- a/cmd/tally-engine/commands.go
+++ b/cmd/tally-engine/commands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/b42labs/tally/internal/engine/period"
+	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/store"
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 )
@@ -294,11 +296,33 @@ func newPricingImportCmd() *cobra.Command {
 			"A catalog is imported once and then referred to by its version, which every rated record carries, " +
 			"so a price change never rewrites what an earlier run billed.",
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			// Whether the file exists and prices the counters it names is decided
-			// by the package that reads it (WP 3.5), so the path is taken as given
-			// rather than checked against the filesystem here.
-			return errNotImplemented
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading the pricing model: %w", err)
+			}
+			// What the parse reports is what is wrong with the model, not which
+			// file held it, and an operator keeps one file per version.
+			model, doc, err := pricing.Parse(data)
+			if err != nil {
+				return fmt.Errorf("%s: %w", args[0], err)
+			}
+
+			db, err := openStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			alreadyImported, err := pricing.Import(cmd.Context(), sqlcgen.New(db.Pool()), model, doc)
+			if err != nil {
+				return err
+			}
+			if alreadyImported {
+				return write(cmd.OutOrStdout(), fmt.Sprintf("pricing model %s already imported", model.Version))
+			}
+			return write(cmd.OutOrStdout(), fmt.Sprintf("imported pricing model %s valid from %s",
+				model.Version, model.ValidFrom.Format(time.RFC3339)))
 		},
 	}
 }
@@ -312,8 +336,30 @@ func newPricingListCmd() *cobra.Command {
 			"A line is a catalog's version and when it was imported, which is what a run's pricing version " +
 			"refers back to.",
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return errNotImplemented
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			db, err := openStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			rows, err := sqlcgen.New(db.Pool()).ListPricingModels(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("listing the pricing models: %w", err)
+			}
+			if len(rows) == 0 {
+				return write(cmd.OutOrStdout(), "no pricing models")
+			}
+
+			lines := make([]string, 0, len(rows))
+			for _, row := range rows {
+				lines = append(lines, fmt.Sprintf("%s valid_from=%s currency=%s imported_at=%s",
+					row.Version,
+					row.ValidFrom.Time.UTC().Format(time.RFC3339),
+					row.Currency,
+					row.ImportedAt.Time.UTC().Format(time.RFC3339)))
+			}
+			return write(cmd.OutOrStdout(), lines...)
 		},
 	}
 }

--- a/cmd/tally-engine/main.go
+++ b/cmd/tally-engine/main.go
@@ -10,12 +10,12 @@
 // Nothing else migrates as a side effect, so a schema change stays an
 // operator's decision rather than something a scheduled run brings along.
 //
-// The migrate subcommands and periods list work. The rest of the tree is the
-// interface the later Phase 3 packages fill in: each of those subcommands
-// carries its full flag surface, checks what it was given, and then reports
-// that it is not implemented. The command line is fixed here so the packages
-// that arrive behind it change what a command does rather than how it is
-// called.
+// The migrate subcommands, periods list, and the pricing import and list
+// work. The rest of the tree is the interface the later Phase 3 packages fill
+// in: each of those subcommands carries its full flag surface, checks what it
+// was given, and then reports that it is not implemented. The command line is
+// fixed here so the packages that arrive behind it change what a command does
+// rather than how it is called.
 //
 // The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.1.
 package main

--- a/cmd/tally-engine/main_test.go
+++ b/cmd/tally-engine/main_test.go
@@ -5,13 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/b42labs/tally/internal/engine/config"
 	"github.com/b42labs/tally/internal/engine/counters"
+	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/store/storetest"
 	enginemigrations "github.com/b42labs/tally/migrations/engine"
 )
@@ -300,6 +303,175 @@ func TestPeriodsList(t *testing.T) {
 	})
 }
 
+func TestPricingCLI(t *testing.T) {
+	db := storetest.NewDB(t)
+	useDatabase(t, db.URL)
+
+	stdout, stderr, err := runCLI(t, "pricing", "list")
+	if err != nil {
+		t.Fatalf("pricing list error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if want := "no pricing models\n"; stdout != want {
+		t.Errorf("stdout of a database without pricing models = %q, want %q", stdout, want)
+	}
+
+	// The committed example, which is the file the operator documentation points
+	// at. Importing it here is what keeps it importable.
+	const example = "../../pricing/2026-03.yaml"
+
+	stdout, stderr, err = runCLI(t, "pricing", "import", example)
+	if err != nil {
+		t.Fatalf("pricing import error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if want := "imported pricing model 2026-03 valid from 2026-03-01T00:00:00Z\n"; stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+
+	// The same file again. A version is imported once, so the second run reports
+	// what is already stored instead of writing or refusing.
+	stdout, stderr, err = runCLI(t, "pricing", "import", example)
+	if err != nil {
+		t.Fatalf("the second pricing import error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if want := "pricing model 2026-03 already imported\n"; stdout != want {
+		t.Errorf("stdout of the second import = %q, want %q", stdout, want)
+	}
+
+	// A version that becomes valid before the one already stored. The listing
+	// orders by valid_from, so it comes out first however late it was imported.
+	earlier := writeModel(t, "2026-02.yaml", modelYAML("2026-02", "2026-02-01T00:00:00Z", "0.02"))
+	stdout, stderr, err = runCLI(t, "pricing", "import", earlier)
+	if err != nil {
+		t.Fatalf("importing the earlier model error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if want := "imported pricing model 2026-02 valid from 2026-02-01T00:00:00Z\n"; stdout != want {
+		t.Errorf("stdout of the earlier model = %q, want %q", stdout, want)
+	}
+
+	stdout, stderr, err = runCLI(t, "pricing", "list")
+	if err != nil {
+		t.Fatalf("pricing list error = %v, want nil (stderr %q)", err, stderr)
+	}
+	want := fmt.Sprintf("2026-02 valid_from=2026-02-01T00:00:00Z currency=EUR imported_at=%s\n"+
+		"2026-03 valid_from=2026-03-01T00:00:00Z currency=EUR imported_at=%s\n",
+		importedAt(t, db, "2026-02"), importedAt(t, db, "2026-03"))
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+
+	t.Run("refuses a model the schema does not accept", func(t *testing.T) {
+		// A currency that is not a three-letter code. Nothing else about the file
+		// differs, so what the import ends on is the validation.
+		invalid := strings.Replace(modelYAML("2026-04", "2026-04-01T00:00:00Z", "0.02"), `"EUR"`, `"Euro"`, 1)
+		path := writeModel(t, "bad-currency.yaml", invalid)
+
+		stdout, _, err := runCLI(t, "pricing", "import", path)
+		if err == nil {
+			t.Fatal("pricing import error = nil, want the invalid model reported")
+		}
+		if want := "validating the pricing model"; !strings.Contains(err.Error(), want) {
+			t.Errorf("pricing import error = %q, want it to contain %q", err, want)
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("pricing import error = %q, want it to name the file %q", err, path)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an import that was refused", stdout)
+		}
+	})
+
+	t.Run("refuses a stored version that prices something else", func(t *testing.T) {
+		// The version the example imported above, under another price. An invoice
+		// names the version it was rated from, so a corrected price belongs in a
+		// new version rather than over this one.
+		path := writeModel(t, "conflict.yaml", modelYAML("2026-03", "2026-03-01T00:00:00Z", "0.03"))
+
+		stdout, _, err := runCLI(t, "pricing", "import", path)
+		if err == nil {
+			t.Fatal("pricing import error = nil, want the version conflict reported")
+		}
+		if !errors.Is(err, pricing.ErrVersionConflict) {
+			t.Errorf("pricing import error = %v, want one matching ErrVersionConflict", err)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an import that was refused", stdout)
+		}
+	})
+
+	t.Run("reports a file it cannot read", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+
+		stdout, _, err := runCLI(t, "pricing", "import", path)
+		if err == nil {
+			t.Fatal("pricing import error = nil, want the unreadable file reported")
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("pricing import error = %q, want it to name the file %q", err, path)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an import that read nothing", stdout)
+		}
+	})
+
+	t.Run("refuses a configuration without a database url", func(t *testing.T) {
+		blankEnvironment(t)
+
+		stdout, _, err := runCLI(t, "pricing", "list")
+		if err == nil {
+			t.Fatal("pricing list error = nil, want the missing database url reported")
+		}
+		if want := "TALLY_ENGINE_DB_URL: must be set"; !strings.Contains(err.Error(), want) {
+			t.Errorf("pricing list error = %q, want it to contain %q", err, want)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed for a query that never ran", stdout)
+		}
+	})
+}
+
+// modelYAML is the smallest model the schema accepts: one platform, one
+// resource type, one dimension. The price is a string, the way the committed
+// example spells its prices.
+func modelYAML(version, validFrom, price string) string {
+	return fmt.Sprintf(`version: %q
+valid_from: %q
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: %q
+`, version, validFrom, price)
+}
+
+// writeModel puts a pricing model file in a directory of its own and returns
+// its path.
+func writeModel(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	return path
+}
+
+// importedAt is when the database stamped the given version, in the form the
+// listing prints it. The column is filled by the database itself, so the
+// expected output can only be built from what was stored.
+func importedAt(t *testing.T, db storetest.DB, version string) string {
+	t.Helper()
+
+	var stamp time.Time
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		"SELECT imported_at FROM pricing_models WHERE version = $1", version).Scan(&stamp); err != nil {
+		t.Fatalf("reading imported_at of the pricing model %s: %v", version, err)
+	}
+	return stamp.UTC().Format(time.RFC3339)
+}
+
 // TestWriteReportsAFailedWrite pins what write promises: output the operator's
 // terminal never received must not leave the process with a zero exit status.
 // Every command above writes into a bytes.Buffer, whose writes never fail, so
@@ -334,9 +506,6 @@ func TestStubsValidateThenRefuse(t *testing.T) {
 			{"finalize", "--period", "2026-03", "--run", runID},
 			{"detect-late", "--period", "2026-03"},
 			{"correct", "--period", "2026-03"},
-			// The file is never opened here, so it does not have to exist.
-			{"pricing", "import", "pricing/2026-03.yaml"},
-			{"pricing", "list"},
 			{"export", "--run", runID, "--format", "json", "--out", "./out"},
 			{"export", "--run", runID, "--format", "csv", "--out", "./out"},
 			{"tick"},

--- a/internal/engine/pricing/parse.go
+++ b/internal/engine/pricing/parse.go
@@ -1,0 +1,222 @@
+package pricing
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Parse reads a pricing model file. It returns the typed model and the
+// canonical JSON document the model was built from, which is the form a version
+// is stored in.
+//
+// The document is canonical in that the same file always yields the same bytes:
+// mapping keys come out sorted, and every scalar keeps the text the file spells
+// it with. That is what lets a re-import be compared against the stored version
+// instead of being decided by the order a map was walked in.
+func Parse(data []byte) (Model, []byte, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+
+	var value any
+	var node yaml.Node
+	switch err := dec.Decode(&node); {
+	case errors.Is(err, io.EOF):
+		// A file with no content at all yields no node to convert. The value
+		// stays nil, encodes as null, and the schema refuses it the way it
+		// refuses any document that is not a mapping.
+	case err != nil:
+		return Model{}, nil, fmt.Errorf("parsing the pricing model: %w", err)
+	default:
+		value, err = generic(&node)
+		if err != nil {
+			return Model{}, nil, fmt.Errorf("parsing the pricing model: %w", err)
+		}
+
+		// Only the first document is read. A second one, appended to add
+		// another platform's prices, would otherwise be stored under a version
+		// that prices none of it.
+		var extra yaml.Node
+		switch err := dec.Decode(&extra); {
+		case errors.Is(err, io.EOF):
+		case err != nil:
+			return Model{}, nil, fmt.Errorf("parsing the pricing model: %w", err)
+		default:
+			return Model{}, nil, errors.New(
+				"parsing the pricing model: the file holds more than one document, the model belongs in the first")
+		}
+	}
+
+	doc, err := json.Marshal(value)
+	if err != nil {
+		return Model{}, nil, fmt.Errorf("encoding the pricing model as a JSON document: %w", err)
+	}
+
+	model, err := ParseDocument(doc)
+	if err != nil {
+		return Model{}, nil, err
+	}
+	return model, doc, nil
+}
+
+// A model an operator writes reaches none of the bounds below. A file written
+// to exhaust the importer reaches them: an alias is expanded at every
+// reference, so a handful of nested anchors multiply into a document the file
+// on disk gives no sign of. yaml.v3 bounds that expansion nowhere on this path,
+// because a decode into a yaml.Node leaves aliases unexpanded and its own
+// budget is only armed by the decoder that expands them.
+//
+// maxValues counts the nodes one conversion visits and maxBytes the text those
+// nodes emit. Neither implies the other, so both are needed: a scalar a
+// hundred thousand aliases name visits a fraction of the node budget and still
+// writes gigabytes into the one buffer json.Marshal builds.
+//
+// maxDepth is what a pricing model nests to, not what the conversion survives.
+// yaml.v3's scanner refuses a document nested past 10000 levels while it is
+// still reading it, so the recursion below is already bounded when it starts.
+const (
+	maxValues = 1 << 20
+	maxDepth  = 64
+	maxBytes  = 16 << 20
+)
+
+// walk is what one conversion carries across the tree: how many values and how
+// many bytes it may still produce, and which anchors the path it is on has
+// already expanded.
+type walk struct {
+	left      int
+	leftBytes int
+	expanded  map[*yaml.Node]bool
+}
+
+// generic converts a decoded YAML node tree into the values encoding/json
+// marshals the canonical document from.
+func generic(node *yaml.Node) (any, error) {
+	w := walk{left: maxValues, leftBytes: maxBytes, expanded: make(map[*yaml.Node]bool)}
+	return w.value(node, 0)
+}
+
+// spend charges the text one scalar writes into the canonical document against
+// the byte budget. Every reference to an anchor emits that text again, so the
+// number of nodes a conversion visits says nothing about how large the
+// document they marshal into gets.
+//
+// What is charged is what encoding/json writes, not what the file spells. It
+// escapes <, >, & and every control character into six bytes apiece, so a file
+// of those understates the buffer json.Marshal builds by as much as a factor of
+// six, and the budget would let through a document six times the size it names.
+func (w *walk) spend(node *yaml.Node) error {
+	width := len(node.Value)
+	for _, c := range []byte(node.Value) {
+		switch {
+		case c == '<', c == '>', c == '&', c < 0x20:
+			width += 5
+		case c == '"', c == '\\':
+			width++
+		}
+	}
+	if w.leftBytes -= width; w.leftBytes < 0 {
+		return fmt.Errorf("line %d: the model expands to more than %d bytes, which is what nested anchors do",
+			node.Line, maxBytes)
+	}
+	return nil
+}
+
+// value converts one node of that tree.
+//
+// A number becomes a json.Number holding the digits the file wrote, so the
+// document carries 0.0008 rather than whatever a float64 renders it back as,
+// and decimal.NewFromString later reads the file's own text. Anything but a
+// string or a number is refused by its tag: an unquoted 2026-03-01T00:00:00Z is
+// a !!timestamp and an unquoted true is a !!bool, and the operator who wrote
+// either needs to be told which scalar to quote.
+func (w *walk) value(node *yaml.Node, depth int) (any, error) {
+	if depth > maxDepth {
+		return nil, fmt.Errorf("line %d: the model nests more than %d levels deep, which no pricing model does",
+			node.Line, maxDepth)
+	}
+	if w.left--; w.left < 0 {
+		return nil, fmt.Errorf("line %d: the model expands to more than %d values, which is what nested anchors do",
+			node.Line, maxValues)
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		// A decoded document holds exactly one value; an empty one leaves the
+		// null an empty file yields.
+		if len(node.Content) == 0 {
+			return nil, nil
+		}
+		return w.value(node.Content[0], depth+1)
+
+	case yaml.MappingNode:
+		mapping := make(map[string]any, len(node.Content)/2)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			if key.Kind != yaml.ScalarNode || key.Tag != "!!str" {
+				return nil, fmt.Errorf("line %d: a mapping key is a %s, and every key of the model is a string",
+					key.Line, key.Tag)
+			}
+			// The last spelling of a repeated key would win silently, which is
+			// how a corrected price ends up next to the one it corrects.
+			if _, repeated := mapping[key.Value]; repeated {
+				return nil, fmt.Errorf("line %d: the key %q is set twice", key.Line, key.Value)
+			}
+			// A key is written into the document too, and an aliased mapping
+			// writes its keys again at every reference.
+			if err := w.spend(key); err != nil {
+				return nil, err
+			}
+
+			converted, err := w.value(value, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			mapping[key.Value] = converted
+		}
+		return mapping, nil
+
+	case yaml.SequenceNode:
+		sequence := make([]any, 0, len(node.Content))
+		for _, item := range node.Content {
+			converted, err := w.value(item, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			sequence = append(sequence, converted)
+		}
+		return sequence, nil
+
+	case yaml.ScalarNode:
+		if err := w.spend(node); err != nil {
+			return nil, err
+		}
+		switch node.Tag {
+		case "!!str":
+			return node.Value, nil
+		case "!!int", "!!float":
+			return json.Number(node.Value), nil
+		default:
+			return nil, fmt.Errorf("line %d: %q is a %s, and a model holds strings and numbers only; quote it",
+				node.Line, node.Value, node.Tag)
+		}
+
+	case yaml.AliasNode:
+		// An anchor is registered before the node it names is parsed, so an
+		// anchor can name a node that holds the alias itself. Expanding that
+		// one would not return.
+		if w.expanded[node.Alias] {
+			return nil, fmt.Errorf("line %d: the anchor %q holds itself", node.Line, node.Value)
+		}
+		w.expanded[node.Alias] = true
+		defer delete(w.expanded, node.Alias)
+		return w.value(node.Alias, depth+1)
+
+	default:
+		return nil, fmt.Errorf("line %d: the document holds a value that is neither a mapping, a sequence, nor a scalar",
+			node.Line)
+	}
+}

--- a/internal/engine/pricing/pricing.go
+++ b/internal/engine/pricing/pricing.go
@@ -1,0 +1,265 @@
+// Package pricing reads a pricing model: the versioned document that says what
+// a unit of every priced metric costs, per platform and resource type. It takes
+// the YAML file an operator writes, checks it against the JSON Schema embedded
+// here, and returns the typed model the rating pass multiplies usage by.
+//
+// A file becomes a canonical JSON document on the way in, and that document is
+// what a version is stored from. Parse hands it back beside the model and
+// ParseDocument reads it again, so a model that came from a file and one that
+// came back from the database go through one code path: a stored version is
+// held to the schema its file was held to. Every scalar keeps the literal text
+// the file spells it with and every mapping key is written in sorted order, so
+// the same file yields the same bytes however often it is imported. What the
+// database holds is JSONB, which Postgres parses on the way in and writes back
+// with its own key order and number formatting, so a stored version is never
+// the bytes Parse returned: a re-import is compared as a parsed model rather
+// than byte for byte.
+//
+// Prices never touch float64. A scalar reaches decimal.NewFromString as text,
+// whether the file spells a price as a number or as a string, because a price
+// that went through a float would carry its rounding error into every amount
+// rated from it. The forbidigo rules in .golangci.yml keep it that way.
+//
+// The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.5.
+package pricing
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// TypeTimeGauge is billed over the time a quantity was held, so the
+	// dimension carries a price per unit and hour.
+	TypeTimeGauge = "time_gauge"
+	// TypeCounter is billed over a quantity the counters pass measured, so the
+	// dimension carries a price per unit.
+	TypeCounter = "counter"
+)
+
+// Model is one version of the pricing model. Pricing is keyed by platform and
+// then by resource type; a resource type the map does not hold is not priced.
+type Model struct {
+	Version   string
+	ValidFrom time.Time
+	Currency  string
+	Pricing   map[string]map[string]ResourcePricing
+}
+
+// ResourcePricing is what one resource type of one platform costs. Dimensions
+// are in the order the file lists them, which is the order the rated records of
+// a resource are written in. The modifier maps are empty where the file sets
+// none, and a state or type the map does not hold is billed unmodified.
+type ResourcePricing struct {
+	Dimensions     []Dimension
+	StateModifiers map[string]decimal.Decimal
+	TypeModifiers  map[string]decimal.Decimal
+}
+
+// Dimension is one priced metric of a resource type. Type decides which of the
+// two prices carries the value: PricePerUnitHour for TypeTimeGauge,
+// PricePerUnit for TypeCounter. The other one is zero.
+type Dimension struct {
+	Metric           string
+	Type             string
+	PricePerUnitHour decimal.Decimal
+	PricePerUnit     decimal.Decimal
+}
+
+// Equal reports whether both models price the same thing. Decimals are compared
+// by value, so a price the file respells as 0.50 rather than "0.5" leaves the
+// model equal, which is what a re-import of an unchanged version has to be. The
+// dimensions of a resource type are compared in order: reordering them reorders
+// the rated records they produce, so it is a different model.
+func (m Model) Equal(other Model) bool {
+	if m.Version != other.Version || m.Currency != other.Currency || !m.ValidFrom.Equal(other.ValidFrom) {
+		return false
+	}
+	if len(m.Pricing) != len(other.Pricing) {
+		return false
+	}
+
+	for platform, types := range m.Pricing {
+		otherTypes, ok := other.Pricing[platform]
+		if !ok || len(types) != len(otherTypes) {
+			return false
+		}
+		for resourceType, entry := range types {
+			otherEntry, ok := otherTypes[resourceType]
+			if !ok || !entry.equal(otherEntry) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// equal reports whether both entries price a resource type the same way.
+func (r ResourcePricing) equal(other ResourcePricing) bool {
+	if len(r.Dimensions) != len(other.Dimensions) {
+		return false
+	}
+	for i, d := range r.Dimensions {
+		o := other.Dimensions[i]
+		if d.Metric != o.Metric || d.Type != o.Type ||
+			!d.PricePerUnitHour.Equal(o.PricePerUnitHour) || !d.PricePerUnit.Equal(o.PricePerUnit) {
+			return false
+		}
+	}
+	return equalModifiers(r.StateModifiers, other.StateModifiers) &&
+		equalModifiers(r.TypeModifiers, other.TypeModifiers)
+}
+
+// equalModifiers compares two modifier maps by value. A nil map and an empty one
+// are the same thing: neither modifies anything.
+func equalModifiers(a, b map[string]decimal.Decimal) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		other, ok := b[key]
+		if !ok || !value.Equal(other) {
+			return false
+		}
+	}
+	return true
+}
+
+// schemaDocument is the JSON Schema every pricing model is checked against. It
+// is embedded rather than read from disk so that a binary and the rules it
+// enforces travel as one artifact.
+//
+//go:embed pricing.schema.json
+var schemaDocument []byte
+
+// schemaURL is the location the embedded schema is compiled under. Nothing
+// loads it: it only gives the document an identity. The scheme is one no loader
+// serves, so a $ref that resolves against it fails to compile instead of
+// reaching for a file on the importing host's filesystem.
+const schemaURL = "tally:pricing-model"
+
+// schema compiles the embedded document once. Compiling costs more than
+// validating against the result, and the document is the same for the life of
+// the process. A compile error is the package's own bug and reaches every
+// caller of Parse and ParseDocument.
+var schema = sync.OnceValues(func() (*jsonschema.Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaDocument))
+	if err != nil {
+		return nil, fmt.Errorf("decoding the pricing schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource(schemaURL, doc); err != nil {
+		return nil, fmt.Errorf("adding the pricing schema: %w", err)
+	}
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return nil, fmt.Errorf("compiling the pricing schema: %w", err)
+	}
+	return compiled, nil
+})
+
+// modelFile is a pricing model as the canonical document spells it.
+type modelFile struct {
+	Version   string                             `json:"version"`
+	ValidFrom string                             `json:"valid_from"`
+	Currency  string                             `json:"currency"`
+	Pricing   map[string]map[string]resourceFile `json:"pricing"`
+}
+
+// resourceFile is one resource type of that document.
+type resourceFile struct {
+	Dimensions     []dimensionFile            `json:"dimensions"`
+	StateModifiers map[string]decimal.Decimal `json:"state_modifiers"`
+	TypeModifiers  map[string]decimal.Decimal `json:"type_modifiers"`
+}
+
+// dimensionFile is one dimension of that document. The price the dimension's
+// type does not carry is absent from the document and stays zero here.
+type dimensionFile struct {
+	Metric           string          `json:"metric"`
+	Type             string          `json:"type"`
+	PricePerUnitHour decimal.Decimal `json:"price_per_unit_hour"`
+	PricePerUnit     decimal.Decimal `json:"price_per_unit"`
+}
+
+// ParseDocument reads a canonical JSON document into a Model. It is the path a
+// document read back from the database takes, and the path Parse takes once it
+// has turned a file into one.
+//
+// The document is checked against the embedded schema first, so what the model
+// is built from is a document the schema accepts. Two rules the schema cannot
+// state are checked afterwards: valid_from has to be an RFC 3339 timestamp, and
+// no resource type may price one metric twice.
+func ParseDocument(doc []byte) (Model, error) {
+	compiled, err := schema()
+	if err != nil {
+		return Model{}, err
+	}
+
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(doc))
+	if err != nil {
+		return Model{}, fmt.Errorf("decoding the pricing model: %w", err)
+	}
+	if err := compiled.Validate(value); err != nil {
+		return Model{}, fmt.Errorf("validating the pricing model: %w", err)
+	}
+
+	var file modelFile
+	if err := json.Unmarshal(doc, &file); err != nil {
+		return Model{}, fmt.Errorf("reading the pricing model: %w", err)
+	}
+
+	// The schema only says valid_from is a string: a model that names no
+	// instant would otherwise be stored and then never selected for a period.
+	validFrom, err := time.Parse(time.RFC3339, file.ValidFrom)
+	if err != nil {
+		return Model{}, fmt.Errorf("reading valid_from %q: %w", file.ValidFrom, err)
+	}
+
+	pricing := make(map[string]map[string]ResourcePricing, len(file.Pricing))
+	for platform, types := range file.Pricing {
+		byType := make(map[string]ResourcePricing, len(types))
+		for resourceType, entry := range types {
+			dimensions := make([]Dimension, 0, len(entry.Dimensions))
+			priced := make(map[string]bool, len(entry.Dimensions))
+
+			for _, d := range entry.Dimensions {
+				// Every dimension is rated on its own, so a metric priced
+				// twice is billed twice under one name.
+				if priced[d.Metric] {
+					return Model{}, fmt.Errorf(
+						"%s/%s prices the metric %s twice, and every dimension is rated on its own",
+						platform, resourceType, d.Metric)
+				}
+				priced[d.Metric] = true
+
+				dimensions = append(dimensions, Dimension(d))
+			}
+
+			byType[resourceType] = ResourcePricing{
+				Dimensions:     dimensions,
+				StateModifiers: entry.StateModifiers,
+				TypeModifiers:  entry.TypeModifiers,
+			}
+		}
+		pricing[platform] = byType
+	}
+
+	return Model{
+		Version: file.Version,
+		// Stored and compared as UTC, so that a version whose file wrote the
+		// offset out selects the same periods as one that wrote Z.
+		ValidFrom: validFrom.UTC(),
+		Currency:  file.Currency,
+		Pricing:   pricing,
+	}, nil
+}

--- a/internal/engine/pricing/pricing.schema.json
+++ b/internal/engine/pricing/pricing.schema.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Tally pricing model",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["version", "valid_from", "currency", "pricing"],
+    "properties": {
+        "version": {"type": "string", "minLength": 1},
+        "valid_from": {"type": "string"},
+        "currency": {"type": "string", "pattern": "^[A-Z]{3}$"},
+        "pricing": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": {"$ref": "#/$defs/resource"}
+            }
+        }
+    },
+    "$defs": {
+        "resource": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["dimensions"],
+            "properties": {
+                "dimensions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"$ref": "#/$defs/dimension"}
+                },
+                "state_modifiers": {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/$defs/price"}
+                },
+                "type_modifiers": {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/$defs/price"}
+                }
+            }
+        },
+        "dimension": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["metric", "type"],
+            "properties": {
+                "metric": {"type": "string", "minLength": 1},
+                "type": {"enum": ["time_gauge", "counter"]},
+                "price_per_unit_hour": {"$ref": "#/$defs/price"},
+                "price_per_unit": {"$ref": "#/$defs/price"}
+            },
+            "oneOf": [
+                {
+                    "properties": {"type": {"const": "time_gauge"}},
+                    "required": ["price_per_unit_hour"],
+                    "not": {"required": ["price_per_unit"]}
+                },
+                {
+                    "properties": {"type": {"const": "counter"}},
+                    "required": ["price_per_unit"],
+                    "not": {"required": ["price_per_unit_hour"]}
+                }
+            ]
+        },
+        "price": {
+            "oneOf": [
+                {"type": "number", "minimum": 0},
+                {"type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$"}
+            ]
+        }
+    }
+}

--- a/internal/engine/pricing/pricing_integration_test.go
+++ b/internal/engine/pricing/pricing_integration_test.go
@@ -1,0 +1,539 @@
+package pricing_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/b42labs/tally/internal/engine/pricing"
+	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
+	"github.com/b42labs/tally/internal/engine/store/storetest"
+)
+
+// importBase is the version the import tests store first. Two dimensions give
+// a reordering something to reorder, and the counter price spelled "0.5" gives
+// a respelling something to respell.
+const importBase = `version: "2026-04"
+valid_from: "2026-04-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.5"
+`
+
+// importRespelled is importBase with the top-level keys in another order and
+// the counter price written as a number. It is a different file and a different
+// document, and it prices exactly what importBase prices.
+const importRespelled = `currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: 0.50
+valid_from: "2026-04-01T00:00:00Z"
+version: "2026-04"
+`
+
+// importChangedPrice raises the price of one dimension of importBase.
+const importChangedPrice = `version: "2026-04"
+valid_from: "2026-04-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.03"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.5"
+`
+
+// importAddedDimension prices one metric of importBase more.
+const importAddedDimension = `version: "2026-04"
+valid_from: "2026-04-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.5"
+`
+
+// importReordered lists the dimensions of importBase the other way around,
+// which reorders the rated records they produce.
+const importReordered = `version: "2026-04"
+valid_from: "2026-04-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.5"
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+`
+
+// importSameValidFrom is a version of its own starting at the instant
+// importBase starts at, which is the collision the unique key on valid_from
+// refuses.
+const importSameValidFrom = `version: "2026-04-fix"
+valid_from: "2026-04-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.03"
+`
+
+// monthlyModel is the smallest model that prices anything. The selection tests
+// import several of them, so the version, the instant and the price are filled
+// in per month.
+const monthlyModel = `version: %q
+valid_from: %q
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: %q
+`
+
+// month is one version built from monthlyModel.
+type month struct {
+	version   string
+	validFrom string
+	price     string
+}
+
+// storedRow is a pricing_models row as a test reads it back, past the package
+// under test, to see what an import wrote.
+type storedRow struct {
+	version    string
+	validFrom  time.Time
+	currency   string
+	document   []byte
+	importedAt time.Time
+}
+
+// parseModel parses a model a test imports and hands back the canonical
+// document beside it, which is what Import stores.
+func parseModel(t *testing.T, document string) (pricing.Model, []byte) {
+	t.Helper()
+
+	model, doc, err := pricing.Parse([]byte(document))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	return model, doc
+}
+
+// importMonths imports every month into a database that holds none of them and
+// returns the models by version.
+func importMonths(t *testing.T, q *sqlcgen.Queries, months ...month) map[string]pricing.Model {
+	t.Helper()
+
+	models := make(map[string]pricing.Model, len(months))
+	for _, m := range months {
+		model, doc := parseModel(t, fmt.Sprintf(monthlyModel, m.version, m.validFrom, m.price))
+		already, err := pricing.Import(t.Context(), q, model, doc)
+		if err != nil {
+			t.Fatalf("Import(%s) error = %v, want nil", m.version, err)
+		}
+		if already {
+			t.Fatalf("Import(%s) alreadyImported = true, want false for a version the database does not hold", m.version)
+		}
+		models[m.version] = model
+	}
+	return models
+}
+
+// readRow reads one stored version.
+func readRow(t *testing.T, db storetest.DB, version string) storedRow {
+	t.Helper()
+
+	var row storedRow
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		`SELECT version, valid_from, currency, document, imported_at FROM pricing_models WHERE version = $1`,
+		version,
+	).Scan(&row.version, &row.validFrom, &row.currency, &row.document, &row.importedAt); err != nil {
+		t.Fatalf("reading the stored pricing model %s: %v", version, err)
+	}
+	return row
+}
+
+// assertUnchanged fails when the row of want is no longer what want holds. A
+// refused import has to leave the stored version exactly as it was, down to
+// the instant it was imported at.
+func assertUnchanged(t *testing.T, db storetest.DB, want storedRow) {
+	t.Helper()
+
+	got := readRow(t, db, want.version)
+	if !got.validFrom.Equal(want.validFrom) || got.currency != want.currency ||
+		!bytes.Equal(got.document, want.document) || !got.importedAt.Equal(want.importedAt) {
+		t.Errorf("the stored row of %s = (%s, %s, %s, %s), want it unchanged at (%s, %s, %s, %s)",
+			want.version, got.validFrom, got.currency, got.document, got.importedAt,
+			want.validFrom, want.currency, want.document, want.importedAt)
+	}
+}
+
+// countModels is the number of stored versions.
+func countModels(t *testing.T, db storetest.DB) int {
+	t.Helper()
+
+	var count int
+	if err := db.Store.Pool().QueryRow(t.Context(), `SELECT count(*) FROM pricing_models`).Scan(&count); err != nil {
+		t.Fatalf("counting the stored pricing models: %v", err)
+	}
+	return count
+}
+
+// sameDocument reports whether two documents hold the same JSON. Postgres
+// stores jsonb as a parsed value and writes it back in its own key order, so
+// the comparison goes through a decode rather than over the bytes.
+func sameDocument(t *testing.T, got, want []byte) bool {
+	t.Helper()
+
+	return reflect.DeepEqual(decodeDocument(t, got), decodeDocument(t, want))
+}
+
+// decodeDocument decodes a document into the generic values the comparison
+// walks. Numbers keep the text they are written with, so a price is never
+// compared as a float.
+func decodeDocument(t *testing.T, doc []byte) any {
+	t.Helper()
+
+	dec := json.NewDecoder(bytes.NewReader(doc))
+	dec.UseNumber()
+
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		t.Fatalf("decoding the document %s: %v", doc, err)
+	}
+	return value
+}
+
+func TestImport(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	model, doc := parseModel(t, importBase)
+
+	already, err := pricing.Import(t.Context(), q, model, doc)
+	if err != nil {
+		t.Fatalf("Import() error = %v, want nil", err)
+	}
+	if already {
+		t.Error("Import() alreadyImported = true, want false for a version the database does not hold")
+	}
+
+	first := readRow(t, db, model.Version)
+	if !first.validFrom.Equal(model.ValidFrom) {
+		t.Errorf("valid_from = %s, want %s", first.validFrom, model.ValidFrom)
+	}
+	if first.currency != model.Currency {
+		t.Errorf("currency = %q, want %q", first.currency, model.Currency)
+	}
+	if !sameDocument(t, first.document, doc) {
+		t.Errorf("document = %s, want %s", first.document, doc)
+	}
+	if count := countModels(t, db); count != 1 {
+		t.Errorf("stored versions = %d, want 1", count)
+	}
+
+	// The version has to come back as the model it went in as: that round trip
+	// is what an import of an existing version is decided by.
+	stored, err := q.GetPricingModel(t.Context(), model.Version)
+	if err != nil {
+		t.Fatalf("GetPricingModel() error = %v, want nil", err)
+	}
+	storedModel, err := pricing.ParseDocument(stored.Document)
+	if err != nil {
+		t.Fatalf("ParseDocument() error = %v, want nil", err)
+	}
+	if !storedModel.Equal(model) {
+		t.Error("the stored model does not equal the imported one, want them equal")
+	}
+
+	t.Run("the same file again is a replay", func(t *testing.T) {
+		already, err := pricing.Import(t.Context(), q, model, doc)
+		if err != nil {
+			t.Fatalf("Import() error = %v, want nil", err)
+		}
+		if !already {
+			t.Error("Import() alreadyImported = false, want true for the version the database holds")
+		}
+		if count := countModels(t, db); count != 1 {
+			t.Errorf("stored versions = %d, want 1", count)
+		}
+		assertUnchanged(t, db, first)
+	})
+
+	t.Run("a respelled file of the same prices is a replay", func(t *testing.T) {
+		respelled, respelledDoc := parseModel(t, importRespelled)
+		if bytes.Equal(respelledDoc, doc) {
+			t.Fatalf("the respelled document equals the stored one, want the test to import other bytes: %s", respelledDoc)
+		}
+
+		already, err := pricing.Import(t.Context(), q, respelled, respelledDoc)
+		if err != nil {
+			t.Fatalf("Import() error = %v, want nil", err)
+		}
+		if !already {
+			t.Error("Import() alreadyImported = false, want true for a version that only respells its prices")
+		}
+		if count := countModels(t, db); count != 1 {
+			t.Errorf("stored versions = %d, want 1", count)
+		}
+		assertUnchanged(t, db, first)
+	})
+
+	t.Run("a changed version is refused", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			document string
+		}{
+			{"a changed price", importChangedPrice},
+			{"an added dimension", importAddedDimension},
+			{"reordered dimensions", importReordered},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				changed, changedDoc := parseModel(t, tc.document)
+
+				already, err := pricing.Import(t.Context(), q, changed, changedDoc)
+				if !errors.Is(err, pricing.ErrVersionConflict) {
+					t.Fatalf("Import() error = %v, want one matching ErrVersionConflict", err)
+				}
+				if !strings.Contains(err.Error(), changed.Version) {
+					t.Errorf("Import() error = %q, want it to name the version %q", err, changed.Version)
+				}
+				if already {
+					t.Error("Import() alreadyImported = true, want false beside a refused import")
+				}
+				assertUnchanged(t, db, first)
+			})
+		}
+	})
+
+	t.Run("a second version cannot start where a stored one starts", func(t *testing.T) {
+		other, otherDoc := parseModel(t, importSameValidFrom)
+
+		_, err := pricing.Import(t.Context(), q, other, otherDoc)
+		if err == nil {
+			t.Fatal("Import() error = nil, want the collision on valid_from reported")
+		}
+		if !strings.Contains(err.Error(), "valid_from") {
+			t.Errorf("Import() error = %q, want it to name valid_from", err)
+		}
+		// The instant is what the operator has to move, and naming it is also
+		// what tells the mapped collision from the driver's own text.
+		if want := other.ValidFrom.Format(time.RFC3339); !strings.Contains(err.Error(), want) {
+			t.Errorf("Import() error = %q, want it to name the instant %s the two versions share", err, want)
+		}
+		// The version is new, it is the instant it starts at that is taken, so
+		// nothing about it conflicts with the prices of another version.
+		if errors.Is(err, pricing.ErrVersionConflict) {
+			t.Error("Import() error matches ErrVersionConflict, want the collision reported as its own failure")
+		}
+		if _, err := q.GetPricingModel(t.Context(), other.Version); !errors.Is(err, pgx.ErrNoRows) {
+			t.Errorf("GetPricingModel(%s) error = %v, want pgx.ErrNoRows for a version that was refused",
+				other.Version, err)
+		}
+	})
+
+	t.Run("reports a database it cannot reach", func(t *testing.T) {
+		// A pool of its own: closing the one the test runs on would take the
+		// remaining reads and the cleanup with it.
+		pool, err := pgxpool.New(t.Context(), db.URL)
+		if err != nil {
+			t.Fatalf("opening a second pool: %v", err)
+		}
+		pool.Close()
+
+		_, err = pricing.Import(t.Context(), sqlcgen.New(pool), model, doc)
+		if err == nil {
+			t.Fatal("Import() error = nil, want the closed pool reported")
+		}
+		if errors.Is(err, pricing.ErrVersionConflict) || errors.Is(err, pricing.ErrNoModel) {
+			t.Errorf("Import() error = %v, want the database failure rather than one of the package's own", err)
+		}
+		if !strings.Contains(err.Error(), model.Version) {
+			t.Errorf("Import() error = %q, want it to name the version %q", err, model.Version)
+		}
+	})
+
+	t.Run("the committed example model round-trips", func(t *testing.T) {
+		example, exampleDoc := parseModel(t, string(readFile(t, examplePath)))
+
+		already, err := pricing.Import(t.Context(), q, example, exampleDoc)
+		if err != nil {
+			t.Fatalf("Import() error = %v, want nil", err)
+		}
+		if already {
+			t.Error("Import() alreadyImported = true, want false for a version the database does not hold")
+		}
+
+		// A file an operator actually holds, imported twice: reimporting one
+		// is the routine an unchanged version has to survive.
+		again, err := pricing.Import(t.Context(), q, example, exampleDoc)
+		if err != nil {
+			t.Fatalf("Import() error = %v, want nil", err)
+		}
+		if !again {
+			t.Error("Import() alreadyImported = false, want true for the version the database holds")
+		}
+	})
+}
+
+func TestForPeriod(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	models := importMonths(t, q,
+		month{"2026-01", "2026-01-01T00:00:00Z", "0.01"},
+		month{"2026-03", "2026-03-01T00:00:00Z", "0.03"},
+		month{"2026-05", "2026-05-01T00:00:00Z", "0.05"},
+	)
+
+	for _, tc := range []struct {
+		periodFrom time.Time
+		want       string
+	}{
+		// A period the newest version starts before is priced by that version
+		// and never by a later one.
+		{time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), "2026-01"},
+		// The instant a version becomes valid belongs to that version.
+		{time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), "2026-03"},
+		{time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "2026-03"},
+		{time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), "2026-05"},
+		{time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), "2026-05"},
+	} {
+		t.Run(tc.periodFrom.Format("2006-01"), func(t *testing.T) {
+			got, err := pricing.ForPeriod(t.Context(), q, tc.periodFrom)
+			if err != nil {
+				t.Fatalf("ForPeriod() error = %v, want nil", err)
+			}
+			if got.Version != tc.want {
+				t.Fatalf("ForPeriod() version = %q, want %q", got.Version, tc.want)
+			}
+			if !got.Equal(models[tc.want]) {
+				t.Error("ForPeriod() does not equal the imported model, want them equal")
+			}
+		})
+	}
+
+	t.Run("a period before every version has no model", func(t *testing.T) {
+		start := time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+
+		got, err := pricing.ForPeriod(t.Context(), q, start)
+		if !errors.Is(err, pricing.ErrNoModel) {
+			t.Fatalf("ForPeriod() error = %v, want one matching ErrNoModel", err)
+		}
+		if want := start.Format(time.RFC3339); !strings.Contains(err.Error(), want) {
+			t.Errorf("ForPeriod() error = %q, want it to name the period start %s", err, want)
+		}
+		if got.Version != "" {
+			t.Errorf("ForPeriod() version = %q, want the zero model beside the error", got.Version)
+		}
+	})
+
+	// Last, because it leaves a version behind that no longer reads. A stored
+	// document stops satisfying the schema when the schema is tightened under
+	// versions that were written before it, and what an operator needs then is
+	// the version to look at rather than a bare pointer into a document.
+	t.Run("names the version of a stored document it cannot read", func(t *testing.T) {
+		const version = "2026-05"
+		if _, err := db.Store.Pool().Exec(t.Context(),
+			`UPDATE pricing_models SET document = $2::jsonb WHERE version = $1`,
+			// Empty on purpose: what names the version in either error is the
+			// wrapping, not something the document still spells.
+			version, `{}`,
+		); err != nil {
+			t.Fatalf("overwriting the stored document of %s: %v", version, err)
+		}
+
+		start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+		if _, err := pricing.ForPeriod(t.Context(), q, start); err == nil {
+			t.Error("ForPeriod() error = nil, want the unreadable document reported")
+		} else if !strings.Contains(err.Error(), version) {
+			t.Errorf("ForPeriod() error = %q, want it to name the version %s", err, version)
+		}
+
+		// Import reads the stored document too, to tell a replay from a
+		// conflict, and one it cannot read is neither.
+		model, doc := parseModel(t, fmt.Sprintf(monthlyModel, version, "2026-05-01T00:00:00Z", "0.05"))
+		already, err := pricing.Import(t.Context(), q, model, doc)
+		if err == nil {
+			t.Error("Import() error = nil, want the unreadable document reported")
+		} else if !strings.Contains(err.Error(), version) {
+			t.Errorf("Import() error = %q, want it to name the version %s", err, version)
+		}
+		if already {
+			t.Error("Import() alreadyImported = true, want false beside a document that does not read")
+		}
+	})
+}
+
+func TestListPricingModels(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	// Imported out of order on purpose: the listing is chronological by
+	// valid_from, not by the order the versions were imported in.
+	importMonths(t, q,
+		month{"2026-05", "2026-05-01T00:00:00Z", "0.05"},
+		month{"2026-01", "2026-01-01T00:00:00Z", "0.01"},
+		month{"2026-03", "2026-03-01T00:00:00Z", "0.03"},
+	)
+
+	rows, err := q.ListPricingModels(t.Context())
+	if err != nil {
+		t.Fatalf("ListPricingModels() error = %v, want nil", err)
+	}
+
+	got := make([]string, 0, len(rows))
+	for _, row := range rows {
+		got = append(got, row.Version)
+	}
+	if want := []string{"2026-01", "2026-03", "2026-05"}; !slices.Equal(got, want) {
+		t.Errorf("ListPricingModels() = %v, want %v", got, want)
+	}
+}

--- a/internal/engine/pricing/pricing_test.go
+++ b/internal/engine/pricing/pricing_test.go
@@ -1,0 +1,752 @@
+package pricing_test
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/engine/pricing"
+)
+
+// examplePath is the model the concept gives as its example, committed at the
+// repository root. Parsing it here is what keeps the file and the schema from
+// drifting apart.
+const examplePath = "../../../pricing/2026-03.yaml"
+
+// oneDimension is the smallest model that prices anything. The spelling tests
+// vary the one price it carries.
+const oneDimension = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: %s
+`
+
+// twoDimensions is the model the equality test varies: one dimension of each
+// type and a modifier, so that a reordering has something to reorder.
+const twoDimensions = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.09"
+      state_modifiers:
+        shutoff: "0.50"
+`
+
+// readFile reads a file the test parses. It takes a testing.TB so that the fuzz
+// target can seed itself from the committed example the table tests parse.
+func readFile(t testing.TB, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return data
+}
+
+// dec builds the decimal a price is expected to carry. The tests construct
+// every price the way the parser does, from text.
+func dec(t *testing.T, text string) decimal.Decimal {
+	t.Helper()
+
+	value, err := decimal.NewFromString(text)
+	if err != nil {
+		t.Fatalf("decimal.NewFromString(%q): %v", text, err)
+	}
+	return value
+}
+
+// mustParse parses a model the test expects to hold.
+func mustParse(t *testing.T, document string) pricing.Model {
+	t.Helper()
+
+	model, _, err := pricing.Parse([]byte(document))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	return model
+}
+
+func TestParseExampleModel(t *testing.T) {
+	model, doc, err := pricing.Parse(readFile(t, examplePath))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	if len(doc) == 0 {
+		t.Error("Parse() document is empty, want the canonical document")
+	}
+
+	if model.Version != "2026-03" {
+		t.Errorf("Version = %q, want %q", model.Version, "2026-03")
+	}
+	if want := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC); !model.ValidFrom.Equal(want) {
+		t.Errorf("ValidFrom = %s, want %s", model.ValidFrom, want)
+	}
+	if model.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", model.Currency, "EUR")
+	}
+
+	wantPlatforms := []string{"gardener", "harbor", "hetzner", "ionos", "openstack", "stackit"}
+	if got := slices.Sorted(maps.Keys(model.Pricing)); !slices.Equal(got, wantPlatforms) {
+		t.Errorf("platforms = %v, want %v", got, wantPlatforms)
+	}
+
+	t.Run("the openstack instance is priced in file order", func(t *testing.T) {
+		instance := model.Pricing["openstack"]["instance"]
+
+		// The price the dimension's type does not carry stays zero, which is
+		// what the pairwise comparison below asserts for both of them.
+		want := []pricing.Dimension{
+			{Metric: "vcpus", Type: pricing.TypeTimeGauge, PricePerUnitHour: dec(t, "0.02")},
+			{Metric: "ram_gb", Type: pricing.TypeTimeGauge, PricePerUnitHour: dec(t, "0.005")},
+			{Metric: "disk_gb", Type: pricing.TypeTimeGauge, PricePerUnitHour: dec(t, "0.001")},
+			{Metric: "egress_gb", Type: pricing.TypeCounter, PricePerUnit: dec(t, "0.09")},
+		}
+		if len(instance.Dimensions) != len(want) {
+			t.Fatalf("Dimensions = %d, want %d", len(instance.Dimensions), len(want))
+		}
+		for i, w := range want {
+			got := instance.Dimensions[i]
+			if got.Metric != w.Metric || got.Type != w.Type {
+				t.Errorf("Dimensions[%d] = %s/%s, want %s/%s", i, got.Metric, got.Type, w.Metric, w.Type)
+			}
+			if !got.PricePerUnitHour.Equal(w.PricePerUnitHour) {
+				t.Errorf("Dimensions[%d].PricePerUnitHour = %s, want %s",
+					i, got.PricePerUnitHour, w.PricePerUnitHour)
+			}
+			if !got.PricePerUnit.Equal(w.PricePerUnit) {
+				t.Errorf("Dimensions[%d].PricePerUnit = %s, want %s", i, got.PricePerUnit, w.PricePerUnit)
+			}
+		}
+
+		wantModifiers := map[string]string{"shelved": "0.0", "shutoff": "0.5"}
+		if len(instance.StateModifiers) != len(wantModifiers) {
+			t.Errorf("StateModifiers = %v, want %v", instance.StateModifiers, wantModifiers)
+		}
+		for state, text := range wantModifiers {
+			got, ok := instance.StateModifiers[state]
+			if !ok {
+				t.Errorf("StateModifiers has no %q, want %s", state, text)
+				continue
+			}
+			if !got.Equal(dec(t, text)) {
+				t.Errorf("StateModifiers[%q] = %s, want %s", state, got, text)
+			}
+		}
+	})
+}
+
+func TestPriceSpellings(t *testing.T) {
+	asString := mustParse(t, fmt.Sprintf(oneDimension, `"0.02"`))
+	asNumber := mustParse(t, fmt.Sprintf(oneDimension, "0.02"))
+
+	// Which spelling the file uses is a matter of taste, so the two models have
+	// to price the same thing: a re-import that only requotes a price is the
+	// same version, not a conflicting one.
+	if !asString.Equal(asNumber) {
+		t.Error("the string-priced model does not equal the number-priced one, want them equal")
+	}
+
+	want := dec(t, "0.02")
+	for name, model := range map[string]pricing.Model{"as a string": asString, "as a number": asNumber} {
+		t.Run(name, func(t *testing.T) {
+			got := model.Pricing["openstack"]["instance"].Dimensions[0].PricePerUnitHour
+			if !got.Equal(want) {
+				t.Errorf("PricePerUnitHour = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestCanonicalDocumentRoundTrip(t *testing.T) {
+	data := readFile(t, examplePath)
+
+	model, doc, err := pricing.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	// A version read back from the database goes through ParseDocument alone,
+	// so it has to yield what the file yielded.
+	stored, err := pricing.ParseDocument(doc)
+	if err != nil {
+		t.Fatalf("ParseDocument() error = %v, want nil", err)
+	}
+	if !stored.Equal(model) {
+		t.Error("the model read back from the document does not equal the parsed one, want them equal")
+	}
+
+	// The document is what an import compares an existing version against, so
+	// the same file may not encode differently from one run to the next.
+	_, again, err := pricing.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	if !bytes.Equal(doc, again) {
+		t.Errorf("the second document is %s, want the first one %s", again, doc)
+	}
+}
+
+func TestParseFailures(t *testing.T) {
+	// A schema failure carries the compiler's own message, which names the
+	// keyword and the place in the document that failed. The operator who wrote
+	// the file has to be able to find the price at fault from it.
+	const schemaFailed = "validating the pricing model"
+
+	tests := []struct {
+		name     string
+		file     string
+		document string
+		want     []string
+	}{
+		{
+			name:     "a file with no content at all",
+			document: "",
+			want:     []string{schemaFailed, "got null, want object"},
+		},
+		{
+			name: "a model that is not a mapping",
+			file: "non-mapping-root.yaml",
+			want: []string{schemaFailed, "got array, want object"},
+		},
+		{
+			name: "a second document",
+			file: "second-document.yaml",
+			want: []string{"the file holds more than one document, the model belongs in the first"},
+		},
+		{
+			name: "a model without a version",
+			file: "missing-version.yaml",
+			want: []string{schemaFailed, "missing property 'version'"},
+		},
+		{
+			name: "a model without valid_from",
+			file: "missing-valid-from.yaml",
+			want: []string{schemaFailed, "missing property 'valid_from'"},
+		},
+		{
+			name: "a model without a currency",
+			file: "missing-currency.yaml",
+			want: []string{schemaFailed, "missing property 'currency'"},
+		},
+		{
+			name: "a model that prices nothing",
+			file: "missing-pricing.yaml",
+			want: []string{schemaFailed, "missing property 'pricing'"},
+		},
+		{
+			name: "a currency that is not ISO 4217",
+			file: "bad-currency.yaml",
+			want: []string{schemaFailed, "at '/currency'", "does not match pattern"},
+		},
+		{
+			name: "a pricing mapping without a platform",
+			file: "empty-pricing.yaml",
+			want: []string{schemaFailed, "at '/pricing'", "minProperties: got 0, want 1"},
+		},
+		{
+			name: "a resource type without dimensions",
+			file: "no-dimensions.yaml",
+			want: []string{schemaFailed, "missing property 'dimensions'"},
+		},
+		{
+			name: "a resource type with an empty list of dimensions",
+			file: "empty-dimensions.yaml",
+			want: []string{schemaFailed, "minItems: got 0, want 1"},
+		},
+		{
+			name: "a dimension type the rating pass does not know",
+			file: "unknown-dimension-type.yaml",
+			want: []string{schemaFailed, "value must be one of 'time_gauge', 'counter'"},
+		},
+		{
+			name: "a time_gauge that carries both prices",
+			file: "time-gauge-with-price-per-unit.yaml",
+			want: []string{schemaFailed, "at '/pricing/openstack/instance/dimensions/0': 'oneOf' failed"},
+		},
+		{
+			name: "a time_gauge that carries neither price",
+			file: "time-gauge-missing-price.yaml",
+			want: []string{schemaFailed, "missing property 'price_per_unit_hour'"},
+		},
+		{
+			name: "a counter that carries both prices",
+			file: "counter-with-price-per-unit-hour.yaml",
+			want: []string{schemaFailed, "at '/pricing/openstack/instance/dimensions/0': 'oneOf' failed"},
+		},
+		{
+			name: "a counter that carries neither price",
+			file: "counter-missing-price.yaml",
+			want: []string{schemaFailed, "missing property 'price_per_unit'"},
+		},
+		{
+			name: "a negative price spelled as a number",
+			file: "negative-price-number.yaml",
+			want: []string{schemaFailed, "minimum: got -0.02, want 0"},
+		},
+		{
+			name: "a negative price spelled as a string",
+			file: "negative-price-string.yaml",
+			want: []string{schemaFailed, "'-0.02' does not match pattern"},
+		},
+		{
+			name: "a negative modifier",
+			file: "negative-modifier.yaml",
+			want: []string{schemaFailed, "at '/pricing/openstack/instance/state_modifiers/shutoff'", "minimum: got -0.5"},
+		},
+		{
+			name: "a key the model form does not know",
+			file: "unknown-key.yaml",
+			want: []string{schemaFailed, "additional properties 'valid_until' not allowed"},
+		},
+		{
+			name: "a key inside a dimension that the model form does not know",
+			file: "unknown-dimension-key.yaml",
+			want: []string{schemaFailed, "additional properties 'price_per_unit_minute' not allowed"},
+		},
+		{
+			name: "one metric priced twice",
+			file: "duplicate-metric.yaml",
+			want: []string{"openstack", "instance", "vcpus"},
+		},
+		{
+			name: "a valid_from that is no timestamp",
+			file: "bad-valid-from.yaml",
+			want: []string{"valid_from", "March 2026"},
+		},
+		{
+			name: "a key set twice",
+			file: "repeated-key.yaml",
+			want: []string{`the key "currency" is set twice`},
+		},
+		{
+			// An unquoted timestamp is the mistake the format invites, so the
+			// refusal names the tag the scalar resolved to rather than leaving
+			// the operator to guess which of them to quote.
+			name: "an unquoted timestamp",
+			document: `version: "2026-03"
+valid_from: 2026-03-01T00:00:00Z
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+`,
+			want: []string{"!!timestamp", "quote it"},
+		},
+		{
+			// A tab where YAML wants spaces is the other mistake the format
+			// invites, and the decoder refuses it before there is a node to
+			// convert. What reaches the operator is the decoder's own message,
+			// under the line that says which step failed.
+			name:     "a file YAML cannot decode",
+			document: "version: \"2026-03\"\n\tcurrency: \"EUR\"\n",
+			want:     []string{"parsing the pricing model"},
+		},
+		{
+			name: "a mapping key that is not a string",
+			document: `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    1: {}
+`,
+			want: []string{"a mapping key is a !!int", "every key of the model is a string"},
+		},
+		{
+			// yaml.v3 registers an anchor before it parses the node it names,
+			// so an anchor can name a node that holds the alias itself. The
+			// expansion has to be refused rather than followed.
+			name: "an anchor that holds itself",
+			document: `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing: &a
+  openstack: *a
+`,
+			want: []string{`the anchor "a" holds itself`},
+		},
+		{
+			name:     "anchors that expand to more values than a model holds",
+			document: nestedAnchors(),
+			want:     []string{"expands to more than", "values, which is what nested anchors do"},
+		},
+		{
+			name:     "anchors that expand to more bytes than a model is",
+			document: aliasedScalar(),
+			want:     []string{"expands to more than", "bytes, which is what nested anchors do"},
+		},
+		{
+			name:     "anchors whose text is short and whose document is not",
+			document: escapedScalar(),
+			want:     []string{"expands to more than", "bytes, which is what nested anchors do"},
+		},
+		{
+			name:     "a model nested deeper than any model nests",
+			document: "root: " + strings.Repeat("[", 70) + strings.Repeat("]", 70) + "\n",
+			want:     []string{"nests more than", "no pricing model does"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(tc.document)
+			if tc.file != "" {
+				data = readFile(t, filepath.Join("testdata", tc.file))
+			}
+
+			_, doc, err := pricing.Parse(data)
+			if err == nil {
+				t.Fatal("Parse() error = nil, want the refusal")
+			}
+			if doc != nil {
+				t.Errorf("Parse() document = %s, want nil", doc)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Parse() error = %q, want it to contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestModelEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		other string
+		equal bool
+	}{
+		{
+			name:  "a modifier respelled as a number",
+			other: strings.Replace(twoDimensions, `shutoff: "0.50"`, "shutoff: 0.5", 1),
+			equal: true,
+		},
+		{
+			name: "the mapping keys written in another order",
+			other: `currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      state_modifiers:
+        shutoff: "0.50"
+      dimensions:
+        - type: "time_gauge"
+          price_per_unit_hour: "0.02"
+          metric: "vcpus"
+        - price_per_unit: "0.09"
+          metric: "egress_gb"
+          type: "counter"
+valid_from: "2026-03-01T00:00:00Z"
+version: "2026-03"
+`,
+			equal: true,
+		},
+		{
+			name:  "a changed price",
+			other: strings.Replace(twoDimensions, `price_per_unit_hour: "0.02"`, `price_per_unit_hour: "0.03"`, 1),
+			equal: false,
+		},
+		{
+			// What a state costs is as much of the model as what a metric
+			// costs: a corrected modifier is a corrected price.
+			name:  "a changed state modifier",
+			other: strings.Replace(twoDimensions, `shutoff: "0.50"`, `shutoff: "0.25"`, 1),
+			equal: false,
+		},
+		{
+			name: "a state modifier the other model does not name",
+			other: strings.Replace(twoDimensions, `        shutoff: "0.50"`,
+				`        shutoff: "0.50"
+        shelved: "0.0"`, 1),
+			equal: false,
+		},
+		{
+			name: "type modifiers where the other model has none",
+			other: twoDimensions + `      type_modifiers:
+        hdd: "0.5"
+`,
+			equal: false,
+		},
+		{
+			name:  "another currency",
+			other: strings.Replace(twoDimensions, `currency: "EUR"`, `currency: "USD"`, 1),
+			equal: false,
+		},
+		{
+			name:  "another valid_from",
+			other: strings.Replace(twoDimensions, `"2026-03-01T00:00:00Z"`, `"2026-03-02T00:00:00Z"`, 1),
+			equal: false,
+		},
+		{
+			name: "a platform the other model does not price",
+			other: twoDimensions + `  hetzner:
+    server:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.015"
+`,
+			equal: false,
+		},
+		{
+			name: "a resource type the other model does not price",
+			other: twoDimensions + `    volume:
+      dimensions:
+        - metric: "size_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.0001"
+`,
+			equal: false,
+		},
+		{
+			name: "one dimension more",
+			other: strings.Replace(twoDimensions, `      state_modifiers:`,
+				`        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+      state_modifiers:`, 1),
+			equal: false,
+		},
+		{
+			// The dimensions decide the order of the rated records a resource
+			// produces, so a reordering is a different model even though it
+			// prices the same metrics.
+			name: "the dimensions reordered",
+			other: `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.09"
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+      state_modifiers:
+        shutoff: "0.50"
+`,
+			equal: false,
+		},
+	}
+
+	base := mustParse(t, twoDimensions)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			other := mustParse(t, tc.other)
+
+			if got := base.Equal(other); got != tc.equal {
+				t.Errorf("Equal() = %t, want %t", got, tc.equal)
+			}
+			// Equality does not depend on which model is asked.
+			if got := other.Equal(base); got != tc.equal {
+				t.Errorf("Equal() the other way round = %t, want %t", got, tc.equal)
+			}
+		})
+	}
+}
+
+// nestedAnchors builds the file the expansion budget exists for: nine anchors,
+// each holding nine references to the one before it. It stays a few hundred
+// bytes on disk and names more values than a machine holds.
+func nestedAnchors() string {
+	var file strings.Builder
+	file.WriteString(`a0: &a0 "x"` + "\n")
+	for level := 1; level < 9; level++ {
+		fmt.Fprintf(&file, "a%d: &a%d [", level, level)
+		for i := range 9 {
+			if i > 0 {
+				file.WriteString(", ")
+			}
+			fmt.Fprintf(&file, "*a%d", level-1)
+		}
+		file.WriteString("]\n")
+	}
+	file.WriteString("pricing: *a8\n")
+	return file.String()
+}
+
+// aliasedScalar builds the file the byte budget exists for: one scalar of 64
+// KiB, named by an anchor three levels of sequences reference eight times each.
+// It visits a thousandth of the values the node budget allows, so counting
+// nodes never refuses it, and it marshals into more bytes than a model is.
+func aliasedScalar() string {
+	var file strings.Builder
+	fmt.Fprintf(&file, "a0: &a0 %q\n", strings.Repeat("x", 64<<10))
+	for level := 1; level < 4; level++ {
+		fmt.Fprintf(&file, "a%d: &a%d [", level, level)
+		for i := range 8 {
+			if i > 0 {
+				file.WriteString(", ")
+			}
+			fmt.Fprintf(&file, "*a%d", level-1)
+		}
+		file.WriteString("]\n")
+	}
+	file.WriteString("pricing: *a3\n")
+	return file.String()
+}
+
+// escapedScalar builds the file the byte budget is charged in escaped bytes
+// for: a scalar of 64 KiB of <, named by an anchor three levels of sequences
+// reference four times each. The text it writes is under 10 MiB, well inside
+// the budget, and encoding/json escapes every < into a six-byte \u003c, so the
+// document it marshals into is nearly 60 MiB.
+func escapedScalar() string {
+	var file strings.Builder
+	fmt.Fprintf(&file, "a0: &a0 %q\n", strings.Repeat("<", 64<<10))
+	for level := 1; level < 4; level++ {
+		fmt.Fprintf(&file, "a%d: &a%d [", level, level)
+		for i := range 4 {
+			if i > 0 {
+				file.WriteString(", ")
+			}
+			fmt.Fprintf(&file, "*a%d", level-1)
+		}
+		file.WriteString("]\n")
+	}
+	file.WriteString("pricing: *a3\n")
+	return file.String()
+}
+
+// anchoredModifiers writes the state modifiers of two resource types once, as
+// an anchor the second one reaches through an alias. It is how an operator
+// factors a modifier block their platforms share.
+const anchoredModifiers = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+      state_modifiers: &states
+        shutoff: "0.50"
+  hetzner:
+    server:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.015"
+      state_modifiers: *states
+`
+
+// expandedModifiers prices what anchoredModifiers prices, with the shared block
+// written out under both resource types.
+const expandedModifiers = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+      state_modifiers:
+        shutoff: "0.50"
+  hetzner:
+    server:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.015"
+      state_modifiers:
+        shutoff: "0.50"
+`
+
+func TestAliasesExpand(t *testing.T) {
+	anchored, anchoredDoc, err := pricing.Parse([]byte(anchoredModifiers))
+	if err != nil {
+		t.Fatalf("Parse() of the anchored file error = %v, want nil", err)
+	}
+	expanded, expandedDoc, err := pricing.Parse([]byte(expandedModifiers))
+	if err != nil {
+		t.Fatalf("Parse() of the expanded file error = %v, want nil", err)
+	}
+
+	// An alias is a spelling, not a price. Whichever of the two files an
+	// operator keeps, importing the other one has to be a replay of the same
+	// version rather than a conflict, and that is decided on the document.
+	if !bytes.Equal(anchoredDoc, expandedDoc) {
+		t.Errorf("the anchored document is %s, want the expanded one %s", anchoredDoc, expandedDoc)
+	}
+	if !anchored.Equal(expanded) {
+		t.Error("the anchored model does not equal the expanded one, want them equal")
+	}
+
+	modifier, ok := anchored.Pricing["hetzner"]["server"].StateModifiers["shutoff"]
+	if !ok {
+		t.Fatal("the aliased resource type carries no shutoff modifier, want the anchor expanded")
+	}
+	if want := dec(t, "0.50"); !modifier.Equal(want) {
+		t.Errorf("StateModifiers[shutoff] = %s, want %s", modifier, want)
+	}
+}
+
+// FuzzParse drives the parser's trust boundary. What reaches it is whatever
+// file an operator pointed the import at, and the invariant is that such a file
+// either parses or is refused: a parse that panicked, ran out of memory, or ran
+// off the stack takes the import command down instead of naming the line that
+// is wrong. A model that parsed carries the document it was built from, and
+// that document has to yield the same model again, because an import of a
+// version the database already holds is decided on that round trip.
+func FuzzParse(f *testing.F) {
+	f.Add(readFile(f, examplePath))
+	f.Add([]byte(twoDimensions))
+	f.Add([]byte(anchoredModifiers))
+	f.Add([]byte(fmt.Sprintf(oneDimension, `"0.02"`)))
+	f.Add([]byte(""))
+	f.Add([]byte("not yaml: ["))
+	f.Add([]byte("a: &x\n  b: *x\n"))
+	f.Add([]byte(nestedAnchors()))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		model, doc, err := pricing.Parse(data)
+		if err != nil {
+			if doc != nil {
+				t.Errorf("Parse() document = %s beside an error, want nil", doc)
+			}
+			return
+		}
+
+		again, err := pricing.ParseDocument(doc)
+		if err != nil {
+			t.Fatalf("ParseDocument() of a document Parse produced: %v", err)
+		}
+		if !again.Equal(model) {
+			t.Error("the model read back from the document does not equal the parsed one, want them equal")
+		}
+	})
+}

--- a/internal/engine/pricing/store.go
+++ b/internal/engine/pricing/store.go
@@ -1,0 +1,110 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
+)
+
+// ErrVersionConflict is what Import returns for a version the database already
+// holds under other prices. An invoice names the version it was rated from and
+// has to stay reproducible from it, so a stored version keeps pricing what it
+// priced when the invoice was written.
+var ErrVersionConflict = errors.New(
+	"this version is already imported and prices something else, and a corrected price belongs in a new version")
+
+// ErrNoModel is what ForPeriod returns for a period that begins before every
+// stored version. Nothing prices it, and rating it against no model would bill
+// every metered resource at zero rather than say what is missing.
+var ErrNoModel = errors.New("no pricing model is valid for this period")
+
+// The unique key over valid_from, as Postgres names it and as it reports a
+// write that breaks it. Matching the constraint rather than the SQLSTATE alone
+// is what keeps another unique violation from being reported as two versions
+// claiming one instant.
+const (
+	uniqueViolation     = "23505"
+	validFromConstraint = "pricing_models_valid_from_key"
+)
+
+// Import stores one version of the pricing model and reports whether the
+// database already held it. It only ever inserts: the document a version was
+// rated from is the document that stays stored under it, and a price that
+// changes is imported under a new version instead of over an old one.
+//
+// A version the database does not hold is written and Import returns false. A
+// version it holds is read back and compared against m: equal models make the
+// import a replay, which returns true and leaves the row alone, and unequal
+// ones an error wrapping ErrVersionConflict. A second version claiming the
+// valid_from of a stored one is refused too, because one instant is priced by
+// one version. That collision is its own error rather than a version conflict:
+// the version is new, it is the instant it starts at that is taken.
+func Import(ctx context.Context, q *sqlcgen.Queries, m Model, doc []byte) (bool, error) {
+	inserted, err := q.InsertPricingModel(ctx, sqlcgen.InsertPricingModelParams{
+		Version:   m.Version,
+		ValidFrom: pgtype.Timestamptz{Time: m.ValidFrom, Valid: true},
+		Currency:  m.Currency,
+		Document:  doc,
+	})
+	if err != nil {
+		// The insert passes over a collision on the version, so valid_from is
+		// the only unique key a write still breaks.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation && pgErr.ConstraintName == validFromConstraint {
+			return false, fmt.Errorf(
+				"importing pricing model %s: another version already starts at valid_from %s, and one instant is priced by one version",
+				m.Version, m.ValidFrom.UTC().Format(time.RFC3339))
+		}
+		return false, fmt.Errorf("importing pricing model %s: %w", m.Version, err)
+	}
+	if inserted > 0 {
+		return false, nil
+	}
+
+	// Nothing was written, so the version is stored already. What tells a
+	// replay from a conflict is the document under it, read back through the
+	// same schema and the same parse the file went through.
+	stored, err := q.GetPricingModel(ctx, m.Version)
+	if err != nil {
+		return false, fmt.Errorf("reading the stored pricing model %s: %w", m.Version, err)
+	}
+	storedModel, err := ParseDocument(stored.Document)
+	if err != nil {
+		return false, fmt.Errorf("reading the stored pricing model %s: %w", m.Version, err)
+	}
+	if !storedModel.Equal(m) {
+		return false, fmt.Errorf("importing pricing model %s: %w", m.Version, ErrVersionConflict)
+	}
+	return true, nil
+}
+
+// ForPeriod returns the version that prices the period beginning at
+// periodFrom: the newest one whose valid_from is at or before that instant. A
+// version that becomes valid later prices later periods only, so importing the
+// prices of April does not reprice March.
+//
+// A period that begins before every stored version yields an error wrapping
+// ErrNoModel.
+func ForPeriod(ctx context.Context, q *sqlcgen.Queries, periodFrom time.Time) (Model, error) {
+	row, err := q.PricingModelForPeriod(ctx, pgtype.Timestamptz{Time: periodFrom, Valid: true})
+	if err != nil {
+		start := periodFrom.UTC().Format(time.RFC3339)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Model{}, fmt.Errorf("selecting the pricing model for the period beginning %s: %w", start, ErrNoModel)
+		}
+		return Model{}, fmt.Errorf("selecting the pricing model for the period beginning %s: %w", start, err)
+	}
+
+	model, err := ParseDocument(row.Document)
+	if err != nil {
+		return Model{}, fmt.Errorf("reading the stored pricing model %s: %w", row.Version, err)
+	}
+	return model, nil
+}

--- a/internal/engine/pricing/testdata/bad-currency.yaml
+++ b/internal/engine/pricing/testdata/bad-currency.yaml
@@ -1,0 +1,12 @@
+# The currency is not the ISO 4217 spelling.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "eur"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/bad-valid-from.yaml
+++ b/internal/engine/pricing/testdata/bad-valid-from.yaml
@@ -1,0 +1,12 @@
+# valid_from is a string, but not an RFC 3339 timestamp.
+version: "2026-03"
+valid_from: "March 2026"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/counter-missing-price.yaml
+++ b/internal/engine/pricing/testdata/counter-missing-price.yaml
@@ -1,0 +1,11 @@
+# The counter dimension carries neither price.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "egress_gb"
+          type: "counter"

--- a/internal/engine/pricing/testdata/counter-with-price-per-unit-hour.yaml
+++ b/internal/engine/pricing/testdata/counter-with-price-per-unit-hour.yaml
@@ -1,0 +1,13 @@
+# The counter dimension carries both prices.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.09"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/duplicate-metric.yaml
+++ b/internal/engine/pricing/testdata/duplicate-metric.yaml
@@ -1,0 +1,15 @@
+# The resource type prices one metric twice.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "vcpus"
+          type: "counter"
+          price_per_unit: "0.09"

--- a/internal/engine/pricing/testdata/empty-dimensions.yaml
+++ b/internal/engine/pricing/testdata/empty-dimensions.yaml
@@ -1,0 +1,9 @@
+# The resource type lists no dimension.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions: []

--- a/internal/engine/pricing/testdata/empty-pricing.yaml
+++ b/internal/engine/pricing/testdata/empty-pricing.yaml
@@ -1,0 +1,6 @@
+# The pricing mapping holds no platform.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing: {}

--- a/internal/engine/pricing/testdata/missing-currency.yaml
+++ b/internal/engine/pricing/testdata/missing-currency.yaml
@@ -1,0 +1,11 @@
+# The model names no currency.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/missing-pricing.yaml
+++ b/internal/engine/pricing/testdata/missing-pricing.yaml
@@ -1,0 +1,4 @@
+# The model prices nothing at all.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"

--- a/internal/engine/pricing/testdata/missing-valid-from.yaml
+++ b/internal/engine/pricing/testdata/missing-valid-from.yaml
@@ -1,0 +1,11 @@
+# The model says nothing about when it becomes valid.
+version: "2026-03"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/missing-version.yaml
+++ b/internal/engine/pricing/testdata/missing-version.yaml
@@ -1,0 +1,11 @@
+# The model names no version.
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/negative-modifier.yaml
+++ b/internal/engine/pricing/testdata/negative-modifier.yaml
@@ -1,0 +1,14 @@
+# The state modifier is negative, which would credit the resource.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+      state_modifiers:
+        shutoff: -0.5

--- a/internal/engine/pricing/testdata/negative-price-number.yaml
+++ b/internal/engine/pricing/testdata/negative-price-number.yaml
@@ -1,0 +1,12 @@
+# The price is negative, spelled as a number.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: -0.02

--- a/internal/engine/pricing/testdata/negative-price-string.yaml
+++ b/internal/engine/pricing/testdata/negative-price-string.yaml
@@ -1,0 +1,12 @@
+# The price is negative, spelled as a string.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "-0.02"

--- a/internal/engine/pricing/testdata/no-dimensions.yaml
+++ b/internal/engine/pricing/testdata/no-dimensions.yaml
@@ -1,0 +1,10 @@
+# The resource type carries modifiers but no dimension to apply them to.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      state_modifiers:
+        shutoff: "0.5"

--- a/internal/engine/pricing/testdata/non-mapping-root.yaml
+++ b/internal/engine/pricing/testdata/non-mapping-root.yaml
@@ -1,0 +1,11 @@
+# The model is a sequence rather than a mapping.
+- version: "2026-03"
+  valid_from: "2026-03-01T00:00:00Z"
+  currency: "EUR"
+  pricing:
+    openstack:
+      instance:
+        dimensions:
+          - metric: "vcpus"
+            type: "time_gauge"
+            price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/repeated-key.yaml
+++ b/internal/engine/pricing/testdata/repeated-key.yaml
@@ -1,0 +1,13 @@
+# The currency was corrected in place, leaving the key set twice.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+currency: "USD"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/second-document.yaml
+++ b/internal/engine/pricing/testdata/second-document.yaml
@@ -1,0 +1,24 @@
+# A second platform was appended as its own document.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+---
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  harbor:
+    repository:
+      dimensions:
+        - metric: "storage_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.00005"

--- a/internal/engine/pricing/testdata/time-gauge-missing-price.yaml
+++ b/internal/engine/pricing/testdata/time-gauge-missing-price.yaml
@@ -1,0 +1,11 @@
+# The time_gauge dimension carries neither price.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"

--- a/internal/engine/pricing/testdata/time-gauge-with-price-per-unit.yaml
+++ b/internal/engine/pricing/testdata/time-gauge-with-price-per-unit.yaml
@@ -1,0 +1,13 @@
+# The time_gauge dimension carries both prices.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+          price_per_unit: "0.09"

--- a/internal/engine/pricing/testdata/unknown-dimension-key.yaml
+++ b/internal/engine/pricing/testdata/unknown-dimension-key.yaml
@@ -1,0 +1,13 @@
+# The dimension carries a key the model form does not know.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+          price_per_unit_minute: "0.0003"

--- a/internal/engine/pricing/testdata/unknown-dimension-type.yaml
+++ b/internal/engine/pricing/testdata/unknown-dimension-type.yaml
@@ -1,0 +1,12 @@
+# The dimension names a type the rating pass does not know.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/pricing/testdata/unknown-key.yaml
+++ b/internal/engine/pricing/testdata/unknown-key.yaml
@@ -1,0 +1,13 @@
+# The root carries a key the model form does not know.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+valid_until: "2026-04-01T00:00:00Z"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"

--- a/internal/engine/rating/rating.go
+++ b/internal/engine/rating/rating.go
@@ -1,0 +1,346 @@
+// Package rating turns the usage drafts of a billing period into amounts: one
+// per draft and dimension of the pricing entry its resource type carries. Rate
+// is a pure function. It reads nothing and writes nothing, so a period is rated
+// from the drafts a caller already holds and the model version that caller
+// resolved.
+//
+// The arithmetic follows roadmap/00-conventions.md section 6. Values are
+// decimals throughout, the one division is money.Div, and the one rounding is
+// money.Round2, applied per dimension per record. Every aggregate a later pass
+// builds is a sum of those rounded amounts, so a total equals the sum of the
+// line items shown beside it.
+//
+// A resource type the model does not price is not billed as free. The resource
+// is skipped and its type is counted in Result.Unpriced, which reaches an
+// operator as a warning in the run's stats. A usage field that holds a value
+// nothing can be read as a number is counted in Result.Unreadable the same way:
+// it is billed as zero, and a line item short by a whole metric has to be
+// visible rather than pass for a resource that consumed nothing.
+//
+// The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.6.
+package rating
+
+import (
+	"cmp"
+	"encoding/json"
+	"slices"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/metering"
+	"github.com/b42labs/tally/internal/engine/pricing"
+	"github.com/b42labs/tally/internal/engine/source"
+)
+
+// The two usage fields rating reads by name rather than because a dimension
+// prices them: the minutes a time_gauge dimension is billed over, which
+// metering writes into every draft under usageMinutes in
+// internal/engine/metering/metering.go, and the size field whose value selects
+// a type modifier. Renaming either one there renames it here.
+const (
+	usageMinutes = "minutes"
+	usageType    = "type"
+)
+
+var (
+	// minutesPerHour converts a draft's minutes into the hours a price per unit
+	// and hour is quoted in.
+	minutesPerHour = decimal.NewFromInt(60)
+	// unmodified is what a state or type the pricing entry does not name is
+	// billed with.
+	unmodified = decimal.NewFromInt(1)
+)
+
+// Result is what one rating pass produced: the amounts of every priced
+// resource, the resource types no price was found for, and the usage fields
+// that held a value no quantity could be read from.
+type Result struct {
+	// Currency is the currency of the model the amounts were rated with. A
+	// model version carries one currency, so every amount here is in it.
+	Currency string
+	// Resources holds one entry per priced resource, in the order the resources
+	// came in. A resource whose type is not priced is not among them.
+	Resources []ResourceRating
+	// Unpriced counts the skipped resources per platform and resource type,
+	// sorted by platform and then by resource type.
+	Unpriced []UnpricedResourceType
+	// Unreadable counts the drafts whose usage held an unreadable value, per
+	// platform, resource type, and field, sorted the same way.
+	Unreadable []UnreadableQuantity
+}
+
+// ResourceRating is one resource and what its drafts are billed as. Records is
+// index-aligned with the drafts it was rated from: Records[i] rates Drafts[i].
+type ResourceRating struct {
+	Resource source.Resource
+	Records  []RecordRating
+}
+
+// RecordRating is one usage draft rated: one amount per dimension of the
+// resource type's pricing entry, in the order the entry lists them.
+type RecordRating struct {
+	Amounts []DimensionAmount
+}
+
+// DimensionAmount is what one dimension of one record costs, rounded with
+// money.Round2. A dimension whose metric the record carries no quantity for is
+// billed as zero and still emitted, so a record shows every dimension it was
+// held against.
+type DimensionAmount struct {
+	Metric string
+	Amount decimal.Decimal
+}
+
+// UnpricedResourceType is a resource type the model does not price, and how
+// many resources of it were skipped. Count counts resources, not their drafts.
+// The run writes the slice into runs.stats.unpriced, which is what the JSON
+// tags name the fields for.
+type UnpricedResourceType struct {
+	Platform     string `json:"platform"`
+	ResourceType string `json:"resource_type"`
+	Count        int    `json:"count"`
+}
+
+// UnreadableQuantity is a usage field a draft held a value under that no
+// quantity could be read from: a size a collector sent as a flavor name, say,
+// which the size schema of its resource type lets through. The field is billed
+// the way an absent one is, at zero, so the run names it rather than leave an
+// invoice short by a whole line with nothing to say so. Count counts drafts,
+// not the dimensions the field was read for. The run writes the slice into
+// runs.stats.unreadable, which is what the JSON tags name the fields for.
+type UnreadableQuantity struct {
+	Platform     string `json:"platform"`
+	ResourceType string `json:"resource_type"`
+	Field        string `json:"field"`
+	Count        int    `json:"count"`
+}
+
+// unpricedKey is the pair Unpriced counts by while the pass runs.
+type unpricedKey struct {
+	platform     string
+	resourceType string
+}
+
+// unreadableKey is the triple Unreadable counts by while the pass runs.
+type unreadableKey struct {
+	platform     string
+	resourceType string
+	field        string
+}
+
+// Rate rates every resource against the model. It returns no error: a resource
+// type the model does not price is reported in Result.Unpriced, a value no
+// quantity reads from in Result.Unreadable, and a quantity a draft does not
+// carry at all is billed as zero, which are the three things that can still be
+// missing once a model has been imported.
+//
+// State and type modifiers apply to time_gauge dimensions only. A counter
+// dimension is the measured quantity times the price of a unit, whatever state
+// the record was in: a gigabyte of egress costs what it costs, however the
+// resource it left was running.
+func Rate(model pricing.Model, resources []metering.ResourceUsage) Result {
+	result := Result{Currency: model.Currency}
+	unpriced := make(map[unpricedKey]int)
+	unreadable := make(map[unreadableKey]int)
+
+	for _, resource := range resources {
+		entry, ok := model.Pricing[resource.Resource.Platform][resource.Resource.ResourceType]
+		if !ok {
+			unpriced[unpricedKey{resource.Resource.Platform, resource.Resource.ResourceType}]++
+			continue
+		}
+
+		records := make([]RecordRating, 0, len(resource.Drafts))
+		for _, draft := range resource.Drafts {
+			amounts, fields := rateDraft(entry, draft)
+			records = append(records, RecordRating{Amounts: amounts})
+			for _, field := range fields {
+				unreadable[unreadableKey{
+					resource.Resource.Platform, resource.Resource.ResourceType, field,
+				}]++
+			}
+		}
+		result.Resources = append(result.Resources, ResourceRating{
+			Resource: resource.Resource,
+			Records:  records,
+		})
+	}
+
+	for key, count := range unpriced {
+		result.Unpriced = append(result.Unpriced, UnpricedResourceType{
+			Platform:     key.platform,
+			ResourceType: key.resourceType,
+			Count:        count,
+		})
+	}
+	slices.SortFunc(result.Unpriced, func(a, b UnpricedResourceType) int {
+		return cmp.Or(
+			cmp.Compare(a.Platform, b.Platform),
+			cmp.Compare(a.ResourceType, b.ResourceType),
+		)
+	})
+
+	for key, count := range unreadable {
+		result.Unreadable = append(result.Unreadable, UnreadableQuantity{
+			Platform:     key.platform,
+			ResourceType: key.resourceType,
+			Field:        key.field,
+			Count:        count,
+		})
+	}
+	slices.SortFunc(result.Unreadable, func(a, b UnreadableQuantity) int {
+		return cmp.Or(
+			cmp.Compare(a.Platform, b.Platform),
+			cmp.Compare(a.ResourceType, b.ResourceType),
+			cmp.Compare(a.Field, b.Field),
+		)
+	})
+
+	return result
+}
+
+// rateDraft rates one draft against the pricing entry of its resource type, in
+// the order the entry lists its dimensions. Beside the amounts it returns the
+// usage fields it found a value under that it could not read, each named once
+// however many dimensions were rated from it.
+func rateDraft(entry pricing.ResourcePricing, draft metering.UsageDraft) ([]DimensionAmount, []string) {
+	var unreadable []string
+	note := func(field string) {
+		if !slices.Contains(unreadable, field) {
+			unreadable = append(unreadable, field)
+		}
+	}
+
+	stateModifier := modifierOr1(entry.StateModifiers, draft.State)
+	typeModifier := unmodified
+	// A size field named type is what the type modifiers of volumes and ionos
+	// servers key on. A resource that carries no type at all has none to be
+	// modified by; one that carries a type nothing reads as a name is billed
+	// unmodified, at a price the operator wrote for no type, so the run names
+	// the field.
+	if value, held := draft.Usage[usageType]; held && value != nil {
+		if name, isName := value.(string); isName {
+			typeModifier = modifierOr1(entry.TypeModifiers, name)
+		} else {
+			note(usageType)
+		}
+	}
+
+	amounts := make([]DimensionAmount, 0, len(entry.Dimensions))
+	for _, dimension := range entry.Dimensions {
+		quantity, readable := quantityOf(draft.Usage, dimension.Metric)
+		if !readable {
+			note(dimension.Metric)
+		}
+
+		// A dimension type the schema does not allow cannot reach here, and
+		// would be billed as zero rather than at a price it does not carry.
+		var cost decimal.Decimal
+		switch dimension.Type {
+		case pricing.TypeTimeGauge:
+			minutes, readable := quantityOf(draft.Usage, usageMinutes)
+			if !readable {
+				note(usageMinutes)
+			}
+			hours := money.Div(minutes, minutesPerHour)
+			cost = hours.Mul(quantity).
+				Mul(dimension.PricePerUnitHour).
+				Mul(stateModifier).
+				Mul(typeModifier)
+		case pricing.TypeCounter:
+			cost = quantity.Mul(dimension.PricePerUnit)
+		}
+
+		amounts = append(amounts, DimensionAmount{
+			Metric: dimension.Metric,
+			Amount: money.Round2(cost),
+		})
+	}
+	return amounts, unreadable
+}
+
+// modifierOr1 is the modifier a key carries, or one where the entry names
+// neither that key nor any modifier at all.
+func modifierOr1(modifiers map[string]decimal.Decimal, key string) decimal.Decimal {
+	if modifier, ok := modifiers[key]; ok {
+		return modifier
+	}
+	return unmodified
+}
+
+// quantityOf reads one quantity out of a draft's usage map. The map holds what
+// metering put there, which is the quantities the engine derived beside the
+// size fields the payload envelope decoded, so a JSON number arrives as a
+// float64. A float never reaches decimal.NewFromFloat: it goes through the
+// shortest text that round-trips it, which is the text encoding/json writes the
+// same value back out as.
+//
+// A string holding digits is a quantity too. It is the spelling a collector
+// reaches for when a size outgrows the range a float64 holds exactly, and a
+// size schema that says nothing about the field, which is what the shipped ones
+// do, lets it through. A price is accepted in both spellings for the same
+// reason, so a quantity spelled that way is read rather than billed at zero.
+//
+// A metric the map does not hold, a metric it holds a null under, and a nil map
+// are zero and readable: nothing was reported, and the dimension is rated at
+// 0.00. A value nothing reads a number from, a flavor name or a boolean, is
+// zero and unreadable, which is what tells a resource that consumed nothing
+// from one whose quantity arrived in a form nothing bills from.
+func quantityOf(usage map[string]any, metric string) (decimal.Decimal, bool) {
+	switch value := usage[metric].(type) {
+	case money.Quantity:
+		return value.Decimal, true
+	case decimal.Decimal:
+		return value, true
+	case int:
+		return decimal.NewFromInt(int64(value)), true
+	case int64:
+		return decimal.NewFromInt(value), true
+	case json.Number:
+		return fromText(value.String())
+	case float64:
+		return fromText(strconv.FormatFloat(value, 'g', -1, 64))
+	case string:
+		return fromText(value)
+	case nil:
+		return decimal.Decimal{}, true
+	default:
+		return decimal.Decimal{}, false
+	}
+}
+
+// The bounds fromText holds a quantity read from text to. Neither is reached by
+// a size a collector reports: a byte count of the largest volume anyone sells
+// is twenty digits and carries no exponent at all.
+//
+// A decimal is a big.Int and an exponent, so 1e2000000000 parses cheaply and
+// materialises 10^2000000000 the first time it is rounded, and 1e-2147483648
+// panics rather than round at all, because multiplying it underflows the int32
+// the exponent is held in. Rate returns no error and recovers from nothing, so
+// the ingested payload the quantity came from would crash every run over its
+// period until someone deleted the event by hand. The bound belongs where the
+// text is read rather than where the arithmetic runs.
+const (
+	maxQuantityExponent = 1000
+	maxQuantityText     = 64
+)
+
+// fromText parses the text of a quantity. Text neither spelling produces is
+// zero and unreadable, and so is text that spells a quantity past the bounds
+// above: a quantity that cannot be read is not one to bill at a guess, and not
+// one to pass off as absent either.
+func fromText(text string) (decimal.Decimal, bool) {
+	if len(text) > maxQuantityText {
+		return decimal.Decimal{}, false
+	}
+	value, err := decimal.NewFromString(text)
+	if err != nil {
+		return decimal.Decimal{}, false
+	}
+	if exponent := value.Exponent(); exponent > maxQuantityExponent || exponent < -maxQuantityExponent {
+		return decimal.Decimal{}, false
+	}
+	return value, true
+}

--- a/internal/engine/rating/rating_test.go
+++ b/internal/engine/rating/rating_test.go
@@ -1,0 +1,540 @@
+package rating_test
+
+import (
+	"encoding/json"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/metering"
+	"github.com/b42labs/tally/internal/engine/pricing"
+	"github.com/b42labs/tally/internal/engine/rating"
+	"github.com/b42labs/tally/internal/engine/source"
+)
+
+// conceptModel is the openstack part of the model the concept gives as its
+// example. The cases below parse it rather than building a pricing.Model by
+// hand, so what is rated is what an operator's file yields.
+const conceptModel = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+        - metric: "disk_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.001"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.09"
+      state_modifiers:
+        shelved: "0.0"
+        shutoff: "0.5"
+    volume:
+      dimensions:
+        - metric: "size_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.0001"
+      type_modifiers:
+        ssd: "1.0"
+        hdd: "0.5"
+    floating_ip:
+      dimensions:
+        - metric: "count"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+`
+
+// counterModel prices one counter metric at one unit of currency, so a rated
+// amount is the quantity the usage map was read as.
+const counterModel = `version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+pricing:
+  openstack:
+    bucket:
+      dimensions:
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "1"
+`
+
+// The resources the cases rate. Only the platform and the resource type select
+// a pricing entry; the rest travels through the pass untouched.
+var (
+	instance   = source.Resource{Cloud: "prod", Platform: "openstack", ResourceType: "instance", ResourceID: "abc-123"}
+	volume     = source.Resource{Cloud: "prod", Platform: "openstack", ResourceType: "volume", ResourceID: "vol-1"}
+	floatingIP = source.Resource{Cloud: "prod", Platform: "openstack", ResourceType: "floating_ip", ResourceID: "fip-1"}
+	bucket     = source.Resource{Cloud: "prod", Platform: "openstack", ResourceType: "bucket", ResourceID: "buck-1"}
+)
+
+// mustParse parses a model the case expects to hold.
+func mustParse(t *testing.T, document string) pricing.Model {
+	t.Helper()
+
+	model, _, err := pricing.Parse([]byte(document))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	return model
+}
+
+// draft builds a usage draft the way metering builds one: the size fields of
+// the interval, plus the minutes its seconds are worth and the count of one
+// that prices a resource by its existence.
+func draft(state string, minutes int64, size map[string]any) metering.UsageDraft {
+	seconds := minutes * 60
+	usage := map[string]any{
+		"minutes": money.NewQuantity(money.Minutes(seconds)),
+		"count":   1,
+	}
+	maps.Copy(usage, size)
+
+	return metering.UsageDraft{
+		State:     state,
+		ProjectID: "proj-456",
+		Seconds:   seconds,
+		Usage:     usage,
+	}
+}
+
+// instanceSize is the m1.large of the concept's example, spelled the way the
+// payload envelope decodes a size: every JSON number is a float64.
+func instanceSize(egressGB float64) map[string]any {
+	return map[string]any{
+		"vcpus":     float64(4),
+		"ram_gb":    float64(8),
+		"disk_gb":   float64(80),
+		"egress_gb": egressGB,
+	}
+}
+
+// wantAmount is one expected amount: the metric it is rated under, and the text
+// the expected decimal is built from.
+type wantAmount struct {
+	metric string
+	amount string
+}
+
+// assertAmounts holds a record's amounts against the dimensions and values it
+// is expected to carry, in order. Decimals are compared by value, so 19.20 and
+// 19.2 are the same amount.
+func assertAmounts(t *testing.T, got []rating.DimensionAmount, want []wantAmount) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("amounts = %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Metric != w.metric {
+			t.Errorf("amount %d is the metric %q, want %q", i, got[i].Metric, w.metric)
+			continue
+		}
+		if expected := decimal.RequireFromString(w.amount); !got[i].Amount.Equal(expected) {
+			t.Errorf("%s = %s, want %s", w.metric, got[i].Amount, w.amount)
+		}
+	}
+}
+
+// rateOne rates the drafts of a single resource and returns its records. It
+// fails the case where the resource type was not priced.
+func rateOne(t *testing.T, model pricing.Model, resource source.Resource, drafts ...metering.UsageDraft) []rating.RecordRating {
+	t.Helper()
+
+	result := rating.Rate(model, []metering.ResourceUsage{{Resource: resource, Drafts: drafts}})
+	if len(result.Resources) != 1 {
+		t.Fatalf("Resources = %d, want 1 (unpriced: %v)", len(result.Resources), result.Unpriced)
+	}
+	if got := len(result.Resources[0].Records); got != len(drafts) {
+		t.Fatalf("Records = %d, want %d", got, len(drafts))
+	}
+	return result.Resources[0].Records
+}
+
+// TestRateEndToEndExample rates the worked example of the concept: one instance
+// that ran for ten days, was shut off for ten, and ran for the rest of March.
+func TestRateEndToEndExample(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	result := rating.Rate(model, []metering.ResourceUsage{{
+		Resource: instance,
+		Drafts: []metering.UsageDraft{
+			draft("active", 14400, instanceSize(18.0)),
+			draft("shutoff", 14400, instanceSize(0)),
+			draft("active", 15840, instanceSize(22.5)),
+		},
+	}})
+
+	if result.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", result.Currency, "EUR")
+	}
+	if len(result.Unpriced) != 0 {
+		t.Errorf("Unpriced = %v, want none: the instance is priced", result.Unpriced)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("Resources = %d, want 1", len(result.Resources))
+	}
+
+	rated := result.Resources[0]
+	if rated.Resource != instance {
+		t.Errorf("Resource = %+v, want %+v", rated.Resource, instance)
+	}
+	if len(rated.Records) != 3 {
+		t.Fatalf("Records = %d, want 3, one per draft", len(rated.Records))
+	}
+
+	records := []struct {
+		name string
+		want []wantAmount
+	}{
+		{
+			name: "active for 240 hours",
+			want: []wantAmount{
+				{"vcpus", "19.20"}, {"ram_gb", "9.60"}, {"disk_gb", "19.20"}, {"egress_gb", "1.62"},
+			},
+		},
+		{
+			name: "shut off for 240 hours, at half the time_gauge price",
+			want: []wantAmount{
+				{"vcpus", "9.60"}, {"ram_gb", "4.80"}, {"disk_gb", "9.60"}, {"egress_gb", "0.00"},
+			},
+		},
+		{
+			name: "active for 264 hours, the egress rounded half away from zero",
+			want: []wantAmount{
+				{"vcpus", "21.12"}, {"ram_gb", "10.56"}, {"disk_gb", "21.12"}, {"egress_gb", "2.03"},
+			},
+		},
+	}
+	for i, record := range records {
+		t.Run(record.name, func(t *testing.T) {
+			assertAmounts(t, rated.Records[i].Amounts, record.want)
+		})
+	}
+}
+
+func TestRateModifiers(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	t.Run("a type modifier halves the volume it names", func(t *testing.T) {
+		records := rateOne(t, model, volume,
+			draft("in-use", 17280, map[string]any{"size_gb": float64(200), "type": "hdd"}))
+
+		assertAmounts(t, records[0].Amounts, []wantAmount{{"size_gb", "2.88"}})
+	})
+
+	t.Run("a state modifier of zero rates every time_gauge dimension as zero", func(t *testing.T) {
+		records := rateOne(t, model, instance, draft("shelved", 14400, instanceSize(4.0)))
+
+		// The counter keeps its price: the state modifier is not applied to it.
+		assertAmounts(t, records[0].Amounts, []wantAmount{
+			{"vcpus", "0.00"}, {"ram_gb", "0.00"}, {"disk_gb", "0.00"}, {"egress_gb", "0.36"},
+		})
+	})
+
+	t.Run("a floating ip is priced by the count of one", func(t *testing.T) {
+		records := rateOne(t, model, floatingIP, draft("active", 44640, nil))
+
+		assertAmounts(t, records[0].Amounts, []wantAmount{{"count", "3.72"}})
+	})
+
+	t.Run("a counter on a modified state is rated unmodified", func(t *testing.T) {
+		records := rateOne(t, model, instance, draft("shutoff", 14400, instanceSize(18.0)))
+
+		// 18.0 × 0.09 is 1.62, not the 0.81 the state modifier would make of it.
+		assertAmounts(t, records[0].Amounts, []wantAmount{
+			{"vcpus", "9.60"}, {"ram_gb", "4.80"}, {"disk_gb", "9.60"}, {"egress_gb", "1.62"},
+		})
+	})
+
+	t.Run("a type nothing names is billed unmodified", func(t *testing.T) {
+		records := rateOne(t, model, volume,
+			draft("in-use", 17280, map[string]any{"size_gb": float64(200), "type": "nvme"}))
+
+		assertAmounts(t, records[0].Amounts, []wantAmount{{"size_gb", "5.76"}})
+	})
+}
+
+// TestRateEmitsEveryDimension rates records that carry no quantity a dimension
+// can be billed from. Every dimension is still emitted, at 0.00 and in the
+// order the pricing entry lists it, so a record shows what it was held against.
+func TestRateEmitsEveryDimension(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	free := []wantAmount{
+		{"vcpus", "0.00"}, {"ram_gb", "0.00"}, {"disk_gb", "0.00"}, {"egress_gb", "0.00"},
+	}
+
+	cases := []struct {
+		name  string
+		draft metering.UsageDraft
+	}{
+		{
+			name:  "no priced metric is in the usage map",
+			draft: draft("active", 14400, nil),
+		},
+		{
+			name:  "a metric carries a string",
+			draft: draft("active", 14400, map[string]any{"vcpus": "m1.small"}),
+		},
+		{
+			name:  "the usage map is nil",
+			draft: metering.UsageDraft{State: "active"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			records := rateOne(t, model, instance, tc.draft)
+
+			assertAmounts(t, records[0].Amounts, free)
+		})
+	}
+}
+
+// TestQuantityTypes rates one counter dimension priced at one, over every type
+// a usage map holds a quantity as.
+func TestQuantityTypes(t *testing.T) {
+	model := mustParse(t, counterModel)
+
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"a money quantity", money.NewQuantity(decimal.RequireFromString("2.5")), "2.50"},
+		{"a decimal", decimal.RequireFromString("2.5"), "2.50"},
+		{"an int", 3, "3.00"},
+		{"an int64", int64(4), "4.00"},
+		{"a json number", json.Number("2.5"), "2.50"},
+		{"a float64", float64(2.5), "2.50"},
+		{"a float64 whose shortest text is exponent notation", float64(1e21), "1e21"},
+		{"a string holding digits", "2.5", "2.50"},
+		{"a string nothing reads a number from", "m1.small", "0.00"},
+		// A decimal is digits and an exponent, so text is cheap to parse and
+		// expensive to compute with: 1e2000000000 is four bytes of exponent and
+		// two billion digits the moment the cost is rounded. The bound is held
+		// at the text, and what it refuses is read the way a flavor name is.
+		{"a string whose exponent no quantity carries", "1e100000", "0.00"},
+		{"a string of more digits than a quantity is spelled with", strings.Repeat("9", 65), "0.00"},
+		{"a type nothing computes with", true, "0.00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			records := rateOne(t, model, bucket, metering.UsageDraft{
+				State: "active",
+				Usage: map[string]any{"egress_gb": tc.value},
+			})
+
+			assertAmounts(t, records[0].Amounts, []wantAmount{{"egress_gb", tc.want}})
+		})
+	}
+}
+
+// TestUnpriced rates resources of types the model does not price, interleaved
+// with one it does.
+func TestUnpriced(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	resource := func(platform, resourceType, id string) metering.ResourceUsage {
+		return metering.ResourceUsage{
+			Resource: source.Resource{Cloud: "prod", Platform: platform, ResourceType: resourceType, ResourceID: id},
+			Drafts:   []metering.UsageDraft{draft("active", 14400, instanceSize(1.0))},
+		}
+	}
+
+	result := rating.Rate(model, []metering.ResourceUsage{
+		resource("openstack", "router", "rtr-1"),
+		{Resource: instance, Drafts: []metering.UsageDraft{draft("active", 14400, instanceSize(18.0))}},
+		resource("hetzner", "server", "srv-1"),
+		resource("openstack", "router", "rtr-2"),
+		resource("openstack", "loadbalancer", "lb-1"),
+	})
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("Resources = %d, want 1: only the instance is priced", len(result.Resources))
+	}
+	if result.Resources[0].Resource != instance {
+		t.Errorf("Resource = %+v, want %+v", result.Resources[0].Resource, instance)
+	}
+
+	want := []rating.UnpricedResourceType{
+		{Platform: "hetzner", ResourceType: "server", Count: 1},
+		{Platform: "openstack", ResourceType: "loadbalancer", Count: 1},
+		{Platform: "openstack", ResourceType: "router", Count: 2},
+	}
+	if len(result.Unpriced) != len(want) {
+		t.Fatalf("Unpriced = %v, want %v", result.Unpriced, want)
+	}
+	for i, w := range want {
+		if result.Unpriced[i] != w {
+			t.Errorf("Unpriced[%d] = %+v, want %+v", i, result.Unpriced[i], w)
+		}
+	}
+
+	t.Run("the slice carries the field names the run's stats are read under", func(t *testing.T) {
+		data, err := json.Marshal(result.Unpriced)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+
+		const document = `[{"platform":"hetzner","resource_type":"server","count":1},` +
+			`{"platform":"openstack","resource_type":"loadbalancer","count":1},` +
+			`{"platform":"openstack","resource_type":"router","count":2}]`
+		if string(data) != document {
+			t.Errorf("Marshal() = %s, want %s", data, document)
+		}
+	})
+}
+
+func TestRateEmptyInput(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	cases := []struct {
+		name      string
+		resources []metering.ResourceUsage
+	}{
+		{"no resources at all", nil},
+		{"an empty resource list", []metering.ResourceUsage{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rating.Rate(model, tc.resources)
+
+			if result.Currency != "EUR" {
+				t.Errorf("Currency = %q, want %q", result.Currency, "EUR")
+			}
+			if len(result.Resources) != 0 {
+				t.Errorf("Resources = %v, want none", result.Resources)
+			}
+			if len(result.Unpriced) != 0 {
+				t.Errorf("Unpriced = %v, want none", result.Unpriced)
+			}
+		})
+	}
+}
+
+// TestUnreadableQuantities rates drafts that hold a value under a field rating
+// reads by name and no quantity comes out of. The field is billed the way an
+// absent one is, at zero, and the pass names it: a line item short by a whole
+// metric must not read as a resource that consumed nothing.
+func TestUnreadableQuantities(t *testing.T) {
+	model := mustParse(t, conceptModel)
+
+	cases := []struct {
+		name     string
+		resource source.Resource
+		draft    metering.UsageDraft
+		want     []rating.UnreadableQuantity
+	}{
+		{
+			// A collector that sends the flavor where the schema of its
+			// resource type says nothing about the field. Nothing reads a
+			// count of vCPUs from a name, so the dimension is billed at zero
+			// and the field is named.
+			name:     "a size sent as a flavor name",
+			resource: instance,
+			draft:    draft("active", 14400, map[string]any{"vcpus": "m1.small", "ram_gb": float64(8)}),
+			want: []rating.UnreadableQuantity{
+				{Platform: "openstack", ResourceType: "instance", Field: "vcpus", Count: 1},
+			},
+		},
+		{
+			// The spelling a collector reaches for when a size can outgrow the
+			// range a float64 holds exactly, and the one a price is written in
+			// too. The digits are the quantity, so nothing is unreadable here.
+			name:     "a size sent as a JSON string",
+			resource: instance,
+			draft:    draft("active", 14400, map[string]any{"vcpus": "4", "ram_gb": float64(8)}),
+		},
+		{
+			// Read once per time_gauge dimension, and the draft it was
+			// unreadable in is one draft however many dimensions read it.
+			name:     "the minutes the draft is billed over",
+			resource: instance,
+			draft: metering.UsageDraft{State: "active", Usage: map[string]any{
+				"minutes": true, "vcpus": float64(4),
+			}},
+			want: []rating.UnreadableQuantity{
+				{Platform: "openstack", ResourceType: "instance", Field: "minutes", Count: 1},
+			},
+		},
+		{
+			// The modifier stays at 1, which is a price the operator did not
+			// write, so the field is named rather than passed for a volume
+			// that carries no type.
+			name:     "a type nothing reads as a name",
+			resource: volume,
+			draft:    draft("in-use", 17280, map[string]any{"size_gb": float64(200), "type": float64(2)}),
+			want: []rating.UnreadableQuantity{
+				{Platform: "openstack", ResourceType: "volume", Field: "type", Count: 1},
+			},
+		},
+		{
+			// A negative exponent rounds to zero, so the amount alone would not
+			// tell this from a resource that consumed nothing. What the bound
+			// refuses is the arithmetic behind it: an exponent near the int32 a
+			// decimal holds it in panics when the hours are multiplied by it.
+			name:     "a size spelled with an exponent past what a quantity carries",
+			resource: instance,
+			draft:    draft("active", 14400, map[string]any{"vcpus": "1e-2000"}),
+			want: []rating.UnreadableQuantity{
+				{Platform: "openstack", ResourceType: "instance", Field: "vcpus", Count: 1},
+			},
+		},
+		{
+			name:     "a metric the payload spelled as null",
+			resource: instance,
+			draft:    draft("active", 14400, map[string]any{"vcpus": nil}),
+		},
+		{
+			name:     "a volume that carries no type at all",
+			resource: volume,
+			draft:    draft("in-use", 17280, map[string]any{"size_gb": float64(200)}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rating.Rate(model, []metering.ResourceUsage{{
+				Resource: tc.resource,
+				Drafts:   []metering.UsageDraft{tc.draft},
+			}})
+
+			if !slices.Equal(result.Unreadable, tc.want) {
+				t.Errorf("Unreadable = %+v, want %+v", result.Unreadable, tc.want)
+			}
+		})
+	}
+
+	t.Run("counts one draft per resource and field", func(t *testing.T) {
+		unreadable := draft("active", 14400, map[string]any{"vcpus": "m1.small"})
+		result := rating.Rate(model, []metering.ResourceUsage{{
+			Resource: instance,
+			Drafts:   []metering.UsageDraft{unreadable, draft("active", 14400, instanceSize(0)), unreadable},
+		}})
+
+		want := []rating.UnreadableQuantity{
+			{Platform: "openstack", ResourceType: "instance", Field: "vcpus", Count: 2},
+		}
+		if !slices.Equal(result.Unreadable, want) {
+			t.Errorf("Unreadable = %+v, want %+v", result.Unreadable, want)
+		}
+
+		// The dimension is still emitted, at the amount an absent quantity
+		// would have been billed at, so the record shows what it was held
+		// against either way.
+		assertAmounts(t, result.Resources[0].Records[0].Amounts, []wantAmount{
+			{"vcpus", "0.00"}, {"ram_gb", "0.00"}, {"disk_gb", "0.00"}, {"egress_gb", "0.00"},
+		})
+	})
+}

--- a/internal/engine/store/queries.sql
+++ b/internal/engine/store/queries.sql
@@ -2,3 +2,25 @@
 SELECT period_from, status, finalized_run_id, finalized_at
 FROM billing_periods
 ORDER BY period_from;
+
+-- name: InsertPricingModel :execrows
+INSERT INTO pricing_models (version, valid_from, currency, document)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (version) DO NOTHING;
+
+-- name: GetPricingModel :one
+SELECT version, valid_from, currency, document, imported_at
+FROM pricing_models
+WHERE version = $1;
+
+-- name: ListPricingModels :many
+SELECT version, valid_from, currency, imported_at
+FROM pricing_models
+ORDER BY valid_from;
+
+-- name: PricingModelForPeriod :one
+SELECT version, valid_from, currency, document, imported_at
+FROM pricing_models
+WHERE valid_from <= $1
+ORDER BY valid_from DESC
+LIMIT 1;

--- a/internal/engine/store/sqlcgen/queries.sql.go
+++ b/internal/engine/store/sqlcgen/queries.sql.go
@@ -11,6 +11,51 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getPricingModel = `-- name: GetPricingModel :one
+SELECT version, valid_from, currency, document, imported_at
+FROM pricing_models
+WHERE version = $1
+`
+
+func (q *Queries) GetPricingModel(ctx context.Context, version string) (PricingModel, error) {
+	row := q.db.QueryRow(ctx, getPricingModel, version)
+	var i PricingModel
+	err := row.Scan(
+		&i.Version,
+		&i.ValidFrom,
+		&i.Currency,
+		&i.Document,
+		&i.ImportedAt,
+	)
+	return i, err
+}
+
+const insertPricingModel = `-- name: InsertPricingModel :execrows
+INSERT INTO pricing_models (version, valid_from, currency, document)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (version) DO NOTHING
+`
+
+type InsertPricingModelParams struct {
+	Version   string
+	ValidFrom pgtype.Timestamptz
+	Currency  string
+	Document  []byte
+}
+
+func (q *Queries) InsertPricingModel(ctx context.Context, arg InsertPricingModelParams) (int64, error) {
+	result, err := q.db.Exec(ctx, insertPricingModel,
+		arg.Version,
+		arg.ValidFrom,
+		arg.Currency,
+		arg.Document,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const listBillingPeriods = `-- name: ListBillingPeriods :many
 SELECT period_from, status, finalized_run_id, finalized_at
 FROM billing_periods
@@ -47,4 +92,63 @@ func (q *Queries) ListBillingPeriods(ctx context.Context) ([]ListBillingPeriodsR
 		return nil, err
 	}
 	return items, nil
+}
+
+const listPricingModels = `-- name: ListPricingModels :many
+SELECT version, valid_from, currency, imported_at
+FROM pricing_models
+ORDER BY valid_from
+`
+
+type ListPricingModelsRow struct {
+	Version    string
+	ValidFrom  pgtype.Timestamptz
+	Currency   string
+	ImportedAt pgtype.Timestamptz
+}
+
+func (q *Queries) ListPricingModels(ctx context.Context) ([]ListPricingModelsRow, error) {
+	rows, err := q.db.Query(ctx, listPricingModels)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPricingModelsRow
+	for rows.Next() {
+		var i ListPricingModelsRow
+		if err := rows.Scan(
+			&i.Version,
+			&i.ValidFrom,
+			&i.Currency,
+			&i.ImportedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const pricingModelForPeriod = `-- name: PricingModelForPeriod :one
+SELECT version, valid_from, currency, document, imported_at
+FROM pricing_models
+WHERE valid_from <= $1
+ORDER BY valid_from DESC
+LIMIT 1
+`
+
+func (q *Queries) PricingModelForPeriod(ctx context.Context, validFrom pgtype.Timestamptz) (PricingModel, error) {
+	row := q.db.QueryRow(ctx, pricingModelForPeriod, validFrom)
+	var i PricingModel
+	err := row.Scan(
+		&i.Version,
+		&i.ValidFrom,
+		&i.Currency,
+		&i.Document,
+		&i.ImportedAt,
+	)
+	return i, err
 }

--- a/pricing/2026-03.yaml
+++ b/pricing/2026-03.yaml
@@ -1,0 +1,100 @@
+# Example pricing model from the concept, section 3.4 (README section
+# "Pricing Model"). A price may be written as a number or as a string: either
+# way it keeps the digits spelled here and is read with decimal.NewFromString,
+# never through a float. `tally-engine pricing import` loads this file.
+version: "2026-03"
+valid_from: "2026-03-01T00:00:00Z"
+currency: "EUR"
+
+pricing:
+  openstack:
+    instance:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.02"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+        - metric: "disk_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.001"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.09"
+      state_modifiers:
+        shelved: "0.0"
+        shutoff: "0.5"
+    volume:
+      dimensions:
+        - metric: "size_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.0001"
+      type_modifiers:
+        ssd: "1.0"
+        hdd: "0.5"
+    floating_ip:
+      dimensions:
+        - metric: "count"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+
+  hetzner:
+    server:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.015"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.004"
+        - metric: "disk_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.0008"
+      state_modifiers:
+        "off": "0.5"
+
+  stackit:
+    server:
+      dimensions:
+        - metric: "vcpus"
+          type: "time_gauge"
+          price_per_unit_hour: "0.025"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.006"
+        - metric: "disk_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.0012"
+
+  ionos:
+    server:
+      dimensions:
+        - metric: "cores"
+          type: "time_gauge"
+          price_per_unit_hour: "0.022"
+        - metric: "ram_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.005"
+
+  gardener:
+    shoot:
+      dimensions:
+        - metric: "worker_count"
+          type: "time_gauge"
+          price_per_unit_hour: "0.10"
+      state_modifiers:
+        hibernated: "0.0"
+
+  harbor:
+    repository:
+      dimensions:
+        - metric: "storage_gb"
+          type: "time_gauge"
+          price_per_unit_hour: "0.00005"
+        - metric: "egress_gb"
+          type: "counter"
+          price_per_unit: "0.12"
+        - metric: "pulls"
+          type: "counter"
+          price_per_unit: "0.0"


### PR DESCRIPTION
Closes #37

Implements WP 3.5 and WP 3.6 of `roadmap/03-phase-3-metering-rating.md` as one slice: a new `internal/engine/pricing` package that parses, validates, imports, lists and selects versioned pricing models, and a new `internal/engine/rating` package that rates metered usage against such a model as a pure function. `pricing import` and `pricing list` stop returning `errNotImplemented`. No migration is added — `pricing_models` exists since `migrations/engine/0001_init.sql`. Nothing here writes `usage_records` or `rated_records`; `run` and `tick` keep returning `errNotImplemented`, as run orchestration is WP 3.8 (#39).

## The change set, in commit order

**`553a354` Ship the concept's example pricing model as `pricing/2026-03.yaml`**
The example model from README section 3.4, with every price and modifier written as a string so it is parsed through `decimal.NewFromString`. `pricing/prototype.yaml` (the WP 1.15 slice artifact) is untouched.

**`2f42546` Add the four `pricing_models` queries and regenerate the sqlcgen**
`InsertPricingModel` (`INSERT ... ON CONFLICT (version) DO NOTHING`, `:execrows`), `GetPricingModel`, `ListPricingModels` (ordered by `valid_from`), and `PricingModelForPeriod` (`valid_from <= $1 ORDER BY valid_from DESC LIMIT 1`). `internal/engine/store/sqlcgen` is regenerated and committed.

**`c406b31` Add pricing parsing, schema validation, and the typed model**
`pricing.Parse` decodes into a `yaml.Node` tree and converts it to a canonical JSON document: mapping keys sorted, every numeric scalar kept as a `json.Number` carrying the file's literal text, so the same file always yields the same bytes and no price ever passes through `float64`. The embedded `pricing.schema.json` (JSON Schema 2020-12, closed with `additionalProperties: false`, compiled once through `santhosh-tekuri/jsonschema/v6` the way `internal/reporting/registry` does) validates that document. Two rules the schema language cannot state are checked in Go: `valid_from` must parse as RFC 3339, and no resource type may price one metric twice. `pricing.ParseDocument` is the single code path shared by a file and by a document read back from the database, so `Parse` = YAML conversion + `ParseDocument`. `Model.Equal` compares by decimal value, so `"0.5"` and `0.50` are the same content while reordered dimensions are not.

**`ce4e1ae` Add `pricing.Import` and `pricing.ForPeriod` over the engine store**
Versions are insert-only. Zero affected rows means the version exists: the stored document is parsed back and compared with `Model.Equal`. An unchanged version reports `alreadyImported` and no error; a changed one is refused with an error wrapping `ErrVersionConflict`, because an invoice has to stay reproducible from the version it names. A second version claiming a stored `valid_from` trips the unique key — SQLSTATE 23505 on `pricing_models_valid_from_key` is mapped to an error naming the instant. `ForPeriod` selects the newest version at or before a period start and maps `pgx.ErrNoRows` to `ErrNoModel`. It has no caller outside its tests yet; #39's run step resolves `runs.pricing_version` through it.

**`a5f689f` Add `rating.Rate` rating usage drafts against a pricing model**
A pure pass over the drafts metering produced: per draft and per dimension of the resource type's pricing entry, one amount, every division through `money.Div` and every amount through `money.Round2`. `time_gauge` is `minutes/60 × quantity × price_per_unit_hour × stateModifier × typeModifier`; `counter` is `quantity × price_per_unit`, with modifiers never applying — a gigabyte of egress costs what it costs whatever state the resource was in. Quantities are read from the mixed-type usage map without ever constructing a decimal from a float (`decimal.NewFromFloat` stays banned by the forbidigo rules); the `float64` size fields the payload envelope decoded go through `strconv.FormatFloat(v, 'g', -1, 64)` and `decimal.NewFromString`. A resource type the model does not price is skipped and counted in `Result.Unpriced` rather than rated as free. `Rate` returns no error. The unit tests pin the concept's worked amounts (19.20 / 9.60 / 1.62, the shutoff record at modifier 0.5, 2.03 from 2.025 rounded half away from zero).

**`98c54ea` Implement the `pricing import` and `pricing list` subcommands**
Both `RunE` bodies go through `openStore` and the pricing package. Import prints `imported pricing model <version> valid from <RFC3339>` or `pricing model <version> already imported`; list prints `<version> valid_from=… currency=… imported_at=…` ordered by `valid_from`, and `no pricing models` for an empty table. Names, arguments and `--help` are unchanged; the two commands leave the not-implemented expectations in `cmd/tally-engine/main_test.go` and are driven against `storetest.NewDB` instead, including an import of the committed `pricing/2026-03.yaml`.

**`5ae4446` Name the pricing subcommands among the implemented ones**
The package doc of `cmd/tally-engine` lists which subcommands work; `pricing import` and `pricing list` join them.

## Divergences from the issue

Two additions the issue does not describe, both visible in the diff:

- **`rating.Result.Unreadable`.** The issue specifies that a non-numeric usage value (a size a collector sent as a flavor name, which the size schema lets through) rates as quantity zero. It still does — but instead of vanishing, the draft is counted in a new `Unreadable []UnreadableQuantity` list, per platform, resource type and field, with JSON tags mirroring `Unpriced` so #39 can write it into `runs.stats.unreadable`. Same reasoning as `Unpriced`: an invoice short by a line should say so rather than be silently short.
- **Conversion bounds in `parse.go`** (`maxValues`, `maxDepth`, `maxBytes`). A decode into a `yaml.Node` leaves aliases unexpanded, so yaml.v3's own expansion budget is never armed on this path and a handful of nested anchors can multiply into a document the file on disk gives no sign of. The conversion therefore charges visited nodes and emitted bytes against explicit budgets. No model an operator writes comes near them.

Everything else follows the issue's acceptance criteria; the failure-case fixtures live in `internal/engine/pricing/testdata/`.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
