### PR TITLE
Prove the engine end to end against the concept's golden examples

### DIFF
--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -1,0 +1,1237 @@
+// The golden suite's harness: the containers a run of the suite starts, the
+// pair of databases each case gets, the fixtures a case is seeded from, and the
+// assertions its expectations are checked with.
+//
+// Every case bills March 2026, [2026-03-01T00:00:00Z, 2026-04-01T00:00:00Z).
+// The values in testdata/golden/<case>/expected.json are derived by hand from
+// README section 3.4 ("Metering Output Examples") and pricing/2026-03.yaml.
+// They are never regenerated from what the engine produced: a number the engine
+// wrote says nothing about whether the engine is right.
+//
+// Events are inserted into the events table and folded into current_resources
+// by projection.Replay, the writer the ingest path folds through, so a case is
+// metered from the candidate index production derives. The metricsql querier is
+// the only seam the suite substitutes, because VictoriaMetrics is another
+// process; everything else a case runs through is the engine's own code.
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/engine/counters"
+	"github.com/b42labs/tally/internal/engine/export"
+	"github.com/b42labs/tally/internal/engine/pricing"
+	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
+	enginestore "github.com/b42labs/tally/internal/engine/store"
+	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
+	enginetest "github.com/b42labs/tally/internal/engine/store/storetest"
+	"github.com/b42labs/tally/internal/reporting/projection"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	reportingstore "github.com/b42labs/tally/internal/reporting/store"
+	reportingsqlcgen "github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	reportingtest "github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+const (
+	// goldenDir holds one directory per case, named after the case.
+	goldenDir = "testdata/golden"
+	// pricingFile is the model every case is rated with: the example model of
+	// the concept, which is what the concept's amounts were computed from.
+	pricingFile = "../../pricing/2026-03.yaml"
+	// pricingVersion is the version that file declares, and what every run of
+	// the suite has to report having rated with.
+	pricingVersion = "2026-03"
+	// currency is the currency that model quotes, carried by every record and
+	// every statement it prices.
+	currency = "EUR"
+	// reportingPoolMaxConns bounds the pool a case opens on its own reporting
+	// database. One case runs at a time and reads through one snapshot, so a
+	// handful leaves the container's connection budget to the pools beside it.
+	reportingPoolMaxConns = 4
+	// maxBulkCount bounds the count of one bulk generator. The largest the
+	// suite carries stands for 812 events, and seedEvents pays a round trip per
+	// event, so anything past this is an extra digit rather than a case, and
+	// expandBulk names it instead of spending minutes on it.
+	maxBulkCount = 5_000
+)
+
+// The billing period every case meters: March 2026, 744 hours. It lies in the
+// past, so no case runs into runs.WarningPeriodNotEnded, and it is written down
+// rather than derived from the wall clock, because the amounts the cases assert
+// are the concept's amounts over exactly this month.
+var (
+	periodFrom = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	periodTo   = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// attributingRelationTypes is what attribution walks for every case, the one
+// relation type the concept's related-costs example uses.
+var attributingRelationTypes = []string{"infrastructure_tenant"}
+
+// goldenFixture is the pair of containers the suite runs its cases in. The
+// cases share them and take a database of their own out of each.
+type goldenFixture struct {
+	engine    enginetest.DB
+	reporting reportingtest.DB
+}
+
+// newGoldenFixture starts both containers. The suite calls it once: a container
+// per case, or one per test function, would pay for the image and the migration
+// chain again for every one of them.
+func newGoldenFixture(t *testing.T) goldenFixture {
+	t.Helper()
+
+	return goldenFixture{engine: enginetest.NewDB(t), reporting: reportingtest.NewDB(t)}
+}
+
+// caseDBs is the pair of databases one case runs against, and the source handle
+// the engine reads the reporting side through.
+type caseDBs struct {
+	engine    *pgxpool.Pool
+	reporting *pgxpool.Pool
+	source    *source.DB
+}
+
+// caseDatabases creates, migrates and opens the two databases of one case, and
+// imports the pricing model into the engine side.
+//
+// Each case gets its own pair rather than a cloud of its own in a shared one: a
+// case that finalizes its period would refuse every regular run after it,
+// whatever order the cases are run in.
+func (f goldenFixture) caseDatabases(t *testing.T, name string) caseDBs {
+	t.Helper()
+
+	ctx := t.Context()
+
+	engineURL := f.engine.NewSiblingDB(t, "golden_"+name)
+	if _, err := enginestore.Migrate(ctx, engineURL); err != nil {
+		t.Fatalf("migrating the engine database of %s: %v", name, err)
+	}
+	engineDB, err := enginestore.New(ctx, engineURL)
+	if err != nil {
+		t.Fatalf("opening the engine pool of %s: %v", name, err)
+	}
+	t.Cleanup(engineDB.Close)
+
+	document, err := os.ReadFile(pricingFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", pricingFile, err)
+	}
+	model, doc, err := pricing.Parse(document)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", pricingFile, err)
+	}
+	if _, err := pricing.Import(ctx, sqlcgen.New(engineDB.Pool()), model, doc); err != nil {
+		t.Fatalf("importing %s: %v", pricingFile, err)
+	}
+
+	reportingURL := f.reporting.NewSiblingDB(t, "golden_"+name)
+	if _, err := reportingstore.Migrate(ctx, reportingURL); err != nil {
+		t.Fatalf("migrating the reporting database of %s: %v", name, err)
+	}
+	reportingDB, err := reportingstore.New(ctx, reportingURL, reportingPoolMaxConns)
+	if err != nil {
+		t.Fatalf("opening the reporting pool of %s: %v", name, err)
+	}
+	t.Cleanup(reportingDB.Close)
+
+	src, err := source.New(ctx, reportingURL)
+	if err != nil {
+		t.Fatalf("opening the reporting source of %s: %v", name, err)
+	}
+	t.Cleanup(src.Close)
+
+	return caseDBs{engine: engineDB.Pool(), reporting: reportingDB.Pool(), source: src}
+}
+
+// eventsFile is events.json, and late.json, which has the same shape: the
+// events a case is seeded with, written out one by one, plus the generators
+// that stand for the ones there are too many of to write out.
+type eventsFile struct {
+	Events []event.Event   `json:"events"`
+	Bulk   []bulkGenerator `json:"bulk"`
+}
+
+// bulkGenerator stands for Count events of one type on one resource, spread
+// over an interval. It is how a case seeds the hundreds of events an events
+// counter counts without listing them.
+type bulkGenerator struct {
+	EventType    string                `json:"event_type"`
+	Count        int                   `json:"count"`
+	From         time.Time             `json:"from"`
+	To           time.Time             `json:"to"`
+	Platform     string                `json:"platform"`
+	Cloud        string                `json:"cloud"`
+	ResourceType string                `json:"resource_type"`
+	ResourceID   string                `json:"resource_id"`
+	ProjectID    string                `json:"project_id"`
+	Payload      event.PayloadEnvelope `json:"payload"`
+}
+
+// registryFile is registry.json: the projects a case's resources are billed
+// under, and the relations attribution walks between them.
+type registryFile struct {
+	Projects  []registryProject  `json:"projects"`
+	Relations []registryRelation `json:"relations"`
+}
+
+// registryProject is one row of the project registry.
+type registryProject struct {
+	Platform   string `json:"platform"`
+	Cloud      string `json:"cloud"`
+	ExternalID string `json:"external_id"`
+}
+
+// registryRelation is one edge between two registered projects. ValidTo is nil
+// where the file says null, which is an edge that is still open.
+type registryRelation struct {
+	Source       projectRef `json:"source"`
+	Target       projectRef `json:"target"`
+	RelationType string     `json:"relation_type"`
+	ValidFrom    time.Time  `json:"valid_from"`
+	ValidTo      *time.Time `json:"valid_to"`
+}
+
+// projectRef names a registered project the way a resource does, by cloud and
+// external id, because the registry's own UUIDs are assigned at seeding time.
+type projectRef struct {
+	Cloud      string `json:"cloud"`
+	ExternalID string `json:"external_id"`
+}
+
+// metricEntry is one stubbed answer of metrics.json: the rendered query, the
+// instant it is asked at, and the value VictoriaMetrics would return.
+type metricEntry struct {
+	Query string    `json:"query"`
+	At    time.Time `json:"at"`
+	Value string    `json:"value"`
+}
+
+// goldenCase is one case's input, everything but its expectations.
+type goldenCase struct {
+	Name string
+	Dir  string
+	// Events is what the case is metered from.
+	Events eventsFile
+	// Registry is the projects and relations of the case.
+	Registry registryFile
+	// Counters is the counter sources file of the case, zero where it has none.
+	Counters counters.Config
+	// Metrics are the stubbed metricsql answers, empty where the case has no
+	// metricsql source.
+	Metrics []metricEntry
+	// Late is late.json, the events a correction of the case re-meters. It is
+	// nil for a case that has none.
+	Late *eventsFile
+}
+
+// loadCase reads one case's fixtures. events.json and registry.json are
+// required; counters.yaml, metrics.json and late.json are read where the case
+// carries them.
+func loadCase(t *testing.T, name string) goldenCase {
+	t.Helper()
+
+	dir := filepath.Join(goldenDir, name)
+	c := goldenCase{Name: name, Dir: dir}
+
+	eventsPath := filepath.Join(dir, "events.json")
+	decodeJSON(t, eventsPath, readRequired(t, eventsPath), &c.Events)
+
+	registryPath := filepath.Join(dir, "registry.json")
+	decodeJSON(t, registryPath, readRequired(t, registryPath), &c.Registry)
+
+	countersPath := filepath.Join(dir, "counters.yaml")
+	if data, found := readOptional(t, countersPath); found {
+		cfg, err := counters.Parse(data)
+		if err != nil {
+			t.Fatalf("decoding %s: %v", countersPath, err)
+		}
+		c.Counters = cfg
+	}
+
+	metricsPath := filepath.Join(dir, "metrics.json")
+	if data, found := readOptional(t, metricsPath); found {
+		decodeJSON(t, metricsPath, data, &c.Metrics)
+	}
+
+	latePath := filepath.Join(dir, "late.json")
+	if data, found := readOptional(t, latePath); found {
+		var late eventsFile
+		decodeJSON(t, latePath, data, &late)
+		c.Late = &late
+	}
+
+	return c
+}
+
+// expectedFile is expected.json: the clouds the run is restricted to and every
+// number the case asserts.
+type expectedFile struct {
+	Clouds           []string            `json:"clouds"`
+	Stats            expectedStats       `json:"stats"`
+	Usage            []expectedUsage     `json:"usage"`
+	Rated            []expectedRated     `json:"rated"`
+	Statements       []expectedStatement `json:"statements"`
+	AbsentStatements []string            `json:"absent_statements"`
+}
+
+// expectedStats is the four counts a run reports.
+type expectedStats struct {
+	Candidates   int `json:"candidates"`
+	UsageRecords int `json:"usage_records"`
+	RatedRecords int `json:"rated_records"`
+	Statements   int `json:"statements"`
+}
+
+// expectedUsage is one usage_records row. Usage maps every key of the stored
+// object to its value written as a string, numbers included, so that no
+// expectation of the suite passes through a float.
+type expectedUsage struct {
+	Cloud        string            `json:"cloud"`
+	Platform     string            `json:"platform"`
+	ResourceType string            `json:"resource_type"`
+	ResourceID   string            `json:"resource_id"`
+	ProjectID    string            `json:"project_id"`
+	State        string            `json:"state"`
+	From         time.Time         `json:"from"`
+	To           time.Time         `json:"to"`
+	Seconds      int64             `json:"seconds"`
+	Usage        map[string]string `json:"usage"`
+}
+
+// expectedRated is one rated record, named by the resource, the interval and
+// the dimension it rates.
+type expectedRated struct {
+	Cloud      string          `json:"cloud"`
+	ResourceID string          `json:"resource_id"`
+	From       time.Time       `json:"from"`
+	Dimension  string          `json:"dimension"`
+	Quantity   decimal.Decimal `json:"quantity"`
+	Amount     decimal.Decimal `json:"amount"`
+}
+
+// expectedStatement is one project statement and the document it carries.
+type expectedStatement struct {
+	Key           string                `json:"key"`
+	Total         decimal.Decimal       `json:"total"`
+	Currency      string                `json:"currency"`
+	BillingPeriod expectedBillingPeriod `json:"billing_period"`
+	ProjectID     string                `json:"project_id"`
+	Platform      string                `json:"platform"`
+	LineItems     []expectedLineItem    `json:"line_items"`
+	RelatedCosts  []expectedRelatedCost `json:"related_costs"`
+}
+
+// expectedBillingPeriod is the interval a document says it bills, written the
+// way the document renders it. It is what says the invoice covers the month the
+// run was asked for rather than one beside it: no amount below it changes with
+// the interval a document is stamped with.
+type expectedBillingPeriod struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// expectedLineItem is one resource on a statement or on a related cost.
+type expectedLineItem struct {
+	ResourceID string           `json:"resource_id"`
+	Total      decimal.Decimal  `json:"total"`
+	Periods    []expectedPeriod `json:"periods"`
+}
+
+// expectedPeriod is one interval of a line item. Usage holds the quantity every
+// dimension was rated from, and Cost one key per dimension plus "total", the
+// way the document renders them.
+type expectedPeriod struct {
+	State         string                     `json:"state"`
+	Hours         decimal.Decimal            `json:"hours"`
+	StateModifier decimal.Decimal            `json:"state_modifier"`
+	Usage         map[string]decimal.Decimal `json:"usage"`
+	Cost          map[string]decimal.Decimal `json:"cost"`
+}
+
+// expectedRelatedCost is one attributed project on the statement of the project
+// it is billed under.
+type expectedRelatedCost struct {
+	RelationType string             `json:"relation_type"`
+	ProjectID    string             `json:"project_id"`
+	Platform     string             `json:"platform"`
+	Total        decimal.Decimal    `json:"total"`
+	LineItems    []expectedLineItem `json:"line_items"`
+}
+
+// loadExpected reads one case's expectations, which every case carries.
+func loadExpected(t *testing.T, name string) expectedFile {
+	t.Helper()
+
+	path := filepath.Join(goldenDir, name, "expected.json")
+	var want expectedFile
+	decodeJSON(t, path, readRequired(t, path), &want)
+	return want
+}
+
+// readRequired reads a fixture file every case must carry. The error names the
+// path and says what was wrong with it, an absent file included.
+func readRequired(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return data
+}
+
+// readOptional reads a fixture file a case may leave out. found is false only
+// for a file that is not there: a file that exists and cannot be read fails the
+// case rather than passing for a case that configures nothing.
+func readOptional(t *testing.T, path string) ([]byte, bool) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil, false
+	case err != nil:
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return data, true
+}
+
+// decodeJSON decodes one fixture file into v, naming the file a failure is in.
+func decodeJSON(t *testing.T, path string, data []byte, v any) {
+	t.Helper()
+
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("decoding %s: %v", path, err)
+	}
+}
+
+// seedEvents writes the events of a fixture and folds them into the projection.
+// The generators are expanded first, so a bulk event is seeded and replayed the
+// way a listed one is.
+func seedEvents(t *testing.T, dbs caseDBs, file eventsFile) {
+	t.Helper()
+
+	events := append(slices.Clone(file.Events), expandBulk(t, file.Bulk)...)
+	if len(events) == 0 {
+		return
+	}
+
+	ctx := t.Context()
+	sizes := registry.New()
+	for _, ev := range events {
+		// A fixture names a source only where the case is about one; every
+		// other event arrived the way a collector's does.
+		if ev.Source == "" {
+			ev.Source = event.SourceCollector
+		}
+		if err := ev.Validate(); err != nil {
+			t.Fatalf("event %s: %v", ev.EventID, err)
+		}
+		checkSize(t, dbs, sizes, ev)
+		payload, err := json.Marshal(ev.Payload)
+		if err != nil {
+			t.Fatalf("event %s: encoding the payload: %v", ev.EventID, err)
+		}
+		// A delete event carries no payload at all. Stored as an empty object it
+		// would be an event that reports a resource without a state rather than
+		// one that reports nothing.
+		var body any
+		if !bytes.Equal(payload, []byte("{}")) {
+			body = payload
+		}
+		if _, err := dbs.reporting.Exec(ctx,
+			`INSERT INTO events (event_id, timestamp, event_type, platform, cloud,
+			                     resource_type, resource_id, project_id, source, payload)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)`,
+			ev.EventID, ev.Timestamp, ev.EventType, ev.Platform, ev.Cloud,
+			ev.ResourceType, ev.ResourceID, ev.ProjectID, string(ev.Source), body); err != nil {
+			t.Fatalf("seeding the event %s: %v", ev.EventID, err)
+		}
+	}
+
+	replay(t, dbs, events)
+}
+
+// checkSize refuses a fixture event the ingest path would have dead-lettered.
+// event.Validate checks the shape of an event and nothing about the size it
+// reports; what decides whether an event enters the events table at all is the
+// size schema registered for its (platform, resource_type), which ingest
+// validates against before it stores anything (internal/reporting/ingest,
+// checkSize). Those schemas are seeded by the reporting migrations the case
+// databases run, so a fixture that would be refused in production must not be
+// metered here either.
+//
+// A pair no row registers is taken unvalidated, which is what the lax pipeline
+// does with it, and what the platforms of the suite the chain seeds no schema
+// for rest on.
+func checkSize(t *testing.T, dbs caseDBs, sizes *registry.Registry, ev event.Event) {
+	t.Helper()
+
+	if ev.Payload.Size == nil {
+		return
+	}
+
+	schema, registered, err := sizes.Validator(t.Context(),
+		reportingsqlcgen.New(dbs.reporting), ev.Platform, ev.ResourceType)
+	if err != nil {
+		t.Fatalf("event %s: reading the size schema: %v", ev.EventID, err)
+	}
+	if !registered {
+		return
+	}
+
+	// The size goes through JSON on its way to the validator the way it does in
+	// ingest: a keyword like "integer" is checked against the type the decoder
+	// produced, not against the one a Go literal happens to carry.
+	raw, err := json.Marshal(ev.Payload.Size)
+	if err != nil {
+		t.Fatalf("event %s: encoding the size: %v", ev.EventID, err)
+	}
+	size, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("event %s: decoding the size: %v", ev.EventID, err)
+	}
+	if err := schema.Validate(size); err != nil {
+		t.Fatalf("event %s: size_schema: %v", ev.EventID, err)
+	}
+}
+
+// expandBulk turns the generators of a fixture into the events they stand for.
+// The timestamps divide each generator's interval into count+1 equal steps and
+// sit on the inner boundaries, so every one of them lies strictly inside the
+// interval and none falls on an instant the timeline splits at. A generator of
+// count 0 expands to nothing.
+//
+// The id of an event names the generator it comes from whole: the cloud, the
+// resource type and the resource id, the event type, both ends of the interval,
+// and the count. A resource is keyed by the triple rather than by cloud and id,
+// and the step the timestamps sit on is derived from the interval together with
+// the count, so a generator that differs in any one of them stands for other
+// events. Leaving one out lets two of them stand for the same ids, which the
+// events table refuses on (event_id, timestamp) where the timestamps agree and
+// silently files two histories under one id where they do not.
+//
+// A negative count, an interval too short for the count, and a count past
+// maxBulkCount are typos in the fixture rather than cases: the first divides by
+// zero, the second truncates the step to nothing and stamps every event the
+// generator stands for on From, which is an instant the timeline splits at in
+// every case the suite carries, and the third spends a round trip per event
+// until a case that runs in seconds reads as a hung one. All three are named
+// here rather than left to divide, to shift a counter's window, or to run out
+// the clock without a fixture line to point at.
+func expandBulk(t *testing.T, generators []bulkGenerator) []event.Event {
+	t.Helper()
+
+	var events []event.Event
+	for _, g := range generators {
+		if g.Count < 0 {
+			t.Fatalf("the %s generator from %s: count = %d, want a count that is not negative",
+				g.EventType, instant(g.From), g.Count)
+		}
+		if g.Count > maxBulkCount {
+			t.Fatalf("the %s generator from %s: count = %d, want at most %d: "+
+				"a larger one is a typo rather than a case",
+				g.EventType, instant(g.From), g.Count, maxBulkCount)
+		}
+		step := g.To.Sub(g.From) / time.Duration(g.Count+1)
+		if g.Count > 0 && step <= 0 {
+			t.Fatalf("the %s generator: [%s, %s) is too short for %d events, "+
+				"which would all be stamped on %s",
+				g.EventType, instant(g.From), instant(g.To), g.Count, instant(g.From))
+		}
+		for i := range g.Count {
+			events = append(events, event.Event{
+				EventID: fmt.Sprintf("bulk-%s-%s-%s-%s-%s-%s-%d-%d",
+					g.Cloud, g.ResourceType, g.ResourceID, g.EventType,
+					g.From.UTC().Format(time.RFC3339), g.To.UTC().Format(time.RFC3339),
+					g.Count, i),
+				Timestamp:    g.From.Add(time.Duration(i+1) * step),
+				EventType:    g.EventType,
+				Platform:     g.Platform,
+				Cloud:        g.Cloud,
+				ResourceType: g.ResourceType,
+				ResourceID:   g.ResourceID,
+				ProjectID:    g.ProjectID,
+				Payload:      g.Payload,
+			})
+		}
+	}
+	return events
+}
+
+// replay folds the seeded events into current_resources, once per resource they
+// name, in the order the resources first appear. The suite never writes that
+// table itself: the candidate index a case is metered from is the one the
+// ingest path derives from the same history.
+func replay(t *testing.T, dbs caseDBs, events []event.Event) {
+	t.Helper()
+
+	ctx := t.Context()
+	tx, err := dbs.reporting.Begin(ctx)
+	if err != nil {
+		t.Fatalf("beginning the projection transaction: %v", err)
+	}
+	// Replay takes a transaction-scoped lock, so it needs one, and a rollback
+	// after the commit below is the no-op the pool expects.
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	seen := make(map[projection.Key]bool, len(events))
+	for _, ev := range events {
+		key := projection.Key{Cloud: ev.Cloud, ResourceType: ev.ResourceType, ResourceID: ev.ResourceID}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if err := projection.Replay(ctx, tx, key, nil); err != nil {
+			t.Fatalf("replaying %s/%s/%s: %v", key.Cloud, key.ResourceType, key.ResourceID, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("committing the projection transaction: %v", err)
+	}
+}
+
+// seedRegistry registers the projects of a case and the relations between them.
+// A project the registry does not hold gets no statement of its own, so every
+// project a case's resources name belongs here.
+func seedRegistry(t *testing.T, dbs caseDBs, reg registryFile) {
+	t.Helper()
+
+	ctx := t.Context()
+	ids := make(map[projectRef]uuid.UUID, len(reg.Projects))
+	for _, p := range reg.Projects {
+		var id uuid.UUID
+		if err := dbs.reporting.QueryRow(ctx,
+			`INSERT INTO projects (platform, cloud, external_id) VALUES ($1, $2, $3) RETURNING id`,
+			p.Platform, p.Cloud, p.ExternalID).Scan(&id); err != nil {
+			t.Fatalf("registering the project %s/%s: %v", p.Cloud, p.ExternalID, err)
+		}
+		ids[projectRef{Cloud: p.Cloud, ExternalID: p.ExternalID}] = id
+	}
+
+	for _, r := range reg.Relations {
+		edge := fmt.Sprintf("%s/%s -> %s/%s",
+			r.Source.Cloud, r.Source.ExternalID, r.Target.Cloud, r.Target.ExternalID)
+		// An end the registry does not hold is a typo in the fixture, and
+		// naming the pair that is missing is what tells which of the two it is.
+		resolve := func(ref projectRef) uuid.UUID {
+			id, ok := ids[ref]
+			if !ok {
+				t.Fatalf("relation %s: no project %s/%s in registry.json", edge, ref.Cloud, ref.ExternalID)
+			}
+			return id
+		}
+		if _, err := dbs.reporting.Exec(ctx,
+			`INSERT INTO project_relations (source_id, target_id, relation_type, valid_from, valid_to)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			resolve(r.Source), resolve(r.Target), r.RelationType, r.ValidFrom, r.ValidTo); err != nil {
+			t.Fatalf("relating %s: %v", edge, err)
+		}
+	}
+}
+
+// seedLate writes the events of late.json, which arrive after a case's first
+// run has been finalized. A case without that file is a case whose test asked
+// for something it does not carry.
+func seedLate(t *testing.T, dbs caseDBs, c goldenCase) {
+	t.Helper()
+
+	if c.Late == nil {
+		t.Fatalf("the case %s carries no late.json", c.Name)
+	}
+	seedEvents(t, dbs, *c.Late)
+}
+
+// queryKey is one stubbed answer's coordinates: the rendered expression and the
+// instant it is asked at, which is the pair the engine calls Query with.
+type queryKey struct{ expr, at string }
+
+// stubQuerier answers the metricsql sources of a case from metrics.json.
+// VictoriaMetrics is another process, so it is the one seam the suite
+// substitutes, and the answers are written down beside the amounts they produce
+// rather than measured.
+type stubQuerier struct {
+	values map[queryKey]decimal.Decimal
+}
+
+var _ counters.Querier = (*stubQuerier)(nil)
+
+// newStubQuerier indexes the stubbed answers of a case by query and instant.
+func newStubQuerier(t *testing.T, entries []metricEntry) *stubQuerier {
+	t.Helper()
+
+	values := make(map[queryKey]decimal.Decimal, len(entries))
+	for _, entry := range entries {
+		value, err := decimal.NewFromString(entry.Value)
+		if err != nil {
+			t.Fatalf("the stubbed value of %q: %v", entry.Query, err)
+		}
+		values[queryKey{expr: entry.Query, at: instant(entry.At)}] = value
+	}
+	return &stubQuerier{values: values}
+}
+
+// instant renders the instant a stubbed answer is keyed on and a failure names
+// an interval by, in UTC so that two spellings of one instant meet.
+func instant(at time.Time) string {
+	return at.UTC().Format(time.RFC3339Nano)
+}
+
+// Query answers one instant query. A pair metrics.json does not hold is an
+// error rather than a zero: a case whose window or whose end instant moved
+// would otherwise be billed for a counter nobody wrote down.
+func (s *stubQuerier) Query(ctx context.Context, expr string, at time.Time) (decimal.Decimal, error) {
+	// A canceled run must be answered as canceled, whatever the map holds.
+	if err := ctx.Err(); err != nil {
+		return decimal.Zero, err
+	}
+
+	value, ok := s.values[queryKey{expr: expr, at: instant(at)}]
+	if !ok {
+		return decimal.Zero, fmt.Errorf("no stubbed metric for %q at %s", expr, instant(at))
+	}
+	return value, nil
+}
+
+// querier is what a case's metricsql sources are answered by, and an untyped
+// nil for a case with none: a typed nil pointer would leave counters.New
+// reporting a querier where the case has none.
+func (c goldenCase) querier(t *testing.T) counters.Querier {
+	t.Helper()
+
+	if len(c.Metrics) == 0 {
+		return nil
+	}
+	return newStubQuerier(t, c.Metrics)
+}
+
+// options is what a case is metered with. The clouds come from expected.json,
+// beside the candidate count they produce.
+func (c goldenCase) options(t *testing.T, clouds []string) runs.Options {
+	t.Helper()
+
+	return runs.Options{
+		PeriodFrom:               periodFrom,
+		PeriodTo:                 periodTo,
+		Clouds:                   clouds,
+		AttributingRelationTypes: attributingRelationTypes,
+		Counters:                 c.Counters,
+		VM:                       c.querier(t),
+	}
+}
+
+// correctOptions is what a case is corrected with. A correction re-meters the
+// period the finalized run recorded, whatever clouds that run was restricted
+// to, so it takes no cloud list.
+func (c goldenCase) correctOptions(t *testing.T) runs.CorrectOptions {
+	t.Helper()
+
+	return runs.CorrectOptions{
+		PeriodFrom:               periodFrom,
+		PeriodTo:                 periodTo,
+		AttributingRelationTypes: attributingRelationTypes,
+		Counters:                 c.Counters,
+		VM:                       c.querier(t),
+	}
+}
+
+// assertClean checks that the run rated with the suite's model and reported
+// nothing to an operator.
+func assertClean(t *testing.T, result runs.Result) {
+	t.Helper()
+
+	if result.PricingVersion != pricingVersion {
+		t.Errorf("PricingVersion = %q, want %q", result.PricingVersion, pricingVersion)
+	}
+	assertNoWarnings(t, result.Stats)
+}
+
+// assertNoWarnings checks that one pass reported nothing to an operator. Every
+// case of the suite is a case the engine has all the data for, so any warning is
+// a finding. A correction re-meters the period whole, so every list a regular
+// run fills is live on it too and is held to the same bar here.
+func assertNoWarnings(t *testing.T, stats runs.Stats) {
+	t.Helper()
+
+	for _, list := range []struct {
+		name    string
+		entries any
+		length  int
+	}{
+		{"warnings", stats.Warnings, len(stats.Warnings)},
+		{"metering_warnings", stats.MeteringWarnings, len(stats.MeteringWarnings)},
+		{"counter_warnings", stats.CounterWarnings, len(stats.CounterWarnings)},
+		{"attribution_warnings", stats.AttributionWarnings, len(stats.AttributionWarnings)},
+		{"unpriced", stats.Unpriced, len(stats.Unpriced)},
+		{"unreadable", stats.Unreadable, len(stats.Unreadable)},
+		{"unregistered_projects", stats.UnregisteredProjects, len(stats.UnregisteredProjects)},
+		{"violations", stats.Violations, len(stats.Violations)},
+	} {
+		if list.length != 0 {
+			t.Errorf("stats %s = %v, want none", list.name, list.entries)
+		}
+	}
+
+	if stats.Error != "" {
+		t.Errorf("stats error = %q, want none", stats.Error)
+	}
+}
+
+// assertStats checks the four counts the run reported.
+func assertStats(t *testing.T, got runs.Stats, want expectedStats) {
+	t.Helper()
+
+	for _, count := range []struct {
+		name      string
+		got, want int
+	}{
+		{"candidates", got.Candidates, want.Candidates},
+		{"usage_records", got.UsageRecords, want.UsageRecords},
+		{"rated_records", got.RatedRecords, want.RatedRecords},
+		{"statements", got.Statements, want.Statements},
+	} {
+		if count.got != count.want {
+			t.Errorf("stats %s = %d, want %d", count.name, count.got, count.want)
+		}
+	}
+}
+
+// storedUsage is one usage_records row as the suite reads it back, past the
+// packages that wrote it.
+type storedUsage struct {
+	cloud, platform, resourceType, resourceID string
+	projectID, state                          string
+	fromTS, toTS                              time.Time
+	seconds                                   int64
+	usage                                     []byte
+}
+
+// assertUsage checks the usage records of a run against the expectation, in the
+// order the query fixes. The intervals a case is split into are what every
+// amount below is computed over, so this is the assertion the rest rests on.
+func assertUsage(t *testing.T, dbs caseDBs, runID uuid.UUID, want []expectedUsage) {
+	t.Helper()
+
+	rows, err := dbs.engine.Query(t.Context(),
+		`SELECT cloud, platform, resource_type, resource_id, project_id, state,
+		        from_ts, to_ts, seconds, usage
+		 FROM usage_records WHERE run_id = $1
+		 ORDER BY cloud, resource_type, resource_id, from_ts`, runID)
+	if err != nil {
+		t.Fatalf("reading the usage records of run %s: %v", runID, err)
+	}
+	defer rows.Close()
+
+	var got []storedUsage
+	for rows.Next() {
+		var row storedUsage
+		if err := rows.Scan(&row.cloud, &row.platform, &row.resourceType, &row.resourceID,
+			&row.projectID, &row.state, &row.fromTS, &row.toTS, &row.seconds, &row.usage); err != nil {
+			t.Fatalf("scanning a usage record of run %s: %v", runID, err)
+		}
+		got = append(got, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the usage records of run %s: %v", runID, err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("usage records = %d, want %d", len(got), len(want))
+	}
+
+	for i, w := range want {
+		g := got[i]
+		record := fmt.Sprintf("%s/%s from %s", g.cloud, g.resourceID, instant(g.fromTS))
+
+		for _, field := range []struct{ name, got, want string }{
+			{"cloud", g.cloud, w.Cloud},
+			{"platform", g.platform, w.Platform},
+			{"resource_type", g.resourceType, w.ResourceType},
+			{"resource_id", g.resourceID, w.ResourceID},
+			{"project_id", g.projectID, w.ProjectID},
+			{"state", g.state, w.State},
+		} {
+			if field.got != field.want {
+				t.Errorf("usage record %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		if !g.fromTS.Equal(w.From) {
+			t.Errorf("usage record %d: from = %s, want %s", i, instant(g.fromTS), instant(w.From))
+		}
+		if !g.toTS.Equal(w.To) {
+			t.Errorf("usage record %d: to = %s, want %s", i, instant(g.toTS), instant(w.To))
+		}
+		if g.seconds != w.Seconds {
+			t.Errorf("usage record %d: seconds = %d, want %d", i, g.seconds, w.Seconds)
+		}
+		assertUsageObject(t, record, g.usage, w.Usage)
+	}
+}
+
+// assertUsageObject compares one stored usage object against the expectation.
+// The object carries the size the provider reported beside the quantities the
+// engine derived, so a number is compared as a decimal and a string verbatim.
+// Neither side may hold a key the other does not: a counter that stopped being
+// measured would otherwise pass for a record that never carried it.
+func assertUsageObject(t *testing.T, record string, raw []byte, want map[string]string) {
+	t.Helper()
+
+	// UseNumber keeps a stored quantity out of a float on the way to the
+	// comparison, which is the one place the suite could lose digits.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var got map[string]any
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("decoding the usage of %s: %v", record, err)
+	}
+
+	for key, value := range got {
+		expected, listed := want[key]
+		if !listed {
+			t.Errorf("the usage of %s carries %s = %v, which expected.json does not list", record, key, value)
+			continue
+		}
+		switch v := value.(type) {
+		case json.Number:
+			wantValue, err := decimal.NewFromString(expected)
+			if err != nil {
+				t.Errorf("the expected %s of %s: %v", key, record, err)
+				continue
+			}
+			gotValue, err := decimal.NewFromString(v.String())
+			if err != nil {
+				t.Errorf("the stored %s of %s: %v", key, record, err)
+				continue
+			}
+			if !gotValue.Equal(wantValue) {
+				t.Errorf("the usage %s of %s = %s, want %s", key, record, v.String(), expected)
+			}
+		case string:
+			if v != expected {
+				t.Errorf("the usage %s of %s = %q, want %q", key, record, v, expected)
+			}
+		default:
+			t.Errorf("the usage %s of %s is a %T, which is neither a number nor a string", key, record, value)
+		}
+	}
+
+	for key := range want {
+		if _, stored := got[key]; !stored {
+			t.Errorf("the usage of %s carries no %s, which expected.json lists", record, key)
+		}
+	}
+}
+
+// ratedKey identifies one rated record among a run's: which resource, which
+// interval, which dimension.
+type ratedKey struct{ cloud, resourceID, from, dimension string }
+
+// assertRated checks the amounts a run billed. The records are matched on what
+// they rate rather than compared in order, so the listing's order is the
+// export's concern and not every case's.
+func assertRated(t *testing.T, got []export.RatedRecord, want []expectedRated) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("rated records = %d, want %d", len(got), len(want))
+	}
+
+	byKey := make(map[ratedKey]export.RatedRecord, len(got))
+	for _, record := range got {
+		byKey[ratedKey{
+			cloud:      record.Resource.Cloud,
+			resourceID: record.Resource.ResourceID,
+			from:       instant(record.FromTS),
+			dimension:  record.Dimension,
+		}] = record
+		if record.Currency != currency {
+			t.Errorf("the currency of the %s of %s/%s = %q, want %q",
+				record.Dimension, record.Resource.Cloud, record.Resource.ResourceID,
+				record.Currency, currency)
+		}
+	}
+
+	for _, w := range want {
+		key := ratedKey{cloud: w.Cloud, resourceID: w.ResourceID, from: instant(w.From), dimension: w.Dimension}
+		record, ok := byKey[key]
+		if !ok {
+			t.Errorf("no rated record for the %s of %s/%s from %s",
+				w.Dimension, w.Cloud, w.ResourceID, key.from)
+			continue
+		}
+		if !record.Quantity.Equal(w.Quantity) {
+			t.Errorf("the %s quantity of %s/%s from %s = %s, want %s",
+				w.Dimension, w.Cloud, w.ResourceID, key.from, record.Quantity, w.Quantity)
+		}
+		if !record.Amount.Equal(w.Amount) {
+			t.Errorf("the %s amount of %s/%s from %s = %s, want %s",
+				w.Dimension, w.Cloud, w.ResourceID, key.from, record.Amount, w.Amount)
+		}
+	}
+}
+
+// assertStatements checks the statements a run rendered, their totals and their
+// documents, and that no key in absent got one. A project that is billed under
+// another one has no statement of its own, and a suite that only checked the
+// statements it expects would not see a second one beside them.
+func assertStatements(
+	t *testing.T,
+	got []statements.Statement,
+	want []expectedStatement,
+	absent []string,
+) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("statements = %d, want %d", len(got), len(want))
+	}
+
+	byKey := make(map[string]statements.Statement, len(got))
+	for _, s := range got {
+		byKey[s.Key] = s
+	}
+
+	for _, key := range absent {
+		if _, billed := byKey[key]; billed {
+			t.Errorf("the run billed a statement %s, which no project of the case may get", key)
+		}
+	}
+
+	for _, w := range want {
+		s, ok := byKey[w.Key]
+		if !ok {
+			t.Errorf("no statement %s", w.Key)
+			continue
+		}
+		if !s.Total.Equal(w.Total) {
+			t.Errorf("the total of %s = %s, want %s", w.Key, s.Total, w.Total)
+		}
+		if s.Currency != w.Currency {
+			t.Errorf("the currency of %s = %q, want %q", w.Key, s.Currency, w.Currency)
+		}
+
+		var doc statements.Document
+		if err := json.Unmarshal(s.Document, &doc); err != nil {
+			t.Fatalf("decoding the document of %s: %v", w.Key, err)
+		}
+		assertBillingPeriod(t, w.Key, doc.BillingPeriod, w.BillingPeriod)
+		for _, field := range []struct{ name, got, want string }{
+			{"project", doc.ProjectID, w.ProjectID},
+			{"platform", doc.Platform, w.Platform},
+		} {
+			if field.got != field.want {
+				t.Errorf("the %s of %s = %q, want %q", field.name, w.Key, field.got, field.want)
+			}
+		}
+		assertLineItems(t, w.Key, doc.LineItems, w.LineItems)
+		assertRelatedCosts(t, w.Key, doc.RelatedCosts, w.RelatedCosts)
+	}
+}
+
+// assertBillingPeriod checks the interval one document says it bills. A
+// statement and a credit note carry the same pair, and both are wired from a
+// period the caller passed rather than derived from what they bill, so neither
+// is checked by any amount on it.
+func assertBillingPeriod(t *testing.T, document string, got statements.BillingPeriod, want expectedBillingPeriod) {
+	t.Helper()
+
+	if got.From != want.From || got.To != want.To {
+		t.Errorf("the billing period of %s = [%s, %s), want [%s, %s)",
+			document, got.From, got.To, want.From, want.To)
+	}
+}
+
+// assertLineItems compares the line items of one document or of one related
+// cost. They are matched by resource id, which is what a line item is about.
+func assertLineItems(t *testing.T, statement string, got []statements.LineItem, want []expectedLineItem) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("the line items of %s = %d, want %d", statement, len(got), len(want))
+	}
+
+	byID := make(map[string]statements.LineItem, len(got))
+	for _, item := range got {
+		byID[item.ResourceID] = item
+	}
+
+	for _, w := range want {
+		item, ok := byID[w.ResourceID]
+		if !ok {
+			t.Fatalf("%s carries no line item for %s", statement, w.ResourceID)
+		}
+		if !item.Total.Equal(w.Total) {
+			t.Errorf("the total of %s in %s = %s, want %s", w.ResourceID, statement, item.Total, w.Total)
+		}
+		assertPeriods(t, w.ResourceID+" in "+statement, item.Periods, w.Periods)
+	}
+}
+
+// assertPeriods compares the periods of one line item in order: their place in
+// that list is the order the resource changed in.
+func assertPeriods(t *testing.T, item string, got []statements.Period, want []expectedPeriod) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("the periods of %s = %d, want %d", item, len(got), len(want))
+	}
+
+	for i, w := range want {
+		g := got[i]
+		if g.State != w.State {
+			t.Errorf("period %d of %s: state = %q, want %q", i, item, g.State, w.State)
+		}
+		if !g.Hours.Equal(w.Hours) {
+			t.Errorf("period %d of %s: hours = %s, want %s", i, item, g.Hours, w.Hours)
+		}
+		if !g.StateModifier.Equal(w.StateModifier) {
+			t.Errorf("period %d of %s: state_modifier = %s, want %s", i, item, g.StateModifier, w.StateModifier)
+		}
+
+		for dimension, quantity := range g.Usage {
+			expected, listed := w.Usage[dimension]
+			if !listed {
+				t.Errorf("period %d of %s was rated from %s = %s, which expected.json does not list",
+					i, item, dimension, quantity)
+				continue
+			}
+			if !quantity.Equal(expected) {
+				t.Errorf("period %d of %s: the %s it was rated from = %s, want %s",
+					i, item, dimension, quantity, expected)
+			}
+		}
+		for dimension := range w.Usage {
+			if _, rated := g.Usage[dimension]; !rated {
+				t.Errorf("period %d of %s was rated from no %s, which expected.json lists",
+					i, item, dimension)
+			}
+		}
+
+		for dimension, amount := range g.Cost {
+			expected, listed := w.Cost[dimension]
+			if !listed {
+				t.Errorf("period %d of %s costs %s = %s, which expected.json does not list",
+					i, item, dimension, amount)
+				continue
+			}
+			if !amount.Equal(expected) {
+				t.Errorf("period %d of %s: the cost of %s = %s, want %s", i, item, dimension, amount, expected)
+			}
+		}
+		for dimension := range w.Cost {
+			if _, billed := g.Cost[dimension]; !billed {
+				t.Errorf("period %d of %s costs no %s, which expected.json lists", i, item, dimension)
+			}
+		}
+	}
+}
+
+// assertRelatedCosts compares the related costs of one document in order, which
+// is the order attribution claimed the projects in.
+func assertRelatedCosts(
+	t *testing.T,
+	statement string,
+	got []statements.RelatedCost,
+	want []expectedRelatedCost,
+) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("the related costs of %s = %d, want %d", statement, len(got), len(want))
+	}
+
+	for i, w := range want {
+		g := got[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"relation_type", g.RelationType, w.RelationType},
+			{"project_id", g.ProjectID, w.ProjectID},
+			{"platform", g.Platform, w.Platform},
+		} {
+			if field.got != field.want {
+				t.Errorf("related cost %d of %s: %s = %q, want %q",
+					i, statement, field.name, field.got, field.want)
+			}
+		}
+		if !g.Total.Equal(w.Total) {
+			t.Errorf("related cost %d of %s: total = %s, want %s", i, statement, g.Total, w.Total)
+		}
+		assertLineItems(t, fmt.Sprintf("the related cost %s of %s", w.ProjectID, statement),
+			g.LineItems, w.LineItems)
+	}
+}
+
+// runStatus is the status one run row carries.
+func runStatus(t *testing.T, dbs caseDBs, id uuid.UUID) string {
+	t.Helper()
+
+	var status string
+	if err := dbs.engine.QueryRow(t.Context(),
+		`SELECT status FROM runs WHERE id = $1`, id).Scan(&status); err != nil {
+		t.Fatalf("reading the status of run %s: %v", id, err)
+	}
+	return status
+}
+
+// periodRow is the status of the case's billing period and the run that closed
+// it, which is the zero id while the period is still open.
+func periodRow(t *testing.T, dbs caseDBs) (status string, finalizedRun uuid.UUID) {
+	t.Helper()
+
+	var finalized *uuid.UUID
+	if err := dbs.engine.QueryRow(t.Context(),
+		`SELECT status, finalized_run_id FROM billing_periods WHERE period_from = $1`,
+		periodFrom).Scan(&status, &finalized); err != nil {
+		t.Fatalf("reading the billing period %s: %v", instant(periodFrom), err)
+	}
+	if finalized != nil {
+		finalizedRun = *finalized
+	}
+	return status, finalizedRun
+}
+
+// countRuns is how many runs the case's period holds, which is what a refused
+// call has to leave at what it was.
+func countRuns(t *testing.T, dbs caseDBs) int {
+	t.Helper()
+
+	var count int
+	if err := dbs.engine.QueryRow(t.Context(),
+		`SELECT count(*) FROM runs WHERE period_from = $1`, periodFrom).Scan(&count); err != nil {
+		t.Fatalf("counting the runs of %s: %v", instant(periodFrom), err)
+	}
+	return count
+}
+
+// countRows is how many rows of one run a table holds. The table name is
+// interpolated because it is a constant of the calling case, one of
+// usage_records, rated_records and project_statements, and no placeholder
+// stands for an identifier.
+func countRows(t *testing.T, dbs caseDBs, table string, runID uuid.UUID) int {
+	t.Helper()
+
+	var count int
+	if err := dbs.engine.QueryRow(t.Context(),
+		fmt.Sprintf(`SELECT count(*) FROM %s WHERE run_id = $1`, table), runID).Scan(&count); err != nil {
+		t.Fatalf("counting the %s of run %s: %v", table, runID, err)
+	}
+	return count
+}

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -1,0 +1,147 @@
+// The golden suite: the worked examples of the concept, run end to end through
+// the engine. A case seeds events into a reporting database, meters, measures,
+// rates and attributes them through runs.Execute, and checks the usage records,
+// the amounts and the statement documents that come out against numbers written
+// down by hand.
+//
+// Every case bills March 2026, [2026-03-01T00:00:00Z, 2026-04-01T00:00:00Z),
+// which is the period README section 3.4 computes its examples over. The
+// expectations come from that section and from pricing/2026-03.yaml, never from
+// a previous run: a failure here is a report about the engine, so the answer to
+// one is to find what changed in the engine, not to write the engine's new
+// number into expected.json.
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestGoldenStubQuerier pins the stub the metricsql sources of the suite are
+// answered by. It needs no database, so the one seam every counter case rests
+// on is checked even where Docker is out of reach.
+func TestGoldenStubQuerier(t *testing.T) {
+	const expr = `egress_gb{cloud="os-golden-e2e",resource_id="abc-123"}[240h]`
+	at := time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC)
+
+	querier := newStubQuerier(t, []metricEntry{{Query: expr, At: at, Value: "18.0"}})
+
+	t.Run("reports a canceled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		if _, err := querier.Query(ctx, expr, at); !errors.Is(err, context.Canceled) {
+			t.Errorf("Query() error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("answers a stubbed pair", func(t *testing.T) {
+		got, err := querier.Query(t.Context(), expr, at)
+		if err != nil {
+			t.Fatalf("Query() error = %v, want nil", err)
+		}
+		if want := decimal.RequireFromString("18.0"); !got.Equal(want) {
+			t.Errorf("Query() = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("refuses an instant nothing was stubbed for", func(t *testing.T) {
+		unstubbed := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		_, err := querier.Query(t.Context(), expr, unstubbed)
+		if err == nil {
+			t.Fatal("Query() error = nil, want one")
+		}
+		want := `no stubbed metric for "egress_gb{cloud=\"os-golden-e2e\",resource_id=\"abc-123\"}[240h]" ` +
+			`at 2026-04-01T00:00:00Z`
+		if err.Error() != want {
+			t.Errorf("Query() error = %q, want %q", err.Error(), want)
+		}
+	})
+}
+
+// TestGoldenExpandBulk pins the invariant the generators of a case rest on:
+// every event one stands for lies strictly inside its interval, so none of them
+// falls on an instant the timeline splits at and is metered into the interval
+// beside the one it was written for. Like the stub above it needs no database.
+func TestGoldenExpandBulk(t *testing.T) {
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 18, 0, 0, 0, 0, time.UTC)
+
+	t.Run("a generator of count 0 stands for nothing", func(t *testing.T) {
+		got := expandBulk(t, []bulkGenerator{{EventType: "repository.pull", From: from, To: to}})
+		if len(got) != 0 {
+			t.Errorf("events = %+v, want none", got)
+		}
+	})
+
+	t.Run("every event lies strictly inside the interval", func(t *testing.T) {
+		got := expandBulk(t, []bulkGenerator{{EventType: "repository.pull", Count: 812, From: from, To: to}})
+		if len(got) != 812 {
+			t.Fatalf("events = %d, want 812", len(got))
+		}
+		for i, ev := range got {
+			if !ev.Timestamp.After(from) || !ev.Timestamp.Before(to) {
+				t.Errorf("event %d is stamped %s, want strictly inside [%s, %s)",
+					i, instant(ev.Timestamp), instant(from), instant(to))
+			}
+		}
+	})
+
+	t.Run("generators of one type name distinct events", func(t *testing.T) {
+		got := expandBulk(t, []bulkGenerator{
+			{
+				EventType: "repository.pull", Count: 3, From: from, To: to,
+				Cloud: "hb-golden-harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+			},
+			{
+				EventType: "repository.pull", Count: 3, From: to, To: periodTo,
+				Cloud: "hb-golden-harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+			},
+			// The same type over the same window on a second repository: the
+			// pair the events table would refuse on (event_id, timestamp) if
+			// the id stood for the interval alone.
+			{
+				EventType: "repository.pull", Count: 3, From: from, To: to,
+				Cloud: "hb-golden-harbor", ResourceType: "repository", ResourceID: "team-beta/app",
+			},
+			// The same id under a second resource type: a resource is keyed by
+			// the triple, so this is a fourth resource rather than the first
+			// one over again.
+			{
+				EventType: "repository.pull", Count: 3, From: from, To: to,
+				Cloud: "hb-golden-harbor", ResourceType: "artifact", ResourceID: "team-alpha/app",
+			},
+			// The first generator's window carried to the end of the period.
+			// The step differs, so these events insert beside the first
+			// generator's rather than conflicting with them, and an id without
+			// To would file two windows of one repository under one set of ids
+			// without anything downstream noticing.
+			{
+				EventType: "repository.pull", Count: 3, From: from, To: periodTo,
+				Cloud: "hb-golden-harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+			},
+			// The first generator's window and count off by one: the step
+			// differs again, and the first three ids would be the first
+			// generator's if the id left the count out.
+			{
+				EventType: "repository.pull", Count: 4, From: from, To: to,
+				Cloud: "hb-golden-harbor", ResourceType: "repository", ResourceID: "team-alpha/app",
+			},
+		})
+		ids := make(map[string]bool, len(got))
+		for _, ev := range got {
+			if ids[ev.EventID] {
+				t.Errorf("the event id %s stands for two events", ev.EventID)
+			}
+			ids[ev.EventID] = true
+		}
+		if len(ids) != 19 {
+			t.Errorf("distinct event ids = %d, want the 19 the six generators stand for", len(ids))
+		}
+	})
+}

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -19,6 +19,9 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/engine/export"
+	"github.com/b42labs/tally/internal/engine/runs"
 )
 
 // TestGoldenStubQuerier pins the stub the metricsql sources of the suite are
@@ -144,4 +147,45 @@ func TestGoldenExpandBulk(t *testing.T) {
 			t.Errorf("distinct event ids = %d, want the 19 the six generators stand for", len(ids))
 		}
 	})
+}
+
+// TestGolden runs the cases that meter one period once and read the result
+// back. Each of them gets its own pair of databases inside the containers the
+// fixture starts, so the cases share the containers and run in any order.
+func TestGolden(t *testing.T) {
+	f := newGoldenFixture(t)
+
+	for _, name := range []string{
+		"instance_resize",
+		"hetzner_upgrade",
+		"volume_resize_retype",
+		"shoot_scale_hibernate",
+		"harbor_counters",
+		"e2e_power_cycle",
+		"related_costs",
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := loadCase(t, name)
+			want := loadExpected(t, name)
+			dbs := f.caseDatabases(t, name)
+
+			seedRegistry(t, dbs, c.Registry)
+			seedEvents(t, dbs, c.Events)
+
+			result, err := runs.Execute(t.Context(), dbs.engine, dbs.source, c.options(t, want.Clouds))
+			if err != nil {
+				t.Fatalf("runs.Execute: %v", err)
+			}
+			assertClean(t, result)
+			assertStats(t, result.Stats, want.Stats)
+			assertUsage(t, dbs, result.RunID, want.Usage)
+
+			run, err := export.Load(t.Context(), dbs.engine, result.RunID)
+			if err != nil {
+				t.Fatalf("export.Load: %v", err)
+			}
+			assertRated(t, run.Rated, want.Rated)
+			assertStatements(t, run.Statements, want.Statements, want.AbsentStatements)
+		})
+	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -13,15 +13,23 @@
 package engine_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/source"
 )
 
 // TestGoldenStubQuerier pins the stub the metricsql sources of the suite are
@@ -149,9 +157,13 @@ func TestGoldenExpandBulk(t *testing.T) {
 	})
 }
 
-// TestGolden runs the cases that meter one period once and read the result
-// back. Each of them gets its own pair of databases inside the containers the
-// fixture starts, so the cases share the containers and run in any order.
+// TestGolden runs the golden suite. Every case gets its own pair of databases
+// inside the one pair of containers the fixture starts, so the cases share the
+// containers without sharing anything they bill, and the image and the
+// migration chains are paid for once rather than once per case.
+//
+// The cases of the loop meter one period once and read the result back. The
+// ones after it carry a month further than that first pass.
 func TestGolden(t *testing.T) {
 	f := newGoldenFixture(t)
 
@@ -188,4 +200,546 @@ func TestGolden(t *testing.T) {
 			assertStatements(t, run.Statements, want.Statements, want.AbsentStatements)
 		})
 	}
+
+	t.Run("correction_credit", func(t *testing.T) { goldenCorrectionCredit(t, f) })
+	t.Run("reproducibility", func(t *testing.T) { goldenReproducibility(t, f) })
+}
+
+// goldenCorrectionCredit runs the correction chain of the concept over the
+// pricing model the suite rates with: a month billed as one active interval,
+// closed, and then reached by the power cycle that arrives after the invoice
+// went out. The credit note it checks is the one README section 3.4 computes,
+// down to the three deltas and the -24.00 they add up to, and the second
+// correction after it checks that a period whose late events have been settled
+// has nothing left to credit.
+func goldenCorrectionCredit(t *testing.T, f goldenFixture) {
+	const (
+		cloud = "os-golden-credit"
+		key   = cloud + "/proj-456"
+	)
+
+	c := loadCase(t, "correction_credit")
+	dbs := f.caseDatabases(t, "correction_credit")
+	ctx := t.Context()
+
+	seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	regular, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, []string{cloud}))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, regular)
+
+	// What the month was billed at before anything arrived late: one interval
+	// over the whole of March, the three gauges of the instance, and the egress
+	// the model prices that nothing measured, billed at zero.
+	run, err := export.Load(ctx, dbs.engine, regular.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	wantAmounts := map[string]decimal.Decimal{
+		"vcpus":     decimal.RequireFromString("59.52"),
+		"ram_gb":    decimal.RequireFromString("29.76"),
+		"disk_gb":   decimal.RequireFromString("59.52"),
+		"egress_gb": decimal.RequireFromString("0.00"),
+	}
+	if len(run.Rated) != len(wantAmounts) {
+		t.Fatalf("rated records = %d, want %d", len(run.Rated), len(wantAmounts))
+	}
+	byDimension := make(map[string]export.RatedRecord, len(run.Rated))
+	for _, record := range run.Rated {
+		byDimension[record.Dimension] = record
+	}
+	for dimension, want := range wantAmounts {
+		record, rated := byDimension[dimension]
+		if !rated {
+			t.Errorf("no rated record for the %s of %s", dimension, key)
+			continue
+		}
+		if !record.Amount.Equal(want) {
+			t.Errorf("the %s amount = %s, want %s", dimension, record.Amount, want)
+		}
+		if !record.FromTS.Equal(periodFrom) {
+			t.Errorf("the %s record starts at %s, want %s",
+				dimension, instant(record.FromTS), instant(periodFrom))
+		}
+		if record.Currency != currency {
+			t.Errorf("the currency of the %s record = %q, want %q", dimension, record.Currency, currency)
+		}
+	}
+	if len(run.Statements) != 1 {
+		t.Fatalf("statements = %d, want the one project of the case", len(run.Statements))
+	}
+	if got := run.Statements[0].Key; got != key {
+		t.Errorf("statement key = %q, want %q", got, key)
+	}
+	if want := decimal.RequireFromString("148.80"); !run.Statements[0].Total.Equal(want) {
+		t.Errorf("the total of %s = %s, want %s", key, run.Statements[0].Total, want)
+	}
+
+	kind, err := runs.Finalize(ctx, dbs.engine, periodFrom, regular.RunID)
+	if err != nil {
+		t.Fatalf("runs.Finalize: %v", err)
+	}
+	if kind != runs.KindRegular {
+		t.Errorf("runs.Finalize closed a %q, want a %q", kind, runs.KindRegular)
+	}
+	status, finalized := periodRow(t, dbs)
+	if status != "finalized" {
+		t.Errorf("the billing period is %q, want finalized", status)
+	}
+	if finalized != regular.RunID {
+		t.Errorf("the period was closed by %s, want the regular run %s", finalized, regular.RunID)
+	}
+
+	// The power cycle, arriving after the month was closed. Its events are
+	// dated inside the period and reach the reporting database at an instant
+	// past the one the finalized run read it at.
+	seedLate(t, dbs, c)
+
+	late, err := runs.DetectLate(ctx, dbs.engine, dbs.source, periodFrom, periodTo)
+	if err != nil {
+		t.Fatalf("runs.DetectLate: %v", err)
+	}
+	if late.RunID != regular.RunID {
+		t.Errorf("the late events are held against %s, want the finalized run %s", late.RunID, regular.RunID)
+	}
+	if late.Kind != runs.KindRegular {
+		t.Errorf("the run the late events are held against is a %q, want a %q", late.Kind, runs.KindRegular)
+	}
+	if late.Truncated != 0 {
+		t.Errorf("Truncated = %d, want none: the case has one resource", late.Truncated)
+	}
+	if len(late.Resources) != 1 {
+		t.Fatalf("late resources = %v, want the one instance the power cycle reached", late.Resources)
+	}
+	wantResource := source.Resource{
+		Cloud: cloud, Platform: "openstack", ResourceType: "instance", ResourceID: "abc-123",
+	}
+	if late.Resources[0].Resource != wantResource {
+		t.Errorf("the late resource = %+v, want %+v", late.Resources[0].Resource, wantResource)
+	}
+	if late.Resources[0].Events != 2 {
+		t.Errorf("the late resource carries %d events, want the two of the power cycle",
+			late.Resources[0].Events)
+	}
+
+	first, err := runs.Correct(ctx, dbs.engine, dbs.source, c.correctOptions(t))
+	if err != nil {
+		t.Fatalf("runs.Correct: %v", err)
+	}
+	if first.CorrectsRunID != regular.RunID {
+		t.Errorf("CorrectsRunID = %s, want the finalized run %s", first.CorrectsRunID, regular.RunID)
+	}
+	if first.PricingVersion != pricingVersion {
+		t.Errorf("PricingVersion = %q, want the %q the corrected run rated with",
+			first.PricingVersion, pricingVersion)
+	}
+	assertNoWarnings(t, first.Stats.Stats)
+	for _, count := range []struct {
+		name      string
+		got, want int
+	}{
+		{"deltas", first.Stats.Deltas, 3},
+		{"usage_records", first.Stats.UsageRecords, 3},
+		{"rated_records", first.Stats.RatedRecords, 12},
+		{"statements", first.Stats.Statements, 1},
+	} {
+		if count.got != count.want {
+			t.Errorf("correction stats %s = %d, want %d", count.name, count.got, count.want)
+		}
+	}
+
+	credit, err := export.Load(ctx, dbs.engine, first.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	// The three gauges the shutoff interval halved, in the order the diff sorts
+	// its keys. The egress both passes rated at zero is no difference, so the
+	// correction writes no delta for it.
+	wantDeltas := []struct{ dimension, old, new, delta string }{
+		{"disk_gb", "59.52", "49.92", "-9.60"},
+		{"ram_gb", "29.76", "24.96", "-4.80"},
+		{"vcpus", "59.52", "49.92", "-9.60"},
+	}
+	if len(credit.Deltas) != len(wantDeltas) {
+		t.Fatalf("deltas = %d, want %d", len(credit.Deltas), len(wantDeltas))
+	}
+	for i, w := range wantDeltas {
+		got := credit.Deltas[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"dimension", got.Dimension, w.dimension},
+			{"cloud", got.Cloud, cloud},
+			{"resource_id", got.ResourceID, "abc-123"},
+			{"project_id", got.ProjectID, "proj-456"},
+			{"currency", got.Currency, currency},
+		} {
+			if field.got != field.want {
+				t.Errorf("delta %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		for _, amount := range []struct {
+			name string
+			got  decimal.Decimal
+			want string
+		}{
+			{"old", got.Old, w.old},
+			{"new", got.New, w.new},
+			// The embedded corrections.Delta carries a field of its own name,
+			// so the difference is one level down from the export record.
+			{"delta", got.Delta.Delta, w.delta},
+		} {
+			if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+				t.Errorf("delta %d: the %s amount of %s = %s, want %s",
+					i, amount.name, w.dimension, amount.got, want)
+			}
+		}
+	}
+
+	if len(credit.Statements) != 1 {
+		t.Fatalf("credit notes = %d, want the one project of the case", len(credit.Statements))
+	}
+	note := credit.Statements[0]
+	if note.Key != key {
+		t.Errorf("credit note key = %q, want %q", note.Key, key)
+	}
+	if want := decimal.RequireFromString("-24.00"); !note.Total.Equal(want) {
+		t.Errorf("the total of the credit note of %s = %s, want %s", key, note.Total, want)
+	}
+	if note.Currency != currency {
+		t.Errorf("the currency of the credit note of %s = %q, want %q", key, note.Currency, currency)
+	}
+	var document corrections.CreditNote
+	if err := json.Unmarshal(note.Document, &document); err != nil {
+		t.Fatalf("decoding the credit note of %s: %v", key, err)
+	}
+	if document.CorrectsRunID != regular.RunID.String() {
+		t.Errorf("the credit note corrects run %s, want the finalized run %s",
+			document.CorrectsRunID, regular.RunID)
+	}
+	// Who the note is for and what it covers. The period is written out rather
+	// than taken from the options the correction was called with: a note stamped
+	// with the month beside the one it credits would agree with those.
+	assertBillingPeriod(t, "the credit note of "+key, document.BillingPeriod,
+		expectedBillingPeriod{From: "2026-03-01T00:00:00Z", To: "2026-04-01T00:00:00Z"})
+	for _, field := range []struct{ name, got, want string }{
+		{"project", document.ProjectID, "proj-456"},
+		{"platform", document.Platform, "openstack"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the %s of the credit note of %s = %q, want %q",
+				field.name, key, field.got, field.want)
+		}
+	}
+	if len(document.RelatedCosts) != 0 {
+		t.Errorf("the credit note of %s carries the related costs %+v, want none: "+
+			"the case registers one project", key, document.RelatedCosts)
+	}
+
+	// The body of the note, which is what the project reads. The deltas above
+	// are the rows the correction wrote; these are the lines it rendered from
+	// them, and nothing so far has compared the two.
+	if len(document.LineItems) != 1 {
+		t.Fatalf("the credit note of %s carries %d line items, want the one instance the power cycle reached",
+			key, len(document.LineItems))
+	}
+	line := document.LineItems[0]
+	for _, field := range []struct{ name, got, want string }{
+		{"resource_type", line.ResourceType, "instance"},
+		{"resource_id", line.ResourceID, "abc-123"},
+		{"platform", line.Platform, "openstack"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the line of the credit note of %s: %s = %q, want %q",
+				key, field.name, field.got, field.want)
+		}
+	}
+	if want := decimal.RequireFromString("-24.00"); !line.Total.Equal(want) {
+		t.Errorf("the total of the line of the credit note of %s = %s, want %s", key, line.Total, want)
+	}
+	if len(line.Dimensions) != len(wantDeltas) {
+		t.Errorf("the line of the credit note of %s credits %d dimensions, want %d",
+			key, len(line.Dimensions), len(wantDeltas))
+	}
+	for _, w := range wantDeltas {
+		change, credited := line.Dimensions[w.dimension]
+		if !credited {
+			t.Errorf("the line of the credit note of %s credits no %s", key, w.dimension)
+			continue
+		}
+		for _, amount := range []struct {
+			name string
+			got  decimal.Decimal
+			want string
+		}{
+			{"old", change.Old.Decimal, w.old},
+			{"new", change.New.Decimal, w.new},
+			{"delta", change.Delta.Decimal, w.delta},
+		} {
+			if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+				t.Errorf("the %s of the %s on the credit note of %s = %s, want %s",
+					amount.name, w.dimension, key, amount.got, want)
+			}
+		}
+	}
+
+	if kind, err = runs.Finalize(ctx, dbs.engine, periodFrom, first.RunID); err != nil {
+		t.Fatalf("runs.Finalize: %v", err)
+	} else if kind != runs.KindCorrection {
+		t.Errorf("runs.Finalize closed a %q, want a %q", kind, runs.KindCorrection)
+	}
+
+	// The finalized correction is the period's truth now, and the power cycle
+	// is in it, so correcting again finds nothing to credit.
+	second, err := runs.Correct(ctx, dbs.engine, dbs.source, c.correctOptions(t))
+	if err != nil {
+		t.Fatalf("runs.Correct: %v", err)
+	}
+	assertNoWarnings(t, second.Stats.Stats)
+	if second.CorrectsRunID != first.RunID {
+		t.Errorf("CorrectsRunID = %s, want the finalized correction %s", second.CorrectsRunID, first.RunID)
+	}
+	if second.Stats.Deltas != 0 {
+		t.Errorf("Stats.Deltas = %d, want none: the power cycle has been settled", second.Stats.Deltas)
+	}
+	if second.Stats.Statements != 0 {
+		t.Errorf("Stats.Statements = %d, want none: there is nothing to credit", second.Stats.Statements)
+	}
+	settled, err := export.Load(ctx, dbs.engine, second.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if len(settled.Deltas) != 0 {
+		t.Errorf("deltas = %+v, want none", settled.Deltas)
+	}
+	if len(settled.Statements) != 0 {
+		t.Errorf("credit notes = %d, want none", len(settled.Statements))
+	}
+	if got := runStatus(t, dbs, second.RunID); got != "completed" {
+		t.Errorf("status = %q, want completed: a correction that found nothing is a correction", got)
+	}
+
+	// Nothing has arrived since the correction closed, and the events that had
+	// are below its snapshot, so the period reads as settled.
+	late, err = runs.DetectLate(ctx, dbs.engine, dbs.source, periodFrom, periodTo)
+	if err != nil {
+		t.Fatalf("runs.DetectLate: %v", err)
+	}
+	if late.RunID != first.RunID {
+		t.Errorf("the late events are held against %s, want the finalized correction %s",
+			late.RunID, first.RunID)
+	}
+	if late.Kind != runs.KindCorrection {
+		t.Errorf("the run the late events are held against is a %q, want a %q",
+			late.Kind, runs.KindCorrection)
+	}
+	if len(late.Resources) != 0 {
+		t.Errorf("late resources = %+v, want none: the correction re-metered them", late.Resources)
+	}
+}
+
+// goldenReproducibility meters one period twice from the same events and checks
+// that the two runs bill the same thing. It is the phase's third exit criterion:
+// a rerun of a month is what an operator does after a failed pass, and a rerun
+// that prices the month differently would make the invoice depend on when it was
+// produced. Both runs are exported to disk, so what is compared is the artifact
+// a customer receives and not only the rows behind it.
+//
+// The case it meters is the power cycle of the loop above, in databases of its
+// own. Two runs that agree with each other and with nothing else would be
+// reproducibly wrong, so the first of them is held against that case's
+// expectations whole rather than against one total written out again here.
+func goldenReproducibility(t *testing.T, f goldenFixture) {
+	const (
+		cloud = "os-golden-e2e"
+		key   = cloud + "/proj-456"
+	)
+
+	c := loadCase(t, "e2e_power_cycle")
+	want := loadExpected(t, "e2e_power_cycle")
+	dbs := f.caseDatabases(t, "reproducibility")
+	ctx := t.Context()
+
+	seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+	dir := t.TempDir()
+
+	// The second run supersedes the first, and export.Load refuses a superseded
+	// run, so the first run is read and written out before the second opens.
+	first, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, first)
+	assertStats(t, first.Stats, want.Stats)
+	assertUsage(t, dbs, first.RunID, want.Usage)
+
+	a, err := export.Load(ctx, dbs.engine, first.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	assertRated(t, a.Rated, want.Rated)
+	assertStatements(t, a.Statements, want.Statements, want.AbsentStatements)
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "a")}).Export(ctx, a); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	second, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, second)
+	if !slices.Equal(second.Superseded, []uuid.UUID{first.RunID}) {
+		t.Errorf("Superseded = %v, want the first run %s", second.Superseded, first.RunID)
+	}
+
+	b, err := export.Load(ctx, dbs.engine, second.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "b")}).Export(ctx, b); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	if len(b.Statements) != len(a.Statements) {
+		t.Fatalf("the second run billed %d statements, want the %d of the first",
+			len(b.Statements), len(a.Statements))
+	}
+	for i, want := range a.Statements {
+		got := b.Statements[i]
+		if got.Key != want.Key {
+			t.Errorf("statement %d: key = %q, want %q", i, got.Key, want.Key)
+		}
+		if !bytes.Equal(got.Document, want.Document) {
+			t.Errorf("the document of %s = %s, want %s", want.Key, got.Document, want.Document)
+		}
+		if !got.Total.Equal(want.Total) {
+			t.Errorf("the total of %s = %s, want %s", want.Key, got.Total, want.Total)
+		}
+		if got.Currency != want.Currency {
+			t.Errorf("the currency of %s = %q, want %q", want.Key, got.Currency, want.Currency)
+		}
+	}
+
+	if len(b.Rated) != len(a.Rated) {
+		t.Fatalf("the second run rated %d records, want the %d of the first", len(b.Rated), len(a.Rated))
+	}
+	for i, want := range a.Rated {
+		got := b.Rated[i]
+		if got.Resource != want.Resource {
+			t.Errorf("rated record %d: resource = %+v, want %+v", i, got.Resource, want.Resource)
+		}
+		for _, field := range []struct{ name, got, want string }{
+			{"project_id", got.ProjectID, want.ProjectID},
+			{"state", got.State, want.State},
+			{"dimension", got.Dimension, want.Dimension},
+			{"currency", got.Currency, want.Currency},
+		} {
+			if field.got != field.want {
+				t.Errorf("rated record %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		if !got.FromTS.Equal(want.FromTS) {
+			t.Errorf("rated record %d: from = %s, want %s", i, instant(got.FromTS), instant(want.FromTS))
+		}
+		if !got.ToTS.Equal(want.ToTS) {
+			t.Errorf("rated record %d: to = %s, want %s", i, instant(got.ToTS), instant(want.ToTS))
+		}
+		if !got.Quantity.Equal(want.Quantity) {
+			t.Errorf("rated record %d: the %s quantity = %s, want %s",
+				i, want.Dimension, got.Quantity, want.Quantity)
+		}
+		if !got.Amount.Equal(want.Amount) {
+			t.Errorf("rated record %d: the %s amount = %s, want %s",
+				i, want.Dimension, got.Amount, want.Amount)
+		}
+	}
+
+	document := export.DocumentFileName(runs.KindRegular, key)
+	if want := "statement-os-golden-e2e%2Fproj-456.json"; document != want {
+		t.Fatalf("export.DocumentFileName = %q, want %q", document, want)
+	}
+	documentA := readExported(t, filepath.Join(dir, "a", document))
+	documentB := readExported(t, filepath.Join(dir, "b", document))
+	if !bytes.Equal(documentA, documentB) {
+		t.Errorf("the two exports of %s differ:\n%s\n%s", document, documentA, documentB)
+	}
+
+	// run_id, started_at, completed_at and stats.snapshot_at name the pass
+	// rather than what it billed, and they differ between two runs of one
+	// period by design. What has to agree is the pricing version and the index
+	// of the documents, which is what exportedRun holds.
+	indexA := readRunIndex(t, filepath.Join(dir, "a"))
+	indexB := readRunIndex(t, filepath.Join(dir, "b"))
+	for _, index := range []struct {
+		dir string
+		run exportedRun
+	}{{dir: "a", run: indexA}, {dir: "b", run: indexB}} {
+		if index.run.PricingVersion == nil {
+			t.Fatalf("the run.json of %s carries no pricing version, want %q", index.dir, pricingVersion)
+		}
+		if *index.run.PricingVersion != pricingVersion {
+			t.Errorf("the pricing version of %s = %q, want %q",
+				index.dir, *index.run.PricingVersion, pricingVersion)
+		}
+	}
+	if len(indexB.Statements) != len(indexA.Statements) {
+		t.Fatalf("the run.json of the second run indexes %d statements, want the %d of the first",
+			len(indexB.Statements), len(indexA.Statements))
+	}
+	for i, want := range indexA.Statements {
+		got := indexB.Statements[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"file", got.File, want.File},
+			{"cloud", got.Cloud, want.Cloud},
+			{"project_id", got.ProjectID, want.ProjectID},
+			{"currency", got.Currency, want.Currency},
+		} {
+			if field.got != field.want {
+				t.Errorf("indexed statement %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		if !got.Total.Equal(want.Total) {
+			t.Errorf("indexed statement %d: total = %s, want %s", i, got.Total, want.Total)
+		}
+	}
+}
+
+// exportedRun is the part of an exported run.json two runs of one period have
+// to agree on: the version they rated with, and the documents they wrote beside
+// the projects those bill.
+type exportedRun struct {
+	PricingVersion *string            `json:"pricing_version"`
+	Statements     []exportedDocument `json:"statements"`
+}
+
+// exportedDocument is one entry of the index run.json carries.
+type exportedDocument struct {
+	File      string          `json:"file"`
+	Cloud     string          `json:"cloud"`
+	ProjectID string          `json:"project_id"`
+	Total     decimal.Decimal `json:"total"`
+	Currency  string          `json:"currency"`
+}
+
+// readRunIndex reads the run.json one export wrote.
+func readRunIndex(t *testing.T, dir string) exportedRun {
+	t.Helper()
+
+	path := filepath.Join(dir, "run.json")
+	var index exportedRun
+	decodeJSON(t, path, readExported(t, path), &index)
+	return index
+}
+
+// readExported reads one file an export wrote, naming the path a failure is on.
+func readExported(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the exported %s: %v", path, err)
+	}
+	return data
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -28,7 +29,10 @@ import (
 
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/export"
+	"github.com/b42labs/tally/internal/engine/invariants"
+	"github.com/b42labs/tally/internal/engine/metering"
 	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/scheduler"
 	"github.com/b42labs/tally/internal/engine/source"
 )
 
@@ -203,6 +207,8 @@ func TestGolden(t *testing.T) {
 
 	t.Run("correction_credit", func(t *testing.T) { goldenCorrectionCredit(t, f) })
 	t.Run("reproducibility", func(t *testing.T) { goldenReproducibility(t, f) })
+	t.Run("invariant_violation", func(t *testing.T) { goldenInvariantViolation(t, f) })
+	t.Run("scheduler_drill", func(t *testing.T) { goldenSchedulerDrill(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -742,4 +748,399 @@ func readExported(t *testing.T, path string) []byte {
 		t.Fatalf("reading the exported %s: %v", path, err)
 	}
 	return data
+}
+
+// goldenInvariantViolation is the negative case of the suite: a period the
+// engine has to refuse. One instance of it carries an update after its delete,
+// which reopens its timeline and bills time no life of the resource covers, so
+// the coverage invariant is breached. The run must fail on that resource, name
+// it alone, and leave nothing behind that a later step could mistake for a
+// billed month: no records, no export, and a period still open.
+func goldenInvariantViolation(t *testing.T, f goldenFixture) {
+	const cloud = "os-golden-violation"
+
+	c := loadCase(t, "invariant_violation")
+	dbs := f.caseDatabases(t, "invariant_violation")
+	ctx := t.Context()
+
+	seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	result, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, []string{cloud}))
+	if err == nil {
+		t.Fatal("runs.Execute error = nil, want the violating resource reported")
+	}
+	var violation *metering.ViolationError
+	if !errors.As(err, &violation) {
+		t.Fatalf("runs.Execute error = %v, want a *metering.ViolationError", err)
+	}
+	// The sound instance shares the period with the broken one, and this length
+	// is what says it was not swept up with it.
+	if len(violation.Resources) != 1 {
+		t.Fatalf("violating resources = %+v, want the one instance the update reopened",
+			violation.Resources)
+	}
+	reported := violation.Resources[0]
+	for _, field := range []struct{ name, got, want string }{
+		{"cloud", reported.Cloud, cloud},
+		{"resource_type", reported.ResourceType, "instance"},
+		{"resource_id", reported.ResourceID, "i-broken"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the violating resource: %s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+	if !slices.ContainsFunc(reported.Violations, func(v invariants.Violation) bool {
+		return v.Invariant == invariants.InvariantCoverage
+	}) {
+		t.Errorf("the violations of i-broken = %+v, want one of %q",
+			reported.Violations, invariants.InvariantCoverage)
+	}
+
+	if result.RunID == uuid.Nil {
+		t.Fatal("runs.Execute reported no run id, want the run it opened and failed")
+	}
+	if got := runStatus(t, dbs, result.RunID); got != "failed" {
+		t.Errorf("status = %q, want failed", got)
+	}
+	// The stats are what an operator reads the period from, so they carry the
+	// same report the caller got.
+	if !reflect.DeepEqual(result.Stats.Violations, violation.Resources) {
+		t.Errorf("stats violations = %+v, want the reported %+v",
+			result.Stats.Violations, violation.Resources)
+	}
+	if result.Stats.Error != err.Error() {
+		t.Errorf("stats error = %q, want the failure %q", result.Stats.Error, err.Error())
+	}
+
+	for _, table := range []string{"usage_records", "rated_records", "project_statements"} {
+		if got := countRows(t, dbs, table, result.RunID); got != 0 {
+			t.Errorf("the failed run holds %d rows in %s, want none", got, table)
+		}
+	}
+
+	if _, err := export.Load(ctx, dbs.engine, result.RunID); !errors.Is(err, export.ErrRunNotExportable) {
+		t.Errorf("export.Load error = %v, want one matching export.ErrRunNotExportable", err)
+	}
+
+	if status, _ := periodRow(t, dbs); status != "open" {
+		t.Errorf("the billing period is %q, want open: a month nothing billed is still to be billed",
+			status)
+	}
+
+	// The whole period is refused, so the instance whose history does describe a
+	// life is not billed either, by this run or by any other.
+	var sound int
+	if err := dbs.engine.QueryRow(ctx,
+		`SELECT count(*) FROM usage_records WHERE resource_id = 'i-sound'`).Scan(&sound); err != nil {
+		t.Fatalf("counting the usage records of i-sound: %v", err)
+	}
+	if sound != 0 {
+		t.Errorf("i-sound holds %d usage records, want none", sound)
+	}
+}
+
+// goldenSchedulerDrill is the phase's fifth exit criterion: one month
+// carried through an operator's calendar by the tick. March is moved into grace
+// when it ends, left alone for the whole grace window, metered at the end of it
+// and not metered again, finalized by hand, credited over the power cycle that
+// arrives after the invoice, and then walked once more without being touched.
+// The clock is an argument of scheduler.Tick, so the days of April are stepped
+// through in one test.
+func goldenSchedulerDrill(t *testing.T, f goldenFixture) {
+	const (
+		cloud = "os-golden-drill"
+		key   = cloud + "/proj-456"
+	)
+
+	c := loadCase(t, "scheduler_drill")
+	dbs := f.caseDatabases(t, "scheduler_drill")
+	ctx := t.Context()
+
+	seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	// The executor the CLI wires runs.Execute into. It counts its calls, because
+	// half of what the drill checks is the ticks that do not meter.
+	calls := 0
+	exec := func(ctx context.Context, from, to time.Time) (uuid.UUID, error) {
+		calls++
+		if !from.Equal(periodFrom) || !to.Equal(periodTo) {
+			t.Errorf("the tick metered [%s, %s), want the March of the case [%s, %s)",
+				instant(from), instant(to), instant(periodFrom), instant(periodTo))
+		}
+		opts := c.options(t, []string{cloud})
+		opts.PeriodFrom, opts.PeriodTo = from, to
+		r, err := runs.Execute(ctx, dbs.engine, dbs.source, opts)
+		return r.RunID, err
+	}
+	tick := func(now time.Time) scheduler.Report {
+		report, err := scheduler.Tick(ctx, dbs.engine, now, scheduler.Options{
+			GraceHours: 72, AutoFinalize: false, Execute: exec,
+		})
+		if err != nil {
+			t.Fatalf("scheduler.Tick at %s: %v", instant(now), err)
+		}
+		return report
+	}
+	// month is the single entry every tick past the end of March reports. A
+	// second month in the walk, a failure or a warning is a finding of its own,
+	// so they are checked here rather than at each of the steps below.
+	month := func(report scheduler.Report, now time.Time) scheduler.MonthReport {
+		if len(report) != 1 {
+			t.Fatalf("the tick at %s walked %d months, want the one of the case",
+				instant(now), len(report))
+		}
+		got := report[0]
+		if got.Month != "2026-03" {
+			t.Errorf("the tick at %s walked %q, want 2026-03", instant(now), got.Month)
+		}
+		if got.Err != nil {
+			t.Errorf("the tick at %s failed the month: %v", instant(now), got.Err)
+		}
+		if got.Warning != nil {
+			t.Errorf("the tick at %s warned: %v", instant(now), got.Warning)
+		}
+		return got
+	}
+
+	// The row tally-engine run --period writes. The walk starts at the earliest
+	// billing period the engine knows, so without it a tick would walk the month
+	// before its clock rather than the March of the case.
+	if _, err := dbs.engine.Exec(ctx,
+		`INSERT INTO billing_periods (period_from, period_to, status) VALUES ($1, $2, 'open')`,
+		periodFrom, periodTo); err != nil {
+		t.Fatalf("recording the billing period %s: %v", instant(periodFrom), err)
+	}
+
+	// The last second of March: the month has not ended, so nothing is due.
+	if report := tick(time.Date(2026, 3, 31, 23, 59, 59, 0, time.UTC)); len(report) != 0 {
+		t.Errorf("the tick inside March walked %+v, want nothing", report)
+	}
+	if status, _ := periodRow(t, dbs); status != "open" {
+		t.Errorf("the billing period is %q, want open", status)
+	}
+	if got := countRuns(t, dbs); got != 0 {
+		t.Errorf("the period holds %d runs, want none", got)
+	}
+	if calls != 0 {
+		t.Errorf("the executor was called %d times, want none inside March", calls)
+	}
+
+	// The first instant of April: March has ended, and its open phase with it.
+	now := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	ended := month(tick(now), now)
+	if want := "open -> grace"; ended.Transition != want {
+		t.Errorf("the tick at the end of March reported %q, want %q", ended.Transition, want)
+	}
+	if ended.RunID != uuid.Nil {
+		t.Errorf("the tick at the end of March metered run %s, want the grace window first", ended.RunID)
+	}
+	if status, _ := periodRow(t, dbs); status != "grace" {
+		t.Errorf("the billing period is %q, want grace", status)
+	}
+	if calls != 0 {
+		t.Errorf("the executor was called %d times, want none: the grace window has just opened", calls)
+	}
+
+	// The last second of the 72 hours late events are waited for.
+	now = time.Date(2026, 4, 3, 23, 59, 59, 0, time.UTC)
+	waiting := month(tick(now), now)
+	if waiting.Transition != "" {
+		t.Errorf("the tick inside the grace window reported the transition %q, want none",
+			waiting.Transition)
+	}
+	if waiting.RunID != uuid.Nil {
+		t.Errorf("the tick inside the grace window metered run %s, want nothing yet", waiting.RunID)
+	}
+	if calls != 0 {
+		t.Errorf("the executor was called %d times, want none inside the grace window", calls)
+	}
+	if got := countRuns(t, dbs); got != 0 {
+		t.Errorf("the period holds %d runs, want none inside the grace window", got)
+	}
+
+	// The grace window has passed: this is the tick that bills the month.
+	now = time.Date(2026, 4, 4, 0, 0, 0, 0, time.UTC)
+	billed := month(tick(now), now)
+	if billed.RunID == uuid.Nil {
+		t.Fatal("the tick at the end of the grace window metered no run, want the regular run of March")
+	}
+	regular := billed.RunID
+	if billed.Finalized {
+		t.Error("the tick closed March, want it left open: AutoFinalize is off")
+	}
+	if calls != 1 {
+		t.Errorf("the executor was called %d times, want once", calls)
+	}
+	if status, _ := periodRow(t, dbs); status != "grace" {
+		t.Errorf("the billing period is %q, want grace: an operator closes a metered month", status)
+	}
+	run, err := export.Load(ctx, dbs.engine, regular)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if run.Status != "completed" {
+		t.Errorf("the metered run is %q, want completed", run.Status)
+	}
+	if len(run.Statements) != 1 {
+		t.Fatalf("statements = %d, want the one project of the case", len(run.Statements))
+	}
+	if got := run.Statements[0].Key; got != key {
+		t.Errorf("statement key = %q, want %q", got, key)
+	}
+	if want := decimal.RequireFromString("148.80"); !run.Statements[0].Total.Equal(want) {
+		t.Errorf("the total of %s = %s, want %s", key, run.Statements[0].Total, want)
+	}
+
+	// The next hourly pass finds a month that carries a completed run, and such
+	// a month is not metered a second time.
+	now = time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
+	if got := month(tick(now), now); got.RunID != uuid.Nil {
+		t.Errorf("the tick after the run metered %s, want nothing", got.RunID)
+	}
+	if calls != 1 {
+		t.Errorf("the executor was called %d times, want the one of the grace step", calls)
+	}
+	if got := countRuns(t, dbs); got != 1 {
+		t.Errorf("the period holds %d runs, want the one the tick metered", got)
+	}
+
+	kind, err := runs.Finalize(ctx, dbs.engine, periodFrom, regular)
+	if err != nil {
+		t.Fatalf("runs.Finalize: %v", err)
+	}
+	if kind != runs.KindRegular {
+		t.Errorf("runs.Finalize closed a %q, want a %q", kind, runs.KindRegular)
+	}
+	status, finalized := periodRow(t, dbs)
+	if status != "finalized" {
+		t.Errorf("the billing period is %q, want finalized", status)
+	}
+	if finalized != regular {
+		t.Errorf("the period was closed by %s, want the metered run %s", finalized, regular)
+	}
+
+	// The power cycle, arriving after the month was closed.
+	seedLate(t, dbs, c)
+
+	late, err := runs.DetectLate(ctx, dbs.engine, dbs.source, periodFrom, periodTo)
+	if err != nil {
+		t.Fatalf("runs.DetectLate: %v", err)
+	}
+	if late.RunID != regular {
+		t.Errorf("the late events are held against %s, want the finalized run %s", late.RunID, regular)
+	}
+	if late.Kind != runs.KindRegular {
+		t.Errorf("the run the late events are held against is a %q, want a %q", late.Kind, runs.KindRegular)
+	}
+	if late.Truncated != 0 {
+		t.Errorf("Truncated = %d, want none: the case has one resource", late.Truncated)
+	}
+	if len(late.Resources) != 1 {
+		t.Fatalf("late resources = %v, want the one instance the power cycle reached", late.Resources)
+	}
+	wantResource := source.Resource{
+		Cloud: cloud, Platform: "openstack", ResourceType: "instance", ResourceID: "abc-123",
+	}
+	if late.Resources[0].Resource != wantResource {
+		t.Errorf("the late resource = %+v, want %+v", late.Resources[0].Resource, wantResource)
+	}
+	if late.Resources[0].Events != 2 {
+		t.Errorf("the late resource carries %d events, want the two of the power cycle",
+			late.Resources[0].Events)
+	}
+
+	correction, err := runs.Correct(ctx, dbs.engine, dbs.source, c.correctOptions(t))
+	if err != nil {
+		t.Fatalf("runs.Correct: %v", err)
+	}
+	assertNoWarnings(t, correction.Stats.Stats)
+	if correction.CorrectsRunID != regular {
+		t.Errorf("CorrectsRunID = %s, want the finalized run %s", correction.CorrectsRunID, regular)
+	}
+	if correction.Stats.Deltas != 3 {
+		t.Errorf("Stats.Deltas = %d, want the three gauges the shutoff interval halved",
+			correction.Stats.Deltas)
+	}
+
+	credit, err := export.Load(ctx, dbs.engine, correction.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	// The three gauges of the instance, in the order the diff sorts its keys.
+	wantDeltas := []struct{ dimension, delta string }{
+		{"disk_gb", "-9.60"},
+		{"ram_gb", "-4.80"},
+		{"vcpus", "-9.60"},
+	}
+	if len(credit.Deltas) != len(wantDeltas) {
+		t.Fatalf("deltas = %d, want %d", len(credit.Deltas), len(wantDeltas))
+	}
+	for i, w := range wantDeltas {
+		got := credit.Deltas[i]
+		if got.Dimension != w.dimension {
+			t.Errorf("delta %d: dimension = %q, want %q", i, got.Dimension, w.dimension)
+		}
+		// The embedded corrections.Delta carries a field of its own name, so the
+		// difference is one level down from the export record.
+		if want := decimal.RequireFromString(w.delta); !got.Delta.Delta.Equal(want) {
+			t.Errorf("delta %d: the %s difference = %s, want %s",
+				i, w.dimension, got.Delta.Delta, want)
+		}
+	}
+	if len(credit.Statements) != 1 {
+		t.Fatalf("credit notes = %d, want the one project of the case", len(credit.Statements))
+	}
+	note := credit.Statements[0]
+	if note.Key != key {
+		t.Errorf("credit note key = %q, want %q", note.Key, key)
+	}
+	if want := decimal.RequireFromString("-24.00"); !note.Total.Equal(want) {
+		t.Errorf("the total of the credit note of %s = %s, want %s", key, note.Total, want)
+	}
+	// The month the note credits, written out rather than taken from the options
+	// the correction was called with: a correction derives its period from the
+	// run it corrects, and a note stamped with the month beside this one would
+	// carry every amount above it unchanged.
+	var document corrections.CreditNote
+	if err := json.Unmarshal(note.Document, &document); err != nil {
+		t.Fatalf("decoding the credit note of %s: %v", key, err)
+	}
+	assertBillingPeriod(t, "the credit note of "+key, document.BillingPeriod,
+		expectedBillingPeriod{From: "2026-03-01T00:00:00Z", To: "2026-04-01T00:00:00Z"})
+	for _, field := range []struct{ name, got, want string }{
+		{"project", document.ProjectID, "proj-456"},
+		{"platform", document.Platform, "openstack"},
+		{"corrects_run_id", document.CorrectsRunID, regular.String()},
+	} {
+		if field.got != field.want {
+			t.Errorf("the %s of the credit note of %s = %q, want %q",
+				field.name, key, field.got, field.want)
+		}
+	}
+
+	// A finalized month is walked and left alone. The correction an operator ran
+	// against it stands, and the tick meters nothing.
+	now = time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+	closed := month(tick(now), now)
+	if closed.Transition != "" {
+		t.Errorf("the tick after the finalization reported the transition %q, want none",
+			closed.Transition)
+	}
+	if closed.RunID != uuid.Nil {
+		t.Errorf("the tick after the finalization named run %s, want none", closed.RunID)
+	}
+	if closed.Finalized {
+		t.Error("the tick closed March, want it already closed by the operator")
+	}
+	if calls != 1 {
+		t.Errorf("the executor was called %d times, want the one of the grace step", calls)
+	}
+	if got := runStatus(t, dbs, correction.RunID); got != "completed" {
+		t.Errorf("the correction is %q, want completed", got)
+	}
+	if status, _ := periodRow(t, dbs); status != "finalized" {
+		t.Errorf("the billing period is %q, want finalized", status)
+	}
 }

--- a/internal/engine/testdata/golden/correction_credit/events.json
+++ b/internal/engine/testdata/golden/correction_credit/events.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-abc-123",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-credit",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/correction_credit/late.json
+++ b/internal/engine/testdata/golden/correction_credit/late.json
@@ -1,0 +1,27 @@
+{
+  "events": [
+    {
+      "event_id": "ev-late-off-abc-123",
+      "timestamp": "2026-03-11T00:00:00Z",
+      "event_type": "compute.instance.power_off.end",
+      "platform": "openstack",
+      "cloud": "os-golden-credit",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "shutoff"}
+    },
+    {
+      "event_id": "ev-late-on-abc-123",
+      "timestamp": "2026-03-21T00:00:00Z",
+      "event_type": "compute.instance.power_on.end",
+      "platform": "openstack",
+      "cloud": "os-golden-credit",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/correction_credit/registry.json
+++ b/internal/engine/testdata/golden/correction_credit/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-credit", "external_id": "proj-456"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/e2e_power_cycle/counters.yaml
+++ b/internal/engine/testdata/golden/e2e_power_cycle/counters.yaml
@@ -1,0 +1,6 @@
+sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'egress_gb{cloud="{cloud}",resource_id="{resource_id}"}[{window}]'

--- a/internal/engine/testdata/golden/e2e_power_cycle/events.json
+++ b/internal/engine/testdata/golden/e2e_power_cycle/events.json
@@ -1,0 +1,41 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-abc-123",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-e2e",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    },
+    {
+      "event_id": "ev-power-off-abc-123",
+      "timestamp": "2026-03-11T00:00:00Z",
+      "event_type": "compute.instance.power_off.end",
+      "platform": "openstack",
+      "cloud": "os-golden-e2e",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "shutoff"}
+    },
+    {
+      "event_id": "ev-power-on-abc-123",
+      "timestamp": "2026-03-21T00:00:00Z",
+      "event_type": "compute.instance.power_on.end",
+      "platform": "openstack",
+      "cloud": "os-golden-e2e",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/e2e_power_cycle/expected.json
+++ b/internal/engine/testdata/golden/e2e_power_cycle/expected.json
@@ -1,0 +1,121 @@
+{
+  "clouds": ["os-golden-e2e"],
+  "stats": {"candidates": 1, "usage_records": 3, "rated_records": 12, "statements": 1},
+  "usage": [
+    {
+      "cloud": "os-golden-e2e",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-11T00:00:00Z",
+      "seconds": 864000,
+      "usage": {
+        "minutes": "14400",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large",
+        "egress_gb": "18.0"
+      }
+    },
+    {
+      "cloud": "os-golden-e2e",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "state": "shutoff",
+      "from": "2026-03-11T00:00:00Z",
+      "to": "2026-03-21T00:00:00Z",
+      "seconds": 864000,
+      "usage": {
+        "minutes": "14400",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large",
+        "egress_gb": "0"
+      }
+    },
+    {
+      "cloud": "os-golden-e2e",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "state": "active",
+      "from": "2026-03-21T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 950400,
+      "usage": {
+        "minutes": "15840",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large",
+        "egress_gb": "22.5"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "19.20"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "9.60"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "19.20"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "18", "amount": "1.62"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-11T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "9.60"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-11T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "4.80"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-11T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "9.60"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-11T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-21T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "21.12"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-21T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "10.56"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-21T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "21.12"},
+    {"cloud": "os-golden-e2e", "resource_id": "abc-123", "from": "2026-03-21T00:00:00Z", "dimension": "egress_gb", "quantity": "22.5", "amount": "2.03"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-e2e/proj-456",
+      "total": "128.45",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-456",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "abc-123",
+          "total": "128.45",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "240.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "18"},
+              "cost": {"vcpus": "19.20", "ram_gb": "9.60", "disk_gb": "19.20", "egress_gb": "1.62", "total": "49.62"}
+            },
+            {
+              "state": "shutoff",
+              "hours": "240.00",
+              "state_modifier": "0.5",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "0"},
+              "cost": {"vcpus": "9.60", "ram_gb": "4.80", "disk_gb": "9.60", "egress_gb": "0.00", "total": "24.00"}
+            },
+            {
+              "state": "active",
+              "hours": "264.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "22.5"},
+              "cost": {"vcpus": "21.12", "ram_gb": "10.56", "disk_gb": "21.12", "egress_gb": "2.03", "total": "54.83"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/e2e_power_cycle/metrics.json
+++ b/internal/engine/testdata/golden/e2e_power_cycle/metrics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "query": "egress_gb{cloud=\"os-golden-e2e\",resource_id=\"abc-123\"}[240h]",
+    "at": "2026-03-11T00:00:00Z",
+    "value": "18.0"
+  },
+  {
+    "query": "egress_gb{cloud=\"os-golden-e2e\",resource_id=\"abc-123\"}[240h]",
+    "at": "2026-03-21T00:00:00Z",
+    "value": "0"
+  },
+  {
+    "query": "egress_gb{cloud=\"os-golden-e2e\",resource_id=\"abc-123\"}[264h]",
+    "at": "2026-04-01T00:00:00Z",
+    "value": "22.5"
+  }
+]

--- a/internal/engine/testdata/golden/e2e_power_cycle/registry.json
+++ b/internal/engine/testdata/golden/e2e_power_cycle/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-e2e", "external_id": "proj-456"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/harbor_counters/counters.yaml
+++ b/internal/engine/testdata/golden/harbor_counters/counters.yaml
@@ -1,0 +1,16 @@
+sources:
+  - platform: harbor
+    resource_type: repository
+    metric: pulls
+    kind: events
+    event_type: repository.pull
+  - platform: harbor
+    resource_type: repository
+    metric: pushes
+    kind: events
+    event_type: repository.push
+  - platform: harbor
+    resource_type: repository
+    metric: egress_gb
+    kind: metricsql
+    query: 'egress_gb{cloud="{cloud}",resource_id="{resource_id}"}[{window}]'

--- a/internal/engine/testdata/golden/harbor_counters/events.json
+++ b/internal/engine/testdata/golden/harbor_counters/events.json
@@ -1,0 +1,82 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-team-alpha-app",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "repository.create",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {
+        "state": "active",
+        "size": {"storage_gb": 10}
+      }
+    },
+    {
+      "event_id": "ev-push-team-alpha-app",
+      "timestamp": "2026-03-18T00:00:00Z",
+      "event_type": "repository.push",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {
+        "state": "active",
+        "size": {"storage_gb": 15}
+      }
+    }
+  ],
+  "bulk": [
+    {
+      "event_type": "repository.pull",
+      "count": 812,
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-18T00:00:00Z",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {"state": "active"}
+    },
+    {
+      "event_type": "repository.pull",
+      "count": 711,
+      "from": "2026-03-18T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {"state": "active"}
+    },
+    {
+      "event_type": "repository.push",
+      "count": 47,
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-18T00:00:00Z",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {"state": "active"}
+    },
+    {
+      "event_type": "repository.push",
+      "count": 22,
+      "from": "2026-03-18T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "platform": "harbor",
+      "cloud": "hb-golden-harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "payload": {"state": "active"}
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/harbor_counters/expected.json
+++ b/internal/engine/testdata/golden/harbor_counters/expected.json
@@ -1,0 +1,86 @@
+{
+  "clouds": ["hb-golden-harbor"],
+  "stats": {"candidates": 1, "usage_records": 2, "rated_records": 6, "statements": 1},
+  "usage": [
+    {
+      "cloud": "hb-golden-harbor",
+      "platform": "harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-18T00:00:00Z",
+      "seconds": 1468800,
+      "usage": {
+        "minutes": "24480",
+        "count": "1",
+        "storage_gb": "10",
+        "pulls": "812",
+        "pushes": "47",
+        "egress_gb": "38.5"
+      }
+    },
+    {
+      "cloud": "hb-golden-harbor",
+      "platform": "harbor",
+      "resource_type": "repository",
+      "resource_id": "team-alpha/app",
+      "project_id": "harbor-team-alpha",
+      "state": "active",
+      "from": "2026-03-18T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1209600,
+      "usage": {
+        "minutes": "20160",
+        "count": "1",
+        "storage_gb": "15",
+        "pulls": "711",
+        "pushes": "23",
+        "egress_gb": "31.2"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-01T00:00:00Z", "dimension": "storage_gb", "quantity": "10", "amount": "0.20"},
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "38.5", "amount": "4.62"},
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-01T00:00:00Z", "dimension": "pulls", "quantity": "812", "amount": "0.00"},
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-18T00:00:00Z", "dimension": "storage_gb", "quantity": "15", "amount": "0.25"},
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-18T00:00:00Z", "dimension": "egress_gb", "quantity": "31.2", "amount": "3.74"},
+    {"cloud": "hb-golden-harbor", "resource_id": "team-alpha/app", "from": "2026-03-18T00:00:00Z", "dimension": "pulls", "quantity": "711", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "hb-golden-harbor/harbor-team-alpha",
+      "total": "8.81",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "harbor-team-alpha",
+      "platform": "harbor",
+      "line_items": [
+        {
+          "resource_id": "team-alpha/app",
+          "total": "8.81",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "408.00",
+              "state_modifier": "1",
+              "usage": {"storage_gb": "10", "egress_gb": "38.5", "pulls": "812"},
+              "cost": {"storage_gb": "0.20", "egress_gb": "4.62", "pulls": "0.00", "total": "4.82"}
+            },
+            {
+              "state": "active",
+              "hours": "336.00",
+              "state_modifier": "1",
+              "usage": {"storage_gb": "15", "egress_gb": "31.2", "pulls": "711"},
+              "cost": {"storage_gb": "0.25", "egress_gb": "3.74", "pulls": "0.00", "total": "3.99"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/harbor_counters/metrics.json
+++ b/internal/engine/testdata/golden/harbor_counters/metrics.json
@@ -1,0 +1,12 @@
+[
+  {
+    "query": "egress_gb{cloud=\"hb-golden-harbor\",resource_id=\"team-alpha/app\"}[408h]",
+    "at": "2026-03-18T00:00:00Z",
+    "value": "38.5"
+  },
+  {
+    "query": "egress_gb{cloud=\"hb-golden-harbor\",resource_id=\"team-alpha/app\"}[336h]",
+    "at": "2026-04-01T00:00:00Z",
+    "value": "31.2"
+  }
+]

--- a/internal/engine/testdata/golden/harbor_counters/registry.json
+++ b/internal/engine/testdata/golden/harbor_counters/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "harbor", "cloud": "hb-golden-harbor", "external_id": "harbor-team-alpha"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/hetzner_upgrade/events.json
+++ b/internal/engine/testdata/golden/hetzner_upgrade/events.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-srv-001",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "server.create",
+      "platform": "hetzner",
+      "cloud": "hz-golden-upgrade",
+      "resource_type": "server",
+      "resource_id": "srv-001",
+      "project_id": "hetzner-proj-42",
+      "payload": {
+        "state": "running",
+        "size": {"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "server_type": "cx21"}
+      }
+    },
+    {
+      "event_id": "ev-resize-srv-001",
+      "timestamp": "2026-03-15T00:00:00Z",
+      "event_type": "server.resize",
+      "platform": "hetzner",
+      "cloud": "hz-golden-upgrade",
+      "resource_type": "server",
+      "resource_id": "srv-001",
+      "project_id": "hetzner-proj-42",
+      "payload": {
+        "state": "running",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "server_type": "cx31"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/hetzner_upgrade/expected.json
+++ b/internal/engine/testdata/golden/hetzner_upgrade/expected.json
@@ -1,0 +1,86 @@
+{
+  "clouds": ["hz-golden-upgrade"],
+  "stats": {"candidates": 1, "usage_records": 2, "rated_records": 6, "statements": 1},
+  "usage": [
+    {
+      "cloud": "hz-golden-upgrade",
+      "platform": "hetzner",
+      "resource_type": "server",
+      "resource_id": "srv-001",
+      "project_id": "hetzner-proj-42",
+      "state": "running",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-15T00:00:00Z",
+      "seconds": 1209600,
+      "usage": {
+        "minutes": "20160",
+        "count": "1",
+        "vcpus": "2",
+        "ram_gb": "4",
+        "disk_gb": "40",
+        "server_type": "cx21"
+      }
+    },
+    {
+      "cloud": "hz-golden-upgrade",
+      "platform": "hetzner",
+      "resource_type": "server",
+      "resource_id": "srv-001",
+      "project_id": "hetzner-proj-42",
+      "state": "running",
+      "from": "2026-03-15T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1468800,
+      "usage": {
+        "minutes": "24480",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "server_type": "cx31"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "2", "amount": "10.08"},
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "4", "amount": "5.38"},
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "40", "amount": "10.75"},
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-15T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "24.48"},
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-15T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "13.06"},
+    {"cloud": "hz-golden-upgrade", "resource_id": "srv-001", "from": "2026-03-15T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "26.11"}
+  ],
+  "statements": [
+    {
+      "key": "hz-golden-upgrade/hetzner-proj-42",
+      "total": "89.86",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "hetzner-proj-42",
+      "platform": "hetzner",
+      "line_items": [
+        {
+          "resource_id": "srv-001",
+          "total": "89.86",
+          "periods": [
+            {
+              "state": "running",
+              "hours": "336.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "2", "ram_gb": "4", "disk_gb": "40"},
+              "cost": {"vcpus": "10.08", "ram_gb": "5.38", "disk_gb": "10.75", "total": "26.21"}
+            },
+            {
+              "state": "running",
+              "hours": "408.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80"},
+              "cost": {"vcpus": "24.48", "ram_gb": "13.06", "disk_gb": "26.11", "total": "63.65"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/hetzner_upgrade/registry.json
+++ b/internal/engine/testdata/golden/hetzner_upgrade/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "hetzner", "cloud": "hz-golden-upgrade", "external_id": "hetzner-proj-42"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/instance_resize/counters.yaml
+++ b/internal/engine/testdata/golden/instance_resize/counters.yaml
@@ -1,0 +1,6 @@
+sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    query: 'egress_gb{cloud="{cloud}",resource_id="{resource_id}"}[{window}]'

--- a/internal/engine/testdata/golden/instance_resize/events.json
+++ b/internal/engine/testdata/golden/instance_resize/events.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-def-456",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-resize",
+      "resource_type": "instance",
+      "resource_id": "def-456",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "flavor": "m1.small"}
+      }
+    },
+    {
+      "event_id": "ev-resize-def-456",
+      "timestamp": "2026-03-16T00:00:00Z",
+      "event_type": "compute.instance.finish_resize.end",
+      "platform": "openstack",
+      "cloud": "os-golden-resize",
+      "resource_type": "instance",
+      "resource_id": "def-456",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/instance_resize/expected.json
+++ b/internal/engine/testdata/golden/instance_resize/expected.json
@@ -1,0 +1,90 @@
+{
+  "clouds": ["os-golden-resize"],
+  "stats": {"candidates": 1, "usage_records": 2, "rated_records": 8, "statements": 1},
+  "usage": [
+    {
+      "cloud": "os-golden-resize",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "def-456",
+      "project_id": "proj-456",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-16T00:00:00Z",
+      "seconds": 1296000,
+      "usage": {
+        "minutes": "21600",
+        "count": "1",
+        "vcpus": "2",
+        "ram_gb": "4",
+        "disk_gb": "40",
+        "flavor": "m1.small",
+        "egress_gb": "12.3"
+      }
+    },
+    {
+      "cloud": "os-golden-resize",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "def-456",
+      "project_id": "proj-456",
+      "state": "active",
+      "from": "2026-03-16T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1382400,
+      "usage": {
+        "minutes": "23040",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large",
+        "egress_gb": "24.7"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "2", "amount": "14.40"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "4", "amount": "7.20"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "40", "amount": "14.40"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "12.3", "amount": "1.11"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-16T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "30.72"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-16T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "15.36"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-16T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "30.72"},
+    {"cloud": "os-golden-resize", "resource_id": "def-456", "from": "2026-03-16T00:00:00Z", "dimension": "egress_gb", "quantity": "24.7", "amount": "2.22"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-resize/proj-456",
+      "total": "116.13",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-456",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "def-456",
+          "total": "116.13",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "360.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "2", "ram_gb": "4", "disk_gb": "40", "egress_gb": "12.3"},
+              "cost": {"vcpus": "14.40", "ram_gb": "7.20", "disk_gb": "14.40", "egress_gb": "1.11", "total": "37.11"}
+            },
+            {
+              "state": "active",
+              "hours": "384.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "24.7"},
+              "cost": {"vcpus": "30.72", "ram_gb": "15.36", "disk_gb": "30.72", "egress_gb": "2.22", "total": "79.02"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/instance_resize/metrics.json
+++ b/internal/engine/testdata/golden/instance_resize/metrics.json
@@ -1,0 +1,12 @@
+[
+  {
+    "query": "egress_gb{cloud=\"os-golden-resize\",resource_id=\"def-456\"}[360h]",
+    "at": "2026-03-16T00:00:00Z",
+    "value": "12.3"
+  },
+  {
+    "query": "egress_gb{cloud=\"os-golden-resize\",resource_id=\"def-456\"}[384h]",
+    "at": "2026-04-01T00:00:00Z",
+    "value": "24.7"
+  }
+]

--- a/internal/engine/testdata/golden/instance_resize/registry.json
+++ b/internal/engine/testdata/golden/instance_resize/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-resize", "external_id": "proj-456"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/invariant_violation/events.json
+++ b/internal/engine/testdata/golden/invariant_violation/events.json
@@ -1,0 +1,54 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-sound",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-violation",
+      "resource_type": "instance",
+      "resource_id": "i-sound",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    },
+    {
+      "event_id": "ev-create-i-broken",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-violation",
+      "resource_type": "instance",
+      "resource_id": "i-broken",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    },
+    {
+      "event_id": "ev-delete-i-broken",
+      "timestamp": "2026-03-05T00:00:00Z",
+      "event_type": "compute.instance.delete.end",
+      "platform": "openstack",
+      "cloud": "os-golden-violation",
+      "resource_type": "instance",
+      "resource_id": "i-broken",
+      "project_id": "proj-456"
+    },
+    {
+      "event_id": "ev-update-i-broken",
+      "timestamp": "2026-03-15T00:00:00Z",
+      "event_type": "compute.instance.update",
+      "platform": "openstack",
+      "cloud": "os-golden-violation",
+      "resource_type": "instance",
+      "resource_id": "i-broken",
+      "project_id": "proj-456",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/invariant_violation/registry.json
+++ b/internal/engine/testdata/golden/invariant_violation/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-violation", "external_id": "proj-456"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/related_costs/events.json
+++ b/internal/engine/testdata/golden/related_costs/events.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-shoot-abc",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "shoot.create.end",
+      "platform": "gardener",
+      "cloud": "gd-golden-related",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "payload": {
+        "state": "active",
+        "size": {"worker_count": 3, "machine_type": "m1.xlarge"}
+      }
+    },
+    {
+      "event_id": "ev-create-worker-1",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-related",
+      "resource_type": "instance",
+      "resource_id": "worker-1",
+      "project_id": "shoot-abc-os-tenant",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 8, "ram_gb": 16, "disk_gb": 160, "flavor": "m1.xlarge"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/related_costs/expected.json
+++ b/internal/engine/testdata/golden/related_costs/expected.json
@@ -1,0 +1,87 @@
+{
+  "clouds": ["gd-golden-related", "os-golden-related"],
+  "stats": {"candidates": 2, "usage_records": 2, "rated_records": 5, "statements": 1},
+  "usage": [
+    {
+      "cloud": "gd-golden-related",
+      "platform": "gardener",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {"minutes": "44640", "count": "1", "worker_count": "3", "machine_type": "m1.xlarge"}
+    },
+    {
+      "cloud": "os-golden-related",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "worker-1",
+      "project_id": "shoot-abc-os-tenant",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {
+        "minutes": "44640",
+        "count": "1",
+        "vcpus": "8",
+        "ram_gb": "16",
+        "disk_gb": "160",
+        "flavor": "m1.xlarge"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "gd-golden-related", "resource_id": "shoot-abc", "from": "2026-03-01T00:00:00Z", "dimension": "worker_count", "quantity": "3", "amount": "223.20"},
+    {"cloud": "os-golden-related", "resource_id": "worker-1", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "8", "amount": "119.04"},
+    {"cloud": "os-golden-related", "resource_id": "worker-1", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "16", "amount": "59.52"},
+    {"cloud": "os-golden-related", "resource_id": "worker-1", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "160", "amount": "119.04"},
+    {"cloud": "os-golden-related", "resource_id": "worker-1", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "gd-golden-related/team-alpha",
+      "total": "520.80",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "team-alpha",
+      "platform": "gardener",
+      "line_items": [
+        {
+          "resource_id": "shoot-abc",
+          "total": "223.20",
+          "periods": [
+            {"state": "active", "hours": "744.00", "state_modifier": "1", "usage": {"worker_count": "3"}, "cost": {"worker_count": "223.20", "total": "223.20"}}
+          ]
+        }
+      ],
+      "related_costs": [
+        {
+          "relation_type": "infrastructure_tenant",
+          "project_id": "shoot-abc-os-tenant",
+          "platform": "openstack",
+          "total": "297.60",
+          "line_items": [
+            {
+              "resource_id": "worker-1",
+              "total": "297.60",
+              "periods": [
+                {
+                  "state": "active",
+                  "hours": "744.00",
+                  "state_modifier": "1",
+                  "usage": {"vcpus": "8", "ram_gb": "16", "disk_gb": "160", "egress_gb": "0"},
+                  "cost": {"vcpus": "119.04", "ram_gb": "59.52", "disk_gb": "119.04", "egress_gb": "0.00", "total": "297.60"}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "absent_statements": ["os-golden-related/shoot-abc-os-tenant"]
+}

--- a/internal/engine/testdata/golden/related_costs/registry.json
+++ b/internal/engine/testdata/golden/related_costs/registry.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {"platform": "gardener", "cloud": "gd-golden-related", "external_id": "team-alpha"},
+    {"platform": "openstack", "cloud": "os-golden-related", "external_id": "shoot-abc-os-tenant"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "gd-golden-related", "external_id": "team-alpha"},
+      "target": {"cloud": "os-golden-related", "external_id": "shoot-abc-os-tenant"},
+      "relation_type": "infrastructure_tenant",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/scheduler_drill/events.json
+++ b/internal/engine/testdata/golden/scheduler_drill/events.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-abc-123",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-drill",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/scheduler_drill/late.json
+++ b/internal/engine/testdata/golden/scheduler_drill/late.json
@@ -1,0 +1,27 @@
+{
+  "events": [
+    {
+      "event_id": "ev-late-off-abc-123",
+      "timestamp": "2026-03-11T00:00:00Z",
+      "event_type": "compute.instance.power_off.end",
+      "platform": "openstack",
+      "cloud": "os-golden-drill",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "shutoff"}
+    },
+    {
+      "event_id": "ev-late-on-abc-123",
+      "timestamp": "2026-03-21T00:00:00Z",
+      "event_type": "compute.instance.power_on.end",
+      "platform": "openstack",
+      "cloud": "os-golden-drill",
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "project_id": "proj-456",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/scheduler_drill/registry.json
+++ b/internal/engine/testdata/golden/scheduler_drill/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-drill", "external_id": "proj-456"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/shoot_scale_hibernate/events.json
+++ b/internal/engine/testdata/golden/shoot_scale_hibernate/events.json
@@ -1,0 +1,55 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-shoot-abc",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "shoot.create.end",
+      "platform": "gardener",
+      "cloud": "gd-golden-shoot",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "payload": {
+        "state": "active",
+        "size": {"worker_count": 3, "machine_type": "m1.xlarge"}
+      }
+    },
+    {
+      "event_id": "ev-scale-shoot-abc",
+      "timestamp": "2026-03-12T00:00:00Z",
+      "event_type": "shoot.worker.scale",
+      "platform": "gardener",
+      "cloud": "gd-golden-shoot",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "payload": {
+        "state": "active",
+        "size": {"worker_count": 5, "machine_type": "m1.xlarge"}
+      }
+    },
+    {
+      "event_id": "ev-hibernate-start-shoot-abc",
+      "timestamp": "2026-03-25T00:00:00Z",
+      "event_type": "shoot.hibernate.start",
+      "platform": "gardener",
+      "cloud": "gd-golden-shoot",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "payload": {"state": "hibernated"}
+    },
+    {
+      "event_id": "ev-hibernate-end-shoot-abc",
+      "timestamp": "2026-03-28T00:00:00Z",
+      "event_type": "shoot.hibernate.end",
+      "platform": "gardener",
+      "cloud": "gd-golden-shoot",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/shoot_scale_hibernate/expected.json
+++ b/internal/engine/testdata/golden/shoot_scale_hibernate/expected.json
@@ -1,0 +1,84 @@
+{
+  "clouds": ["gd-golden-shoot"],
+  "stats": {"candidates": 1, "usage_records": 4, "rated_records": 4, "statements": 1},
+  "usage": [
+    {
+      "cloud": "gd-golden-shoot",
+      "platform": "gardener",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-12T00:00:00Z",
+      "seconds": 950400,
+      "usage": {"minutes": "15840", "count": "1", "worker_count": "3", "machine_type": "m1.xlarge"}
+    },
+    {
+      "cloud": "gd-golden-shoot",
+      "platform": "gardener",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "state": "active",
+      "from": "2026-03-12T00:00:00Z",
+      "to": "2026-03-25T00:00:00Z",
+      "seconds": 1123200,
+      "usage": {"minutes": "18720", "count": "1", "worker_count": "5", "machine_type": "m1.xlarge"}
+    },
+    {
+      "cloud": "gd-golden-shoot",
+      "platform": "gardener",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "state": "hibernated",
+      "from": "2026-03-25T00:00:00Z",
+      "to": "2026-03-28T00:00:00Z",
+      "seconds": 259200,
+      "usage": {"minutes": "4320", "count": "1", "worker_count": "5", "machine_type": "m1.xlarge"}
+    },
+    {
+      "cloud": "gd-golden-shoot",
+      "platform": "gardener",
+      "resource_type": "shoot",
+      "resource_id": "shoot-abc",
+      "project_id": "team-alpha",
+      "state": "active",
+      "from": "2026-03-28T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 345600,
+      "usage": {"minutes": "5760", "count": "1", "worker_count": "5", "machine_type": "m1.xlarge"}
+    }
+  ],
+  "rated": [
+    {"cloud": "gd-golden-shoot", "resource_id": "shoot-abc", "from": "2026-03-01T00:00:00Z", "dimension": "worker_count", "quantity": "3", "amount": "79.20"},
+    {"cloud": "gd-golden-shoot", "resource_id": "shoot-abc", "from": "2026-03-12T00:00:00Z", "dimension": "worker_count", "quantity": "5", "amount": "156.00"},
+    {"cloud": "gd-golden-shoot", "resource_id": "shoot-abc", "from": "2026-03-25T00:00:00Z", "dimension": "worker_count", "quantity": "5", "amount": "0.00"},
+    {"cloud": "gd-golden-shoot", "resource_id": "shoot-abc", "from": "2026-03-28T00:00:00Z", "dimension": "worker_count", "quantity": "5", "amount": "48.00"}
+  ],
+  "statements": [
+    {
+      "key": "gd-golden-shoot/team-alpha",
+      "total": "283.20",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "team-alpha",
+      "platform": "gardener",
+      "line_items": [
+        {
+          "resource_id": "shoot-abc",
+          "total": "283.20",
+          "periods": [
+            {"state": "active", "hours": "264.00", "state_modifier": "1", "usage": {"worker_count": "3"}, "cost": {"worker_count": "79.20", "total": "79.20"}},
+            {"state": "active", "hours": "312.00", "state_modifier": "1", "usage": {"worker_count": "5"}, "cost": {"worker_count": "156.00", "total": "156.00"}},
+            {"state": "hibernated", "hours": "72.00", "state_modifier": "0", "usage": {"worker_count": "5"}, "cost": {"worker_count": "0.00", "total": "0.00"}},
+            {"state": "active", "hours": "96.00", "state_modifier": "1", "usage": {"worker_count": "5"}, "cost": {"worker_count": "48.00", "total": "48.00"}}
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/shoot_scale_hibernate/registry.json
+++ b/internal/engine/testdata/golden/shoot_scale_hibernate/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "gardener", "cloud": "gd-golden-shoot", "external_id": "team-alpha"}
+  ],
+  "relations": []
+}

--- a/internal/engine/testdata/golden/volume_resize_retype/events.json
+++ b/internal/engine/testdata/golden/volume_resize_retype/events.json
@@ -1,0 +1,47 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-vol-789",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "volume.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-volume",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "in-use",
+        "size": {"size_gb": 100, "type": "ssd"}
+      }
+    },
+    {
+      "event_id": "ev-resize-vol-789",
+      "timestamp": "2026-03-10T00:00:00Z",
+      "event_type": "volume.resize.end",
+      "platform": "openstack",
+      "cloud": "os-golden-volume",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "in-use",
+        "size": {"size_gb": 200, "type": "ssd"}
+      }
+    },
+    {
+      "event_id": "ev-retype-vol-789",
+      "timestamp": "2026-03-20T00:00:00Z",
+      "event_type": "volume.retype",
+      "platform": "openstack",
+      "cloud": "os-golden-volume",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "payload": {
+        "state": "in-use",
+        "size": {"size_gb": 200, "type": "hdd"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/volume_resize_retype/expected.json
+++ b/internal/engine/testdata/golden/volume_resize_retype/expected.json
@@ -1,0 +1,70 @@
+{
+  "clouds": ["os-golden-volume"],
+  "stats": {"candidates": 1, "usage_records": 3, "rated_records": 3, "statements": 1},
+  "usage": [
+    {
+      "cloud": "os-golden-volume",
+      "platform": "openstack",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "state": "in-use",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-03-10T00:00:00Z",
+      "seconds": 777600,
+      "usage": {"minutes": "12960", "count": "1", "size_gb": "100", "type": "ssd"}
+    },
+    {
+      "cloud": "os-golden-volume",
+      "platform": "openstack",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "state": "in-use",
+      "from": "2026-03-10T00:00:00Z",
+      "to": "2026-03-20T00:00:00Z",
+      "seconds": 864000,
+      "usage": {"minutes": "14400", "count": "1", "size_gb": "200", "type": "ssd"}
+    },
+    {
+      "cloud": "os-golden-volume",
+      "platform": "openstack",
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "project_id": "proj-456",
+      "state": "in-use",
+      "from": "2026-03-20T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1036800,
+      "usage": {"minutes": "17280", "count": "1", "size_gb": "200", "type": "hdd"}
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-volume", "resource_id": "vol-789", "from": "2026-03-01T00:00:00Z", "dimension": "size_gb", "quantity": "100", "amount": "2.16"},
+    {"cloud": "os-golden-volume", "resource_id": "vol-789", "from": "2026-03-10T00:00:00Z", "dimension": "size_gb", "quantity": "200", "amount": "4.80"},
+    {"cloud": "os-golden-volume", "resource_id": "vol-789", "from": "2026-03-20T00:00:00Z", "dimension": "size_gb", "quantity": "200", "amount": "2.88"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-volume/proj-456",
+      "total": "9.84",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-456",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "vol-789",
+          "total": "9.84",
+          "periods": [
+            {"state": "in-use", "hours": "216.00", "state_modifier": "1", "usage": {"size_gb": "100"}, "cost": {"size_gb": "2.16", "total": "2.16"}},
+            {"state": "in-use", "hours": "240.00", "state_modifier": "1", "usage": {"size_gb": "200"}, "cost": {"size_gb": "4.80", "total": "4.80"}},
+            {"state": "in-use", "hours": "288.00", "state_modifier": "1", "usage": {"size_gb": "200"}, "cost": {"size_gb": "2.88", "total": "2.88"}}
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": []
+}

--- a/internal/engine/testdata/golden/volume_resize_retype/registry.json
+++ b/internal/engine/testdata/golden/volume_resize_retype/registry.json
@@ -1,0 +1,6 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-volume", "external_id": "proj-456"}
+  ],
+  "relations": []
+}


### PR DESCRIPTION
Closes #42

The concept's worked examples were checked by hand against each package as it landed. Nothing ran them end to end, so an interval a pass moved, a counter window that shifted, or a modifier applied in the wrong place could each stay inside a pass whose own tests still pass. This branch adds the golden suite of WP 3.11: a test-only package `engine_test` under `internal/engine/` that seeds a real Reporting database with the concept's examples, imports the shipped `pricing/2026-03.yaml`, drives the engine through its package API, and asserts exact numbers. Nothing outside test code and fixtures changes — 3615 added lines, all of them under `internal/engine/golden_*_test.go` and `internal/engine/testdata/golden/`.

## How the expectations were derived

Every number the suite asserts is derived **by hand** from README section 3.4 and `pricing/2026-03.yaml`. No fixture and no expectation was produced by writing engine output back into a file: a number the engine wrote says nothing about whether the engine is right. A mismatch is therefore a report about the engine, not an expectation to rewrite. Usage objects are compared key by key in both directions — an unexpected key fails the case — and every quantity goes through `decimal`, so nothing the suite asserts passes through a float.

## The commits, in order

### 1. `89b5399` Add the golden suite harness under internal/engine

`golden_fixture_test.go` is what every case runs on. Two containers start once for the whole suite and each case takes a database out of each, because a case that finalizes its period would refuse every later regular run whatever order the cases run in. The engine side gets the migration chain and `pricing/2026-03.yaml` imported; the reporting side gets the chain and a source handle.

A case is seeded from files: `events.json` (with bulk generators for the hundreds of events an events counter counts), `registry.json`, `counters.yaml`, `metrics.json` for the stubbed MetricsQL answers, and `late.json` for the events a correction re-meters. The seeder inserts events and then folds them into `current_resources` through `projection.Replay`, so a case is metered from the candidate index the ingest path derives rather than from a row the test wrote. Every size a fixture reports is validated against the schema the reporting migrations register for its `(platform, resource_type)` first — the same gate that decides whether an event enters the `events` table at all — so a fixture production would dead-letter is not metered here either.

The stub querier is the only seam the suite substitutes, VictoriaMetrics being another process. Two database-free tests pin the harness itself:

- `TestGoldenStubQuerier` — a canceled context, a stubbed pair, and the refusal of an instant nothing was stubbed for. A pair the file does not hold is an error rather than a zero, so a case whose window moved fails instead of billing a counter nobody wrote down.
- `TestGoldenExpandBulk` — every event a generator stands for lies strictly inside its interval, and a generator too short for its count is refused rather than left to stamp them all on one instant.

`seedLate`, `correctOptions`, `runStatus`, `periodRow`, `countRuns` and `countRows` land with the harness and are unused until the later commits' cases arrive.

### 2. `8ab5585` Add the seven table golden cases of the concept's examples

`TestGolden` meters one period per case over March 2026 and reads the result back: the usage records the period was split into, the amounts every dimension was billed at, and the statement document a project receives.

| case | what it exercises | total |
| --- | --- | --- |
| `instance_resize` | flavor resize mid-month, egress measured over each interval's own window | 116.13 EUR |
| `hetzner_upgrade` | the same shape on a platform whose prices differ | 89.86 EUR |
| `volume_resize_retype` | volume grows and moves ssd → hdd: a type modifier, state modifier stays 1 | 9.84 EUR |
| `shoot_scale_hibernate` | workers scale and the shoot hibernates: state modifier 0, hibernated interval still carries its worker count | 283.20 EUR |
| `harbor_counters` | 1592 generated pull/push events over two intervals, storage and egress beside them | 8.81 EUR |
| `e2e_power_cycle` | power off and on: the shutoff interval bills at half, its counter dimension does not | 128.45 EUR |
| `related_costs` | an OpenStack tenant attributed to the Gardener project that owns it | 223.20 EUR + 297.60 EUR related |

Two details the fixtures encode deliberately: the generated `harbor_counters` timestamps sit strictly inside their generator's interval, so none lands on an instant the timeline splits at, and the size-changing push at the boundary is counted into the interval it opens. `pushes` is measured but priced by nothing, which is what keeps it in the usage object and off the statement. In `related_costs` the tenant gets no statement of its own — the case asserts that absence — and its 297.60 EUR appear as a related cost under the owning project.

### 3. `3dd4703` Add the correction credit and reproducibility golden cases

Two of the concept's claims are not about one pass. Both had been checked per package against pricing models written for those tests; neither had run over the model the suite rates with.

- **`correction_credit`** bills March as one active interval at 148.80 EUR, closes it, then lets the concept's power cycle arrive late. `DetectLate` names the instance and its two events; the correction credits `disk_gb`, `ram_gb` and `vcpus` by -9.60, -4.80 and -9.60 — the -24.00 the credit note carries — and its document names the run it corrects in `corrects_run_id`. The egress the model prices and nothing measured is rated at zero on both sides, so it produces no delta. After that correction is finalized, a second one finds nothing left to credit and the period reads as settled.
- **`reproducibility`** meters the power cycle month twice in databases of its own and exports both runs to disk. The statements, their documents byte for byte, and every rated record agree; the two statement files are identical; and `run.json` agrees on the pricing version and on what it names. `run_id`, `started_at`, `completed_at` and `stats.snapshot_at` name the pass rather than what it billed, which is why the index is compared on the rest. The first of the two runs is held against the whole of what the `e2e_power_cycle` case expects — two runs that agreed with each other and not with the concept would still fail.

### 4. `6c1d93f` Add the invariant violation and scheduler drill golden cases

A period the engine must **refuse** is the other half of the criterion.

- **`invariant_violation`** seeds an instance whose update after its delete reopens its timeline, and checks that the run fails on that resource alone, names the coverage invariant, writes no usage, rated or statement rows, refuses to export, and leaves the month `open`. The sound instance beside it is what says the refusal is about the resource and not about the case.
- **`scheduler_drill`** (phase exit criterion 5) carries one month through the operator's calendar with `scheduler.Tick` as the only driver: March moves into grace when it ends, waits out the 72 hours, is metered once at the end of them, is not metered again by the pass after it, and is walked untouched once an operator has finalized it. The late-arriving correction over the power cycle runs between the last two ticks, so the drill also checks the credit note the tick neither produces nor disturbs. The clock is an argument of `Tick`, so April's days are stepped through in one test.

The `scheduler_drill` fixtures are the `correction_credit` ones under a cloud of their own, because a case that finalizes its period cannot share a database with one that meters it again.

## Divergences from the issue

Three, all in test structure rather than in what is asserted:

1. **The four procedural cases are subtests of `TestGolden`, not top-level functions.** The issue named `TestGoldenCorrectionCredit`, `TestGoldenReproducibility`, `TestGoldenInvariantViolation` and `TestGoldenSchedulerDrill`. They are `t.Run("correction_credit", …)` etc. inside `TestGolden`, backed by `goldenCorrectionCredit(t, f)` and siblings, so all eleven cases share the one `goldenFixture` and the container pair starts once for the suite instead of once per top-level function. `-run 'TestGolden'` still selects everything; `-run 'TestGolden/scheduler_drill'` selects one case.
2. **There is no `testdata/golden/reproducibility/` directory.** The reproducibility case loads the `e2e_power_cycle` fixtures and takes a database pair named `reproducibility`, which is what lets it assert the first run against that case's expectations whole. So `testdata/golden/` holds ten case directories, not the eleven the issue's Affected Areas listed.
3. **`TestGoldenExpandBulk` is new**, beside the `TestGoldenStubQuerier` the issue named — the bulk generators need pinning without a database for the same reason the stub querier does.

## Verification

`internal/engine/` held no non-test Go file before this branch and still holds none; a directory of test files alone is already how `deploy/kubernetes/base/*/manifest_test.go` are built, and `go vet ./...`, `go test ./...` and golangci-lint in `.github/workflows/ci.yaml` handle it. The suite needs Docker for its testcontainers.

```
go test ./internal/engine/ -run 'TestGolden' -count=1
go vet ./... && golangci-lint run
```

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
