### PR TITLE
Resolve pricing adjustments from the project graph and apply them to statements

### DIFF
--- a/cmd/tally-engine/.env.example
+++ b/cmd/tally-engine/.env.example
@@ -60,6 +60,18 @@ TALLY_ENGINE_AUTO_FINALIZE=false
 # refused at startup.
 TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES=infrastructure_tenant
 
+# Relation types adjustment resolution walks from a statement's project to
+# collect the pricing adjustments that apply to it, comma-separated. Defaults
+# to managed_by,member_of. The explicitly empty value turns adjustments off. A
+# type named here and in TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES is walked by
+# attribution and by adjustment resolution.
+TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES=managed_by,member_of
+
+# How many relation levels that walk follows from the statement's project; 1 is
+# the project's own relations. At least 1, and 3 by default; the empty type
+# list above is what turns adjustments off.
+TALLY_ENGINE_ADJUSTMENT_DEPTH=3
+
 # Path to the counter sources YAML, the file that declares which counters exist
 # and how each one is measured; counter-sources.example.yaml beside this file
 # shows the format. The explicitly empty value means no counter sources. A path

--- a/cmd/tally-engine/commands.go
+++ b/cmd/tally-engine/commands.go
@@ -212,6 +212,8 @@ func newRunCmd() *cobra.Command {
 				PeriodTo:                 to,
 				Clouds:                   clouds,
 				AttributingRelationTypes: p.cfg.AttributingRelationTypes,
+				AdjustmentRelationTypes:  p.cfg.AdjustmentRelationTypes,
+				AdjustmentDepth:          p.cfg.AdjustmentDepth,
 				Counters:                 p.counterSources,
 				VM:                       p.vm,
 			})
@@ -357,6 +359,8 @@ func newCorrectCmd() *cobra.Command {
 				PeriodFrom:               from,
 				PeriodTo:                 to,
 				AttributingRelationTypes: p.cfg.AttributingRelationTypes,
+				AdjustmentRelationTypes:  p.cfg.AdjustmentRelationTypes,
+				AdjustmentDepth:          p.cfg.AdjustmentDepth,
 				Counters:                 p.counterSources,
 				VM:                       p.vm,
 			})
@@ -585,6 +589,8 @@ func newTickCmd() *cobra.Command {
 						PeriodFrom:               from,
 						PeriodTo:                 to,
 						AttributingRelationTypes: p.cfg.AttributingRelationTypes,
+						AdjustmentRelationTypes:  p.cfg.AdjustmentRelationTypes,
+						AdjustmentDepth:          p.cfg.AdjustmentDepth,
 						Counters:                 p.counterSources,
 						VM:                       p.vm,
 					})
@@ -613,6 +619,12 @@ func runLines(month string, result runs.Result) []string {
 		fmt.Sprintf("run %s completed for %s with pricing model %s", result.RunID, month, result.PricingVersion),
 		fmt.Sprintf("metered %d candidates into %d usage records, %d rated records and %d project statements",
 			result.Stats.Candidates, result.Stats.UsageRecords, result.Stats.RatedRecords, result.Stats.Statements))
+	// A deployment whose project graph carries no adjustments gets no line at
+	// all: a run that applied none is the ordinary case, and a zero printed
+	// beside every run reads as a setting that was turned off by mistake.
+	if result.Stats.AdjustmentRecords > 0 {
+		lines = append(lines, fmt.Sprintf("applied %d pricing adjustments", result.Stats.AdjustmentRecords))
+	}
 	for _, id := range result.Superseded {
 		lines = append(lines, fmt.Sprintf("superseded run %s", id))
 	}
@@ -692,10 +704,18 @@ func correctLines(month string, result runs.CorrectionResult) []string {
 			result.RunID, result.CorrectsRunID, month, result.PricingVersion),
 		fmt.Sprintf("metered %d candidates into %d usage records and %d rated records",
 			result.Stats.Candidates, result.Stats.UsageRecords, result.Stats.RatedRecords))
-	if result.Stats.Deltas > 0 {
+	// What a correction changed about a discount or a kickback is booked as an
+	// adjustment delta, which the rated count does not carry: a correction that
+	// re-rated nothing and moved a partner's kickback all the same would read as
+	// a month that stands.
+	switch {
+	case result.Stats.AdjustmentDeltas > 0:
+		lines = append(lines, fmt.Sprintf("%d deltas and %d adjustment deltas in %d credit notes",
+			result.Stats.Deltas, result.Stats.AdjustmentDeltas, result.Stats.Statements))
+	case result.Stats.Deltas > 0:
 		lines = append(lines, fmt.Sprintf("%d deltas in %d credit notes",
 			result.Stats.Deltas, result.Stats.Statements))
-	} else {
+	default:
 		lines = append(lines, fmt.Sprintf("no deltas: the finalized numbers of %s stand", month))
 	}
 	for _, id := range result.Superseded {
@@ -717,15 +737,17 @@ func correctLines(month string, result runs.CorrectionResult) []string {
 // nothing gets no line.
 func recordedWarningsLine(stats runs.Stats) (string, bool) {
 	recorded := len(stats.MeteringWarnings) + len(stats.CounterWarnings) + len(stats.AttributionWarnings) +
-		len(stats.Unpriced) + len(stats.Unreadable) + len(stats.UnregisteredProjects)
+		len(stats.AdjustmentWarnings) + len(stats.Unpriced) + len(stats.Unreadable) +
+		len(stats.UnregisteredProjects)
 	if recorded == 0 {
 		return "", false
 	}
 	return fmt.Sprintf(
-		"warnings recorded in runs.stats: %d metering, %d counter, %d attribution, "+
+		"warnings recorded in runs.stats: %d metering, %d counter, %d attribution, %d adjustment, "+
 			"%d unpriced resource types, %d unreadable fields, %d unregistered projects",
 		len(stats.MeteringWarnings), len(stats.CounterWarnings), len(stats.AttributionWarnings),
-		len(stats.Unpriced), len(stats.Unreadable), len(stats.UnregisteredProjects)), true
+		len(stats.AdjustmentWarnings), len(stats.Unpriced), len(stats.Unreadable),
+		len(stats.UnregisteredProjects)), true
 }
 
 // tickLines is what tick prints: one line per step a month took, in the order

--- a/cmd/tally-engine/main_test.go
+++ b/cmd/tally-engine/main_test.go
@@ -545,6 +545,57 @@ func TestRunAndFinalizeCLI(t *testing.T) {
 		}
 	})
 
+	// The cases above run with the adjustment relation types blanked, which is
+	// adjustments turned off, so the lines they pin are the lines of a run that
+	// resolves none. This one turns them on the way a deployment leaves them.
+	t.Run("prints the adjustments it applied", func(t *testing.T) {
+		t.Setenv("TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES", "managed_by,member_of")
+
+		adjusted, _ := billingMonth(-6)
+		adjustedMonth := period.Format(adjusted)
+		const (
+			adjustedCloud   = "os-cli-adjusted"
+			adjustedProject = "proj-cli-adjusted"
+		)
+		f.seedProject(t, adjustedCloud, adjustedProject)
+		f.seedInstance(t, adjustedCloud, "i-cli-adjusted", adjustedProject, adjusted)
+		// Valid from a month before the one that is metered, so the relation
+		// covers the whole of it.
+		f.seedRelation(t, f.projectIDOf(t, adjustedCloud, adjustedProject),
+			f.seedVirtualProject(t, "partner", "partner-corp"),
+			"managed_by", resellerAdjustments, adjusted.AddDate(0, -1, 0))
+
+		stdout, stderr, err := runCLI(t, "run", "--period", adjustedMonth, "--clouds", adjustedCloud)
+		if err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		want := fmt.Sprintf("run %s completed for %s with pricing model %s\n"+
+			"metered 1 candidates into 1 usage records, 1 rated records and 1 project statements\n"+
+			"applied 2 pricing adjustments\n",
+			f.completedRun(t, adjusted), adjustedMonth, modelVersion)
+		if stdout != want {
+			t.Errorf("stdout of run = %q, want %q", stdout, want)
+		}
+	})
+
+	// A depth of zero would resolve no relation at all, which is what turning
+	// the relation types off says. config.Load runs before either database is
+	// dialed, so this is refused without a connection.
+	t.Run("refuses an adjustment depth below one", func(t *testing.T) {
+		t.Setenv("TALLY_ENGINE_ADJUSTMENT_DEPTH", "0")
+
+		stdout, _, err := runCLI(t, "run", "--period", month)
+		if err == nil {
+			t.Fatal("run error = nil, want the adjustment depth reported")
+		}
+		if want := "TALLY_ENGINE_ADJUSTMENT_DEPTH: 0 must be at least 1"; !strings.Contains(err.Error(), want) {
+			t.Errorf("run error = %q, want it to contain %q", err, want)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by a run that never loaded", stdout)
+		}
+	})
+
 	t.Run("refuses a configuration without a reporting database url", func(t *testing.T) {
 		useDatabase(t, f.engine.URL)
 
@@ -680,6 +731,65 @@ func TestDetectLateAndCorrectCLI(t *testing.T) {
 	if stdout != want {
 		t.Errorf("stdout of periods list = %q, want %q", stdout, want)
 	}
+
+	// A correction of a month a partner resells books what the resize changed
+	// about the three instances and what that changed about the discount and
+	// the kickback. Both counts belong on one line: an adjustment delta that the
+	// rated count does not carry is money a partner is owed.
+	t.Run("prints the adjustment deltas", func(t *testing.T) {
+		t.Setenv("TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES", "managed_by,member_of")
+
+		adjusted, _ := billingMonth(-7)
+		adjustedMonth := period.Format(adjusted)
+		const (
+			adjustedCloud   = "os-cli-adjusted-correct"
+			adjustedProject = "proj-cli-adjusted-correct"
+		)
+		instances := []string{"i-adjusted-1", "i-adjusted-2", "i-adjusted-3"}
+
+		f.seedProject(t, adjustedCloud, adjustedProject)
+		for _, instance := range instances {
+			f.seedInstance(t, adjustedCloud, instance, adjustedProject, adjusted)
+		}
+		f.seedRelation(t, f.projectIDOf(t, adjustedCloud, adjustedProject),
+			f.seedVirtualProject(t, "partner", "partner-corp-correct"),
+			"managed_by", resellerAdjustments, adjusted.AddDate(0, -1, 0))
+
+		stdout, stderr, err := runCLI(t, "run", "--period", adjustedMonth, "--clouds", adjustedCloud)
+		if err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		// The lines of a run are pinned by the run cases; what this one needs
+		// from it is that the month was billed with the two adjustments on it.
+		if want := "applied 2 pricing adjustments\n"; !strings.HasSuffix(stdout, want) {
+			t.Errorf("stdout of run = %q, want it to end with %q", stdout, want)
+		}
+		adjustedRun := f.completedRun(t, adjusted)
+		if _, stderr, err := runCLI(t, "finalize", "--period", adjustedMonth,
+			"--run", adjustedRun.String()); err != nil {
+			t.Fatalf("finalize error = %v, want nil (stderr %q)", err, stderr)
+		}
+
+		// One resize per instance, each halving its vcpus halfway through its
+		// life, all of them after the run read the month.
+		for _, instance := range instances {
+			f.seedEvent(t, adjustedCloud, instance, adjustedProject, "ev-resize-"+instance,
+				"compute.instance.resize.end", adjusted.Add(48*time.Hour),
+				`{"state":"active","size":{"vcpus":2,"ram_gb":8,"disk_gb":80,"flavor":"m1.large"}}`)
+		}
+
+		stdout, stderr, err = runCLI(t, "correct", "--period", adjustedMonth)
+		if err != nil {
+			t.Fatalf("correct error = %v, want nil (stderr %q)", err, stderr)
+		}
+		want := fmt.Sprintf("run %s completed as a correction of run %s for %s with pricing model %s\n"+
+			"metered 3 candidates into 6 usage records and 6 rated records\n"+
+			"3 deltas and 2 adjustment deltas in 1 credit notes\n",
+			f.completedCorrection(t, adjusted), adjustedRun, adjustedMonth, modelVersion)
+		if stdout != want {
+			t.Errorf("stdout of correct = %q, want %q", stdout, want)
+		}
+	})
 
 	t.Run("detect-late needs no counter sources", func(t *testing.T) {
 		missing := filepath.Join(t.TempDir(), "missing.yaml")
@@ -1079,6 +1189,14 @@ func TestTickCLI(t *testing.T) {
 // rated with, which they print beside the run.
 const modelVersion = "v1"
 
+// resellerAdjustments is the metadata of the relation between a project and the
+// partner that resells it: 15 percent off what the project is rated, and 10
+// percent of what is left owed to the partner beside the net. Two adjustments,
+// which is what the cases that read them see reported.
+const resellerAdjustments = `{"pricing_adjustments":[` +
+	`{"type":"discount","rate":"0.15","scope":"all"},` +
+	`{"type":"kickback","rate":"0.10","scope":"all"}]}`
+
 // pipelineFixture is the pair of databases a run works over: the engine
 // database it is written to, and the reporting database it reads its resources
 // and events from. The CLI is pointed at both through the environment, the way
@@ -1125,6 +1243,58 @@ func (f pipelineFixture) seedProject(t *testing.T, cloud, externalID string) {
 		`INSERT INTO projects (platform, cloud, external_id) VALUES ('openstack', $1, $2)`,
 		cloud, externalID); err != nil {
 		t.Fatalf("seeding the project %s: %v", externalID, err)
+	}
+}
+
+// seedVirtualProject registers a project that owns no resources: the partner a
+// reseller relation points at. Its cloud is its platform, which is what a
+// virtual project carries there, and it returns the registry id a relation
+// names it by.
+func (f pipelineFixture) seedVirtualProject(t *testing.T, platform, externalID string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := f.reporting.Store.Pool().QueryRow(t.Context(),
+		`INSERT INTO projects (platform, cloud, external_id) VALUES ($1, $1, $2) RETURNING id`,
+		platform, externalID).Scan(&id); err != nil {
+		t.Fatalf("seeding the %s project %s: %v", platform, externalID, err)
+	}
+	return id
+}
+
+// projectIDOf is the registry id of one project, which a relation names and
+// seedProject does not report.
+func (f pipelineFixture) projectIDOf(t *testing.T, cloud, externalID string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := f.reporting.Store.Pool().QueryRow(t.Context(),
+		`SELECT id FROM projects WHERE cloud = $1 AND external_id = $2`,
+		cloud, externalID).Scan(&id); err != nil {
+		t.Fatalf("reading the id of the project %s/%s: %v", cloud, externalID, err)
+	}
+	return id
+}
+
+// seedRelation writes one edge of the project graph. An empty metadata is the
+// empty document a relation created without one carries, and the relation is
+// left open, so it covers every month a case meters from validFrom on.
+func (f pipelineFixture) seedRelation(
+	t *testing.T,
+	sourceID, targetID uuid.UUID,
+	relationType, metadata string,
+	validFrom time.Time,
+) {
+	t.Helper()
+
+	if metadata == "" {
+		metadata = "{}"
+	}
+	if _, err := f.reporting.Store.Pool().Exec(t.Context(),
+		`INSERT INTO project_relations (source_id, target_id, relation_type, metadata, valid_from)
+		 VALUES ($1, $2, $3, $4::jsonb, $5)`,
+		sourceID, targetID, relationType, metadata, validFrom); err != nil {
+		t.Fatalf("seeding the %s relation of %s: %v", relationType, sourceID, err)
 	}
 }
 

--- a/deploy/kubernetes/base/tally-engine/tally-engine.yaml
+++ b/deploy/kubernetes/base/tally-engine/tally-engine.yaml
@@ -110,6 +110,13 @@ spec:
                   value: "false"
                 - name: TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES
                   value: infrastructure_tenant
+                # The relation types a statement's pricing adjustments are
+                # collected over; the empty list turns adjustments off.
+                - name: TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES
+                  value: managed_by,member_of
+                # How many relation levels that walk follows, at least 1.
+                - name: TALLY_ENGINE_ADJUSTMENT_DEPTH
+                  value: "3"
                 # Where the metricsql counter sources are queried. Nothing reads
                 # it while the sources below are empty, because the client is
                 # built only for a source that needs it.

--- a/internal/core/adjustment/adjustment.go
+++ b/internal/core/adjustment/adjustment.go
@@ -7,7 +7,8 @@
 // It is the one place the Reporting API reads pricing_adjustments from, so the
 // API spells neither the member name nor the schema out again. The API holds a
 // written relation to the schema and answers 422 for a document it refuses
-// (decision D2).
+// (decision D2). The engine in internal/engine/adjustments is the second reader
+// of the member, and it takes the adjustments as the values Parse returns.
 //
 // The package does no I/O.
 //
@@ -25,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/shopspring/decimal"
 )
 
 // MetadataKey is the member of a relation's metadata that carries the
@@ -39,6 +41,31 @@ const MetadataKey = "pricing_adjustments"
 // because both keywords are evaluated: the walk would report every element of
 // an array past the cap before the length was ever named.
 const MaxAdjustments = 64
+
+// The adjustment types, in the order decision D3 applies them.
+const (
+	TypeSurcharge       = "surcharge"
+	TypeDiscount        = "discount"
+	TypeProjectDiscount = "project_discount"
+	TypeKickback        = "kickback"
+)
+
+// TypeOrder lists the four types in application order. The index of a type in
+// it is what the engine sorts by, so the order of the elements inside one
+// relation's array does not decide what a rated amount passes through first.
+var TypeOrder = []string{TypeSurcharge, TypeDiscount, TypeProjectDiscount, TypeKickback}
+
+// ScopeAll is the scope that matches every rated amount (decision D5).
+const ScopeAll = "all"
+
+// Adjustment is one element of the array. The rate is the decimal the text
+// spells, so nothing between the request body and the statement rounds it.
+type Adjustment struct {
+	Type        string          // one of the types TypeOrder names
+	Rate        decimal.Decimal // between 0 and 1, as the schema's pattern admits
+	Scope       string          // ScopeAll, a platform, or a platform and a resource type
+	Description string          // empty when the element carries none
+}
 
 // Violation is one place the schema refused, located inside the array.
 type Violation struct {
@@ -131,26 +158,91 @@ func Validate(doc []byte) error {
 	return nil
 }
 
+// Parse holds the JSON text of the adjustments array to the schema and returns
+// the adjustments it spells, in the order the array lists them. Everything the
+// schema refuses comes back as Validate's error, so a caller reads the types,
+// rates and scopes of the result without checking them again.
+func Parse(doc []byte) ([]Adjustment, error) {
+	if err := Validate(doc); err != nil {
+		return nil, err
+	}
+
+	var elements []struct {
+		Type        string `json:"type"`
+		Rate        string `json:"rate"`
+		Scope       string `json:"scope"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(doc, &elements); err != nil {
+		return nil, fmt.Errorf("reading the pricing adjustments: %w", err)
+	}
+
+	adjustments := make([]Adjustment, 0, len(elements))
+	for i, element := range elements {
+		// The schema's pattern admits nothing the decimal package rejects, so
+		// this error is the package's own bug rather than a caller's document.
+		rate, err := decimal.NewFromString(element.Rate)
+		if err != nil {
+			return nil, fmt.Errorf("reading the rate of adjustment %d: %w", i, err)
+		}
+		adjustments = append(adjustments, Adjustment{
+			Type:        element.Type,
+			Rate:        rate,
+			Scope:       element.Scope,
+			Description: element.Description,
+		})
+	}
+	return adjustments, nil
+}
+
 // ValidateMetadata holds the adjustments of a whole relation metadata document
 // to the schema. Metadata without the member is not an error: the relation
 // adjusts nothing, and the caller writes it as it stands. A member that is
 // there is validated, so a caller that has to refuse a malformed one gets the
 // *InvalidError.
 func ValidateMetadata(metadata []byte) error {
+	_, _, err := FromMetadata(metadata)
+	return err
+}
+
+// FromMetadata reads the adjustments out of a whole relation metadata
+// document. The second result says whether the metadata carries the member at
+// all, which is what separates a relation that adjusts nothing from one whose
+// member is there and refused: a member the schema refuses comes back as true
+// beside the *InvalidError.
+func FromMetadata(metadata []byte) ([]Adjustment, bool, error) {
 	if len(metadata) == 0 {
-		return nil
+		return nil, false, nil
 	}
 
 	var members map[string]json.RawMessage
 	if err := json.Unmarshal(metadata, &members); err != nil {
-		return fmt.Errorf("decoding the relation metadata: %w", err)
+		return nil, false, fmt.Errorf("decoding the relation metadata: %w", err)
 	}
 
 	member, ok := members[MetadataKey]
 	if !ok {
-		return nil
+		return nil, false, nil
 	}
-	return Validate(member)
+	adjustments, err := Parse(member)
+	return adjustments, true, err
+}
+
+// ScopeMatches reports whether a scope covers the rated amounts of one platform
+// and resource type (decision D5). ScopeAll covers every amount, a scope of one
+// part covers a whole platform, and a scope of two parts covers one resource
+// type of one platform. The comparison is exact and case sensitive, the way the
+// schema admits the scope and the platforms name themselves.
+func ScopeMatches(scope, platform, resourceType string) bool {
+	if scope == ScopeAll {
+		return true
+	}
+
+	scopePlatform, scopeResourceType, hasResourceType := strings.Cut(scope, ".")
+	if scopePlatform != platform {
+		return false
+	}
+	return !hasResourceType || scopeResourceType == resourceType
 }
 
 // invalidFrom turns the validator's error into the violations a caller reports.

--- a/internal/core/adjustment/adjustment_test.go
+++ b/internal/core/adjustment/adjustment_test.go
@@ -3,8 +3,11 @@ package adjustment_test
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/adjustment"
 )
@@ -400,6 +403,145 @@ func TestInvalidErrorNamesEveryViolation(t *testing.T) {
 	})
 }
 
+func TestParseAcceptsTheConceptExample(t *testing.T) {
+	adjustments, err := adjustment.Parse([]byte(conceptExample))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	assertAdjustments(t, adjustments, []adjustment.Adjustment{
+		{
+			Type:        adjustment.TypeDiscount,
+			Rate:        decimal.RequireFromString("0.15"),
+			Scope:       adjustment.ScopeAll,
+			Description: "Reseller end-customer discount",
+		},
+		{
+			Type:        adjustment.TypeKickback,
+			Rate:        decimal.RequireFromString("0.10"),
+			Scope:       adjustment.ScopeAll,
+			Description: "Reseller commission on net revenue",
+		},
+	})
+}
+
+func TestParseReturnsWhatTheTextSpells(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want []adjustment.Adjustment
+	}{
+		{
+			name: "an element without a description",
+			doc:  `[{"type":"surcharge","rate":"0.123456","scope":"openstack.instance"}]`,
+			want: []adjustment.Adjustment{{
+				Type:  adjustment.TypeSurcharge,
+				Rate:  decimal.RequireFromString("0.123456"),
+				Scope: "openstack.instance",
+			}},
+		},
+		{
+			// The rate is read off its text, so the places it was written with
+			// say nothing about the number it stands for.
+			name: "a rate written out to six decimal places",
+			doc:  `[{"type":"project_discount","rate":"1.000000","scope":"openstack"}]`,
+			want: []adjustment.Adjustment{{
+				Type:  adjustment.TypeProjectDiscount,
+				Rate:  decimal.RequireFromString("1"),
+				Scope: "openstack",
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adjustments, err := adjustment.Parse([]byte(tc.doc))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+			assertAdjustments(t, adjustments, tc.want)
+		})
+	}
+}
+
+func TestParseRefuses(t *testing.T) {
+	// What the schema refuses, Parse refuses in the same words, so a caller
+	// answering 422 reads the place off the violation.
+	t.Run("a rate written as a number", func(t *testing.T) {
+		adjustments, err := adjustment.Parse([]byte(`[{"type":"discount","rate":0.15,"scope":"all"}]`))
+		if adjustments != nil {
+			t.Errorf("Parse() = %v, want no adjustments", adjustments)
+		}
+
+		var invalid *adjustment.InvalidError
+		if !errors.As(err, &invalid) {
+			t.Fatalf("Parse() error = %v, want *adjustment.InvalidError", err)
+		}
+		if len(invalid.Violations) != 1 {
+			t.Fatalf("Parse() reported %d violations, want 1: %v", len(invalid.Violations), invalid)
+		}
+		if location := invalid.Violations[0].Location; location != "/0/rate" {
+			t.Errorf("violation location = %q, want %q", location, "/0/rate")
+		}
+	})
+
+	tests := []struct {
+		name string
+		doc  []byte
+	}{
+		{name: "a truncated array", doc: []byte("[")},
+		{name: "no document at all", doc: nil},
+		{name: "an empty document", doc: []byte{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adjustments, err := adjustment.Parse(tc.doc)
+			if adjustments != nil {
+				t.Errorf("Parse() = %v, want no adjustments", adjustments)
+			}
+			if err == nil {
+				t.Fatal("Parse() error = nil, want a decoding error")
+			}
+			if !strings.Contains(err.Error(), "decoding the pricing adjustments") {
+				t.Errorf("Parse() error = %q, want it to contain %q", err, "decoding the pricing adjustments")
+			}
+
+			// Text that is not JSON never reached the schema, so it must not
+			// look to a caller like a document the schema refused.
+			var invalid *adjustment.InvalidError
+			if errors.As(err, &invalid) {
+				t.Errorf("Parse() error = %v, want no *adjustment.InvalidError", err)
+			}
+		})
+	}
+}
+
+// assertAdjustments compares the adjustments a call returned with the ones the
+// text spells. The rates are compared with Equal, because a decimal keeps the
+// places its text was written with.
+func assertAdjustments(t *testing.T, got, want []adjustment.Adjustment) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d adjustments, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Type != want[i].Type {
+			t.Errorf("adjustment %d type = %q, want %q", i, got[i].Type, want[i].Type)
+		}
+		if !got[i].Rate.Equal(want[i].Rate) {
+			t.Errorf("adjustment %d rate = %v, want %v", i, got[i].Rate, want[i].Rate)
+		}
+		if got[i].Scope != want[i].Scope {
+			t.Errorf("adjustment %d scope = %q, want %q", i, got[i].Scope, want[i].Scope)
+		}
+		if got[i].Description != want[i].Description {
+			t.Errorf("adjustment %d description = %q, want %q", i, got[i].Description, want[i].Description)
+		}
+	}
+}
+
 func TestValidateMetadata(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -478,6 +620,198 @@ func TestValidateMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFromMetadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		metadata      []byte
+		wantFound     bool
+		want          []adjustment.Adjustment
+		wantViolation string
+		wantErr       string
+	}{
+		{name: "no metadata at all", metadata: nil},
+		{name: "an empty document", metadata: []byte{}},
+		{name: "the null document", metadata: []byte(`null`)},
+		{name: "an empty object", metadata: []byte(`{}`)},
+		{name: "metadata without the member", metadata: []byte(`{"owner":"team-a"}`)},
+		{
+			// The member is there, so the relation is one that adjusts, and
+			// the caller hears that beside the refusal.
+			name:          "the member set to null",
+			metadata:      []byte(`{"pricing_adjustments":null}`),
+			wantFound:     true,
+			wantViolation: "got null, want array",
+		},
+		{
+			name:          "the member set to an empty array",
+			metadata:      []byte(`{"pricing_adjustments":[]}`),
+			wantFound:     true,
+			wantViolation: "minItems: got 0, want 1",
+		},
+		{
+			name: "the member beside other metadata",
+			metadata: []byte(
+				`{"owner":"team-a","pricing_adjustments":[{"type":"discount","rate":"0.15","scope":"all"}]}`),
+			wantFound: true,
+			want: []adjustment.Adjustment{{
+				Type:  adjustment.TypeDiscount,
+				Rate:  decimal.RequireFromString("0.15"),
+				Scope: adjustment.ScopeAll,
+			}},
+		},
+		{
+			name:     "an array instead of an object",
+			metadata: []byte(`[]`),
+			wantErr:  "decoding the relation metadata",
+		},
+		{
+			name:     "a number instead of an object",
+			metadata: []byte(`1`),
+			wantErr:  "decoding the relation metadata",
+		},
+		{
+			name:     "a truncated document",
+			metadata: []byte(`{"pricing_adjustments":`),
+			wantErr:  "decoding the relation metadata",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adjustments, found, err := adjustment.FromMetadata(tc.metadata)
+
+			if found != tc.wantFound {
+				t.Errorf("FromMetadata() found = %v, want %v", found, tc.wantFound)
+			}
+
+			switch {
+			case tc.wantViolation != "":
+				var invalid *adjustment.InvalidError
+				if !errors.As(err, &invalid) {
+					t.Fatalf("FromMetadata() error = %v, want *adjustment.InvalidError", err)
+				}
+				if len(invalid.Violations) != 1 {
+					t.Fatalf("FromMetadata() reported %d violations, want 1: %v", len(invalid.Violations), invalid)
+				}
+				if message := invalid.Violations[0].Message; !strings.Contains(message, tc.wantViolation) {
+					t.Errorf("violation message = %q, want it to contain %q", message, tc.wantViolation)
+				}
+			case tc.wantErr != "":
+				if err == nil {
+					t.Fatalf("FromMetadata() error = nil, want one containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("FromMetadata() error = %q, want it to contain %q", err, tc.wantErr)
+				}
+			default:
+				if err != nil {
+					t.Fatalf("FromMetadata() error = %v, want nil", err)
+				}
+				assertAdjustments(t, adjustments, tc.want)
+			}
+		})
+	}
+}
+
+func TestScopeMatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		scope        string
+		platform     string
+		resourceType string
+		want         bool
+	}{
+		{
+			name: "the scope all", scope: adjustment.ScopeAll,
+			platform: "openstack", resourceType: "instance", want: true,
+		},
+		{
+			name: "a platform scope on its platform", scope: "openstack",
+			platform: "openstack", resourceType: "instance", want: true,
+		},
+		{
+			name: "a resource type scope on its resource type", scope: "openstack.instance",
+			platform: "openstack", resourceType: "instance", want: true,
+		},
+		{
+			name: "a scope with underscores on both sides", scope: "gardener_dev.shoot_node",
+			platform: "gardener_dev", resourceType: "shoot_node", want: true,
+		},
+		{
+			name: "a platform scope on another platform", scope: "openstack",
+			platform: "gardener", resourceType: "shoot",
+		},
+		{
+			name: "a resource type scope on another resource type", scope: "openstack.instance",
+			platform: "openstack", resourceType: "volume",
+		},
+		{
+			name: "a resource type scope on another platform", scope: "openstack.instance",
+			platform: "gardener", resourceType: "instance",
+		},
+		{
+			// The scopes are compared as they are stored, so a scope that only
+			// differs in case matches nothing.
+			name: "a platform scope in the wrong case", scope: "Openstack",
+			platform: "openstack", resourceType: "instance",
+		},
+		{
+			name: "an empty scope", scope: "",
+			platform: "openstack", resourceType: "instance",
+		},
+		{
+			name: "a platform scope on no platform at all", scope: "openstack",
+			platform: "", resourceType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := adjustment.ScopeMatches(tc.scope, tc.platform, tc.resourceType)
+			if got != tc.want {
+				t.Errorf("ScopeMatches(%q, %q, %q) = %v, want %v",
+					tc.scope, tc.platform, tc.resourceType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypeOrderMatchesTheSchema(t *testing.T) {
+	t.Run("the order the adjustments are applied in", func(t *testing.T) {
+		want := []string{"surcharge", "discount", "project_discount", "kickback"}
+		if !slices.Equal(adjustment.TypeOrder, want) {
+			t.Errorf("TypeOrder = %v, want %v", adjustment.TypeOrder, want)
+		}
+	})
+
+	// Every type the order names is a type the schema admits, so nothing the
+	// engine sorts by is a document the API would have refused.
+	for _, adjustmentType := range adjustment.TypeOrder {
+		t.Run("the type "+adjustmentType, func(t *testing.T) {
+			doc := fmt.Sprintf(`[{"type":%q,"rate":"0.15","scope":%q}]`, adjustmentType, adjustment.ScopeAll)
+
+			adjustments, err := adjustment.Parse([]byte(doc))
+			if err != nil {
+				t.Fatalf("Parse() error = %v, want nil", err)
+			}
+			assertAdjustments(t, adjustments, []adjustment.Adjustment{{
+				Type:  adjustmentType,
+				Rate:  decimal.RequireFromString("0.15"),
+				Scope: adjustment.ScopeAll,
+			}})
+		})
+	}
+
+	t.Run("a type in the wrong case", func(t *testing.T) {
+		_, err := adjustment.Parse([]byte(`[{"type":"Discount","rate":"0.15","scope":"all"}]`))
+
+		var invalid *adjustment.InvalidError
+		if !errors.As(err, &invalid) {
+			t.Fatalf("Parse() error = %v, want *adjustment.InvalidError", err)
+		}
+	})
 }
 
 func TestConstantsMatchTheSchema(t *testing.T) {

--- a/internal/core/money/money.go
+++ b/internal/core/money/money.go
@@ -19,6 +19,10 @@ const (
 	// are rounded and rendered at. It is exported for the reason AmountPlaces
 	// is.
 	QuantityPlaces = 4
+	// RatePlaces is the scale the rate of a pricing adjustment is rendered at.
+	// Six fractional digits is what the adjustments schema admits, and the
+	// constant is exported for the reason AmountPlaces is.
+	RatePlaces = 6
 	// divisionScale is the working precision every division runs at, set
 	// explicitly so no result depends on decimal.DivisionPrecision.
 	divisionScale = 28
@@ -88,4 +92,23 @@ func NewQuantity(d decimal.Decimal) Quantity {
 // MarshalJSON renders the quantity as a JSON number with exactly four decimal places.
 func (q Quantity) MarshalJSON() ([]byte, error) {
 	return []byte(q.StringFixed(QuantityPlaces)), nil
+}
+
+// Rate is the rate of a pricing adjustment that serializes at the six-place
+// scale the adjustments schema admits. A bare decimal renders 0.150000 as 0.15,
+// which drops the scale the rate was written with.
+type Rate struct {
+	decimal.Decimal
+}
+
+// NewRate wraps a decimal for serialization. It does not round: a rate is
+// parsed from an adjustments document, which admits at most six fractional
+// digits.
+func NewRate(d decimal.Decimal) Rate {
+	return Rate{Decimal: d}
+}
+
+// MarshalJSON renders the rate as a JSON number with exactly six decimal places.
+func (r Rate) MarshalJSON() ([]byte, error) {
+	return []byte(r.StringFixed(RatePlaces)), nil
 }

--- a/internal/core/money/money_test.go
+++ b/internal/core/money/money_test.go
@@ -204,3 +204,57 @@ func TestQuantityMarshalsInsideAStruct(t *testing.T) {
 		t.Errorf("Marshal() = %s, want %s", got, want)
 	}
 }
+
+func TestRateMarshalsWithSixDecimals(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "0.15", want: "0.150000"},
+		{in: "0.1", want: "0.100000"},
+		{in: "1", want: "1.000000"},
+		{in: "0.123456", want: "0.123456"},
+		{in: "0", want: "0.000000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := json.Marshal(money.NewRate(dec(t, tc.in)))
+			if err != nil {
+				t.Fatalf("Marshal() = %v, want nil", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%s) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRateMarshalsInsideAStruct(t *testing.T) {
+	// A rate is written onto a statement document nested in an adjustment
+	// record, so the six places must survive the enclosing struct rather than
+	// collapsing to 0.15.
+	body := struct {
+		Rate money.Rate `json:"rate"`
+	}{Rate: money.NewRate(dec(t, "0.15"))}
+
+	got, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal() = %v, want nil", err)
+	}
+	if want := `{"rate":0.150000}`; string(got) != want {
+		t.Errorf("Marshal() = %s, want %s", got, want)
+	}
+}
+
+func TestRateDecodesFromAJSONNumber(t *testing.T) {
+	// Decoding comes from the embedded decimal, so the trailing zeros the
+	// marshaller writes read back as the rate they were derived from.
+	var got money.Rate
+	if err := json.Unmarshal([]byte("0.150000"), &got); err != nil {
+		t.Fatalf("Unmarshal() = %v, want nil", err)
+	}
+	if want := dec(t, "0.15"); !got.Equal(want) {
+		t.Errorf("Unmarshal(0.150000) = %s, want %s", got, want)
+	}
+}

--- a/internal/engine/adjustments/adjustments.go
+++ b/internal/engine/adjustments/adjustments.go
@@ -1,0 +1,448 @@
+// Package adjustments resolves the pricing adjustments a project's relations
+// carry and applies them to the rated amounts of its statement. New parses the
+// graph of one run, Adjust applies it to one statement. Both are pure: the
+// package does no I/O.
+//
+// The resolution is a breadth-first walk from the statement's project over the
+// outgoing adjustment-carrying relations, bounded by the depth the caller
+// configures (decision D6). Every relation is visited once, so a relation two
+// paths reach adjusts once, and a cycle among the relations ends on the visited
+// set. The relations are taken as given: the caller loads the ones whose
+// validity overlaps the period, and each of them applies to the whole period
+// (decision D4).
+//
+// The collected adjustments apply in the order surcharge, discount, project
+// discount, kickback (decision D3), ties broken by relation id and then by the
+// position of the element in its relation's array. A surcharge is computed on
+// the base, so two surcharges add rather than compound. A discount and a
+// project discount are computed on the running net, so they stack
+// multiplicatively. A kickback is computed on the running net and leaves it
+// alone: it is what a partner is owed rather than what the customer pays.
+//
+// The "running net per scope partition" of the roadmap's pseudocode is read
+// here as one running amount per (platform, resource type) bucket of the bases.
+// An adjustment covers the buckets its scope matches (decision D5, through
+// adjustment.ScopeMatches), and its line is rounded once, by money.Round2
+// (decision D7). That rounded amount is then apportioned back over the buckets
+// it covers, every bucket but the last taking its own rounded share and the
+// last taking the remainder, so the shares sum to the line exactly and every
+// bucket stays a two-place amount.
+//
+// A kickback whose relation target is not a partner is skipped, and New reports
+// it as WarningKickbackTargetNotPartner. A commission owed to a project that is
+// not a partner entity is a mistake in the registry rather than an intent to
+// bill, and the run says so instead of paying it.
+//
+// The normative specification is roadmap/05-phase-5-commercial-pricing.md,
+// WP 5.3.
+package adjustments
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/adjustment"
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/core/project"
+	"github.com/b42labs/tally/internal/engine/source"
+)
+
+// WarningKickbackTargetNotPartner marks a relation whose kickbacks were not
+// applied because its target is not a partner.
+const WarningKickbackTargetNotPartner = "adjustment_kickback_target_not_partner"
+
+// Warning is one finding of the resolution. It is JSON-tagged because the run
+// writes the warnings into runs.stats verbatim.
+type Warning struct {
+	// Code is WarningKickbackTargetNotPartner.
+	Code string `json:"code"`
+	// RelationID is the relation whose kickbacks were dropped, as text.
+	RelationID string `json:"relation_id"`
+	// TargetPlatform is the platform of that relation's target, which is what
+	// the kickbacks were dropped over.
+	TargetPlatform string `json:"target_platform"`
+	// TargetID is the external id of that relation's target.
+	TargetID string `json:"target_id"`
+}
+
+// Base is one rated line of a statement, own or related: what the scoped sums
+// are built from.
+type Base struct {
+	// Platform and ResourceType are what an adjustment's scope is matched
+	// against.
+	Platform, ResourceType string
+	// Amount is what the line was rated at.
+	Amount decimal.Decimal
+}
+
+// Line is one applied adjustment as the document renders it and a record
+// stores it. The field order is the order it is marshalled in.
+type Line struct {
+	Type         string `json:"type"`
+	RelationType string `json:"relation_type"`
+	// RelationTarget is the external id of the relation's target, which is the
+	// beneficiary of a kickback.
+	RelationTarget string     `json:"relation_target"`
+	RelationID     string     `json:"relation_id"`
+	Scope          string     `json:"scope"`
+	Description    string     `json:"description,omitempty"`
+	Rate           money.Rate `json:"rate"`
+	// Base is the amount the rate was applied to.
+	Base money.Amount `json:"base"`
+	// Amount is signed: a discount is negative.
+	Amount money.Amount `json:"amount"`
+}
+
+// Outcome is what the adjustments of one statement come to.
+type Outcome struct {
+	// BaseCost is the sum of the bases, the total Phase 3 rated.
+	BaseCost decimal.Decimal
+	// Lines holds every collected adjustment in application order, a zero one
+	// included, so the document shows everything that reached the statement. It
+	// is nil when the walk collected nothing.
+	Lines []Line
+	// NetCost is BaseCost plus every non-kickback amount: what the customer
+	// pays.
+	NetCost decimal.Decimal
+	// KickbackTotal is the sum of the kickback amounts, which NetCost does not
+	// hold.
+	KickbackTotal decimal.Decimal
+}
+
+// Adjuster holds the parsed adjustment graph of one run.
+type Adjuster struct {
+	edges []edge
+	// bySource indexes the edges by the project they leave, so a walk reads the
+	// relations of its frontier rather than every relation of the run. Without
+	// it a statement costs one pass over the whole graph per level, and a run
+	// bills as many statements as the registry holds projects.
+	bySource map[uuid.UUID][]int
+	depth    int
+}
+
+// edge is one relation with what it adjusts. The target travels along because a
+// kickback names it as the beneficiary and because its platform decides whether
+// a kickback is paid at all.
+type edge struct {
+	relation    source.Relation
+	target      source.Project
+	adjustments []adjustment.Adjustment
+	// err is what the relation's stored pricing_adjustments failed to be read
+	// with. It is kept here rather than returned by New so that only a walk
+	// which reaches the relation fails: see the comment on New.
+	err error
+}
+
+// applied is one collected adjustment with where it came from: the relation and
+// its target for the line, and the position in the relation's array to order
+// two adjustments of one relation and one type.
+type applied struct {
+	adjustment adjustment.Adjustment
+	relation   source.Relation
+	target     source.Project
+	index      int
+}
+
+// bucket is one (platform, resource type) partition of the bases: what a scope
+// is matched against and what a running net is kept per.
+type bucket struct {
+	platform     string
+	resourceType string
+}
+
+// New parses the adjustments of every relation once per run, rather than once
+// per statement. The relations are expected in ascending id order, the order
+// source.Snapshot.Relations returns them in, and the edges keep it.
+//
+// A depth below 1 is an error: a walk that does not take its first level reads
+// no relation at all, and asking for that is a mistake rather than a way to
+// turn adjustments off (an empty relation type list is that).
+//
+// A relation whose pricing_adjustments member the schema refuses is refused as
+// well, because a relation whose stored array cannot be read must not bill as
+// though it carried nothing. It is refused by the Adjust of the first statement
+// whose walk reaches that relation rather than here: project_relations.metadata
+// is a free-form document one tenant writes, and a stale one of a project this
+// run bills nothing from would otherwise fail every run and every tick of the
+// whole deployment. Metadata without the member is an edge that carries
+// nothing.
+//
+// Both ends of every relation have to be among the projects, which the
+// registry's foreign keys and the snapshot already hold; the check is here
+// because a line names its target's external id.
+//
+// The kickbacks of a relation whose target is not a partner are dropped, one
+// warning per relation, and the other adjustments of that relation stay. The
+// warnings come back in the order the relations were given.
+func New(relations []source.Relation, projects []source.Project, depth int) (*Adjuster, []Warning, error) {
+	if depth < 1 {
+		return nil, nil, fmt.Errorf("the adjustment walk depth is %d, and has to be at least 1", depth)
+	}
+
+	registry := make(map[uuid.UUID]source.Project, len(projects))
+	for _, entry := range projects {
+		registry[entry.ID] = entry
+	}
+
+	var warnings []Warning
+	edges := make([]edge, 0, len(relations))
+	for _, relation := range relations {
+		from, held := registry[relation.SourceID]
+		if !held {
+			return nil, nil, fmt.Errorf(
+				"relation %s names the project %s, which the registry snapshot does not hold",
+				relation.ID, relation.SourceID)
+		}
+		target, held := registry[relation.TargetID]
+		if !held {
+			return nil, nil, fmt.Errorf(
+				"relation %s names the project %s, which the registry snapshot does not hold",
+				relation.ID, relation.TargetID)
+		}
+
+		parsed, _, err := adjustment.FromMetadata(relation.Metadata)
+		if err != nil {
+			err = fmt.Errorf("the pricing adjustments of relation %s (%s %s/%s -> %s/%s): %w",
+				relation.ID, relation.RelationType,
+				from.Cloud, from.ExternalID, target.Cloud, target.ExternalID, err)
+			edges = append(edges, edge{relation: relation, target: target, err: err})
+			continue
+		}
+		if target.Platform != project.PlatformPartner {
+			var dropped bool
+			parsed, dropped = withoutKickbacks(parsed)
+			if dropped {
+				warnings = append(warnings, Warning{
+					Code:           WarningKickbackTargetNotPartner,
+					RelationID:     relation.ID.String(),
+					TargetPlatform: target.Platform,
+					TargetID:       target.ExternalID,
+				})
+			}
+		}
+		edges = append(edges, edge{relation: relation, target: target, adjustments: parsed})
+	}
+
+	bySource := make(map[uuid.UUID][]int, len(edges))
+	for i, e := range edges {
+		bySource[e.relation.SourceID] = append(bySource[e.relation.SourceID], i)
+	}
+	return &Adjuster{edges: edges, bySource: bySource, depth: depth}, warnings, nil
+}
+
+// Adjust applies to one project's rated amounts what the walk from it collects.
+// A project no relation names, or a project whose relations carry nothing,
+// comes back as its base cost with no lines. The one error is a relation the
+// walk reaches whose stored adjustments could not be read, which New kept for
+// this call: such a statement is not billed at all rather than billed as though
+// the relation carried nothing.
+//
+// The bases are summed per bucket, and an adjustment applies to the buckets its
+// scope covers. Bases of more than one platform are what an attributed
+// project's related costs bring in, and they are adjusted along with the
+// project's own.
+func (a *Adjuster) Adjust(project uuid.UUID, bases []Base) (Outcome, error) {
+	walked, err := a.collect(project)
+	if err != nil {
+		return Outcome{}, err
+	}
+
+	buckets, base := sumBases(bases)
+	running := make(map[bucket]decimal.Decimal, len(buckets))
+
+	outcome := Outcome{BaseCost: decimal.Zero, KickbackTotal: decimal.Zero}
+	for _, b := range buckets {
+		running[b] = base[b]
+		outcome.BaseCost = outcome.BaseCost.Add(base[b])
+	}
+	outcome.NetCost = outcome.BaseCost
+
+	for _, collected := range walked {
+		covered := matching(buckets, collected.adjustment.Scope)
+		negative := collected.adjustment.Type == adjustment.TypeDiscount ||
+			collected.adjustment.Type == adjustment.TypeProjectDiscount
+
+		// A surcharge is rated on the base, everything else on the running net
+		// of the buckets its scope covers.
+		from := running
+		if collected.adjustment.Type == adjustment.TypeSurcharge {
+			from = base
+		}
+		lineBase := sum(from, covered)
+		amount := money.Round2(lineBase.Mul(collected.adjustment.Rate))
+		if negative {
+			amount = amount.Neg()
+		}
+		outcome.Lines = append(outcome.Lines, collected.line(lineBase, amount))
+
+		if collected.adjustment.Type == adjustment.TypeKickback {
+			outcome.KickbackTotal = outcome.KickbackTotal.Add(amount)
+			continue
+		}
+		outcome.NetCost = outcome.NetCost.Add(amount)
+
+		// The line's own amount is apportioned over the buckets it covers, the
+		// last of them taking what the rounded shares of the others left, so the
+		// shares sum to the line and every bucket keeps two places.
+		rest := amount
+		for i, b := range covered {
+			part := rest
+			if i < len(covered)-1 {
+				part = money.Round2(from[b].Mul(collected.adjustment.Rate))
+				if negative {
+					part = part.Neg()
+				}
+				rest = rest.Sub(part)
+			}
+			running[b] = running[b].Add(part)
+		}
+	}
+	return outcome, nil
+}
+
+// collect walks the graph from one project and returns what it finds, in the
+// order it is applied in. A relation is visited at most once however many paths
+// reach it (decision D6), which is what ends a cycle as well: a level that
+// visits nothing empties the frontier. A relation the walk reaches whose stored
+// adjustments New could not read fails the whole call, so nothing is billed
+// short of the adjustments that relation carries.
+//
+// The frontier is read through bySource, so the walk costs the relations of the
+// projects it reaches rather than every relation of the run. The visited set
+// already made the collected set independent of the order the edges are taken
+// in, and the sort below fixes the order the adjustments apply in.
+func (a *Adjuster) collect(start uuid.UUID) ([]applied, error) {
+	frontier := map[uuid.UUID]bool{start: true}
+	visited := make(map[uuid.UUID]bool)
+
+	// The lowest-numbered edge the walk reached that carries a failure, so the
+	// error a run reports is the same one however the frontier was walked: the
+	// edges are in relation id order.
+	unreadable := -1
+	var collected []applied
+	for level := 1; level <= a.depth && len(frontier) > 0; level++ {
+		next := make(map[uuid.UUID]bool)
+		for from := range frontier {
+			for _, i := range a.bySource[from] {
+				e := a.edges[i]
+				if visited[e.relation.ID] {
+					continue
+				}
+				visited[e.relation.ID] = true
+				next[e.relation.TargetID] = true
+				if e.err != nil {
+					if unreadable < 0 || i < unreadable {
+						unreadable = i
+					}
+					continue
+				}
+				for index, parsed := range e.adjustments {
+					collected = append(collected, applied{
+						adjustment: parsed,
+						relation:   e.relation,
+						target:     e.target,
+						index:      index,
+					})
+				}
+			}
+		}
+		frontier = next
+	}
+	if unreadable >= 0 {
+		return nil, a.edges[unreadable].err
+	}
+
+	slices.SortFunc(collected, func(x, y applied) int {
+		if order := cmp.Compare(typeRank(x.adjustment.Type), typeRank(y.adjustment.Type)); order != 0 {
+			return order
+		}
+		// The ids compare as their 16 bytes, which is the order the relations
+		// are loaded in (decision D4).
+		if order := bytes.Compare(x.relation.ID[:], y.relation.ID[:]); order != 0 {
+			return order
+		}
+		return cmp.Compare(x.index, y.index)
+	})
+	return collected, nil
+}
+
+// line renders one collected adjustment against the base it was rated on and
+// the amount it came to.
+func (c applied) line(base, amount decimal.Decimal) Line {
+	return Line{
+		Type:           c.adjustment.Type,
+		RelationType:   c.relation.RelationType,
+		RelationTarget: c.target.ExternalID,
+		RelationID:     c.relation.ID.String(),
+		Scope:          c.adjustment.Scope,
+		Description:    c.adjustment.Description,
+		Rate:           money.NewRate(c.adjustment.Rate),
+		Base:           money.NewAmount(base),
+		Amount:         money.NewAmount(amount),
+	}
+}
+
+// withoutKickbacks drops the kickbacks of one relation and reports whether it
+// carried any. The clone leaves the caller's slice as it was.
+func withoutKickbacks(adjustments []adjustment.Adjustment) ([]adjustment.Adjustment, bool) {
+	kept := slices.DeleteFunc(slices.Clone(adjustments), func(parsed adjustment.Adjustment) bool {
+		return parsed.Type == adjustment.TypeKickback
+	})
+	return kept, len(kept) != len(adjustments)
+}
+
+// sumBases sums the bases per bucket and returns the buckets in the order the
+// apportioning walks them: by platform, then by resource type.
+func sumBases(bases []Base) ([]bucket, map[bucket]decimal.Decimal) {
+	sums := make(map[bucket]decimal.Decimal, len(bases))
+	buckets := make([]bucket, 0, len(bases))
+	for _, b := range bases {
+		key := bucket{platform: b.Platform, resourceType: b.ResourceType}
+		if _, held := sums[key]; !held {
+			buckets = append(buckets, key)
+			sums[key] = decimal.Zero
+		}
+		sums[key] = sums[key].Add(b.Amount)
+	}
+
+	slices.SortFunc(buckets, func(x, y bucket) int {
+		if order := cmp.Compare(x.platform, y.platform); order != 0 {
+			return order
+		}
+		return cmp.Compare(x.resourceType, y.resourceType)
+	})
+	return buckets, sums
+}
+
+// matching is the buckets one scope covers, in bucket order. It is empty for a
+// scope no rated amount of the statement falls under, and such an adjustment
+// touches nothing.
+func matching(buckets []bucket, scope string) []bucket {
+	covered := make([]bucket, 0, len(buckets))
+	for _, b := range buckets {
+		if adjustment.ScopeMatches(scope, b.platform, b.resourceType) {
+			covered = append(covered, b)
+		}
+	}
+	return covered
+}
+
+// sum adds up the amounts of the given buckets.
+func sum(amounts map[bucket]decimal.Decimal, buckets []bucket) decimal.Decimal {
+	total := decimal.Zero
+	for _, b := range buckets {
+		total = total.Add(amounts[b])
+	}
+	return total
+}
+
+// typeRank is the position of a type in the application order of decision D3.
+// Every type the schema admits is in it.
+func typeRank(adjustmentType string) int {
+	return slices.Index(adjustment.TypeOrder, adjustmentType)
+}

--- a/internal/engine/adjustments/adjustments_test.go
+++ b/internal/engine/adjustments/adjustments_test.go
@@ -1,0 +1,848 @@
+package adjustments_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/adjustment"
+	"github.com/b42labs/tally/internal/engine/adjustments"
+	"github.com/b42labs/tally/internal/engine/source"
+)
+
+// The clouds of the registry the cases mirror. A partner and a meta-project
+// carry their platform as their cloud (decision D1).
+const (
+	openstackCloud = "os-prod"
+	partnerCloud   = "partner"
+	metaCloud      = "meta"
+)
+
+// The two relation types that carry adjustments.
+const (
+	managedBy = "managed_by"
+	memberOf  = "member_of"
+)
+
+// projectID and relationID derive a uuid from a number, so a case names its
+// projects and its relations by that number and the ascending order of the
+// numbers is the ascending order of the ids. Relations reach New in that order,
+// which is what orders two adjustments of the same type.
+func projectID(n int) uuid.UUID {
+	return uuid.MustParse(fmt.Sprintf("0000000a-0000-0000-0000-%012d", n))
+}
+
+func relationID(n int) uuid.UUID {
+	return uuid.MustParse(fmt.Sprintf("0000000b-0000-0000-0000-%012d", n))
+}
+
+// project is registry entry n.
+func project(n int, cloud, platform, externalID string) source.Project {
+	return source.Project{
+		ID:         projectID(n),
+		Platform:   platform,
+		Cloud:      cloud,
+		ExternalID: externalID,
+	}
+}
+
+// relation is edge n, from the adjusted project to the one whose metadata
+// adjusts it. The validity is left zero: New is given the relations that
+// overlap the period (decision D4).
+func relation(n, from, to int, relationType, metadata string) source.Relation {
+	edge := source.Relation{
+		ID:           relationID(n),
+		SourceID:     projectID(from),
+		TargetID:     projectID(to),
+		RelationType: relationType,
+	}
+	if metadata != "" {
+		edge.Metadata = json.RawMessage(metadata)
+	}
+	return edge
+}
+
+// metadata is the relation metadata document that carries the given elements.
+func metadata(elements ...string) string {
+	return `{"pricing_adjustments":[` + strings.Join(elements, ",") + `]}`
+}
+
+// element is one adjustment of that array.
+func element(adjustmentType, rate, scope string) string {
+	return fmt.Sprintf(`{"type":%q,"rate":%q,"scope":%q}`, adjustmentType, rate, scope)
+}
+
+// base is one rated line of the statement being adjusted.
+func base(platform, resourceType, amount string) adjustments.Base {
+	return adjustments.Base{
+		Platform:     platform,
+		ResourceType: resourceType,
+		Amount:       decimal.RequireFromString(amount),
+	}
+}
+
+// newAdjuster builds the adjuster of a case that expects neither warnings nor
+// an error.
+func newAdjuster(t *testing.T, relations []source.Relation, projects []source.Project, depth int) *adjustments.Adjuster {
+	t.Helper()
+
+	adjuster, warnings, err := adjustments.New(relations, projects, depth)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("New() warnings = %+v, want none", warnings)
+	}
+	return adjuster
+}
+
+// adjusted is the outcome of one Adjust a case expects to succeed.
+func adjusted(
+	t *testing.T,
+	adjuster *adjustments.Adjuster,
+	project uuid.UUID,
+	bases []adjustments.Base,
+) adjustments.Outcome {
+	t.Helper()
+
+	outcome, err := adjuster.Adjust(project, bases)
+	if err != nil {
+		t.Fatalf("Adjust() error = %v, want nil", err)
+	}
+	return outcome
+}
+
+// assertDecimal holds one decimal against the amount expected of it, at the two
+// places money is rounded and rendered at.
+func assertDecimal(t *testing.T, name string, got decimal.Decimal, want string) {
+	t.Helper()
+
+	if !got.Equal(decimal.RequireFromString(want)) {
+		t.Errorf("%s = %v, want %v", name, got.StringFixed(2), want)
+	}
+}
+
+// assertLine holds one line against everything but its relation type, which
+// only the cases that give their edges different types assert.
+func assertLine(
+	t *testing.T, got adjustments.Line,
+	adjustmentType, relationTarget string, relation uuid.UUID,
+	scope, rate, lineBase, amount string,
+) {
+	t.Helper()
+
+	if got.Type != adjustmentType {
+		t.Errorf("Type = %v, want %v", got.Type, adjustmentType)
+	}
+	if got.RelationTarget != relationTarget {
+		t.Errorf("RelationTarget = %v, want %v", got.RelationTarget, relationTarget)
+	}
+	if got.RelationID != relation.String() {
+		t.Errorf("RelationID = %v, want %v", got.RelationID, relation)
+	}
+	if got.Scope != scope {
+		t.Errorf("Scope = %v, want %v", got.Scope, scope)
+	}
+	if !got.Rate.Equal(decimal.RequireFromString(rate)) {
+		t.Errorf("Rate = %v, want %v", got.Rate, rate)
+	}
+	assertDecimal(t, "Base", got.Base.Decimal, lineBase)
+	assertDecimal(t, "Amount", got.Amount.Decimal, amount)
+}
+
+// assertLineCount holds the number of lines against the number expected, and
+// ends the case where they differ: every further assertion indexes into them.
+func assertLineCount(t *testing.T, outcome adjustments.Outcome, want int) {
+	t.Helper()
+
+	if len(outcome.Lines) != want {
+		t.Fatalf("Lines = %d lines (%+v), want %d", len(outcome.Lines), outcome.Lines, want)
+	}
+}
+
+// resellerGraph is the registry of the concept's example: one OpenStack project
+// managed by one partner.
+func resellerGraph() []source.Project {
+	return []source.Project{
+		project(1, openstackCloud, "openstack", "customer-proj-1"),
+		project(2, partnerCloud, "partner", "partner-corp"),
+	}
+}
+
+// TestAdjustResellerRelation bills the concept's reseller case: a discount the
+// customer sees and a kickback the partner is owed, both on the same relation.
+func TestAdjustResellerRelation(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(
+			element("discount", "0.15", "all"),
+			element("kickback", "0.10", "all"),
+		)),
+	}
+	adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "1200.00"),
+	})
+
+	assertDecimal(t, "BaseCost", outcome.BaseCost, "1200.00")
+	assertLineCount(t, outcome, 2)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all", "0.15", "1200.00", "-180.00")
+	if outcome.Lines[0].RelationType != managedBy {
+		t.Errorf("RelationType = %v, want %v", outcome.Lines[0].RelationType, managedBy)
+	}
+	assertLine(t, outcome.Lines[1], "kickback", "partner-corp", relationID(1), "all", "0.10", "1020.00", "102.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "1020.00")
+	assertDecimal(t, "KickbackTotal", outcome.KickbackTotal, "102.00")
+}
+
+// TestAdjustStacksDiscountsMultiplicatively holds the second discount against
+// what the first one left, not against the base.
+func TestAdjustStacksDiscountsMultiplicatively(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "customer-proj-1"),
+		project(2, partnerCloud, "partner", "partner-corp"),
+		project(3, partnerCloud, "partner", "partner-two"),
+	}
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+		relation(2, 1, 3, managedBy, metadata(element("discount", "0.15", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, projects, 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 2)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all", "0.10", "100.00", "-10.00")
+	assertLine(t, outcome.Lines[1], "discount", "partner-two", relationID(2), "all", "0.15", "90.00", "-13.50")
+	assertDecimal(t, "NetCost", outcome.NetCost, "76.50")
+}
+
+// TestAdjustAppliesTypesInFixedOrder applies the three types of one relation in
+// the order of decision D3, whatever order the array lists them in.
+func TestAdjustAppliesTypesInFixedOrder(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(
+			element("kickback", "0.10", "all"),
+			element("discount", "0.15", "all"),
+			element("surcharge", "0.10", "all"),
+		)),
+	}
+	adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "1000.00"),
+	})
+
+	assertLineCount(t, outcome, 3)
+	assertLine(t, outcome.Lines[0], "surcharge", "partner-corp", relationID(1), "all", "0.10", "1000.00", "100.00")
+	assertLine(t, outcome.Lines[1], "discount", "partner-corp", relationID(1), "all", "0.15", "1100.00", "-165.00")
+	assertLine(t, outcome.Lines[2], "kickback", "partner-corp", relationID(1), "all", "0.10", "935.00", "93.50")
+	assertDecimal(t, "NetCost", outcome.NetCost, "935.00")
+	assertDecimal(t, "KickbackTotal", outcome.KickbackTotal, "93.50")
+}
+
+// TestAdjustAddsSurchargesOnTheBase rates the second surcharge on the base the
+// first one was rated on, so the two add rather than compound.
+func TestAdjustAddsSurchargesOnTheBase(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(
+			element("surcharge", "0.10", "all"),
+			element("surcharge", "0.05", "all"),
+		)),
+	}
+	adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 2)
+	assertLine(t, outcome.Lines[0], "surcharge", "partner-corp", relationID(1), "all", "0.10", "100.00", "10.00")
+	assertLine(t, outcome.Lines[1], "surcharge", "partner-corp", relationID(1), "all", "0.05", "100.00", "5.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "115.00")
+}
+
+// TestAdjustAppliesProjectDiscountAfterDiscount orders the types rather than
+// the relations: the project discount of the smaller relation id still applies
+// after the discount of the larger one.
+func TestAdjustAppliesProjectDiscountAfterDiscount(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "customer-proj-1"),
+		project(2, partnerCloud, "partner", "partner-corp"),
+		project(3, metaCloud, "meta", "customer-alpha"),
+	}
+	relations := []source.Relation{
+		relation(1, 1, 3, memberOf, metadata(element("project_discount", "0.05", "all"))),
+		relation(2, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, projects, 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 2)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(2), "all", "0.10", "100.00", "-10.00")
+	assertLine(t, outcome.Lines[1], "project_discount", "customer-alpha", relationID(1), "all", "0.05", "90.00", "-4.50")
+	assertDecimal(t, "NetCost", outcome.NetCost, "85.50")
+}
+
+// TestAdjustPartitionsByScope rates an adjustment on the buckets its scope
+// covers, which may be one of them, all of them, or none.
+func TestAdjustPartitionsByScope(t *testing.T) {
+	bases := []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+		base("openstack", "volume", "50.00"),
+	}
+	cases := []struct {
+		name     string
+		scope    string
+		lineBase string
+		amount   string
+		net      string
+	}{
+		{name: "one resource type", scope: "openstack.instance", lineBase: "100.00", amount: "-20.00", net: "130.00"},
+		{name: "a whole platform", scope: "openstack", lineBase: "150.00", amount: "-30.00", net: "120.00"},
+		{name: "a platform the statement has nothing of", scope: "gardener", lineBase: "0.00", amount: "0.00", net: "150.00"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			relations := []source.Relation{
+				relation(1, 1, 2, managedBy, metadata(element("discount", "0.20", testCase.scope))),
+			}
+			adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+			outcome := adjusted(t, adjuster, projectID(1), bases)
+
+			assertLineCount(t, outcome, 1)
+			assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1),
+				testCase.scope, "0.20", testCase.lineBase, testCase.amount)
+			assertDecimal(t, "NetCost", outcome.NetCost, testCase.net)
+		})
+	}
+}
+
+// TestAdjustApportionsOverBuckets rounds one line once and spreads it over the
+// buckets it covers, the last bucket taking the remainder. What the buckets
+// took is read off the base of a second discount scoped to one of them.
+func TestAdjustApportionsOverBuckets(t *testing.T) {
+	bases := []adjustments.Base{
+		base("openstack", "instance", "33.33"),
+		base("openstack", "volume", "33.33"),
+		base("gardener", "shoot", "33.33"),
+	}
+	cases := []struct {
+		name       string
+		scope      string
+		secondBase string
+	}{
+		{name: "the first bucket in bucket order", scope: "gardener", secondBase: "30.00"},
+		{name: "the second bucket in bucket order", scope: "openstack.instance", secondBase: "30.00"},
+		{name: "the last bucket, which took the remainder", scope: "openstack.volume", secondBase: "29.99"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			relations := []source.Relation{
+				relation(1, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+				relation(2, 1, 2, managedBy, metadata(element("discount", "0.10", testCase.scope))),
+			}
+			adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+			outcome := adjusted(t, adjuster, projectID(1), bases)
+
+			assertLineCount(t, outcome, 2)
+			assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all", "0.10", "99.99", "-10.00")
+			assertLine(t, outcome.Lines[1], "discount", "partner-corp", relationID(2),
+				testCase.scope, "0.10", testCase.secondBase, "-3.00")
+			assertDecimal(t, "NetCost", outcome.NetCost, "86.99")
+		})
+	}
+
+	t.Run("the discount alone", func(t *testing.T) {
+		relations := []source.Relation{
+			relation(1, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+		}
+		adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+		outcome := adjusted(t, adjuster, projectID(1), bases)
+
+		assertDecimal(t, "BaseCost", outcome.BaseCost, "99.99")
+		assertLineCount(t, outcome, 1)
+		assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all", "0.10", "99.99", "-10.00")
+		assertDecimal(t, "NetCost", outcome.NetCost, "89.99")
+	})
+}
+
+// TestAdjustKickbackLeavesTheNetAlone emits what the partner is owed without
+// taking it off what the customer pays.
+func TestAdjustKickbackLeavesTheNetAlone(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(element("kickback", "0.10", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 1)
+	assertLine(t, outcome.Lines[0], "kickback", "partner-corp", relationID(1), "all", "0.10", "100.00", "10.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "100.00")
+	assertDecimal(t, "KickbackTotal", outcome.KickbackTotal, "10.00")
+}
+
+// TestAdjustLimitsTheWalkDepth inherits a discount over two hops, which a walk
+// of one level does not reach.
+func TestAdjustLimitsTheWalkDepth(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "customer-proj-1"),
+		project(2, metaCloud, "meta", "customer-alpha"),
+		project(3, metaCloud, "meta", "group-north"),
+	}
+	relations := []source.Relation{
+		relation(1, 1, 2, memberOf, ""),
+		relation(2, 2, 3, memberOf, metadata(element("project_discount", "0.05", "all"))),
+	}
+	cases := []struct {
+		name  string
+		depth int
+		lines int
+		net   string
+	}{
+		{name: "one level short of the discount", depth: 1, lines: 0, net: "100.00"},
+		{name: "the level the discount sits on", depth: 2, lines: 1, net: "95.00"},
+		{name: "one level past the discount", depth: 3, lines: 1, net: "95.00"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			adjuster := newAdjuster(t, relations, projects, testCase.depth)
+
+			outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+				base("openstack", "instance", "100.00"),
+			})
+
+			assertLineCount(t, outcome, testCase.lines)
+			if testCase.lines > 0 {
+				assertLine(t, outcome.Lines[0], "project_discount", "group-north", relationID(2),
+					"all", "0.05", "100.00", "-5.00")
+			}
+			assertDecimal(t, "NetCost", outcome.NetCost, testCase.net)
+		})
+	}
+}
+
+// TestAdjustVisitsEveryRelationOnce applies the discount of a relation two
+// paths reach once (decision D6).
+func TestAdjustVisitsEveryRelationOnce(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "customer-proj-1"),
+		project(2, metaCloud, "meta", "team-north"),
+		project(3, metaCloud, "meta", "team-south"),
+		project(4, metaCloud, "meta", "customer-alpha"),
+		project(5, partnerCloud, "partner", "partner-corp"),
+	}
+	relations := []source.Relation{
+		relation(1, 1, 2, memberOf, ""),
+		relation(2, 1, 3, memberOf, ""),
+		relation(3, 2, 4, memberOf, ""),
+		relation(4, 3, 4, memberOf, ""),
+		relation(5, 4, 5, managedBy, metadata(element("discount", "0.10", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, projects, 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 1)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(5), "all", "0.10", "100.00", "-10.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "90.00")
+}
+
+// TestAdjustEndsOnACycle walks a graph the registry refuses to create: each of
+// two projects a member of the other. The visited set and the depth end it, and
+// each relation adjusts once.
+func TestAdjustEndsOnACycle(t *testing.T) {
+	projects := []source.Project{
+		project(1, metaCloud, "meta", "group-north"),
+		project(2, metaCloud, "meta", "group-south"),
+	}
+	relations := []source.Relation{
+		relation(1, 1, 2, memberOf, metadata(element("discount", "0.10", "all"))),
+		relation(2, 2, 1, memberOf, metadata(element("discount", "0.10", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, projects, 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+	})
+
+	assertLineCount(t, outcome, 2)
+	assertLine(t, outcome.Lines[0], "discount", "group-south", relationID(1), "all", "0.10", "100.00", "-10.00")
+	assertLine(t, outcome.Lines[1], "discount", "group-north", relationID(2), "all", "0.10", "90.00", "-9.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "81.00")
+}
+
+// TestAdjustKeepsArrayOrderOnTies applies two adjustments of one relation and
+// one type in the order the array lists them in, which is the last tiebreaker.
+func TestAdjustKeepsArrayOrderOnTies(t *testing.T) {
+	cases := []struct {
+		name    string
+		first   string
+		second  string
+		amounts [2]string
+		bases   [2]string
+	}{
+		{
+			name:  "the smaller rate first",
+			first: "0.10", second: "0.20",
+			bases: [2]string{"100.00", "90.00"}, amounts: [2]string{"-10.00", "-18.00"},
+		},
+		{
+			name:  "the larger rate first",
+			first: "0.20", second: "0.10",
+			bases: [2]string{"100.00", "80.00"}, amounts: [2]string{"-20.00", "-8.00"},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			relations := []source.Relation{
+				relation(1, 1, 2, managedBy, metadata(
+					element("discount", testCase.first, "all"),
+					element("discount", testCase.second, "all"),
+				)),
+			}
+			adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+			outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+				base("openstack", "instance", "100.00"),
+			})
+
+			assertLineCount(t, outcome, 2)
+			assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all",
+				testCase.first, testCase.bases[0], testCase.amounts[0])
+			assertLine(t, outcome.Lines[1], "discount", "partner-corp", relationID(1), "all",
+				testCase.second, testCase.bases[1], testCase.amounts[1])
+		})
+	}
+}
+
+// TestNewIsIndependentOfRelationOrder bills the same statement from the same
+// relations handed over in three different orders. The same graph and the same
+// period have to yield the same invoice however often they are billed.
+func TestNewIsIndependentOfRelationOrder(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(element("surcharge", "0.10", "all"))),
+		relation(2, 1, 2, managedBy, metadata(element("discount", "0.15", "all"))),
+		relation(3, 1, 2, managedBy, metadata(element("kickback", "0.10", "all"))),
+	}
+	orders := [][]source.Relation{
+		{relations[0], relations[1], relations[2]},
+		{relations[2], relations[1], relations[0]},
+		{relations[1], relations[2], relations[0]},
+	}
+
+	var outcomes []adjustments.Outcome
+	for _, order := range orders {
+		adjuster := newAdjuster(t, order, resellerGraph(), 3)
+		outcomes = append(outcomes, adjusted(t, adjuster, projectID(1), []adjustments.Base{
+			base("openstack", "instance", "1000.00"),
+		}))
+	}
+
+	assertLineCount(t, outcomes[0], 3)
+	assertLine(t, outcomes[0].Lines[0], "surcharge", "partner-corp", relationID(1), "all", "0.10", "1000.00", "100.00")
+	assertLine(t, outcomes[0].Lines[1], "discount", "partner-corp", relationID(2), "all", "0.15", "1100.00", "-165.00")
+	assertLine(t, outcomes[0].Lines[2], "kickback", "partner-corp", relationID(3), "all", "0.10", "935.00", "93.50")
+	for i, outcome := range outcomes[1:] {
+		if !reflect.DeepEqual(outcome, outcomes[0]) {
+			t.Errorf("Adjust() of order %d = %+v, want %+v", i+1, outcome, outcomes[0])
+		}
+	}
+}
+
+// TestNewWarnsOnKickbackToNonPartner drops the kickbacks of a relation that
+// does not point at a partner and keeps everything else that relation carries.
+func TestNewWarnsOnKickbackToNonPartner(t *testing.T) {
+	cases := []struct {
+		name     string
+		target   source.Project
+		platform string
+		external string
+	}{
+		{
+			name:     "a meta-project",
+			target:   project(2, metaCloud, "meta", "customer-alpha"),
+			platform: "meta", external: "customer-alpha",
+		},
+		{
+			name:     "a real project",
+			target:   project(2, openstackCloud, "openstack", "customer-proj-2"),
+			platform: "openstack", external: "customer-proj-2",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			projects := []source.Project{
+				project(1, openstackCloud, "openstack", "customer-proj-1"),
+				testCase.target,
+			}
+			relations := []source.Relation{
+				relation(1, 1, 2, memberOf, metadata(
+					element("project_discount", "0.05", "all"),
+					element("kickback", "0.10", "all"),
+				)),
+			}
+
+			adjuster, warnings, err := adjustments.New(relations, projects, 3)
+			if err != nil {
+				t.Fatalf("New() error = %v, want nil", err)
+			}
+			want := []adjustments.Warning{{
+				Code:           adjustments.WarningKickbackTargetNotPartner,
+				RelationID:     relationID(1).String(),
+				TargetPlatform: testCase.platform,
+				TargetID:       testCase.external,
+			}}
+			if !reflect.DeepEqual(warnings, want) {
+				t.Errorf("New() warnings = %+v, want %+v", warnings, want)
+			}
+
+			outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+				base("openstack", "instance", "100.00"),
+			})
+
+			assertLineCount(t, outcome, 1)
+			assertLine(t, outcome.Lines[0], "project_discount", testCase.external, relationID(1),
+				"all", "0.05", "100.00", "-5.00")
+			assertDecimal(t, "NetCost", outcome.NetCost, "95.00")
+			assertDecimal(t, "KickbackTotal", outcome.KickbackTotal, "0.00")
+		})
+	}
+}
+
+// TestAdjustRefusesUnreadableAdjustments fails the statement whose walk reaches
+// a relation whose stored adjustments cannot be read, rather than billing it as
+// though the relation carried none.
+func TestAdjustRefusesUnreadableAdjustments(t *testing.T) {
+	t.Run("adjustments the schema refuses", func(t *testing.T) {
+		relations := []source.Relation{
+			relation(1, 1, 2, managedBy, `{"pricing_adjustments":[{"type":"discount","rate":0.15,"scope":"all"}]}`),
+		}
+		adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+		_, err := adjuster.Adjust(projectID(1), []adjustments.Base{
+			base("openstack", "instance", "100.00"),
+		})
+
+		if err == nil {
+			t.Fatal("Adjust() error = nil, want an error")
+		}
+		for _, want := range []string{
+			"the pricing adjustments of relation ",
+			relationID(1).String(),
+			"os-prod/customer-proj-1",
+			"partner/partner-corp",
+			"do not match the schema",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Adjust() error = %v, want it to contain %q", err, want)
+			}
+		}
+		var invalid *adjustment.InvalidError
+		if !errors.As(err, &invalid) {
+			t.Errorf("Adjust() error = %v, want an *adjustment.InvalidError", err)
+		}
+	})
+
+	t.Run("metadata that is not an object", func(t *testing.T) {
+		relations := []source.Relation{relation(1, 1, 2, managedBy, `[]`)}
+		adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+		_, err := adjuster.Adjust(projectID(1), nil)
+
+		if err == nil || !strings.Contains(err.Error(), "decoding the relation metadata") {
+			t.Fatalf("Adjust() error = %v, want it to contain %q", err, "decoding the relation metadata")
+		}
+	})
+
+	t.Run("a depth below one", func(t *testing.T) {
+		_, _, err := adjustments.New(nil, resellerGraph(), 0)
+
+		want := "the adjustment walk depth is 0, and has to be at least 1"
+		if err == nil || err.Error() != want {
+			t.Fatalf("New() error = %v, want %q", err, want)
+		}
+	})
+}
+
+// TestAdjustBillsPastAnUnreachableUnreadableRelation keeps one tenant's stale
+// relation metadata out of every other tenant's statement. The engine loads the
+// adjustment relations of the whole deployment, so a document written before
+// the API validated the member -- or by an import that went around it -- would
+// otherwise fail every run and every tick until somebody edited the reporting
+// database by hand.
+func TestAdjustBillsPastAnUnreachableUnreadableRelation(t *testing.T) {
+	projects := append(resellerGraph(),
+		project(3, openstackCloud, "openstack", "customer-proj-3"),
+		project(4, metaCloud, "meta", "customer-beta"),
+	)
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(element("discount", "0.15", "all"))),
+		// Another tenant's, reachable from neither project 1 nor project 2.
+		relation(2, 3, 4, memberOf, `{"pricing_adjustments":[]}`),
+	}
+	adjuster := newAdjuster(t, relations, projects, 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), []adjustments.Base{
+		base("openstack", "instance", "1000.00"),
+	})
+
+	assertLineCount(t, outcome, 1)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1),
+		"all", "0.15", "1000.00", "-150.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "850.00")
+
+	// The tenant that owns the unreadable relation is still refused.
+	if _, err := adjuster.Adjust(projectID(3), nil); err == nil {
+		t.Error("Adjust() of the project the relation leaves error = nil, want an error")
+	}
+}
+
+// TestNewRefusesUnknownProject refuses a relation whose ends the snapshot does
+// not hold, because a line names its target's external id.
+func TestNewRefusesUnknownProject(t *testing.T) {
+	projects := []source.Project{project(1, openstackCloud, "openstack", "customer-proj-1")}
+	relations := []source.Relation{
+		relation(1, 1, 9, managedBy, metadata(element("discount", "0.10", "all"))),
+	}
+
+	_, _, err := adjustments.New(relations, projects, 3)
+
+	want := "which the registry snapshot does not hold"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("New() error = %v, want it to contain %q", err, want)
+	}
+	if !strings.Contains(err.Error(), projectID(9).String()) {
+		t.Errorf("New() error = %v, want it to name the project %v", err, projectID(9))
+	}
+}
+
+// TestAdjustWithoutRelations bills a statement nothing adjusts, whether the run
+// holds no relations at all or none that names the project.
+func TestAdjustWithoutRelations(t *testing.T) {
+	bases := []adjustments.Base{
+		base("openstack", "instance", "100.00"),
+		base("openstack", "volume", "50.00"),
+	}
+	assertUnadjusted := func(t *testing.T, outcome adjustments.Outcome) {
+		t.Helper()
+
+		assertDecimal(t, "BaseCost", outcome.BaseCost, "150.00")
+		if outcome.Lines != nil {
+			t.Errorf("Lines = %+v, want nil", outcome.Lines)
+		}
+		assertDecimal(t, "NetCost", outcome.NetCost, "150.00")
+		assertDecimal(t, "KickbackTotal", outcome.KickbackTotal, "0.00")
+	}
+
+	t.Run("a run without relations", func(t *testing.T) {
+		adjuster := newAdjuster(t, nil, resellerGraph(), 3)
+
+		assertUnadjusted(t, adjusted(t, adjuster, projectID(1), bases))
+	})
+
+	t.Run("a project no relation names", func(t *testing.T) {
+		projects := append(resellerGraph(), project(3, openstackCloud, "openstack", "customer-proj-3"))
+		relations := []source.Relation{
+			relation(1, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+		}
+		adjuster := newAdjuster(t, relations, projects, 3)
+
+		assertUnadjusted(t, adjusted(t, adjuster, projectID(3), bases))
+	})
+}
+
+// TestAdjustWithoutBases still shows the adjustment that reached the statement,
+// on a base of nothing.
+func TestAdjustWithoutBases(t *testing.T) {
+	relations := []source.Relation{
+		relation(1, 1, 2, managedBy, metadata(element("discount", "0.10", "all"))),
+	}
+	adjuster := newAdjuster(t, relations, resellerGraph(), 3)
+
+	outcome := adjusted(t, adjuster, projectID(1), nil)
+
+	assertDecimal(t, "BaseCost", outcome.BaseCost, "0.00")
+	assertLineCount(t, outcome, 1)
+	assertLine(t, outcome.Lines[0], "discount", "partner-corp", relationID(1), "all", "0.10", "0.00", "0.00")
+	assertDecimal(t, "NetCost", outcome.NetCost, "0.00")
+}
+
+// TestMarshalJSON renders a line and a warning the way the statement document
+// and the run's stats carry them.
+func TestMarshalJSON(t *testing.T) {
+	adjust := func(t *testing.T, kickback string) adjustments.Outcome {
+		t.Helper()
+
+		relations := []source.Relation{
+			relation(1, 1, 2, managedBy, metadata(element("discount", "0.15", "all"), kickback)),
+		}
+		return adjusted(t, newAdjuster(t, relations, resellerGraph(), 3), projectID(1), []adjustments.Base{
+			base("openstack", "instance", "1200.00"),
+		})
+	}
+	assertJSON := func(t *testing.T, value any, want string) {
+		t.Helper()
+
+		got, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v, want nil", err)
+		}
+		if string(got) != want {
+			t.Errorf("Marshal() = %s, want %s", got, want)
+		}
+	}
+
+	t.Run("a line without a description", func(t *testing.T) {
+		outcome := adjust(t, element("kickback", "0.10", "all"))
+
+		assertLineCount(t, outcome, 2)
+		assertJSON(t, outcome.Lines[1], fmt.Sprintf(
+			`{"type":"kickback","relation_type":"managed_by","relation_target":"partner-corp",`+
+				`"relation_id":%q,"scope":"all","rate":0.100000,"base":1020.00,"amount":102.00}`,
+			relationID(1)))
+	})
+
+	t.Run("a line with a description", func(t *testing.T) {
+		outcome := adjust(t, `{"type":"kickback","rate":"0.10","scope":"all",`+
+			`"description":"Reseller commission on net revenue"}`)
+
+		assertLineCount(t, outcome, 2)
+		assertJSON(t, outcome.Lines[1], fmt.Sprintf(
+			`{"type":"kickback","relation_type":"managed_by","relation_target":"partner-corp",`+
+				`"relation_id":%q,"scope":"all","description":"Reseller commission on net revenue",`+
+				`"rate":0.100000,"base":1020.00,"amount":102.00}`,
+			relationID(1)))
+	})
+
+	t.Run("a warning", func(t *testing.T) {
+		assertJSON(t, adjustments.Warning{
+			Code:           adjustments.WarningKickbackTargetNotPartner,
+			RelationID:     relationID(1).String(),
+			TargetPlatform: "meta",
+			TargetID:       "customer-alpha",
+		}, fmt.Sprintf(
+			`{"code":"adjustment_kickback_target_not_partner","relation_id":%q,`+
+				`"target_platform":"meta","target_id":"customer-alpha"}`,
+			relationID(1)))
+	})
+}

--- a/internal/engine/config/config.go
+++ b/internal/engine/config/config.go
@@ -32,6 +32,8 @@ const (
 	envGraceHours       = "TALLY_ENGINE_GRACE_HOURS"
 	envAutoFinalize     = "TALLY_ENGINE_AUTO_FINALIZE"
 	envAttributingTypes = "TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES"
+	envAdjustmentTypes  = "TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES"
+	envAdjustmentDepth  = "TALLY_ENGINE_ADJUSTMENT_DEPTH"
 	envCounterSources   = "TALLY_ENGINE_COUNTER_SOURCES"
 )
 
@@ -48,6 +50,8 @@ var EnvNames = []string{
 	envGraceHours,
 	envAutoFinalize,
 	envAttributingTypes,
+	envAdjustmentTypes,
+	envAdjustmentDepth,
 	envCounterSources,
 }
 
@@ -94,6 +98,15 @@ type Config struct {
 	// "member_of" and "managed_by" reach a virtual project and attribute no cost,
 	// so a list naming either is refused.
 	AttributingRelationTypes []string `env:"TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES" envDefault:"infrastructure_tenant"`
+	// AdjustmentRelationTypes are the relation types adjustment resolution walks
+	// from a statement's project to collect the pricing adjustments that apply
+	// to it, "managed_by" and "member_of" by default. Setting the variable to
+	// the empty string yields the empty list, which turns adjustments off. A
+	// type in both lists is walked by attribution and by adjustment resolution.
+	AdjustmentRelationTypes []string `env:"TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES" envDefault:"managed_by,member_of"`
+	// AdjustmentDepth is how many relation levels the walk follows from the
+	// statement's project; 1 is the project's own relations. It is at least 1.
+	AdjustmentDepth int `env:"TALLY_ENGINE_ADJUSTMENT_DEPTH" envDefault:"3"`
 	// CounterSourcesPath is the path to the counter sources YAML, the file that
 	// declares which counters exist and how each one is measured;
 	// cmd/tally-engine/counter-sources.example.yaml shows the format. Setting
@@ -150,6 +163,22 @@ func Load() (Config, error) {
 		if project.IsVirtualRelationType(relationType) {
 			return Config{}, fmt.Errorf("%s: %q reaches a virtual project and attributes no cost", envAttributingTypes, relationType)
 		}
+	}
+	// The adjustment list is read the same way, and its explicitly empty value is
+	// the one switch that turns adjustments off. No type is refused here: the
+	// walk is independent of attribution, so a type named in both lists is walked
+	// by attribution and by adjustment resolution.
+	adjustmentRaw, isSet := os.LookupEnv(envAdjustmentTypes)
+	if isSet && adjustmentRaw == "" {
+		cfg.AdjustmentRelationTypes = []string{}
+	}
+	if slices.Contains(cfg.AdjustmentRelationTypes, "") {
+		return Config{}, fmt.Errorf("%s: %q must not contain an empty relation type", envAdjustmentTypes, adjustmentRaw)
+	}
+	// A depth below 1 would walk nothing while adjustments stay on, which the
+	// empty type list already says.
+	if cfg.AdjustmentDepth < 1 {
+		return Config{}, fmt.Errorf("%s: %d must be at least 1", envAdjustmentDepth, cfg.AdjustmentDepth)
 	}
 	// The counter sources path is read the same way: only the explicit empty
 	// value means no counter sources, which counters.Load honors by reading

--- a/internal/engine/config/config_test.go
+++ b/internal/engine/config/config_test.go
@@ -68,6 +68,12 @@ func TestLoadDefaults(t *testing.T) {
 	if want := []string{"infrastructure_tenant"}; !slices.Equal(cfg.AttributingRelationTypes, want) {
 		t.Errorf("AttributingRelationTypes = %q, want %q", cfg.AttributingRelationTypes, want)
 	}
+	if want := []string{"managed_by", "member_of"}; !slices.Equal(cfg.AdjustmentRelationTypes, want) {
+		t.Errorf("AdjustmentRelationTypes = %q, want %q", cfg.AdjustmentRelationTypes, want)
+	}
+	if cfg.AdjustmentDepth != 3 {
+		t.Errorf("AdjustmentDepth = %d, want 3", cfg.AdjustmentDepth)
+	}
 	if want := "/etc/tally/counter-sources.yaml"; cfg.CounterSourcesPath != want {
 		t.Errorf("CounterSourcesPath = %q, want %q", cfg.CounterSourcesPath, want)
 	}
@@ -224,6 +230,124 @@ func TestAttributingTypesExplicitEmpty(t *testing.T) {
 		}
 		if want := []string{"infrastructure_tenant"}; !slices.Equal(cfg.AttributingRelationTypes, want) {
 			t.Errorf("AttributingRelationTypes = %q, want %q", cfg.AttributingRelationTypes, want)
+		}
+	})
+}
+
+func TestAdjustmentTypesExplicitEmpty(t *testing.T) {
+	t.Run("an explicitly empty value turns adjustments off", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_ENGINE_DB_URL":                    "postgres://tally@localhost/engine",
+			"TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES": "",
+		})
+
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if len(cfg.AdjustmentRelationTypes) != 0 {
+			t.Errorf("AdjustmentRelationTypes = %q, want the empty list", cfg.AdjustmentRelationTypes)
+		}
+	})
+
+	t.Run("a named list replaces the default", func(t *testing.T) {
+		tests := []struct {
+			value string
+			want  []string
+		}{
+			{value: "managed_by", want: []string{"managed_by"}},
+			// The list is independent of the attributing one, so a type named in
+			// both is walked by attribution and by adjustment resolution.
+			{value: "infrastructure_tenant,member_of", want: []string{"infrastructure_tenant", "member_of"}},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.value, func(t *testing.T) {
+				setEnv(t, map[string]string{
+					"TALLY_ENGINE_DB_URL":                    "postgres://tally@localhost/engine",
+					"TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES": tc.value,
+				})
+
+				cfg, err := config.Load()
+				if err != nil {
+					t.Fatalf("Load() error = %v, want nil", err)
+				}
+				if !slices.Equal(cfg.AdjustmentRelationTypes, tc.want) {
+					t.Errorf("AdjustmentRelationTypes = %q, want %q", cfg.AdjustmentRelationTypes, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("a stray comma is rejected", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_ENGINE_DB_URL":                    "postgres://tally@localhost/engine",
+			"TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES": "managed_by,,member_of",
+		})
+
+		_, err := config.Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES") {
+			t.Errorf("Load() error = %q, want it to name TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES", err)
+		}
+		if want := "must not contain an empty relation type"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Load() error = %q, want it to contain %q", err, want)
+		}
+	})
+}
+
+func TestAdjustmentDepth(t *testing.T) {
+	t.Run("one level is the shallowest walk", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_ENGINE_DB_URL":           "postgres://tally@localhost/engine",
+			"TALLY_ENGINE_ADJUSTMENT_DEPTH": "1",
+		})
+
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if cfg.AdjustmentDepth != 1 {
+			t.Errorf("AdjustmentDepth = %d, want 1", cfg.AdjustmentDepth)
+		}
+	})
+
+	t.Run("a depth below one is rejected", func(t *testing.T) {
+		for _, value := range []string{"0", "-1"} {
+			t.Run(value, func(t *testing.T) {
+				setEnv(t, map[string]string{
+					"TALLY_ENGINE_DB_URL":           "postgres://tally@localhost/engine",
+					"TALLY_ENGINE_ADJUSTMENT_DEPTH": value,
+				})
+
+				_, err := config.Load()
+				if err == nil {
+					t.Fatal("Load() error = nil, want an error")
+				}
+				if !strings.Contains(err.Error(), "TALLY_ENGINE_ADJUSTMENT_DEPTH") {
+					t.Errorf("Load() error = %q, want it to name TALLY_ENGINE_ADJUSTMENT_DEPTH", err)
+				}
+				if want := "must be at least 1"; !strings.Contains(err.Error(), want) {
+					t.Errorf("Load() error = %q, want it to contain %q", err, want)
+				}
+			})
+		}
+	})
+
+	t.Run("a value that is not an integer is rejected", func(t *testing.T) {
+		setEnv(t, map[string]string{
+			"TALLY_ENGINE_DB_URL":           "postgres://tally@localhost/engine",
+			"TALLY_ENGINE_ADJUSTMENT_DEPTH": "three",
+		})
+
+		_, err := config.Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want an error")
+		}
+		if want := "parsing the environment"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Load() error = %q, want it to contain %q", err, want)
 		}
 	})
 }

--- a/internal/engine/corrections/corrections.go
+++ b/internal/engine/corrections/corrections.go
@@ -12,6 +12,13 @@
 // deltas instead: a project's own resources are its line items, and every
 // project attributed to it arrives as a related cost beside them.
 //
+// Adjustments are neither a resource nor a dimension, so the adjustment records
+// of the two passes are diffed on a key of their own: the statement they were
+// applied to, the relation they came from, and the type, the scope and the rate
+// of the element. Their differences render on the credit note beside the rated
+// deltas, and the note's total is what the correction settles after them
+// (roadmap/05-phase-5-commercial-pricing.md, WP 5.3).
+//
 // The orchestration is elsewhere. The run row that carries the correction, the
 // period lock it runs under, and the writing of the deltas and the credit notes
 // live in internal/engine/runs.
@@ -29,6 +36,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/money"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/metering"
@@ -50,6 +58,43 @@ type Key struct {
 // smaller than the finalized run billed is money owed back.
 type Delta struct {
 	Key
+	Old, New, Delta decimal.Decimal
+}
+
+// AdjustmentKey is what the adjustment records of two passes are diffed by: the
+// statement the adjustment was applied to, the relation it came from, and the
+// type, the scope and the rate of the element. Two elements of one relation
+// that agree on all three are one adjustment as far as the diff goes, because
+// nothing else on the line tells them apart.
+//
+// Rate is the six-place text money.Rate renders, the scale the adjustments
+// schema admits, because a decimal is not a map key.
+type AdjustmentKey struct {
+	StatementKey, RelationID, Type, Scope, Rate string
+}
+
+// AdjustmentAmount is one side of the adjustment diff: what the records under
+// one key add up to, the relation they came from and the rate they were applied
+// at. The relation and the rate travel with the amount so a delta names them
+// without the statements being read again.
+type AdjustmentAmount struct {
+	RelationType, RelationTarget string
+	// RateValue is AdjustmentKey.Rate as the decimal it was rendered from, which
+	// is what a credit-note line writes.
+	RateValue decimal.Decimal
+	Amount    decimal.Decimal
+}
+
+// AdjustmentDelta is one non-zero difference between the adjustments of the two
+// passes. Delta is New minus Old, the way Delta.Delta is, and it carries the
+// sign of the amounts it is taken between: a discount the correction applies
+// less of comes out positive, which is money the project owes back.
+type AdjustmentDelta struct {
+	AdjustmentKey
+	RelationType, RelationTarget string
+	// RateValue is AdjustmentKey.Rate as a decimal, the way AdjustmentAmount
+	// carries it.
+	RateValue       decimal.Decimal
 	Old, New, Delta decimal.Decimal
 }
 
@@ -75,8 +120,21 @@ type CreditNote struct {
 	CorrectsRunID string                   `json:"corrects_run_id"`
 	LineItems     []LineItem               `json:"line_items"`
 	RelatedCosts  []RelatedCost            `json:"related_costs"`
-	Total         money.Amount             `json:"total"`
-	Currency      string                   `json:"currency"`
+	// BaseDelta is what the line items and the related costs add up to before
+	// the adjustments, NetDelta what they come to after them, and KickbackDelta
+	// what a partner's commission changed by beside the net rather than as part
+	// of it. The four members are nil on a note no adjustment delta reached,
+	// whose bytes hold none of them. Total is the net delta where they are
+	// there, which is what the correction settles.
+	//
+	// None of them carries a currency of its own: every amount on the note is in
+	// the currency Currency names, the way Total already renders.
+	BaseDelta     *money.Amount      `json:"base_delta,omitempty"`
+	Adjustments   []AdjustmentChange `json:"adjustments,omitempty"`
+	NetDelta      *money.Amount      `json:"net_delta,omitempty"`
+	KickbackDelta *money.Amount      `json:"kickback_delta,omitempty"`
+	Total         money.Amount       `json:"total"`
+	Currency      string             `json:"currency"`
 }
 
 // LineItem is one resource's deltas as one project is credited or debited for
@@ -97,6 +155,22 @@ type Change struct {
 	Old   money.Amount `json:"old"`
 	New   money.Amount `json:"new"`
 	Delta money.Amount `json:"delta"`
+}
+
+// AdjustmentChange is one adjustment on the credit note: the relation it came
+// from, what the run being corrected applied, what the correction applied, and
+// the difference the project is credited or debited for. The field order is the
+// order it is marshalled in.
+type AdjustmentChange struct {
+	Type           string       `json:"type"`
+	RelationType   string       `json:"relation_type"`
+	RelationTarget string       `json:"relation_target"`
+	RelationID     string       `json:"relation_id"`
+	Scope          string       `json:"scope"`
+	Rate           money.Rate   `json:"rate"`
+	Old            money.Amount `json:"old"`
+	New            money.Amount `json:"new"`
+	Delta          money.Amount `json:"delta"`
 }
 
 // RelatedCost is one attributed project's deltas on the credit note of the
@@ -164,6 +238,35 @@ func Amounts(usage []metering.ResourceUsage, rated rating.Result) (map[Key]decim
 	return amounts, nil
 }
 
+// AdjustmentAmounts sums what the adjustments of one pass came to, per key. A
+// statement carries its applied adjustments beside its total, and two elements
+// of one relation that agree on type, scope and rate are summed under one key.
+//
+// A pass whose statements carry no adjustments yields an empty map, which is
+// what a period that adjusted nothing is diffed as: every key of the other side
+// becomes a delta.
+func AdjustmentAmounts(sts []statements.Statement) map[AdjustmentKey]AdjustmentAmount {
+	amounts := make(map[AdjustmentKey]AdjustmentAmount)
+	for _, statement := range sts {
+		for _, line := range statement.Adjustments {
+			key := AdjustmentKey{
+				StatementKey: statement.Key,
+				RelationID:   line.RelationID,
+				Type:         line.Type,
+				Scope:        line.Scope,
+				Rate:         line.Rate.StringFixed(money.RatePlaces),
+			}
+			amounts[key] = AdjustmentAmount{
+				RelationType:   line.RelationType,
+				RelationTarget: line.RelationTarget,
+				RateValue:      line.Rate.Decimal,
+				Amount:         amounts[key].Amount.Add(line.Amount.Decimal),
+			}
+		}
+	}
+	return amounts
+}
+
 // Diff is what changed between the two passes: one Delta per key they disagree
 // on, sorted by cloud, platform, resource type, resource id, project id, and
 // dimension. A key one side does not hold counts as zero there, so a resource
@@ -211,6 +314,67 @@ func appendDelta(deltas []Delta, key Key, old, current decimal.Decimal) []Delta 
 	return append(deltas, Delta{Key: key, Old: old, New: current, Delta: difference})
 }
 
+// DiffAdjustments is what changed between the adjustments of the two passes:
+// one AdjustmentDelta per key they disagree on, sorted by statement key,
+// relation id, the application order of the type (adjustment.TypeOrder), scope
+// and rate. A key one side does not hold counts as zero there, so an adjustment
+// the correction no longer applies is credited back whole and one it applies
+// for the first time is charged whole.
+//
+// A key the two sides agree on is left out, one both of them applied at zero
+// included. Passes that adjusted the same, two empty ones included, yield nil
+// rather than an empty slice.
+func DiffAdjustments(old, current map[AdjustmentKey]AdjustmentAmount) []AdjustmentDelta {
+	var deltas []AdjustmentDelta
+	for key, amount := range current {
+		// A key old does not hold reads as the zero decimal, which is what the
+		// correction applying the adjustment for the first time diffs against.
+		deltas = appendAdjustmentDelta(deltas, key, amount, old[key].Amount, amount.Amount)
+	}
+	for key, amount := range old {
+		if _, held := current[key]; held {
+			continue
+		}
+		deltas = appendAdjustmentDelta(deltas, key, amount, amount.Amount, decimal.Zero)
+	}
+
+	slices.SortFunc(deltas, func(a, b AdjustmentDelta) int {
+		return cmp.Or(
+			cmp.Compare(a.StatementKey, b.StatementKey),
+			cmp.Compare(a.RelationID, b.RelationID),
+			cmp.Compare(slices.Index(adjustment.TypeOrder, a.Type), slices.Index(adjustment.TypeOrder, b.Type)),
+			cmp.Compare(a.Scope, b.Scope),
+			cmp.Compare(a.Rate, b.Rate),
+		)
+	})
+	return deltas
+}
+
+// appendAdjustmentDelta keeps one difference where there is one. The relation
+// and the rate come from the side the key is read off, which is the current one
+// wherever it holds the key. The two amounts are already rounded, and their
+// difference is not rounded again.
+func appendAdjustmentDelta(
+	deltas []AdjustmentDelta,
+	key AdjustmentKey,
+	relation AdjustmentAmount,
+	old, current decimal.Decimal,
+) []AdjustmentDelta {
+	difference := current.Sub(old)
+	if difference.IsZero() {
+		return deltas
+	}
+	return append(deltas, AdjustmentDelta{
+		AdjustmentKey:  key,
+		RelationType:   relation.RelationType,
+		RelationTarget: relation.RelationTarget,
+		RateValue:      relation.RateValue,
+		Old:            old,
+		New:            current,
+		Delta:          difference,
+	})
+}
+
 // BuildCreditNotes renders one credit note per project that owns at least one
 // delta. The grouping is the one statements.Build applies to a period's rated
 // records, over the deltas instead: a project's own resources are its line
@@ -223,19 +387,26 @@ func appendDelta(deltas []Delta, key Key, old, current decimal.Decimal) []Delta 
 // not hold is credited standalone under that raw id and named in
 // BuildResult.Unregistered.
 //
-// A note's total is the sum of its line items and its related costs, so a
-// project that is owed money reads a negative total. Correcting nothing is not
-// an error: without deltas there is nothing to credit and no document comes
-// back.
+// An adjustment delta lands on the note of the statement key it names, and
+// creates that note where no rated delta did. Such a note shows what its lines
+// came to before the adjustments, the changes themselves, and what they come to
+// after them; its total is the net delta. A note no adjustment delta reached
+// renders as it does without adjustments at all.
+//
+// A note's total is the sum of its line items and its related costs, adjusted
+// by the changes it carries, so a project that is owed money reads a negative
+// total. Correcting nothing is not an error: without deltas of either kind
+// there is nothing to credit and no document comes back.
 func BuildCreditNotes(
 	periodFrom, periodTo time.Time,
 	correctsRunID uuid.UUID,
 	currency string,
 	deltas []Delta,
+	adjustmentDeltas []AdjustmentDelta,
 	projects []source.Project,
 	res attribution.Resolution,
 ) (BuildResult, error) {
-	if len(deltas) == 0 {
+	if len(deltas) == 0 && len(adjustmentDeltas) == 0 {
 		return BuildResult{}, nil
 	}
 
@@ -311,6 +482,14 @@ func BuildCreditNotes(
 		documentOf(documents, own.key, own.project.ExternalID, own.project.Platform).add(items)
 	}
 
+	for _, change := range adjustmentDeltas {
+		document, err := adjustedDocument(documents, byPair, change.StatementKey)
+		if err != nil {
+			return BuildResult{}, err
+		}
+		document.changes = append(document.changes, change)
+	}
+
 	result.Statements = make([]statements.Statement, 0, len(documents))
 	for _, document := range documents {
 		statement, err := document.render(billingPeriod, correctsRunID, currency)
@@ -364,6 +543,9 @@ type builder struct {
 	platform  string
 	items     []LineItem
 	related   []related
+	// changes holds the adjustment deltas of the note, in the order
+	// DiffAdjustments sorted them.
+	changes []AdjustmentDelta
 }
 
 // related is one related-costs entry and the pair of the project it credits,
@@ -448,6 +630,32 @@ func documentOf(documents map[ownerKey]*builder, key ownerKey, projectID, platfo
 	return document
 }
 
+// adjustedDocument is the note an adjustment delta lands on: the one the rated
+// deltas already created for the statement key, or a new one for the pair the
+// key names. An adjustment reaches a statement over a relation of a registered
+// project, so a pair the registry does not hold is refused rather than credited
+// under a document named after nobody.
+func adjustedDocument(
+	documents map[ownerKey]*builder,
+	byPair map[ownerKey]source.Project,
+	key string,
+) (*builder, error) {
+	cloud, projectID, err := statements.ParseKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("reading the statement key of an adjustment delta: %w", err)
+	}
+
+	pair := ownerKey{cloud: cloud, projectID: projectID}
+	if document, held := documents[pair]; held {
+		return document, nil
+	}
+	project, registered := byPair[pair]
+	if !registered {
+		return nil, fmt.Errorf("the adjustment deltas of %s name a project the registry does not hold", key)
+	}
+	return documentOf(documents, pair, project.ExternalID, project.Platform), nil
+}
+
 // add puts one owner's lines on the note. Only the project the note is keyed to
 // bills its lines here; every other one arrives as a related cost.
 func (d *builder) add(items []LineItem) {
@@ -455,9 +663,14 @@ func (d *builder) add(items []LineItem) {
 }
 
 // render marshals the credit note. The lines and the related costs are already
-// ordered among themselves, the related entries are ordered here, and the map
-// keys of a line are ordered by encoding/json, so the bytes are a function of
-// the deltas alone.
+// ordered among themselves, the related entries are ordered here, the changes
+// keep the order DiffAdjustments sorted them in, and the map keys of a line are
+// ordered by encoding/json, so the bytes are a function of the deltas alone.
+//
+// The changes apply to the sum of every line the note credits, its own and the
+// related ones, because that sum is what the adjustments of the two passes were
+// applied to. A note without changes leaves the four adjustment members nil and
+// is the document an unadjusted correction renders.
 func (d *builder) render(
 	billingPeriod statements.BillingPeriod,
 	correctsRunID uuid.UUID,
@@ -483,6 +696,41 @@ func (d *builder) render(
 	for _, entry := range d.related {
 		note.RelatedCosts = append(note.RelatedCosts, entry.cost)
 		total = total.Add(entry.cost.Total.Decimal)
+	}
+
+	if len(d.changes) > 0 {
+		baseDelta := money.NewAmount(total)
+		net, kickback := total, decimal.Zero
+		changes := make([]AdjustmentChange, 0, len(d.changes))
+		for _, change := range d.changes {
+			changes = append(changes, AdjustmentChange{
+				Type:           change.Type,
+				RelationType:   change.RelationType,
+				RelationTarget: change.RelationTarget,
+				RelationID:     change.RelationID,
+				Scope:          change.Scope,
+				Rate:           money.NewRate(change.RateValue),
+				Old:            money.NewAmount(change.Old),
+				New:            money.NewAmount(change.New),
+				Delta:          money.NewAmount(change.Delta),
+			})
+
+			// A kickback is what a partner is owed rather than what the customer
+			// pays, so it stands beside the net rather than in it.
+			if change.Type == adjustment.TypeKickback {
+				kickback = kickback.Add(change.Delta)
+				continue
+			}
+			net = net.Add(change.Delta)
+		}
+
+		netDelta := money.NewAmount(net)
+		kickbackDelta := money.NewAmount(kickback)
+		note.BaseDelta = &baseDelta
+		note.Adjustments = changes
+		note.NetDelta = &netDelta
+		note.KickbackDelta = &kickbackDelta
+		total = net
 	}
 	note.Total = money.NewAmount(total)
 

--- a/internal/engine/corrections/corrections_test.go
+++ b/internal/engine/corrections/corrections_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/metering"
@@ -75,8 +77,11 @@ const (
 )
 
 // infrastructureTenant is the attributing relation type of the concept's
-// example.
-const infrastructureTenant = "infrastructure_tenant"
+// example, managedBy the one its pricing adjustments hang on.
+const (
+	infrastructureTenant = "infrastructure_tenant"
+	managedBy            = "managed_by"
+)
 
 // The period the cases correct: March 2026, the one the concept works through.
 var (
@@ -199,8 +204,57 @@ func delta(k corrections.Key, old, current string) corrections.Delta {
 	return corrections.Delta{Key: k, Old: before, New: after, Delta: after.Sub(before)}
 }
 
+// adjustmentLine is one applied adjustment of a statement, spelled the way the
+// resolution renders one. Every case hangs its adjustments on a managed_by
+// relation, which is where a partner's discounts and kickbacks sit.
+func adjustmentLine(typ string, relation uuid.UUID, target, scope, rate, base, amount string) adjustments.Line {
+	return adjustments.Line{
+		Type:           typ,
+		RelationType:   managedBy,
+		RelationTarget: target,
+		RelationID:     relation.String(),
+		Scope:          scope,
+		Rate:           money.NewRate(decimal.RequireFromString(rate)),
+		Base:           money.NewAmount(decimal.RequireFromString(base)),
+		Amount:         money.NewAmount(decimal.RequireFromString(amount)),
+	}
+}
+
+// adjustmentKey is one key of the adjustment diff, its rate the six-place text
+// money.Rate renders.
+func adjustmentKey(statementKey string, relation uuid.UUID, typ, scope, rate string) corrections.AdjustmentKey {
+	return corrections.AdjustmentKey{
+		StatementKey: statementKey,
+		RelationID:   relation.String(),
+		Type:         typ,
+		Scope:        scope,
+		Rate:         rate,
+	}
+}
+
+// adjustmentDelta is one difference of the adjustment diff, built from the two
+// amounts as text so a case reads the numbers it credits.
+func adjustmentDelta(
+	k corrections.AdjustmentKey,
+	relationType, target, old, current string,
+) corrections.AdjustmentDelta {
+	before := decimal.RequireFromString(old)
+	after := decimal.RequireFromString(current)
+
+	return corrections.AdjustmentDelta{
+		AdjustmentKey:  k,
+		RelationType:   relationType,
+		RelationTarget: target,
+		RateValue:      decimal.RequireFromString(k.Rate),
+		Old:            before,
+		New:            after,
+		Delta:          after.Sub(before),
+	}
+}
+
 // notes renders one correction the way a run does: the deltas are handed to
-// BuildCreditNotes with the registry they were diffed against.
+// BuildCreditNotes with the registry they were diffed against. A case that
+// corrects no adjustment goes through here, which is every case of Phase 3.
 func notes(
 	t *testing.T,
 	deltas []corrections.Delta,
@@ -209,7 +263,21 @@ func notes(
 ) corrections.BuildResult {
 	t.Helper()
 
-	result, err := corrections.BuildCreditNotes(periodFrom, periodTo, correctsRunID, "EUR", deltas, projects, res)
+	return adjustedNotes(t, deltas, nil, projects, res)
+}
+
+// adjustedNotes renders one correction that also corrects adjustments.
+func adjustedNotes(
+	t *testing.T,
+	deltas []corrections.Delta,
+	changes []corrections.AdjustmentDelta,
+	projects []source.Project,
+	res attribution.Resolution,
+) corrections.BuildResult {
+	t.Helper()
+
+	result, err := corrections.BuildCreditNotes(
+		periodFrom, periodTo, correctsRunID, "EUR", deltas, changes, projects, res)
 	if err != nil {
 		t.Fatalf("BuildCreditNotes() error = %v, want nil", err)
 	}
@@ -259,6 +327,52 @@ func assertAmount(t *testing.T, amounts map[corrections.Key]decimal.Decimal, k c
 		return
 	}
 	assertDecimal(t, k.Dimension, amount, want)
+}
+
+// assertAdjustmentAmount holds one key of an adjustment amount map against the
+// text it is expected to spell. A key the map does not hold fails the case.
+func assertAdjustmentAmount(
+	t *testing.T,
+	amounts map[corrections.AdjustmentKey]corrections.AdjustmentAmount,
+	k corrections.AdjustmentKey,
+	want string,
+) {
+	t.Helper()
+
+	amount, held := amounts[k]
+	if !held {
+		t.Errorf("the %s of relation %s on %s is missing, want %s", k.Type, k.RelationID, k.StatementKey, want)
+		return
+	}
+	assertDecimal(t, k.Type, amount.Amount, want)
+}
+
+// assertOptionalAmount holds one of the four adjustment members of a credit
+// note against the text it is expected to spell. A member the note does not
+// carry fails the case.
+func assertOptionalAmount(t *testing.T, name string, got *money.Amount, want string) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatalf("%s = null, want %s", name, want)
+	}
+	assertDecimal(t, name, got.Decimal, want)
+}
+
+// assertMemberOrder holds the raw document against the order it declares its
+// members in. Each name is searched for behind the one before it, so a member
+// out of place, or one the document does not hold at all, fails the case.
+func assertMemberOrder(t *testing.T, name string, document []byte, members []string) {
+	t.Helper()
+
+	rest := document
+	for _, member := range members {
+		at := bytes.Index(rest, []byte(`"`+member+`":`))
+		if at < 0 {
+			t.Fatalf("%s = %s, want %q behind the members before it", name, document, member)
+		}
+		rest = rest[at+len(member):]
+	}
 }
 
 // assertChange holds one dimension of a line item against the three amounts the
@@ -417,6 +531,71 @@ func TestAmountsMisaligned(t *testing.T) {
 	})
 }
 
+// TestAdjustmentAmounts sums the adjustments of one pass. Two elements of one
+// relation that agree on type, scope and rate reach one key, because nothing
+// else on the line tells them apart, and the relation they came from travels
+// with the sum.
+func TestAdjustmentAmounts(t *testing.T) {
+	partner := statements.Key(openstackCloud, "proj-456")
+	reseller := statements.Key(gardenerCloud, "team-alpha")
+	sts := []statements.Statement{
+		{
+			Key: partner,
+			Adjustments: []adjustments.Line{
+				adjustmentLine(adjustment.TypeDiscount, relationID(1), "partner-corp",
+					adjustment.ScopeAll, "0.15", "148.80", "-22.32"),
+				adjustmentLine(adjustment.TypeKickback, relationID(1), "partner-corp",
+					adjustment.ScopeAll, "0.10", "126.48", "12.65"),
+			},
+		},
+		{
+			Key: reseller,
+			// Two elements of one relation that differ in nothing the diff is
+			// keyed by: the statement is adjusted twice and the key is summed.
+			Adjustments: []adjustments.Line{
+				adjustmentLine(adjustment.TypeDiscount, relationID(2), "reseller-gmbh",
+					adjustment.ScopeAll, "0.10", "10.00", "-1.00"),
+				adjustmentLine(adjustment.TypeDiscount, relationID(2), "reseller-gmbh",
+					adjustment.ScopeAll, "0.10", "9.00", "-0.90"),
+			},
+		},
+	}
+
+	amounts := corrections.AdjustmentAmounts(sts)
+
+	if len(amounts) != 3 {
+		t.Fatalf("AdjustmentAmounts() = %d keys, want 3: the two of the partner and the summed one", len(amounts))
+	}
+	assertAdjustmentAmount(t, amounts,
+		adjustmentKey(partner, relationID(1), adjustment.TypeDiscount, adjustment.ScopeAll, "0.150000"), "-22.32")
+	assertAdjustmentAmount(t, amounts,
+		adjustmentKey(partner, relationID(1), adjustment.TypeKickback, adjustment.ScopeAll, "0.100000"), "12.65")
+
+	summed := adjustmentKey(reseller, relationID(2), adjustment.TypeDiscount, adjustment.ScopeAll, "0.100000")
+	assertAdjustmentAmount(t, amounts, summed, "-1.90")
+	if got := amounts[summed]; got.RelationType != managedBy || got.RelationTarget != "reseller-gmbh" {
+		t.Errorf("the relation of the summed key = %s/%s, want %s/reseller-gmbh",
+			got.RelationType, got.RelationTarget, managedBy)
+	}
+
+	t.Run("no statements", func(t *testing.T) {
+		got := corrections.AdjustmentAmounts(nil)
+		if got == nil {
+			t.Fatalf("AdjustmentAmounts() = nil, want an empty map")
+		}
+		if len(got) != 0 {
+			t.Errorf("AdjustmentAmounts() = %d keys, want none", len(got))
+		}
+	})
+
+	t.Run("statements no adjustment reached", func(t *testing.T) {
+		got := corrections.AdjustmentAmounts([]statements.Statement{{Key: partner}, {Key: reseller}})
+		if len(got) != 0 {
+			t.Errorf("AdjustmentAmounts() = %d keys, want none", len(got))
+		}
+	})
+}
+
 // TestDiff diffs two passes that disagree on some keys and agree on others. A
 // key one side does not hold counts as zero there, a key both sides rated the
 // same is left out, and the deltas come back in the order D6 lists the key in.
@@ -500,6 +679,100 @@ func TestDiffNothing(t *testing.T) {
 	})
 }
 
+// TestDiffAdjustments diffs the adjustments of two passes. The re-metered
+// amounts of the concept's correction carry a smaller discount and a smaller
+// kickback than the finalized run applied, and the correction applies a
+// discount of a second relation the finalized run did not apply at all.
+func TestDiffAdjustments(t *testing.T) {
+	partner := statements.Key(openstackCloud, "proj-456")
+	discount := adjustmentKey(partner, relationID(1), adjustment.TypeDiscount, adjustment.ScopeAll, "0.150000")
+	kickback := adjustmentKey(partner, relationID(1), adjustment.TypeKickback, adjustment.ScopeAll, "0.100000")
+	added := adjustmentKey(partner, relationID(2), adjustment.TypeDiscount, adjustment.ScopeAll, "0.100000")
+
+	amount := func(target, value string) corrections.AdjustmentAmount {
+		return corrections.AdjustmentAmount{
+			RelationType:   managedBy,
+			RelationTarget: target,
+			Amount:         decimal.RequireFromString(value),
+		}
+	}
+	// The keys go in unordered on both sides, so the order the deltas come back
+	// in is the one DiffAdjustments applies rather than the one they were
+	// written in.
+	old := map[corrections.AdjustmentKey]corrections.AdjustmentAmount{
+		kickback: amount("partner-corp", "12.65"),
+		discount: amount("partner-corp", "-22.32"),
+	}
+	current := map[corrections.AdjustmentKey]corrections.AdjustmentAmount{
+		added:    amount("reseller-gmbh", "-1.00"),
+		kickback: amount("partner-corp", "10.61"),
+		discount: amount("partner-corp", "-18.72"),
+	}
+
+	got := corrections.DiffAdjustments(old, current)
+
+	order := make([]corrections.AdjustmentKey, 0, len(got))
+	for _, difference := range got {
+		order = append(order, difference.AdjustmentKey)
+	}
+	// The discount and the kickback of one relation are ordered by the
+	// application order of their types, the second relation by its id.
+	if want := []corrections.AdjustmentKey{discount, kickback, added}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("DiffAdjustments() keys = %v, want %v", order, want)
+	}
+
+	cases := []struct {
+		name                     string
+		delta                    corrections.AdjustmentDelta
+		target                   string
+		old, current, difference string
+	}{
+		{"a discount the correction applies less of", got[0], "partner-corp", "-22.32", "-18.72", "3.60"},
+		{"a kickback the correction applies less of", got[1], "partner-corp", "12.65", "10.61", "-2.04"},
+		{"an adjustment only the correction applies", got[2], "reseller-gmbh", "0.00", "-1.00", "-1.00"},
+	}
+	for _, want := range cases {
+		t.Run(want.name, func(t *testing.T) {
+			assertDecimal(t, "Old", want.delta.Old, want.old)
+			assertDecimal(t, "New", want.delta.New, want.current)
+			assertDecimal(t, "Delta", want.delta.Delta, want.difference)
+			if want.delta.RelationType != managedBy || want.delta.RelationTarget != want.target {
+				t.Errorf("the relation = %s/%s, want %s/%s",
+					want.delta.RelationType, want.delta.RelationTarget, managedBy, want.target)
+			}
+		})
+	}
+
+	t.Run("an adjustment only the finalized run applied", func(t *testing.T) {
+		deltas := corrections.DiffAdjustments(old, nil)
+
+		if len(deltas) != 2 {
+			t.Fatalf("DiffAdjustments() = %d deltas, want 2: both are reversed whole", len(deltas))
+		}
+		assertDecimal(t, "Old", deltas[0].Old, "-22.32")
+		assertDecimal(t, "New", deltas[0].New, "0.00")
+		assertDecimal(t, "Delta", deltas[0].Delta, "22.32")
+		// The current side does not hold the key, so the relation is read off
+		// the old one rather than left empty.
+		if deltas[0].RelationTarget != "partner-corp" {
+			t.Errorf("RelationTarget = %q, want partner-corp", deltas[0].RelationTarget)
+		}
+	})
+
+	t.Run("two passes that adjusted nothing", func(t *testing.T) {
+		empty := map[corrections.AdjustmentKey]corrections.AdjustmentAmount{}
+		if deltas := corrections.DiffAdjustments(empty, empty); deltas != nil {
+			t.Errorf("DiffAdjustments() = %v, want nil", deltas)
+		}
+	})
+
+	t.Run("two passes that adjusted the same", func(t *testing.T) {
+		if deltas := corrections.DiffAdjustments(current, current); deltas != nil {
+			t.Errorf("DiffAdjustments() = %v, want nil", deltas)
+		}
+	})
+}
+
 // TestBuildCreditNotesPowerCycle renders the concept's correction: the instance
 // finalized as active all March, re-metered with the shutoff the late events
 // revealed. The note is held against the fixture byte for byte, and its numbers
@@ -560,6 +833,158 @@ func TestBuildCreditNotesPowerCycle(t *testing.T) {
 	if !bytes.Equal(statement.Document, want) {
 		t.Errorf("Document =\n%s\nwant\n%s", statement.Document, want)
 	}
+}
+
+// TestBuildCreditNotesAdjustments renders the concept's correction with the
+// adjustments it re-applied: the discount and the kickback of the partner
+// relation come out smaller on the re-metered amounts, so the note credits the
+// rated deltas and charges back what the smaller discount no longer discounts.
+func TestBuildCreditNotesAdjustments(t *testing.T) {
+	projects := []source.Project{project(1, openstackCloud, "openstack", "proj-456")}
+	instance := func(dimension string) corrections.Key {
+		return key(openstackCloud, "openstack", "instance", "abc-123", "proj-456", dimension)
+	}
+	deltas := []corrections.Delta{
+		delta(instance("vcpus"), "59.52", "49.92"),
+		delta(instance("ram_gb"), "29.76", "24.96"),
+		delta(instance("disk_gb"), "59.52", "49.92"),
+	}
+	statementKey := statements.Key(openstackCloud, "proj-456")
+	changes := []corrections.AdjustmentDelta{
+		adjustmentDelta(
+			adjustmentKey(statementKey, relationID(1), adjustment.TypeDiscount, adjustment.ScopeAll, "0.150000"),
+			managedBy, "partner-corp", "-22.32", "-18.72"),
+		adjustmentDelta(
+			adjustmentKey(statementKey, relationID(1), adjustment.TypeKickback, adjustment.ScopeAll, "0.100000"),
+			managedBy, "partner-corp", "12.65", "10.61"),
+	}
+
+	result := adjustedNotes(t, deltas, changes, projects, attribution.Resolve(projects, nil))
+
+	if got := keys(result); !reflect.DeepEqual(got, []string{statementKey}) {
+		t.Fatalf("credit note keys = %v, want only %s", got, statementKey)
+	}
+	statement := result.Statements[0]
+	// The statement's total is the net delta, which is what the correction
+	// settles: the kickback is owed to the partner rather than by the customer.
+	assertDecimal(t, "Total", statement.Total, "-20.40")
+
+	assertMemberOrder(t, "the note", statement.Document, []string{
+		"billing_period", "project_id", "platform", "corrects_run_id", "line_items", "related_costs",
+		"base_delta", "adjustments", "net_delta", "kickback_delta", "total", "currency",
+	})
+	at := bytes.Index(statement.Document, []byte(`"adjustments":`))
+	if at < 0 {
+		t.Fatalf("Document = %s, want an adjustments member", statement.Document)
+	}
+	assertMemberOrder(t, "the first change", statement.Document[at:], []string{
+		"type", "relation_type", "relation_target", "relation_id", "scope", "rate", "old", "new", "delta",
+	})
+	// A rate is written at the six places the adjustments schema admits, the
+	// way an amount is written at two.
+	if !bytes.Contains(statement.Document, []byte(`"rate":0.150000`)) {
+		t.Errorf("Document = %s, want the discount rate at six places", statement.Document)
+	}
+
+	note := noteOf(t, statement)
+	assertOptionalAmount(t, "BaseDelta", note.BaseDelta, "-24.00")
+	assertOptionalAmount(t, "NetDelta", note.NetDelta, "-20.40")
+	assertOptionalAmount(t, "KickbackDelta", note.KickbackDelta, "-2.04")
+	assertDecimal(t, "note total", note.Total.Decimal, "-20.40")
+
+	if len(note.Adjustments) != 2 {
+		t.Fatalf("Adjustments = %d, want 2, the discount and the kickback", len(note.Adjustments))
+	}
+	for i, want := range []struct {
+		typ                            string
+		rate, old, current, difference string
+	}{
+		{adjustment.TypeDiscount, "0.15", "-22.32", "-18.72", "3.60"},
+		{adjustment.TypeKickback, "0.10", "12.65", "10.61", "-2.04"},
+	} {
+		t.Run(want.typ, func(t *testing.T) {
+			got := note.Adjustments[i]
+			if got.Type != want.typ {
+				t.Errorf("Type = %q, want %q", got.Type, want.typ)
+			}
+			if got.RelationType != managedBy || got.RelationTarget != "partner-corp" {
+				t.Errorf("the relation = %s/%s, want %s/partner-corp", got.RelationType, got.RelationTarget, managedBy)
+			}
+			if got.RelationID != relationID(1).String() {
+				t.Errorf("RelationID = %q, want %q", got.RelationID, relationID(1))
+			}
+			if got.Scope != adjustment.ScopeAll {
+				t.Errorf("Scope = %q, want %q", got.Scope, adjustment.ScopeAll)
+			}
+			assertDecimal(t, "rate", got.Rate.Decimal, want.rate)
+			assertDecimal(t, "old", got.Old.Decimal, want.old)
+			assertDecimal(t, "new", got.New.Decimal, want.current)
+			assertDecimal(t, "delta", got.Delta.Decimal, want.difference)
+		})
+	}
+}
+
+// TestBuildCreditNotesAdjustmentsOnly renders a correction whose rated amounts
+// came out the same and whose adjustments did not: the relations of the period
+// changed, so there is money to settle without a single resource being rated
+// differently.
+func TestBuildCreditNotesAdjustmentsOnly(t *testing.T) {
+	projects := []source.Project{project(1, openstackCloud, "openstack", "proj-456")}
+	statementKey := statements.Key(openstackCloud, "proj-456")
+	change := func(key string) corrections.AdjustmentDelta {
+		return adjustmentDelta(
+			adjustmentKey(key, relationID(1), adjustment.TypeDiscount, adjustment.ScopeAll, "0.100000"),
+			managedBy, "partner-corp", "0.00", "-1.00")
+	}
+
+	t.Run("a note the adjustment deltas alone create", func(t *testing.T) {
+		result := adjustedNotes(t, nil, []corrections.AdjustmentDelta{change(statementKey)}, projects,
+			attribution.Resolve(projects, nil))
+
+		if got := keys(result); !reflect.DeepEqual(got, []string{statementKey}) {
+			t.Fatalf("credit note keys = %v, want only %s", got, statementKey)
+		}
+		statement := result.Statements[0]
+		assertDecimal(t, "Total", statement.Total, "-1.00")
+		// Nothing was rated differently, and the two lists are rendered as empty
+		// arrays rather than as null, the way a note built from rated deltas
+		// renders them.
+		for _, member := range []string{`"line_items":[],`, `"related_costs":[],`} {
+			if !bytes.Contains(statement.Document, []byte(member)) {
+				t.Errorf("Document = %s, want %s", statement.Document, member)
+			}
+		}
+
+		note := noteOf(t, statement)
+		if note.ProjectID != "proj-456" || note.Platform != "openstack" {
+			t.Errorf("the note names %s/%s, want proj-456/openstack", note.ProjectID, note.Platform)
+		}
+		assertOptionalAmount(t, "BaseDelta", note.BaseDelta, "0.00")
+		assertOptionalAmount(t, "NetDelta", note.NetDelta, "-1.00")
+		assertOptionalAmount(t, "KickbackDelta", note.KickbackDelta, "0.00")
+		assertDecimal(t, "note total", note.Total.Decimal, "-1.00")
+		if len(note.Adjustments) != 1 {
+			t.Fatalf("Adjustments = %d, want 1, the discount", len(note.Adjustments))
+		}
+		assertDecimal(t, "delta", note.Adjustments[0].Delta.Decimal, "-1.00")
+	})
+
+	// An adjustment reaches a statement over a relation of a registered
+	// project, so a key no registry row matches is a delta of a pass this
+	// registry was never diffed against rather than money owed to somebody.
+	t.Run("a statement key the registry does not hold", func(t *testing.T) {
+		ghost := statements.Key(openstackCloud, "proj-ghost")
+		got, err := corrections.BuildCreditNotes(periodFrom, periodTo, correctsRunID, "EUR", nil,
+			[]corrections.AdjustmentDelta{change(ghost)}, projects, attribution.Resolve(projects, nil))
+
+		if !reflect.DeepEqual(got, corrections.BuildResult{}) {
+			t.Errorf("BuildCreditNotes() = %v, want no notes beside the error", got)
+		}
+		want := "the adjustment deltas of " + ghost + " name a project the registry does not hold"
+		if err == nil || err.Error() != want {
+			t.Fatalf("BuildCreditNotes() error = %v, want %q", err, want)
+		}
+	})
 }
 
 // TestBuildCreditNotesAttributed credits the concept's related-costs example: a
@@ -710,7 +1135,7 @@ func TestBuildCreditNotesNoDeltas(t *testing.T) {
 	projects := []source.Project{project(1, openstackCloud, "openstack", "proj-456")}
 
 	got, err := corrections.BuildCreditNotes(
-		periodFrom, periodTo, correctsRunID, "EUR", nil, projects, attribution.Resolve(projects, nil))
+		periodFrom, periodTo, correctsRunID, "EUR", nil, nil, projects, attribution.Resolve(projects, nil))
 	if err != nil {
 		t.Fatalf("BuildCreditNotes() error = %v, want nil", err)
 	}

--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -85,6 +85,14 @@ var (
 // relation type the concept's related-costs example uses.
 var attributingRelationTypes = []string{"infrastructure_tenant"}
 
+// adjustmentRelationTypes and adjustmentDepth are what adjustment resolution
+// walks for every case, the defaults of the deployment. The managed_by and
+// member_of edges of virtual_relations carry no adjustments, so a run of the
+// suite proves that walking them leaves every statement at the Phase 3 bytes.
+var adjustmentRelationTypes = []string{"managed_by", "member_of"}
+
+const adjustmentDepth = 3
+
 // goldenFixture is the pair of containers the suite runs its cases in. The
 // cases share them and take a database of their own out of each.
 type goldenFixture struct {
@@ -734,6 +742,8 @@ func (c goldenCase) options(t *testing.T, clouds []string) runs.Options {
 		PeriodTo:                 periodTo,
 		Clouds:                   clouds,
 		AttributingRelationTypes: attributingRelationTypes,
+		AdjustmentRelationTypes:  adjustmentRelationTypes,
+		AdjustmentDepth:          adjustmentDepth,
 		Counters:                 c.Counters,
 		VM:                       c.querier(t),
 	}
@@ -749,6 +759,8 @@ func (c goldenCase) correctOptions(t *testing.T) runs.CorrectOptions {
 		PeriodFrom:               periodFrom,
 		PeriodTo:                 periodTo,
 		AttributingRelationTypes: attributingRelationTypes,
+		AdjustmentRelationTypes:  adjustmentRelationTypes,
+		AdjustmentDepth:          adjustmentDepth,
 		Counters:                 c.Counters,
 		VM:                       c.querier(t),
 	}
@@ -781,6 +793,7 @@ func assertNoWarnings(t *testing.T, stats runs.Stats) {
 		{"metering_warnings", stats.MeteringWarnings, len(stats.MeteringWarnings)},
 		{"counter_warnings", stats.CounterWarnings, len(stats.CounterWarnings)},
 		{"attribution_warnings", stats.AttributionWarnings, len(stats.AttributionWarnings)},
+		{"adjustment_warnings", stats.AdjustmentWarnings, len(stats.AdjustmentWarnings)},
 		{"unpriced", stats.Unpriced, len(stats.Unpriced)},
 		{"unreadable", stats.Unreadable, len(stats.Unreadable)},
 		{"unregistered_projects", stats.UnregisteredProjects, len(stats.UnregisteredProjects)},

--- a/internal/engine/runs/correct.go
+++ b/internal/engine/runs/correct.go
@@ -303,7 +303,7 @@ func produceCorrection(
 	deltas := corrections.Diff(old, current)
 
 	notes, err := corrections.BuildCreditNotes(
-		opts.PeriodFrom, opts.PeriodTo, baselineID, model.Currency, deltas, projects, resolution)
+		opts.PeriodFrom, opts.PeriodTo, baselineID, model.Currency, deltas, nil, projects, resolution)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/runs/correct.go
+++ b/internal/engine/runs/correct.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/counters"
@@ -20,6 +22,7 @@ import (
 	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/rating"
 	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 )
 
@@ -33,6 +36,14 @@ type CorrectOptions struct {
 	// AttributingRelationTypes are the relation types attribution walks. An
 	// empty list is attribution turned off.
 	AttributingRelationTypes []string
+	// AdjustmentRelationTypes are the relation types adjustment resolution
+	// walks from a statement's project. An empty list is adjustments turned
+	// off.
+	AdjustmentRelationTypes []string
+	// AdjustmentDepth bounds that walk: how many relation levels it follows
+	// from the statement's project, at least 1. The configuration checks it,
+	// and so does adjustments.New.
+	AdjustmentDepth int
 	// Counters is the counter sources file of the deployment, empty where it
 	// measures no counter metric.
 	Counters counters.Config
@@ -66,10 +77,12 @@ type CorrectionResult struct {
 // CorrectionStats is what a correction stores in runs.stats: everything a
 // regular run counts, under the same keys, and the deltas it wrote beside them.
 // Statements counts the credit notes, which are the documents a correction
-// renders.
+// renders. AdjustmentDeltas counts the adjustments the correction applies
+// differently than the run it corrects.
 type CorrectionStats struct {
 	Stats
-	Deltas int `json:"deltas"`
+	Deltas           int `json:"deltas"`
+	AdjustmentDeltas int `json:"adjustment_deltas"`
 }
 
 // Correct meters a finalized period again with the pricing version the latest
@@ -184,6 +197,10 @@ func correct(
 	if err != nil {
 		return result, err
 	}
+	oldAdjustments, err := baselineAdjustments(ctx, q, baselineID, model)
+	if err != nil {
+		return result, err
+	}
 
 	// A nil cloud list is bound as the empty array rather than passed on: pgx
 	// encodes nil as SQL NULL and runs.clouds is NOT NULL. Both spellings mean
@@ -214,12 +231,15 @@ func correct(
 		PeriodTo:                 opts.PeriodTo,
 		Clouds:                   clouds,
 		AttributingRelationTypes: opts.AttributingRelationTypes,
+		AdjustmentRelationTypes:  opts.AdjustmentRelationTypes,
+		AdjustmentDepth:          opts.AdjustmentDepth,
 		Counters:                 opts.Counters,
 		VM:                       opts.VM,
 	}
 
 	var stats CorrectionStats
-	superseded, err := produceCorrection(ctx, engine, reporting, pass, model, result.RunID, baselineID, old, &stats)
+	superseded, err := produceCorrection(
+		ctx, engine, reporting, pass, model, result.RunID, baselineID, old, oldAdjustments, &stats)
 	if err != nil {
 		stats.Error = err.Error()
 		result.Stats = stats
@@ -267,10 +287,56 @@ func baselineAmounts(ctx context.Context, q *sqlcgen.Queries, baselineID uuid.UU
 	return amounts, nil
 }
 
+// baselineAdjustments sums what the corrected run applied, per the key the
+// adjustments of the two passes are diffed by. A rate or an amount that is not
+// a number, and a row applied in another currency than the model prices in, are
+// refused by naming what carries them: a difference built from either would be
+// arithmetic over two different things, and a numeric with no coefficient is
+// not a decimal at all. A run with no adjustment records, one finalized before
+// the records existed included, yields an empty map, against which every
+// adjustment the correction applies is a delta of its own size.
+func baselineAdjustments(ctx context.Context, q *sqlcgen.Queries, baselineID uuid.UUID, model pricing.Model) (
+	map[corrections.AdjustmentKey]corrections.AdjustmentAmount, error,
+) {
+	rows, err := q.ListAdjustmentRecords(ctx, uuidValue(baselineID))
+	if err != nil {
+		return nil, fmt.Errorf("reading the adjustment records of run %s: %w", baselineID, err)
+	}
+
+	amounts := make(map[corrections.AdjustmentKey]corrections.AdjustmentAmount, len(rows))
+	for _, row := range rows {
+		relationID := uuid.UUID(row.RelationID.Bytes)
+		if !row.Amount.Valid || row.Amount.NaN || !row.Rate.Valid || row.Rate.NaN {
+			return nil, fmt.Errorf("the %s adjustment of relation %s on %s of run %s is not a number",
+				row.Type, relationID, row.ProjectID, baselineID)
+		}
+		if row.Currency != model.Currency {
+			return nil, fmt.Errorf("the finalized run %s carries an adjustment in %s and pricing model %s is in %s",
+				baselineID, row.Currency, model.Version, model.Currency)
+		}
+		rate := decimal.NewFromBigInt(row.Rate.Int, row.Rate.Exp)
+		key := corrections.AdjustmentKey{
+			StatementKey: row.ProjectID,
+			RelationID:   relationID.String(),
+			Type:         row.Type,
+			Scope:        row.Scope,
+			Rate:         rate.StringFixed(money.RatePlaces),
+		}
+		amounts[key] = corrections.AdjustmentAmount{
+			RelationType:   row.RelationType,
+			RelationTarget: row.RelationTarget,
+			RateValue:      rate,
+			Amount:         amounts[key].Amount.Add(decimal.NewFromBigInt(row.Amount.Int, row.Amount.Exp)),
+		}
+	}
+	return amounts, nil
+}
+
 // produceCorrection meters, rates, diffs, renders and writes one correction,
-// and returns the completed corrections it superseded. old is what the run
-// being corrected billed, and stats is filled as the passes report, so a
-// failure carries what the correction got to rather than an empty object.
+// and returns the completed corrections it superseded. old and oldAdjustments
+// are what the run being corrected billed and applied, and stats is filled as
+// the passes report, so a failure carries what the correction got to rather
+// than an empty object.
 func produceCorrection(
 	ctx context.Context,
 	engine *pgxpool.Pool,
@@ -279,9 +345,10 @@ func produceCorrection(
 	model pricing.Model,
 	runID, baselineID uuid.UUID,
 	old map[corrections.Key]decimal.Decimal,
+	oldAdjustments map[corrections.AdjustmentKey]corrections.AdjustmentAmount,
 	stats *CorrectionStats,
 ) ([]uuid.UUID, error) {
-	metered, projects, relations, err := meter(ctx, reporting, opts, &stats.Stats)
+	metered, g, err := meter(ctx, reporting, opts, &stats.Stats)
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +360,23 @@ func produceCorrection(
 	stats.Unpriced = rated.Unpriced
 	stats.Unreadable = rated.Unreadable
 
-	resolution := attribution.Resolve(projects, relations)
+	resolution := attribution.Resolve(g.projects, g.attributing)
 	stats.AttributionWarnings = resolution.Warnings
+
+	// No adjustment relation type is adjustments turned off, and a nil adjuster
+	// is what the statement build renders a period without them from. The error
+	// passes through as it is: it names the depth or the relation it could not
+	// be built from. A relation whose stored adjustments cannot be read fails
+	// the statement build below instead, and only where a walk reaches it.
+	var adjuster *adjustments.Adjuster
+	if len(opts.AdjustmentRelationTypes) > 0 {
+		var warnings []adjustments.Warning
+		adjuster, warnings, err = adjustments.New(g.adjusting, g.projects, opts.AdjustmentDepth)
+		if err != nil {
+			return nil, err
+		}
+		stats.AdjustmentWarnings = warnings
+	}
 
 	current, err := corrections.Amounts(metered.Resources, rated)
 	if err != nil {
@@ -302,8 +384,25 @@ func produceCorrection(
 	}
 	deltas := corrections.Diff(old, current)
 
+	// The full statements of the re-metered period. Their documents are
+	// discarded, because what a correction stores are its credit notes; what
+	// the build is run for are the adjustment lines, which become the
+	// correction's own adjustment records and the current side of the
+	// adjustment diff.
+	built, err := statements.Build(
+		opts.PeriodFrom, opts.PeriodTo, metered.Resources, rated, g.projects, resolution, adjuster)
+	if err != nil {
+		return nil, err
+	}
+	records, err := adjustmentRows(runID, built.Statements)
+	if err != nil {
+		return nil, err
+	}
+	adjustmentDeltas := corrections.DiffAdjustments(oldAdjustments, corrections.AdjustmentAmounts(built.Statements))
+
 	notes, err := corrections.BuildCreditNotes(
-		opts.PeriodFrom, opts.PeriodTo, baselineID, model.Currency, deltas, nil, projects, resolution)
+		opts.PeriodFrom, opts.PeriodTo, baselineID, model.Currency,
+		deltas, adjustmentDeltas, g.projects, resolution)
 	if err != nil {
 		return nil, err
 	}
@@ -327,11 +426,14 @@ func produceCorrection(
 	stats.UsageRecords = len(usage)
 	stats.RatedRecords = len(amounts)
 	stats.Statements = len(notes.Statements)
+	stats.AdjustmentRecords = len(records)
 	stats.Deltas = len(deltas)
+	stats.AdjustmentDeltas = len(adjustmentDeltas)
 
 	payload, err := json.Marshal(*stats)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling the stats of run %s: %w", runID, err)
 	}
-	return write(ctx, engine, opts.PeriodFrom, runID, KindCorrection, usage, amounts, differences, notes.Statements, payload)
+	return write(ctx, engine, opts.PeriodFrom, runID, KindCorrection,
+		usage, amounts, differences, records, notes.Statements, payload)
 }

--- a/internal/engine/runs/correct_integration_test.go
+++ b/internal/engine/runs/correct_integration_test.go
@@ -81,6 +81,47 @@ func (f fixture) closedMonth(t *testing.T, from, to time.Time, cloud string) uui
 	return result.RunID
 }
 
+// closedAdjustedMonth closes one period the way closedMonth does, with the
+// adjustment options the adjusted cases run with. It is the state a correction
+// of a month billed at a reseller's rates starts from.
+func (f fixture) closedAdjustedMonth(t *testing.T, from, to time.Time, cloud string) uuid.UUID {
+	t.Helper()
+
+	result, err := f.execute(t, runs.Options{
+		PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+		AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+	if _, err := f.finalize(t, from, result.RunID); err != nil {
+		t.Fatalf("Finalize() error = %v, want nil", err)
+	}
+	return result.RunID
+}
+
+// appliedAdjustment is one adjustment record as the cases below state it: what
+// it is, what it was rated on and what it came to. The relation and the
+// beneficiary the row carries beside them are stated by the cases of
+// TestExecute.
+type appliedAdjustment struct{ typ, base, amount string }
+
+// assertAdjustments fails when a run's adjustment records are not these, in the
+// order readAdjustments returns them. It is what the adjusted side of a month
+// is stated with, the way assertWholeMonth states the rated one.
+func (f fixture) assertAdjustments(t *testing.T, runID uuid.UUID, want ...appliedAdjustment) {
+	t.Helper()
+
+	records := f.readAdjustments(t, runID)
+	got := make([]appliedAdjustment, 0, len(records))
+	for _, record := range records {
+		got = append(got, appliedAdjustment{typ: record.typ, base: record.base, amount: record.amount})
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the adjustment records of run %s are %+v, want %+v", runID, got, want)
+	}
+}
+
 // assertWholeMonth fails when the run did not bill its one resource for the 744
 // hours of a 31-day month. It is what the deltas of the cases below are
 // differences against, so it is stated before they are read.
@@ -115,6 +156,7 @@ func (f fixture) assertEmptyRun(t *testing.T, runID uuid.UUID) {
 		{records: "rated records", count: len(f.readRated(t, runID))},
 		{records: "correction deltas", count: len(f.readDeltas(t, runID))},
 		{records: "statements", count: len(f.readStatements(t, runID))},
+		{records: "adjustment records", count: len(f.readAdjustments(t, runID))},
 	} {
 		if tc.count != 0 {
 			t.Errorf("the failed correction holds %d %s, want the transaction rolled back", tc.count, tc.records)
@@ -122,10 +164,32 @@ func (f fixture) assertEmptyRun(t *testing.T, runID uuid.UUID) {
 	}
 }
 
+// assertNothingCorrected fails when a correction found anything to settle:
+// neither a rated delta nor an adjustment one, and so no credit note.
+func (f fixture) assertNothingCorrected(t *testing.T, result runs.CorrectionResult) {
+	t.Helper()
+
+	if result.Stats.Deltas != 0 {
+		t.Errorf("Stats.Deltas = %d, want none", result.Stats.Deltas)
+	}
+	if result.Stats.AdjustmentDeltas != 0 {
+		t.Errorf("Stats.AdjustmentDeltas = %d, want none", result.Stats.AdjustmentDeltas)
+	}
+	stats := f.readStats(t, result.RunID)
+	for _, key := range []string{"deltas", "adjustment_deltas"} {
+		if got := number(t, stats, key); got != "0" {
+			t.Errorf("stats %s = %s, want 0", key, got)
+		}
+	}
+	if got := f.readStatementTotals(t, result.RunID); len(got) != 0 {
+		t.Errorf("statement totals = %v, want none: there is nothing to credit", got)
+	}
+}
+
 // TestCorrect runs against the pricing model of the concept's example. Every
 // case keeps to its own month and its own cloud: a correction of a month
 // supersedes the other corrections of that month whatever cloud they metered,
-// and a month is finalized once. The three cases that bill a whole month take
+// and a month is finalized once. The five cases that bill a whole month take
 // the 31-day months thirtyOneDayMonth walks back to, and the others take
 // offsets past the deepest of those.
 func TestCorrect(t *testing.T) {
@@ -457,7 +521,7 @@ func TestCorrect(t *testing.T) {
 			seed     func(t *testing.T, from, to time.Time)
 		}{
 			{
-				name: "open with a completed run", offset: -8, status: "open", runCount: 1,
+				name: "open with a completed run", offset: -25, status: "open", runCount: 1,
 				seed: func(t *testing.T, from, to time.Time) {
 					const cloud = "os-correct-open-run"
 					f.seedProject(t, cloud, "proj-456")
@@ -470,11 +534,11 @@ func TestCorrect(t *testing.T) {
 				},
 			},
 			{
-				name: "grace without a run", offset: -9, status: "grace", runCount: 0,
+				name: "grace without a run", offset: -26, status: "grace", runCount: 0,
 				seed: func(t *testing.T, from, to time.Time) { f.seedPeriod(t, from, to, "grace") },
 			},
 			{
-				name: "open without a run", offset: -10, status: "open", runCount: 0,
+				name: "open without a run", offset: -27, status: "open", runCount: 0,
 				seed: func(t *testing.T, from, to time.Time) { f.seedPeriod(t, from, to, "open") },
 			},
 		} {
@@ -500,7 +564,7 @@ func TestCorrect(t *testing.T) {
 	})
 
 	t.Run("refuses a month it does not know", func(t *testing.T) {
-		from, to := month(-11)
+		from, to := month(-21)
 
 		_, err := f.correct(t, runs.CorrectOptions{PeriodFrom: from, PeriodTo: to})
 		if !errors.Is(err, runs.ErrPeriodNotFinalized) {
@@ -791,6 +855,303 @@ func TestCorrect(t *testing.T) {
 		}
 		f.assertEmptyRun(t, result.RunID)
 	})
+
+	// A month billed at a reseller's rates and corrected: the late power cycle
+	// changes what the resource cost, and the discount and the kickback that
+	// were computed off it change with it.
+	t.Run("credits the adjustment and kickback effects of a late power cycle", func(t *testing.T) {
+		from, to := thirtyOneDayMonth(4)
+		const cloud = "os-correct-adjusted"
+		const key = cloud + "/proj-456"
+		f.seedProject(t, cloud, "proj-456")
+		vm := wholeMonth(cloud, "abc-adjusted", "proj-456", from, to, standardSize)
+		f.seedResource(t, vm)
+		relation := f.seedRelation(t, f.projectIDOf(t, cloud, "proj-456"),
+			f.seedVirtualProject(t, "partner", "partner-adjusted"),
+			"managed_by", resellerAdjustments, from.AddDate(0, -1, 0), nil)
+
+		finalized := f.closedAdjustedMonth(t, from, to, cloud)
+		f.assertWholeMonth(t, finalized)
+		if got := f.readStatementTotals(t, finalized)[key]; got != "126.48" {
+			t.Errorf("the finalized statement totals %s, want the 148.80 of the month less 15 percent", got)
+		}
+		f.assertAdjustments(t, finalized,
+			appliedAdjustment{typ: "discount", base: "148.80", amount: "-22.32"},
+			appliedAdjustment{typ: "kickback", base: "126.48", amount: "12.65"})
+
+		// The concept's power cycle, arriving after the month was billed.
+		received := f.snapshotTime(t)
+		f.seedEventReceived(t, vm, "ev-off-abc-adjusted", "compute.instance.power_off.end",
+			from.Add(10*24*time.Hour), received, `{"state":"shutoff"}`)
+		f.seedEventReceived(t, vm, "ev-on-abc-adjusted", "compute.instance.power_on.end",
+			from.Add(20*24*time.Hour), received, `{"state":"active"}`)
+
+		result, err := f.correct(t, runs.CorrectOptions{
+			PeriodFrom: from, PeriodTo: to,
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err != nil {
+			t.Fatalf("Correct() error = %v, want nil", err)
+		}
+
+		wantDeltas := []deltaRow{
+			{
+				correctsRunID: finalized, projectID: "proj-456", dimension: "disk_gb",
+				oldAmount: "59.52", newAmount: "49.92", delta: "-9.60", currency: "EUR",
+			},
+			{
+				correctsRunID: finalized, projectID: "proj-456", dimension: "ram_gb",
+				oldAmount: "29.76", newAmount: "24.96", delta: "-4.80", currency: "EUR",
+			},
+			{
+				correctsRunID: finalized, projectID: "proj-456", dimension: "vcpus",
+				oldAmount: "59.52", newAmount: "49.92", delta: "-9.60", currency: "EUR",
+			},
+		}
+		if got := f.readDeltas(t, result.RunID); !slices.Equal(got, wantDeltas) {
+			t.Errorf("deltas = %+v, want %+v, the ten days the resource was off", got, wantDeltas)
+		}
+		// The correction applies the relation again, over the 124.80 the month
+		// now rates at, and stores what that came to under itself.
+		f.assertAdjustments(t, result.RunID,
+			appliedAdjustment{typ: "discount", base: "124.80", amount: "-18.72"},
+			appliedAdjustment{typ: "kickback", base: "106.08", amount: "10.61"})
+		if result.Stats.AdjustmentRecords != 2 {
+			t.Errorf("Stats.AdjustmentRecords = %d, want the two the correction applied",
+				result.Stats.AdjustmentRecords)
+		}
+		if result.Stats.AdjustmentDeltas != 2 {
+			t.Errorf("Stats.AdjustmentDeltas = %d, want the two adjustments that came out differently",
+				result.Stats.AdjustmentDeltas)
+		}
+		if got := number(t, f.readStats(t, result.RunID), "adjustment_deltas"); got != "2" {
+			t.Errorf("stats adjustment_deltas = %s, want 2", got)
+		}
+
+		// What the customer is credited is the usage that fell away less the
+		// discount that fell away with it, and the partner is owed 2.04 less.
+		note := f.readStatementDocument(t, result.RunID, key)
+		for _, tc := range []struct{ field, want string }{
+			{"base_delta", "-24.00"},
+			{"net_delta", "-20.40"},
+			{"kickback_delta", "-2.04"},
+			{"total", "-20.40"},
+		} {
+			if got := number(t, note, tc.field); got != tc.want {
+				t.Errorf("the credit note's %s = %s, want %s", tc.field, got, tc.want)
+			}
+		}
+		changes := list(t, note, "adjustments")
+		if len(changes) != 2 {
+			t.Fatalf("the credit note holds %d adjustment changes, want the discount and the kickback",
+				len(changes))
+		}
+		for i, tc := range []struct{ typ, old, updated, delta string }{
+			{typ: "discount", old: "-22.32", updated: "-18.72", delta: "3.60"},
+			{typ: "kickback", old: "12.65", updated: "10.61", delta: "-2.04"},
+		} {
+			if got := text(t, changes[i], "type"); got != tc.typ {
+				t.Errorf("adjustment change %d is a %s, want a %s", i, got, tc.typ)
+			}
+			if got := text(t, changes[i], "relation_id"); got != relation.String() {
+				t.Errorf("the %s change names relation %s, want %s", tc.typ, got, relation)
+			}
+			for _, amount := range []struct{ field, want string }{
+				{"old", tc.old}, {"new", tc.updated}, {"delta", tc.delta},
+			} {
+				if got := number(t, changes[i], amount.field); got != amount.want {
+					t.Errorf("the %s change's %s = %s, want %s", tc.typ, amount.field, got, amount.want)
+				}
+			}
+		}
+		if got := f.readStatementTotals(t, result.RunID); !maps.Equal(got, map[string]string{key: "-20.40"}) {
+			t.Errorf("statement totals = %v, want the credit note of %s at -20.40", got, key)
+		}
+	})
+
+	// A relation that reached the registry after the month was closed: the
+	// correction applies its discount for the first time, and the whole of it is
+	// what the credit note settles, over a month whose usage did not change.
+	t.Run("credits an adjustment a correction applies for the first time", func(t *testing.T) {
+		from, to := thirtyOneDayMonth(5)
+		const cloud = "os-correct-adjusted-late"
+		const key = cloud + "/proj-456"
+		f.seedProject(t, cloud, "proj-456")
+		f.seedResource(t, wholeMonth(cloud, "abc-late-discount", "proj-456", from, to, standardSize))
+
+		finalized := f.closedMonth(t, from, to, cloud)
+		f.assertWholeMonth(t, finalized)
+		f.assertAdjustments(t, finalized)
+
+		relation := f.seedRelation(t, f.projectIDOf(t, cloud, "proj-456"),
+			f.seedVirtualProject(t, "partner", "partner-late"),
+			"managed_by", discountAdjustments, from.AddDate(0, -1, 0), nil)
+
+		result, err := f.correct(t, runs.CorrectOptions{
+			PeriodFrom: from, PeriodTo: to,
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err != nil {
+			t.Fatalf("Correct() error = %v, want nil", err)
+		}
+		if result.Stats.Deltas != 0 {
+			t.Errorf("Stats.Deltas = %d, want none: no event of the month arrived late", result.Stats.Deltas)
+		}
+		if got := f.readDeltas(t, result.RunID); len(got) != 0 {
+			t.Errorf("deltas = %+v, want none", got)
+		}
+		if result.Stats.AdjustmentDeltas != 1 {
+			t.Errorf("Stats.AdjustmentDeltas = %d, want the one discount the month was billed without",
+				result.Stats.AdjustmentDeltas)
+		}
+
+		note := f.readStatementDocument(t, result.RunID, key)
+		if got := list(t, note, "line_items"); len(got) != 0 {
+			t.Errorf("the credit note holds %d line items, want none: what changed is the adjustment", len(got))
+		}
+		for _, tc := range []struct{ field, want string }{
+			{"base_delta", "0.00"},
+			{"net_delta", "-14.88"},
+			{"total", "-14.88"},
+		} {
+			if got := number(t, note, tc.field); got != tc.want {
+				t.Errorf("the credit note's %s = %s, want %s", tc.field, got, tc.want)
+			}
+		}
+		changes := list(t, note, "adjustments")
+		if len(changes) != 1 {
+			t.Fatalf("the credit note holds %d adjustment changes, want the one discount", len(changes))
+		}
+		if got := text(t, changes[0], "relation_id"); got != relation.String() {
+			t.Errorf("the change names relation %s, want %s", got, relation)
+		}
+		for _, tc := range []struct{ field, want string }{
+			{"old", "0.00"},
+			{"new", "-14.88"},
+			{"delta", "-14.88"},
+		} {
+			if got := number(t, changes[0], tc.field); got != tc.want {
+				t.Errorf("the change's %s = %s, want %s", tc.field, got, tc.want)
+			}
+		}
+		if got := f.readStatementTotals(t, result.RunID); !maps.Equal(got, map[string]string{key: "-14.88"}) {
+			t.Errorf("statement totals = %v, want the credit note of %s at -14.88", got, key)
+		}
+	})
+
+	// A correction of an adjusted month that finds nothing: the adjustments come
+	// to what the month was billed at, so there is no delta and no credit note,
+	// and the correction stores its own records all the same.
+	t.Run("finds nothing to correct twice", func(t *testing.T) {
+		from, to := month(-22)
+		const cloud = "os-correct-adjusted-twice"
+		f.seedProject(t, cloud, "proj-456")
+		f.seedResource(t, instance(cloud, "i-twice", "proj-456", from, standardSize))
+		f.seedRelation(t, f.projectIDOf(t, cloud, "proj-456"),
+			f.seedVirtualProject(t, "partner", "partner-twice"),
+			"managed_by", resellerAdjustments, from.AddDate(0, -1, 0), nil)
+
+		finalized := f.closedAdjustedMonth(t, from, to, cloud)
+		applied := []appliedAdjustment{
+			{typ: "discount", base: "9.60", amount: "-1.44"},
+			{typ: "kickback", base: "8.16", amount: "0.82"},
+		}
+		f.assertAdjustments(t, finalized, applied...)
+
+		opts := runs.CorrectOptions{
+			PeriodFrom: from, PeriodTo: to,
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		}
+		first, err := f.correct(t, opts)
+		if err != nil {
+			t.Fatalf("Correct() error = %v, want nil", err)
+		}
+		if first.CorrectsRunID != finalized {
+			t.Errorf("CorrectsRunID = %s, want the finalized run %s", first.CorrectsRunID, finalized)
+		}
+		f.assertNothingCorrected(t, first)
+		f.assertAdjustments(t, first.RunID, applied...)
+
+		if _, err := f.finalize(t, from, first.RunID); err != nil {
+			t.Fatalf("Finalize() error = %v, want nil", err)
+		}
+
+		// The finalized correction is the period's truth now, and its own
+		// adjustment records are what the next correction is diffed against.
+		second, err := f.correct(t, opts)
+		if err != nil {
+			t.Fatalf("Correct() error = %v, want nil", err)
+		}
+		if second.CorrectsRunID != first.RunID {
+			t.Errorf("CorrectsRunID = %s, want the finalized correction %s", second.CorrectsRunID, first.RunID)
+		}
+		f.assertNothingCorrected(t, second)
+		f.assertAdjustments(t, second.RunID, applied...)
+	})
+
+	// Two baselines nothing can be a difference against. Both are broken while
+	// the run is still completed, because the trigger of migration 0002 holds
+	// the records of a finalized run against every update (D8).
+	for _, tc := range []struct {
+		name     string
+		offset   int
+		cloud    string
+		resource string
+		partner  string
+		update   string
+		want     string
+	}{
+		{
+			name: "refuses a baseline adjustment that is not a number", offset: -23,
+			cloud: "os-correct-baseline-nan", resource: "i-baseline-nan", partner: "partner-nan",
+			update: `UPDATE adjustment_records SET amount = 'NaN' WHERE run_id = $1`,
+			want:   "is not a number",
+		},
+		{
+			name: "refuses a baseline adjustment in another currency", offset: -24,
+			cloud: "os-correct-baseline-currency", resource: "i-baseline-currency", partner: "partner-usd",
+			update: `UPDATE adjustment_records SET currency = 'USD' WHERE run_id = $1`,
+			want:   "carries an adjustment in USD",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to := month(tc.offset)
+			f.seedProject(t, tc.cloud, "proj-456")
+			f.seedResource(t, instance(tc.cloud, tc.resource, "proj-456", from, standardSize))
+			f.seedRelation(t, f.projectIDOf(t, tc.cloud, "proj-456"),
+				f.seedVirtualProject(t, "partner", tc.partner),
+				"managed_by", discountAdjustments, from.AddDate(0, -1, 0), nil)
+
+			baseline, err := f.execute(t, runs.Options{
+				PeriodFrom: from, PeriodTo: to, Clouds: []string{tc.cloud},
+				AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+			})
+			if err != nil {
+				t.Fatalf("Execute() error = %v, want nil", err)
+			}
+			if _, err := f.engine.Store.Pool().Exec(t.Context(), tc.update, baseline.RunID); err != nil {
+				t.Fatalf("breaking the adjustment record of run %s: %v", baseline.RunID, err)
+			}
+			if _, err := f.finalize(t, from, baseline.RunID); err != nil {
+				t.Fatalf("Finalize() error = %v, want nil", err)
+			}
+
+			_, err = f.correct(t, runs.CorrectOptions{
+				PeriodFrom: from, PeriodTo: to,
+				AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+			})
+			if err == nil {
+				t.Fatal("Correct() error = nil, want the baseline refused")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Correct() error = %q, want it to say %q", err, tc.want)
+			}
+			if got := f.countRuns(t, from); got != 1 {
+				t.Errorf("the period holds %d runs, want only the finalized one: "+
+					"the baseline is read before the run row", got)
+			}
+		})
+	}
 }
 
 // TestCorrectReportsAnUpstreamFailure breaks the reporting database under a

--- a/internal/engine/runs/runs.go
+++ b/internal/engine/runs/runs.go
@@ -3,7 +3,10 @@
 // rendering over one reporting snapshot, and writes what came out under that
 // run. What a period is billed as is decided by the packages this one calls;
 // what belongs here is the order they run in, the run's bookkeeping, and the
-// stats an operator reads a finished run from.
+// stats an operator reads a finished run from. Adjustment resolution runs
+// between attribution and the statement build, and the adjustment records its
+// lines become are written in the run's one write transaction beside the rest
+// of the output.
 //
 // A run either writes its whole output or none of it. The records, the
 // supersede of the run it replaces, and the completion are one transaction, so
@@ -44,6 +47,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/counters"
 	"github.com/b42labs/tally/internal/engine/metering"
@@ -115,6 +119,14 @@ type Options struct {
 	// AttributingRelationTypes are the relation types attribution walks. An
 	// empty list is attribution turned off.
 	AttributingRelationTypes []string
+	// AdjustmentRelationTypes are the relation types adjustment resolution
+	// walks from a statement's project. An empty list is adjustments turned
+	// off.
+	AdjustmentRelationTypes []string
+	// AdjustmentDepth bounds that walk: how many relation levels it follows
+	// from the statement's project, at least 1. The configuration checks it,
+	// and so does adjustments.New.
+	AdjustmentDepth int
 	// Counters is the counter sources file of the deployment, empty where it
 	// measures no counter metric.
 	Counters counters.Config
@@ -148,10 +160,12 @@ type Stats struct {
 	UsageRecords         int                              `json:"usage_records"`
 	RatedRecords         int                              `json:"rated_records"`
 	Statements           int                              `json:"statements"`
+	AdjustmentRecords    int                              `json:"adjustment_records,omitempty"`
 	Warnings             []Warning                        `json:"warnings,omitempty"`
 	MeteringWarnings     []metering.Warning               `json:"metering_warnings,omitempty"`
 	CounterWarnings      []counters.Warning               `json:"counter_warnings,omitempty"`
 	AttributionWarnings  []attribution.Warning            `json:"attribution_warnings,omitempty"`
+	AdjustmentWarnings   []adjustments.Warning            `json:"adjustment_warnings,omitempty"`
 	Unpriced             []rating.UnpricedResourceType    `json:"unpriced,omitempty"`
 	Unreadable           []rating.UnreadableQuantity      `json:"unreadable,omitempty"`
 	UnregisteredProjects []statements.UnregisteredProject `json:"unregistered_projects,omitempty"`
@@ -385,7 +399,7 @@ func produce(
 	runID uuid.UUID,
 	stats *Stats,
 ) ([]uuid.UUID, error) {
-	metered, projects, relations, err := meter(ctx, reporting, opts, stats)
+	metered, g, err := meter(ctx, reporting, opts, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -397,10 +411,26 @@ func produce(
 	stats.Unpriced = rated.Unpriced
 	stats.Unreadable = rated.Unreadable
 
-	resolution := attribution.Resolve(projects, relations)
+	resolution := attribution.Resolve(g.projects, g.attributing)
 	stats.AttributionWarnings = resolution.Warnings
 
-	built, err := statements.Build(opts.PeriodFrom, opts.PeriodTo, metered.Resources, rated, projects, resolution, nil)
+	// No adjustment relation type is adjustments turned off, and a nil adjuster
+	// is what the statement build renders a period without them from. The error
+	// passes through as it is: it names the depth or the relation it could not
+	// be built from. A relation whose stored adjustments cannot be read fails
+	// the statement build below instead, and only where a walk reaches it.
+	var adjuster *adjustments.Adjuster
+	if len(opts.AdjustmentRelationTypes) > 0 {
+		var warnings []adjustments.Warning
+		adjuster, warnings, err = adjustments.New(g.adjusting, g.projects, opts.AdjustmentDepth)
+		if err != nil {
+			return nil, err
+		}
+		stats.AdjustmentWarnings = warnings
+	}
+
+	built, err := statements.Build(
+		opts.PeriodFrom, opts.PeriodTo, metered.Resources, rated, g.projects, resolution, adjuster)
 	if err != nil {
 		return nil, err
 	}
@@ -414,15 +444,20 @@ func produce(
 	if err != nil {
 		return nil, err
 	}
+	records, err := adjustmentRows(runID, built.Statements)
+	if err != nil {
+		return nil, err
+	}
 	stats.UsageRecords = len(usage)
 	stats.RatedRecords = len(amounts)
 	stats.Statements = len(built.Statements)
+	stats.AdjustmentRecords = len(records)
 
 	payload, err := json.Marshal(*stats)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling the stats of run %s: %w", runID, err)
 	}
-	return write(ctx, engine, opts.PeriodFrom, runID, KindRegular, usage, amounts, nil, built.Statements, payload)
+	return write(ctx, engine, opts.PeriodFrom, runID, KindRegular, usage, amounts, nil, records, built.Statements, payload)
 }
 
 // warnPeriodNotEnded warns about a month that has not ended, which is metered
@@ -441,6 +476,16 @@ func warnPeriodNotEnded(stats *Stats, periodTo time.Time) {
 	})
 }
 
+// graph is what one snapshot read of the registry hands the passes: the
+// projects of the period, the relations attribution walks, and the relations
+// adjustment resolution walks. The two relation lists are read separately
+// because each pass names its own types, and a type both lists name is read
+// twice.
+type graph struct {
+	projects               []source.Project
+	attributing, adjusting []source.Relation
+}
+
 // meter reads everything one run takes from the reporting database: the drafts
 // of the period, the counter metrics measured into them, and the project graph
 // they are attributed over.
@@ -450,11 +495,11 @@ func warnPeriodNotEnded(stats *Stats, periodTo time.Time) {
 // and the drafts it slices into see the same data, and the graph is read before
 // the connection is given back rather than while the period is being rated.
 func meter(ctx context.Context, reporting *source.DB, opts Options, stats *Stats) (
-	*metering.Result, []source.Project, []source.Relation, error,
+	*metering.Result, graph, error,
 ) {
 	snap, err := reporting.Snapshot(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, graph{}, err
 	}
 	// The snapshot is closed explicitly once the graph is read; this covers the
 	// paths that do not get there. Closing an already closed snapshot reports
@@ -479,33 +524,37 @@ func meter(ctx context.Context, reporting *source.DB, opts Options, stats *Stats
 		if errors.As(err, &violation) {
 			stats.Violations = violation.Resources
 		}
-		return nil, nil, nil, err
+		return nil, graph{}, err
 	}
 	stats.Candidates = metered.Candidates
 	stats.MeteringWarnings = metered.Warnings
 
 	measurer, err := counters.New(opts.Counters, snap, opts.VM)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("preparing the counter sources: %w", err)
+		return nil, graph{}, fmt.Errorf("preparing the counter sources: %w", err)
 	}
 	counterWarnings, err := measurer.Apply(ctx, metered.Resources)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, graph{}, err
 	}
 	stats.CounterWarnings = counterWarnings
 
 	projects, err := snap.Projects(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, graph{}, err
 	}
-	relations, err := snap.Relations(ctx, opts.AttributingRelationTypes, opts.PeriodFrom, opts.PeriodTo)
+	attributing, err := snap.Relations(ctx, opts.AttributingRelationTypes, opts.PeriodFrom, opts.PeriodTo)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, graph{}, err
+	}
+	adjusting, err := snap.Relations(ctx, opts.AdjustmentRelationTypes, opts.PeriodFrom, opts.PeriodTo)
+	if err != nil {
+		return nil, graph{}, err
 	}
 	if err := snap.Close(ctx); err != nil {
-		return nil, nil, nil, err
+		return nil, graph{}, err
 	}
-	return metered, projects, relations, nil
+	return metered, graph{projects: projects, attributing: attributing, adjusting: adjusting}, nil
 }
 
 // write stores one run's output and ends the run, in one transaction: the
@@ -531,6 +580,7 @@ func write(
 	usage []sqlcgen.CreateUsageRecordsParams,
 	amounts []sqlcgen.CreateRatedRecordsParams,
 	deltas []sqlcgen.CreateCorrectionDeltasParams,
+	adjustmentRecords []sqlcgen.CreateAdjustmentRecordsParams,
 	sts []statements.Statement,
 	payload []byte,
 ) ([]uuid.UUID, error) {
@@ -567,6 +617,11 @@ func write(
 	}
 	if err := statements.Persist(ctx, q, runID, sts); err != nil {
 		return nil, err
+	}
+	if len(adjustmentRecords) > 0 {
+		if _, err := q.CreateAdjustmentRecords(ctx, adjustmentRecords); err != nil {
+			return nil, fmt.Errorf("writing the adjustment records of run %s: %w", runID, err)
+		}
 	}
 	superseded, err := q.SupersedeCompletedRuns(ctx, sqlcgen.SupersedeCompletedRunsParams{
 		PeriodFrom: timestamptz(periodFrom),

--- a/internal/engine/runs/runs.go
+++ b/internal/engine/runs/runs.go
@@ -400,7 +400,7 @@ func produce(
 	resolution := attribution.Resolve(projects, relations)
 	stats.AttributionWarnings = resolution.Warnings
 
-	built, err := statements.Build(opts.PeriodFrom, opts.PeriodTo, metered.Resources, rated, projects, resolution)
+	built, err := statements.Build(opts.PeriodFrom, opts.PeriodTo, metered.Resources, rated, projects, resolution, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/runs/runs_integration_test.go
+++ b/internal/engine/runs/runs_integration_test.go
@@ -40,6 +40,25 @@ const (
 	largeSize    = `{"vcpus":625000000000,"ram_gb":2500000000000}`
 )
 
+// resellerAdjustments is what a relation to a reseller carries: 15 percent off
+// what the customer is billed, and 10 percent of what is left owed to the
+// partner. discountAdjustments is the one discount the cases that need nothing
+// else take.
+const (
+	resellerAdjustments = `{"pricing_adjustments":[` +
+		`{"type":"discount","rate":"0.15","scope":"all"},` +
+		`{"type":"kickback","rate":"0.10","scope":"all"}]}`
+	discountAdjustments = `{"pricing_adjustments":[{"type":"discount","rate":"0.10","scope":"all"}]}`
+)
+
+// adjustmentDepth is how deep the cases that resolve adjustments walk the
+// project graph, and adjustmentRelationTypes are the relation types they walk.
+// Three levels is past every graph the cases seed, and an empty type list is
+// adjustments turned off, which one of the cases runs with.
+const adjustmentDepth = 3
+
+var adjustmentRelationTypes = []string{"managed_by", "member_of"}
+
 // pricingDocument is the model every case is rated with. valid_from is filled
 // in with an instant before every period the cases meter.
 const pricingDocument = `version: "v1"
@@ -102,8 +121,8 @@ func month(offset int) (from, to time.Time) {
 //
 // The walk starts at offset -2 so that no month it returns is the one a test
 // runs in or the one before it. Seven months of twelve have 31 days, so the
-// third one is at most five offsets further back, which is what the offsets the
-// other cases pick stay clear of.
+// fifth one is at most eight offsets further back, which is what the offsets
+// the other cases pick stay clear of.
 func thirtyOneDayMonth(n int) (from, to time.Time) {
 	for offset := -2; ; offset-- {
 		from, to = month(offset)
@@ -302,6 +321,61 @@ func (f fixture) seedProject(t *testing.T, cloud, externalID string) {
 	}
 }
 
+// seedVirtualProject registers a project that owns no resources: a partner or
+// a meta-project. Its cloud is its platform, which is what a virtual project
+// carries there, and it returns the registry id a relation names it by.
+func (f fixture) seedVirtualProject(t *testing.T, platform, externalID string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := f.reporting.Store.Pool().QueryRow(t.Context(),
+		`INSERT INTO projects (platform, cloud, external_id) VALUES ($1, $1, $2) RETURNING id`,
+		platform, externalID).Scan(&id); err != nil {
+		t.Fatalf("seeding the %s project %s: %v", platform, externalID, err)
+	}
+	return id
+}
+
+// projectIDOf is the registry id of one project, which a relation names and
+// seedProject does not report.
+func (f fixture) projectIDOf(t *testing.T, cloud, externalID string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	if err := f.reporting.Store.Pool().QueryRow(t.Context(),
+		`SELECT id FROM projects WHERE cloud = $1 AND external_id = $2`,
+		cloud, externalID).Scan(&id); err != nil {
+		t.Fatalf("reading the id of the project %s/%s: %v", cloud, externalID, err)
+	}
+	return id
+}
+
+// seedRelation writes one edge of the project graph and returns its id. An
+// empty metadata is the empty document a relation created without one carries,
+// and a nil validTo leaves the relation open. The two validity instants are
+// what fixes a relation to the periods it adjusts (D4).
+func (f fixture) seedRelation(
+	t *testing.T,
+	sourceID, targetID uuid.UUID,
+	relationType, metadata string,
+	validFrom time.Time,
+	validTo *time.Time,
+) uuid.UUID {
+	t.Helper()
+
+	if metadata == "" {
+		metadata = "{}"
+	}
+	var id uuid.UUID
+	if err := f.reporting.Store.Pool().QueryRow(t.Context(),
+		`INSERT INTO project_relations (source_id, target_id, relation_type, metadata, valid_from, valid_to)
+		 VALUES ($1, $2, $3, $4::jsonb, $5, $6) RETURNING id`,
+		sourceID, targetID, relationType, metadata, validFrom, validTo).Scan(&id); err != nil {
+		t.Fatalf("seeding the %s relation of %s: %v", relationType, sourceID, err)
+	}
+	return id
+}
+
 // runRow is a runs row as the cases read it back, past the package under test.
 // corrects_run_id is nullable, and a regular run reads as the zero id.
 type runRow struct {
@@ -445,6 +519,57 @@ func (f fixture) readStatements(t *testing.T, runID uuid.UUID) []string {
 	return keys
 }
 
+// adjustmentRow is an adjustment_records row as the cases read it back. The
+// rate and the two amounts are read as text, which is what keeps the assertion
+// off floats (roadmap/00-conventions.md section 6), and so is the relation id,
+// because that is what a case compares it against. beneficiary is nil on every
+// row but a kickback's.
+type adjustmentRow struct {
+	projectID      string
+	relationID     string
+	relationType   string
+	relationTarget string
+	beneficiary    *string
+	typ            string
+	scope          string
+	rate           string
+	base           string
+	amount         string
+	currency       string
+}
+
+// readAdjustments reads a run's adjustment records, in the order
+// ListAdjustmentRecords returns them, which is the order a correction diffs
+// them in.
+func (f fixture) readAdjustments(t *testing.T, runID uuid.UUID) []adjustmentRow {
+	t.Helper()
+
+	rows, err := f.engine.Store.Pool().Query(t.Context(),
+		`SELECT project_id, relation_id::text, relation_type, relation_target, beneficiary,
+		        type, scope, rate::text, base::text, amount::text, currency
+		 FROM adjustment_records WHERE run_id = $1
+		 ORDER BY project_id, relation_id, type, scope, rate, amount`, runID)
+	if err != nil {
+		t.Fatalf("reading the adjustment records of run %s: %v", runID, err)
+	}
+	defer rows.Close()
+
+	var records []adjustmentRow
+	for rows.Next() {
+		var row adjustmentRow
+		if err := rows.Scan(&row.projectID, &row.relationID, &row.relationType, &row.relationTarget,
+			&row.beneficiary, &row.typ, &row.scope, &row.rate, &row.base, &row.amount,
+			&row.currency); err != nil {
+			t.Fatalf("scanning an adjustment record of run %s: %v", runID, err)
+		}
+		records = append(records, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the adjustment records of run %s: %v", runID, err)
+	}
+	return records
+}
+
 // deltaRow is a correction_deltas row as the cases read it back. The three
 // amounts are read as text, which is what keeps the assertion off floats
 // (roadmap/00-conventions.md section 6).
@@ -519,13 +644,21 @@ func (f fixture) readStatementTotals(t *testing.T, runID uuid.UUID) map[string]s
 func (f fixture) readStatementDocument(t *testing.T, runID uuid.UUID, key string) map[string]any {
 	t.Helper()
 
+	return decodeJSON(t, f.readStatementBytes(t, runID, key))
+}
+
+// readStatementBytes reads one stored statement as the bytes the column holds,
+// which is what the case that renders one document twice compares.
+func (f fixture) readStatementBytes(t *testing.T, runID uuid.UUID, key string) []byte {
+	t.Helper()
+
 	var raw []byte
 	if err := f.engine.Store.Pool().QueryRow(t.Context(),
 		`SELECT document FROM project_statements WHERE run_id = $1 AND project_id = $2`,
 		runID, key).Scan(&raw); err != nil {
 		t.Fatalf("reading the statement of run %s for %s: %v", runID, key, err)
 	}
-	return decodeJSON(t, raw)
+	return raw
 }
 
 // readStats reads a run's stats as the generic values a case asserts over.
@@ -645,6 +778,26 @@ func assertCounts(t *testing.T, stats map[string]any, candidates, usage, rated, 
 	} {
 		if got := number(t, stats, tc.key); got != tc.want {
 			t.Errorf("stats %s = %s, want %s", tc.key, got, tc.want)
+		}
+	}
+}
+
+// assertNoRecords fails when a run holds any record at all, which is what a run
+// that failed before its write transaction has to leave behind.
+func (f fixture) assertNoRecords(t *testing.T, runID uuid.UUID) {
+	t.Helper()
+
+	for _, tc := range []struct {
+		records string
+		count   int
+	}{
+		{records: "usage records", count: len(f.readUsage(t, runID))},
+		{records: "rated records", count: len(f.readRated(t, runID))},
+		{records: "statements", count: len(f.readStatements(t, runID))},
+		{records: "adjustment records", count: len(f.readAdjustments(t, runID))},
+	} {
+		if tc.count != 0 {
+			t.Errorf("the failed run holds %d %s, want none", tc.count, tc.records)
 		}
 	}
 }
@@ -782,7 +935,8 @@ func TestExecute(t *testing.T) {
 		}
 
 		assertAbsent(t, stats, "warnings", "counter_warnings", "attribution_warnings",
-			"unpriced", "unreadable", "violations", "error")
+			"unpriced", "unreadable", "violations", "error",
+			"adjustment_records", "adjustment_warnings")
 	})
 
 	t.Run("leaves the period status alone", func(t *testing.T) {
@@ -1316,6 +1470,341 @@ func TestExecute(t *testing.T) {
 			if got := number(t, stored, tc.metric); got != tc.want {
 				t.Errorf("usage %s = %s, want %s", tc.metric, got, tc.want)
 			}
+		}
+	})
+
+	t.Run("applies the adjustments of a reseller relation", func(t *testing.T) {
+		from, to := month(-22)
+		const cloud = "os-run-reseller"
+		const key = cloud + "/proj-reseller"
+		f.seedProject(t, cloud, "proj-reseller")
+		f.seedResource(t, instance(cloud, "i-reseller", "proj-reseller", from, standardSize))
+		// The partner the project is managed by, and the relation that carries
+		// what its customers are billed at. It opens before the period, so it
+		// adjusts the whole of it.
+		relation := f.seedRelation(t, f.projectIDOf(t, cloud, "proj-reseller"),
+			f.seedVirtualProject(t, "partner", "partner-corp"),
+			"managed_by", resellerAdjustments, from.AddDate(0, -1, 0), nil)
+
+		result, err := f.execute(t, runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+
+		// 5.76 rated, 15 percent off it, and 10 percent of what is left owed to
+		// the partner beside the net rather than in it.
+		document := f.readStatementDocument(t, result.RunID, key)
+		for _, tc := range []struct{ field, want string }{
+			{"base_cost", "5.76"},
+			{"net_cost", "4.90"},
+			{"kickback_total", "0.49"},
+			{"total", "4.90"},
+		} {
+			if got := number(t, document, tc.field); got != tc.want {
+				t.Errorf("the statement's %s = %s, want %s", tc.field, got, tc.want)
+			}
+		}
+		lines := list(t, document, "adjustments")
+		if len(lines) != 2 {
+			t.Fatalf("the statement holds %d adjustments, want the discount and the kickback", len(lines))
+		}
+		for i, tc := range []struct{ typ, base, amount string }{
+			{typ: "discount", base: "5.76", amount: "-0.86"},
+			{typ: "kickback", base: "4.90", amount: "0.49"},
+		} {
+			if got := text(t, lines[i], "type"); got != tc.typ {
+				t.Errorf("adjustment %d is a %s, want a %s", i, got, tc.typ)
+			}
+			if got := number(t, lines[i], "base"); got != tc.base {
+				t.Errorf("the %s is rated on %s, want %s", tc.typ, got, tc.base)
+			}
+			if got := number(t, lines[i], "amount"); got != tc.amount {
+				t.Errorf("the %s is %s, want %s", tc.typ, got, tc.amount)
+			}
+		}
+		if got := f.readStatementTotals(t, result.RunID)[key]; got != "4.90" {
+			t.Errorf("the stored total of %s is %s, want the 4.90 the customer pays", key, got)
+		}
+
+		// One record per applied adjustment, each naming the relation it came
+		// from, and the partner named as owed the kickback alone.
+		records := f.readAdjustments(t, result.RunID)
+		if len(records) != 2 {
+			t.Fatalf("the run holds %d adjustment records, want one per applied adjustment", len(records))
+		}
+		for i, tc := range []struct{ typ, rate, base, amount, beneficiary string }{
+			{typ: "discount", rate: "0.150000", base: "5.76", amount: "-0.86"},
+			{typ: "kickback", rate: "0.100000", base: "4.90", amount: "0.49", beneficiary: "partner-corp"},
+		} {
+			want := adjustmentRow{
+				projectID: key, relationID: relation.String(), relationType: "managed_by",
+				relationTarget: "partner-corp", typ: tc.typ, scope: "all",
+				rate: tc.rate, base: tc.base, amount: tc.amount, currency: "EUR",
+			}
+			got := records[i]
+			beneficiary := ""
+			if got.beneficiary != nil {
+				beneficiary = *got.beneficiary
+			}
+			got.beneficiary = nil
+			if got != want || beneficiary != tc.beneficiary {
+				t.Errorf("the %s record is %+v owed to %q, want %+v owed to %q",
+					tc.typ, got, beneficiary, want, tc.beneficiary)
+			}
+		}
+
+		stats := f.readStats(t, result.RunID)
+		if got := number(t, stats, "adjustment_records"); got != "2" {
+			t.Errorf("stats adjustment_records = %s, want 2", got)
+		}
+		assertAbsent(t, stats, "adjustment_warnings")
+	})
+
+	t.Run("applies a relation closed inside the period and not one closed before it", func(t *testing.T) {
+		from, to := month(-23)
+		const cloud = "os-run-relation-validity"
+		f.seedProject(t, cloud, "proj-validity")
+		f.seedResource(t, instance(cloud, "i-validity", "proj-validity", from, standardSize))
+		project := f.projectIDOf(t, cloud, "proj-validity")
+
+		// A relation is read when its validity overlaps the period, and it then
+		// adjusts the whole of it (D4). One of these two was closed halfway
+		// through the month and one an hour before it began.
+		inside := from.Add(15 * 24 * time.Hour)
+		before := from.Add(-time.Hour)
+		overlapping := f.seedRelation(t, project, f.seedVirtualProject(t, "partner", "partner-inside"),
+			"managed_by", discountAdjustments, from.AddDate(0, -1, 0), &inside)
+		f.seedRelation(t, project, f.seedVirtualProject(t, "partner", "partner-before"),
+			"managed_by", discountAdjustments, from.AddDate(0, -2, 0), &before)
+
+		result, err := f.execute(t, runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+
+		records := f.readAdjustments(t, result.RunID)
+		if len(records) != 1 {
+			t.Fatalf("the run holds %d adjustment records, want the one of the relation the period overlaps",
+				len(records))
+		}
+		if records[0].relationID != overlapping.String() {
+			t.Errorf("the record names relation %s, want the %s the period overlaps",
+				records[0].relationID, overlapping)
+		}
+		if records[0].amount != "-0.58" {
+			t.Errorf("the discount is %s, want -0.58, a tenth of the 5.76 the month was rated at",
+				records[0].amount)
+		}
+	})
+
+	t.Run("leaves a statement alone when adjustments are turned off", func(t *testing.T) {
+		from, to := month(-24)
+		const cloud = "os-run-adjustments-off"
+		const key = cloud + "/proj-off"
+		f.seedProject(t, cloud, "proj-off")
+		f.seedResource(t, instance(cloud, "i-off", "proj-off", from, standardSize))
+		opts := runs.Options{PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud}}
+
+		unadjusted, err := f.execute(t, opts)
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+		document := f.readStatementBytes(t, unadjusted.RunID, key)
+
+		// The relation exists now, and the run still walks no relation type at
+		// all, which is what turns the resolution off.
+		f.seedRelation(t, f.projectIDOf(t, cloud, "proj-off"),
+			f.seedVirtualProject(t, "partner", "partner-off"),
+			"managed_by", resellerAdjustments, from.AddDate(0, -1, 0), nil)
+
+		result, err := f.execute(t, opts)
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+		if got := f.readStatementBytes(t, result.RunID, key); !bytes.Equal(got, document) {
+			t.Errorf("the statement is %s, want the %s it was rendered as before the relation existed",
+				got, document)
+		}
+		if got := len(f.readAdjustments(t, result.RunID)); got != 0 {
+			t.Errorf("the run holds %d adjustment records, want none", got)
+		}
+	})
+
+	t.Run("warns about a kickback to a meta-project", func(t *testing.T) {
+		from, to := month(-25)
+		const cloud = "os-run-kickback-warning"
+		const key = cloud + "/proj-warning"
+		f.seedProject(t, cloud, "proj-warning")
+		f.seedResource(t, instance(cloud, "i-warning", "proj-warning", from, standardSize))
+		// A meta-project is not a partner, so the kickback of the relation is
+		// dropped and the project discount beside it is applied.
+		relation := f.seedRelation(t, f.projectIDOf(t, cloud, "proj-warning"),
+			f.seedVirtualProject(t, "meta", "customer-alpha"), "member_of",
+			`{"pricing_adjustments":[{"type":"project_discount","rate":"0.05","scope":"all"},`+
+				`{"type":"kickback","rate":"0.10","scope":"all"}]}`,
+			from.AddDate(0, -1, 0), nil)
+
+		result, err := f.execute(t, runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+		if run := f.readRun(t, result.RunID); run.status != "completed" {
+			t.Errorf("status = %q, want completed: a kickback nobody is owed is a warning, not a failure",
+				run.status)
+		}
+
+		records := f.readAdjustments(t, result.RunID)
+		if len(records) != 1 {
+			t.Fatalf("the run holds %d adjustment records, want the project discount alone", len(records))
+		}
+		if records[0].typ != "project_discount" || records[0].base != "5.76" || records[0].amount != "-0.29" {
+			t.Errorf("the record is %+v, want the project discount of -0.29 on 5.76", records[0])
+		}
+
+		document := f.readStatementDocument(t, result.RunID, key)
+		if got := len(list(t, document, "adjustments")); got != 1 {
+			t.Errorf("the statement holds %d adjustments, want the project discount alone", got)
+		}
+		if got := number(t, document, "kickback_total"); got != "0.00" {
+			t.Errorf("kickback_total = %s, want 0.00: nobody is owed the commission", got)
+		}
+
+		warnings := list(t, f.readStats(t, result.RunID), "adjustment_warnings")
+		if len(warnings) != 1 {
+			t.Fatalf("adjustment_warnings = %v, want the one dropped kickback", warnings)
+		}
+		for _, tc := range []struct{ field, want string }{
+			{"code", "adjustment_kickback_target_not_partner"},
+			{"relation_id", relation.String()},
+			{"target_id", "customer-alpha"},
+		} {
+			if got := text(t, warnings[0], tc.field); got != tc.want {
+				t.Errorf("the warning's %s = %q, want %q", tc.field, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("fails the run on a relation whose adjustments the schema refuses", func(t *testing.T) {
+		from, to := month(-26)
+		const cloud = "os-run-adjustment-invalid"
+		f.seedProject(t, cloud, "proj-invalid")
+		f.seedResource(t, instance(cloud, "i-invalid", "proj-invalid", from, standardSize))
+		// A type the schema does not admit, which the registry's own API refuses
+		// on the way in. A relation whose stored array cannot be read must not
+		// bill as though it carried nothing.
+		//
+		// It is valid for this month alone, because a relation the resolution
+		// cannot parse fails every run whose period it overlaps, whatever
+		// project it names, and the months of the other cases are not this
+		// one's to fail.
+		relation := f.seedRelation(t, f.projectIDOf(t, cloud, "proj-invalid"),
+			f.seedVirtualProject(t, "partner", "partner-invalid"), "managed_by",
+			`{"pricing_adjustments":[{"type":"rebate","rate":"0.15","scope":"all"}]}`,
+			from, &to)
+
+		result, err := f.execute(t, runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err == nil {
+			t.Fatal("Execute() error = nil, want the relation the schema refuses reported")
+		}
+		for _, want := range []string{relation.String(), "do not match the schema"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Execute() error = %q, want it to name %q", err, want)
+			}
+		}
+
+		if run := f.readRun(t, result.RunID); run.status != "failed" {
+			t.Errorf("status = %q, want failed", run.status)
+		}
+		if got := text(t, f.readStats(t, result.RunID), "error"); got != err.Error() {
+			t.Errorf("stats error = %q, want the failure %q", got, err.Error())
+		}
+		f.assertNoRecords(t, result.RunID)
+	})
+
+	t.Run("writes nothing when an adjustment is out of range", func(t *testing.T) {
+		from, to := month(-27)
+		const cloud = "os-run-adjustment-overflow"
+		f.seedProject(t, cloud, "proj-adjustment-overflow")
+		// Two dimensions of six hundred billion each: every rated amount fits
+		// the column, and the surcharge on what they add up to does not, so the
+		// run is refused before its first insert.
+		f.seedResource(t, instance(cloud, "i-adjustment-overflow", "proj-adjustment-overflow", from, largeSize))
+		f.seedRelation(t, f.projectIDOf(t, cloud, "proj-adjustment-overflow"),
+			f.seedVirtualProject(t, "partner", "partner-overflow"), "managed_by",
+			`{"pricing_adjustments":[{"type":"surcharge","rate":"1","scope":"all"}]}`,
+			from.AddDate(0, -1, 0), nil)
+
+		result, err := f.execute(t, runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		})
+		if err == nil {
+			t.Fatal("Execute() error = nil, want the oversized adjustment refused")
+		}
+		if want := "past the 999999999999.99 the column holds"; !strings.Contains(err.Error(), want) {
+			t.Errorf("Execute() error = %q, want it to say %q", err, want)
+		}
+
+		if run := f.readRun(t, result.RunID); run.status != "failed" {
+			t.Errorf("status = %q, want failed", run.status)
+		}
+		f.assertNoRecords(t, result.RunID)
+	})
+
+	t.Run("stores the adjustment records with the run", func(t *testing.T) {
+		from, to := month(-28)
+		const cloud = "os-run-adjustment-records"
+		f.seedProject(t, cloud, "proj-records")
+		f.seedResource(t, instance(cloud, "i-records", "proj-records", from, standardSize))
+		f.seedRelation(t, f.projectIDOf(t, cloud, "proj-records"),
+			f.seedVirtualProject(t, "partner", "partner-records"), "managed_by",
+			resellerAdjustments, from.AddDate(0, -1, 0), nil)
+		opts := runs.Options{
+			PeriodFrom: from, PeriodTo: to, Clouds: []string{cloud},
+			AdjustmentRelationTypes: adjustmentRelationTypes, AdjustmentDepth: adjustmentDepth,
+		}
+
+		first, err := f.execute(t, opts)
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+		records := f.readAdjustments(t, first.RunID)
+		if len(records) != 2 {
+			t.Fatalf("the run holds %d adjustment records, want the discount and the kickback", len(records))
+		}
+		for _, record := range records {
+			if record.currency != "EUR" {
+				t.Errorf("the %s record is in %s, want the EUR the period was rated in",
+					record.typ, record.currency)
+			}
+		}
+
+		second, err := f.execute(t, opts)
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+		if !slices.Equal(second.Superseded, []uuid.UUID{first.RunID}) {
+			t.Errorf("Superseded = %v, want the completed run %s", second.Superseded, first.RunID)
+		}
+		// The records of a superseded run stay for the audit, the way its usage
+		// records do, and the run that replaced it holds its own.
+		if got := len(f.readAdjustments(t, first.RunID)); got != 2 {
+			t.Errorf("the superseded run holds %d adjustment records, want its own kept", got)
+		}
+		if got := len(f.readAdjustments(t, second.RunID)); got != 2 {
+			t.Errorf("the second run holds %d adjustment records, want the two it applied", got)
 		}
 	})
 }

--- a/internal/engine/runs/runs_test.go
+++ b/internal/engine/runs/runs_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/counters"
@@ -28,6 +30,10 @@ import (
 var metered = source.Resource{
 	Cloud: "os-prod-eu1", Platform: "openstack", ResourceType: "instance", ResourceID: "def-456",
 }
+
+// adjustedRelation is the relation the adjustments of the pure cases below came
+// from, as the text a line carries it in.
+const adjustedRelation = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
 
 // instantOf is one instant of the fixtures below.
 func instantOf(t *testing.T, text string) time.Time {
@@ -69,11 +75,12 @@ func TestStatsJSONShape(t *testing.T) {
 	project := uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
 	stats := Stats{
-		SnapshotAt:   &snapshotAt,
-		Candidates:   3,
-		UsageRecords: 4,
-		RatedRecords: 5,
-		Statements:   2,
+		SnapshotAt:        &snapshotAt,
+		Candidates:        3,
+		UsageRecords:      4,
+		RatedRecords:      5,
+		Statements:        2,
+		AdjustmentRecords: 6,
 		Warnings: []Warning{{
 			Code:   WarningPeriodNotEnded,
 			Detail: "period_to 2026-04-01T00:00:00Z has not passed yet",
@@ -89,6 +96,10 @@ func TestStatsJSONShape(t *testing.T) {
 		}},
 		AttributionWarnings: []attribution.Warning{{
 			Code: attribution.WarningCycle, ProjectID: project,
+		}},
+		AdjustmentWarnings: []adjustments.Warning{{
+			Code: adjustments.WarningKickbackTargetNotPartner, RelationID: adjustedRelation,
+			TargetPlatform: "meta", TargetID: "customer-alpha",
 		}},
 		Unpriced: []rating.UnpricedResourceType{{
 			Platform: metered.Platform, ResourceType: "volume", Count: 1,
@@ -114,7 +125,7 @@ func TestStatsJSONShape(t *testing.T) {
 	}
 
 	want := `{"snapshot_at":"2026-03-01T00:00:00Z",` +
-		`"candidates":3,"usage_records":4,"rated_records":5,"statements":2,` +
+		`"candidates":3,"usage_records":4,"rated_records":5,"statements":2,"adjustment_records":6,` +
 		`"warnings":[{"code":"period_not_ended",` +
 		`"detail":"period_to 2026-04-01T00:00:00Z has not passed yet"}],` +
 		`"metering_warnings":[{"cloud":"os-prod-eu1","resource_type":"instance","resource_id":"def-456",` +
@@ -124,6 +135,9 @@ func TestStatsJSONShape(t *testing.T) {
 		`"code":"counter_source_failed","detail":"the store did not answer"}],` +
 		`"attribution_warnings":[{"code":"attribution_cycle",` +
 		`"project_id":"6ba7b810-9dad-11d1-80b4-00c04fd430c8"}],` +
+		`"adjustment_warnings":[{"code":"adjustment_kickback_target_not_partner",` +
+		`"relation_id":"` + adjustedRelation + `",` +
+		`"target_platform":"meta","target_id":"customer-alpha"}],` +
 		`"unpriced":[{"platform":"openstack","resource_type":"volume","count":1}],` +
 		`"unreadable":[{"platform":"openstack","resource_type":"instance","field":"vcpus","count":2}],` +
 		`"unregistered_projects":[{"cloud":"os-prod-eu1","project_id":"proj-456","resources":1}],` +
@@ -152,9 +166,9 @@ func TestStatsJSONOmitsEmptyLists(t *testing.T) {
 }
 
 // TestCorrectionStatsJSONShape pins the object a correction stores in
-// runs.stats: the keys of a regular run, flattened, with the delta count beside
-// them. An operator reads a correction the way they read a run, and the one key
-// that is new is the one that says how much it found.
+// runs.stats: the keys of a regular run, flattened, with the delta counts
+// beside them. An operator reads a correction the way they read a run, and the
+// keys that are new are the two that say how much it found.
 func TestCorrectionStatsJSONShape(t *testing.T) {
 	snapshotAt := instantOf(t, "2026-03-01T00:00:00Z")
 
@@ -163,7 +177,8 @@ func TestCorrectionStatsJSONShape(t *testing.T) {
 			SnapshotAt: &snapshotAt, Candidates: 3, UsageRecords: 4, RatedRecords: 5,
 			Statements: 2, Error: "x",
 		},
-		Deltas: 7,
+		Deltas:           7,
+		AdjustmentDeltas: 2,
 	})
 	if err != nil {
 		t.Fatalf("Marshal error = %v, want nil", err)
@@ -171,20 +186,21 @@ func TestCorrectionStatsJSONShape(t *testing.T) {
 
 	want := `{"snapshot_at":"2026-03-01T00:00:00Z",` +
 		`"candidates":3,"usage_records":4,"rated_records":5,"statements":2,` +
-		`"error":"x","deltas":7}`
+		`"error":"x","deltas":7,"adjustment_deltas":2}`
 	if string(got) != want {
 		t.Errorf("Marshal =\n%s\nwant\n%s", got, want)
 	}
 
-	// A correction that found nothing reports its counts and a delta count of
-	// zero: the key stays, because no deltas is what such a correction says.
+	// A correction that found nothing reports its counts and delta counts of
+	// zero: the keys stay, because no deltas is what such a correction says.
 	got, err = json.Marshal(CorrectionStats{
 		Stats: Stats{Candidates: 1, UsageRecords: 2, RatedRecords: 4, Statements: 1},
 	})
 	if err != nil {
 		t.Fatalf("Marshal error = %v, want nil", err)
 	}
-	want = `{"candidates":1,"usage_records":2,"rated_records":4,"statements":1,"deltas":0}`
+	want = `{"candidates":1,"usage_records":2,"rated_records":4,"statements":1,` +
+		`"deltas":0,"adjustment_deltas":0}`
 	if string(got) != want {
 		t.Errorf("Marshal = %s, want %s", got, want)
 	}
@@ -352,6 +368,199 @@ func TestDeltaRowsShape(t *testing.T) {
 		if row.ID == (pgtype.UUID{}) {
 			t.Errorf("row %d carries no id, want the one it is written under", i)
 		}
+	}
+}
+
+// lineOf is one applied adjustment of the statements the cases below build
+// their rows from, at the rate and the two amounts the case passes as text.
+func lineOf(t *testing.T, adjustmentType, target, rate, adjustedBase, adjusted string) adjustments.Line {
+	t.Helper()
+
+	return adjustments.Line{
+		Type:           adjustmentType,
+		RelationType:   "managed_by",
+		RelationTarget: target,
+		RelationID:     adjustedRelation,
+		Scope:          "all",
+		Rate:           money.NewRate(decimal.RequireFromString(rate)),
+		Base:           money.NewAmount(decimal.RequireFromString(adjustedBase)),
+		Amount:         money.NewAmount(decimal.RequireFromString(adjusted)),
+	}
+}
+
+// adjustedStatements are the two statements of the shape case: one that two
+// adjustments reached and one that none did.
+func adjustedStatements(t *testing.T) []statements.Statement {
+	t.Helper()
+
+	return []statements.Statement{
+		{
+			Key:      "os-prod-eu1/customer-proj-1",
+			Currency: "EUR",
+			Adjustments: []adjustments.Line{
+				lineOf(t, adjustment.TypeDiscount, "partner-corp", "0.15", "1200.00", "-180.00"),
+				lineOf(t, adjustment.TypeKickback, "partner-corp", "0.10", "1020.00", "102.00"),
+			},
+		},
+		{Key: "os-prod-eu1/customer-proj-2", Currency: "EUR"},
+	}
+}
+
+// TestAdjustmentRowsShape is what one adjustment line reaches the columns as:
+// the statement it was applied to, the relation it came from, and the rate at
+// six places beside the base and the amount at two, each as the text of the
+// decimal rather than as a float. The beneficiary is the relation's target on a
+// kickback and nothing on the other types, because a kickback is the one
+// adjustment somebody is owed the amount of. A statement no adjustment reached
+// writes no row.
+func TestAdjustmentRowsShape(t *testing.T) {
+	runID := uuid.New()
+
+	rows, err := adjustmentRows(runID, adjustedStatements(t))
+	if err != nil {
+		t.Fatalf("adjustmentRows() error = %v, want nil", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("adjustmentRows() = %d rows, want one per adjustment line", len(rows))
+	}
+
+	for i, row := range rows {
+		if row.RunID != uuidValue(runID) {
+			t.Errorf("row %d run = %v, want %v", i, row.RunID, uuidValue(runID))
+		}
+		if row.ProjectID != "os-prod-eu1/customer-proj-1" {
+			t.Errorf("row %d statement = %q, want the one its line was applied to", i, row.ProjectID)
+		}
+		if want := uuidValue(uuid.MustParse(adjustedRelation)); row.RelationID != want {
+			t.Errorf("row %d relation = %v, want %v", i, row.RelationID, want)
+		}
+		if row.RelationType != "managed_by" || row.RelationTarget != "partner-corp" {
+			t.Errorf("row %d relation = (%s, %s), want (managed_by, partner-corp)",
+				i, row.RelationType, row.RelationTarget)
+		}
+		if row.Scope != "all" || row.Currency != "EUR" {
+			t.Errorf("row %d = (%s, %s), want (all, EUR)", i, row.Scope, row.Currency)
+		}
+	}
+
+	for _, tc := range []struct {
+		index                        int
+		adjustmentType               string
+		rate, adjustedBase, adjusted string
+		beneficiary                  string
+	}{
+		{
+			index: 0, adjustmentType: adjustment.TypeDiscount,
+			rate: "0.150000", adjustedBase: "1200.00", adjusted: "-180.00",
+		},
+		{
+			index: 1, adjustmentType: adjustment.TypeKickback,
+			rate: "0.100000", adjustedBase: "1020.00", adjusted: "102.00",
+			beneficiary: "partner-corp",
+		},
+	} {
+		row := rows[tc.index]
+		if row.Type != tc.adjustmentType {
+			t.Errorf("row %d type = %q, want %q", tc.index, row.Type, tc.adjustmentType)
+		}
+		for _, field := range []struct {
+			name  string
+			value pgtype.Numeric
+			want  string
+		}{
+			{name: "rate", value: row.Rate, want: tc.rate},
+			{name: "base", value: row.Base, want: tc.adjustedBase},
+			{name: "amount", value: row.Amount, want: tc.adjusted},
+		} {
+			if got := numericText(t, field.value); got != field.want {
+				t.Errorf("row %d %s = %s, want %s", tc.index, field.name, got, field.want)
+			}
+		}
+		switch {
+		case tc.beneficiary == "" && row.Beneficiary.Valid:
+			t.Errorf("row %d beneficiary = %q, want none: a %s is owed to nobody",
+				tc.index, row.Beneficiary.String, tc.adjustmentType)
+		case tc.beneficiary != "" && (!row.Beneficiary.Valid || row.Beneficiary.String != tc.beneficiary):
+			t.Errorf("row %d beneficiary = %+v, want %q", tc.index, row.Beneficiary, tc.beneficiary)
+		}
+	}
+
+	// The ids are generated here rather than left to the column default,
+	// because COPY evaluates no defaults.
+	if rows[0].ID == rows[1].ID {
+		t.Error("both rows carry one id, want an id per row")
+	}
+}
+
+// TestAdjustmentRowsOversized refuses an adjustment whose base or amount is
+// past what NUMERIC(14,2) holds. The database would report it as a numeric
+// field overflow naming the column alone, which says nothing about the
+// statement it was applied to or the relation it came from.
+func TestAdjustmentRowsOversized(t *testing.T) {
+	adjusted := func(line adjustments.Line) []statements.Statement {
+		return []statements.Statement{{
+			Key: "os-prod-eu1/customer-proj-1", Currency: "EUR",
+			Adjustments: []adjustments.Line{line},
+		}}
+	}
+
+	t.Run("the largest base the column holds is written", func(t *testing.T) {
+		rows, err := adjustmentRows(uuid.New(), adjusted(
+			lineOf(t, adjustment.TypeDiscount, "partner-corp", "0.15", "999999999999.99", "-180.00")))
+		if err != nil {
+			t.Fatalf("adjustmentRows() error = %v, want nil", err)
+		}
+		if len(rows) != 1 {
+			t.Errorf("adjustmentRows() = %d rows, want the base at the bound written", len(rows))
+		}
+	})
+
+	t.Run("an amount past the bound", func(t *testing.T) {
+		rows, err := adjustmentRows(uuid.New(), adjusted(
+			lineOf(t, adjustment.TypeKickback, "partner-corp", "0.10", "1200.00", "1000000000000.00")))
+		if err == nil {
+			t.Fatal("adjustmentRows() error = nil, want the oversized amount refused")
+		}
+		if rows != nil {
+			t.Errorf("adjustmentRows() = %v, want no rows: a refused adjustment leaves nothing to write", rows)
+		}
+		for _, want := range []string{
+			adjustment.TypeKickback, adjustedRelation, "os-prod-eu1/customer-proj-1",
+			"past the 999999999999.99 the column holds",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("adjustmentRows() error = %q, want it to name %q", err, want)
+			}
+		}
+	})
+}
+
+// TestAdjustmentRowsEmpty is a run that adjusted nothing: no rows, and the
+// empty slice rather than a nil one, because the write skips an adjustment list
+// of no length rather than passing a nil through the COPY.
+func TestAdjustmentRowsEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sts  []statements.Statement
+	}{
+		{name: "no statements at all"},
+		{name: "statements no adjustment reached", sts: []statements.Statement{
+			{Key: "os-prod-eu1/customer-proj-1", Currency: "EUR"},
+			{Key: "os-prod-eu1/customer-proj-2", Currency: "EUR"},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := adjustmentRows(uuid.New(), tc.sts)
+			if err != nil {
+				t.Fatalf("adjustmentRows() error = %v, want nil", err)
+			}
+			if rows == nil {
+				t.Fatal("adjustmentRows() = nil, want an empty slice")
+			}
+			if len(rows) != 0 {
+				t.Errorf("adjustmentRows() = %d rows, want none", len(rows))
+			}
+		})
 	}
 }
 

--- a/internal/engine/runs/store.go
+++ b/internal/engine/runs/store.go
@@ -9,10 +9,13 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
+	"github.com/b42labs/tally/internal/core/money"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/metering"
 	"github.com/b42labs/tally/internal/engine/rating"
 	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 )
 
@@ -175,6 +178,76 @@ func deltaRows(runID, correctsRunID uuid.UUID, deltas []corrections.Delta, curre
 			Delta:         amounts[2],
 			Currency:      currency,
 		})
+	}
+	return rows, nil
+}
+
+// adjustmentRows builds the adjustment records of one run: one row per
+// adjustment line of every statement, in statement and then application order,
+// each naming the relation the adjustment came from. Beneficiary carries the
+// relation's target on a kickback and nothing on the other types, because a
+// kickback is the one adjustment somebody is owed the amount of.
+//
+// The ids are generated here rather than left to the column default, because
+// COPY evaluates no defaults.
+//
+// A base or an amount past what the column holds is refused before the first
+// insert, named by its type, its relation and its statement, for the reason
+// ratedRows refuses one. So is a relation id that does not parse, which the
+// line carrying it as the text of a uuid.UUID leaves unreachable.
+func adjustmentRows(runID uuid.UUID, sts []statements.Statement) (
+	[]sqlcgen.CreateAdjustmentRecordsParams, error,
+) {
+	rows := make([]sqlcgen.CreateAdjustmentRecordsParams, 0, len(sts))
+	for _, st := range sts {
+		for _, line := range st.Adjustments {
+			relationID, err := uuid.Parse(line.RelationID)
+			if err != nil {
+				return nil, fmt.Errorf("reading the relation id %q of the %s adjustment on %s: %w",
+					line.RelationID, line.Type, st.Key, err)
+			}
+
+			// The three columns are NUMERIC, the rate at six places and the two
+			// amounts at two, and the decimals reach them as their own text
+			// rather than through a float.
+			var rate pgtype.Numeric
+			if err := rate.Scan(line.Rate.StringFixed(money.RatePlaces)); err != nil {
+				return nil, fmt.Errorf("reading the %s adjustment of relation %s on %s: %w",
+					line.Type, line.RelationID, st.Key, err)
+			}
+			var amounts [2]pgtype.Numeric
+			for i, value := range [2]decimal.Decimal{line.Base.Decimal, line.Amount.Decimal} {
+				if value.Abs().GreaterThan(maxRatedAmount) {
+					return nil, fmt.Errorf(
+						"the %s adjustment of relation %s on %s is %s, past the %s the column holds: "+
+							"a usage value it was rated from is out of range",
+						line.Type, line.RelationID, st.Key, value.StringFixed(2), maxRatedAmount)
+				}
+				if err := amounts[i].Scan(value.StringFixed(2)); err != nil {
+					return nil, fmt.Errorf("reading the %s adjustment of relation %s on %s: %w",
+						line.Type, line.RelationID, st.Key, err)
+				}
+			}
+
+			rows = append(rows, sqlcgen.CreateAdjustmentRecordsParams{
+				ID:             uuidValue(uuid.New()),
+				RunID:          uuidValue(runID),
+				ProjectID:      st.Key,
+				RelationID:     uuidValue(relationID),
+				RelationType:   line.RelationType,
+				RelationTarget: line.RelationTarget,
+				Beneficiary: pgtype.Text{
+					String: line.RelationTarget,
+					Valid:  line.Type == adjustment.TypeKickback,
+				},
+				Type:     line.Type,
+				Scope:    line.Scope,
+				Rate:     rate,
+				Base:     amounts[0],
+				Amount:   amounts[1],
+				Currency: st.Currency,
+			})
+		}
 	}
 	return rows, nil
 }

--- a/internal/engine/source/queries.sql
+++ b/internal/engine/source/queries.sql
@@ -41,7 +41,7 @@ ORDER BY cloud, external_id;
 -- the period produced before it closed; v1 does not prorate a relation within a
 -- period.
 -- name: ListRelationsOverlapping :many
-SELECT id, source_id, target_id, relation_type, valid_from, valid_to
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to
 FROM project_relations
 WHERE relation_type = ANY(sqlc.arg('relation_types')::text[])
   AND valid_from < sqlc.arg('period_to')::timestamptz

--- a/internal/engine/source/source.go
+++ b/internal/engine/source/source.go
@@ -337,8 +337,11 @@ type Relation struct {
 	SourceID     uuid.UUID
 	TargetID     uuid.UUID
 	RelationType string
-	ValidFrom    time.Time
-	ValidTo      *time.Time
+	// Metadata is the stored document as JSONB renders it, {} for a relation
+	// created without one. It is read by adjustment resolution.
+	Metadata  json.RawMessage
+	ValidFrom time.Time
+	ValidTo   *time.Time
 }
 
 // Relations lists the relations of the given types whose validity overlaps the
@@ -348,6 +351,9 @@ type Relation struct {
 // An empty type list is attribution turned off, which is what an explicitly
 // empty TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES configures. No query runs then,
 // because every relation type is one attribution would not walk.
+//
+// Adjustment resolution is the second reader of these relations, and an empty
+// type list turns its walk off the same way.
 func (s *Snapshot) Relations(ctx context.Context, relationTypes []string, periodFrom, periodTo time.Time) ([]Relation, error) {
 	if len(relationTypes) == 0 {
 		return []Relation{}, nil
@@ -368,6 +374,7 @@ func (s *Snapshot) Relations(ctx context.Context, relationTypes []string, period
 			SourceID:     row.SourceID,
 			TargetID:     row.TargetID,
 			RelationType: row.RelationType,
+			Metadata:     json.RawMessage(row.Metadata),
 			ValidFrom:    row.ValidFrom.Time.UTC(),
 		}
 		if row.ValidTo.Valid {

--- a/internal/engine/source/source_test.go
+++ b/internal/engine/source/source_test.go
@@ -3,6 +3,7 @@ package source_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"reflect"
@@ -15,7 +16,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/event"
 	"github.com/b42labs/tally/internal/engine/source"
 	"github.com/b42labs/tally/internal/reporting/store/storetest"
@@ -593,8 +596,18 @@ func TestProjectGraph(t *testing.T) {
 		ID: uuid.New(), SourceID: far.ID, TargetID: second.ID,
 		RelationType: relationType, ValidFrom: insidePeriod,
 	}
+	// The one relation carrying metadata, which adjustment resolution reads
+	// the pricing adjustments out of. The document carries a second member so
+	// that the read is seen to hand the whole metadata on rather than the
+	// adjustments alone.
+	adjusted := source.Relation{
+		ID: uuid.New(), SourceID: first.ID, TargetID: second.ID,
+		RelationType: relationType, ValidFrom: beforePeriod,
+		Metadata: json.RawMessage(
+			`{"owner":"team-a","pricing_adjustments":[{"type":"discount","rate":"0.15","scope":"all"}]}`),
+	}
 	for _, relation := range []source.Relation{
-		open, closedInside, startedInside,
+		open, closedInside, startedInside, adjusted,
 		// Closed at the first instant of the period, which no longer overlaps
 		// it: the predicate is valid_to > period_from.
 		{
@@ -626,11 +639,46 @@ func TestProjectGraph(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Relations() error = %v, want nil", err)
 		}
+		// JSONB stores a document by its members rather than by its text, so
+		// the metadata of the adjusted relation comes back in Postgres' order
+		// and is read through the parser below instead of compared as text.
+		var adjustedMetadata json.RawMessage
+		for i := range got {
+			if got[i].ID != adjusted.ID {
+				continue
+			}
+			adjustedMetadata = got[i].Metadata
+			got[i].Metadata = adjusted.Metadata
+		}
 		// Ordered by id, which Postgres compares byte-wise.
-		want := []source.Relation{open, closedInside, startedInside}
+		want := []source.Relation{open, closedInside, startedInside, adjusted}
+		for i := range want {
+			// A relation seeded without metadata carries the empty document,
+			// which JSONB renders as exactly {}.
+			if want[i].Metadata == nil {
+				want[i].Metadata = json.RawMessage("{}")
+			}
+		}
 		slices.SortFunc(want, func(a, b source.Relation) int { return bytes.Compare(a.ID[:], b.ID[:]) })
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Relations() = %+v, want %+v", got, want)
+		}
+
+		adjustments, found, err := adjustment.FromMetadata(adjustedMetadata)
+		if err != nil {
+			t.Fatalf("FromMetadata(%s) error = %v, want nil", adjustedMetadata, err)
+		}
+		if !found {
+			t.Fatalf("FromMetadata(%s) found = false, want true", adjustedMetadata)
+		}
+		if len(adjustments) != 1 {
+			t.Fatalf("FromMetadata(%s) = %+v, want one adjustment", adjustedMetadata, adjustments)
+		}
+		rate := decimal.RequireFromString("0.15")
+		if a := adjustments[0]; a.Type != adjustment.TypeDiscount ||
+			!a.Rate.Equal(rate) || a.Scope != adjustment.ScopeAll {
+			t.Errorf("FromMetadata(%s)[0] = %+v, want the %s of %s over %q",
+				adjustedMetadata, a, adjustment.TypeDiscount, rate, adjustment.ScopeAll)
 		}
 	})
 
@@ -727,7 +775,11 @@ func TestReaderRole(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Relations() error = %v, want nil", err)
 		}
-		if want := []source.Relation{relation}; !reflect.DeepEqual(relations, want) {
+		// The metadata column is covered by the same grant on the table, and a
+		// relation seeded without metadata carries the empty document.
+		wantRelation := relation
+		wantRelation.Metadata = json.RawMessage("{}")
+		if want := []source.Relation{wantRelation}; !reflect.DeepEqual(relations, want) {
 			t.Errorf("Relations() = %+v, want %+v", relations, want)
 		}
 
@@ -1029,14 +1081,20 @@ func seedProject(t *testing.T, pool *pgxpool.Pool, p source.Project) {
 	}
 }
 
-// seedRelation writes one edge of the project graph.
+// seedRelation writes one edge of the project graph. A relation without
+// metadata is written with the empty document, the same one the column
+// defaults to.
 func seedRelation(t *testing.T, pool *pgxpool.Pool, r source.Relation) {
 	t.Helper()
 
+	metadata := []byte(r.Metadata)
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
 	if _, err := pool.Exec(t.Context(),
-		`INSERT INTO project_relations (id, source_id, target_id, relation_type, valid_from, valid_to)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		r.ID, r.SourceID, r.TargetID, r.RelationType, r.ValidFrom, r.ValidTo); err != nil {
+		`INSERT INTO project_relations (id, source_id, target_id, relation_type, valid_from, valid_to, metadata)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+		r.ID, r.SourceID, r.TargetID, r.RelationType, r.ValidFrom, r.ValidTo, metadata); err != nil {
 		t.Fatalf("seeding the relation %s: %v", r.ID, err)
 	}
 }

--- a/internal/engine/source/sqlcgen/queries.sql.go
+++ b/internal/engine/source/sqlcgen/queries.sql.go
@@ -292,7 +292,7 @@ func (q *Queries) ListProjects(ctx context.Context) ([]ListProjectsRow, error) {
 }
 
 const listRelationsOverlapping = `-- name: ListRelationsOverlapping :many
-SELECT id, source_id, target_id, relation_type, valid_from, valid_to
+SELECT id, source_id, target_id, relation_type, metadata, valid_from, valid_to
 FROM project_relations
 WHERE relation_type = ANY($1::text[])
   AND valid_from < $2::timestamptz
@@ -311,6 +311,7 @@ type ListRelationsOverlappingRow struct {
 	SourceID     uuid.UUID
 	TargetID     uuid.UUID
 	RelationType string
+	Metadata     []byte
 	ValidFrom    pgtype.Timestamptz
 	ValidTo      pgtype.Timestamptz
 }
@@ -333,6 +334,7 @@ func (q *Queries) ListRelationsOverlapping(ctx context.Context, arg ListRelation
 			&i.SourceID,
 			&i.TargetID,
 			&i.RelationType,
+			&i.Metadata,
 			&i.ValidFrom,
 			&i.ValidTo,
 		); err != nil {

--- a/internal/engine/statements/statements.go
+++ b/internal/engine/statements/statements.go
@@ -24,7 +24,16 @@
 // run reports through runs.stats: usage somebody consumed is not dropped
 // because nobody registered the project it ran in.
 //
-// The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.7.
+// A caller that passes an adjuster has the pricing adjustments of the
+// statement's project applied here: the document then shows the base cost the
+// period was rated at, one line per adjustment, the net cost and the kickbacks
+// a partner is owed. Its total is the net cost, which is what the customer
+// pays. A statement no adjustment reaches holds none of those members and
+// renders the same bytes as one built without an adjuster.
+//
+// The normative specification is roadmap/03-phase-3-metering-rating.md, WP 3.7,
+// and roadmap/05-phase-5-commercial-pricing.md, WP 5.3, for the adjustment
+// members.
 package statements
 
 import (
@@ -40,6 +49,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/metering"
 	"github.com/b42labs/tally/internal/engine/rating"
@@ -100,6 +110,10 @@ type Statement struct {
 	Total decimal.Decimal
 	// Currency is the currency of the model the period was rated with.
 	Currency string
+	// Adjustments holds the adjustment lines the document shows, which the run
+	// stores as the statement's adjustment records. It is nil on a statement no
+	// adjustment reached.
+	Adjustments []adjustments.Line
 }
 
 // UnregisteredProject is a project id drafts carried that the registry does not
@@ -121,8 +135,21 @@ type Document struct {
 	Platform      string        `json:"platform"`
 	LineItems     []LineItem    `json:"line_items"`
 	RelatedCosts  []RelatedCost `json:"related_costs"`
-	Total         money.Amount  `json:"total"`
-	Currency      string        `json:"currency"`
+	// BaseCost is what the line items and the related costs add up to before
+	// the adjustments, NetCost what they come to after them, and KickbackTotal
+	// what a partner is owed beside the net cost rather than as part of it. The
+	// four members are nil on a statement no adjustment reached, whose bytes
+	// hold none of them. Total is the net cost where they are there, which is
+	// what the customer pays.
+	//
+	// None of them carries a currency of its own: every amount in the document
+	// is in the currency Currency names, the way Total already renders.
+	BaseCost      *money.Amount      `json:"base_cost,omitempty"`
+	Adjustments   []adjustments.Line `json:"adjustments,omitempty"`
+	NetCost       *money.Amount      `json:"net_cost,omitempty"`
+	KickbackTotal *money.Amount      `json:"kickback_total,omitempty"`
+	Total         money.Amount       `json:"total"`
+	Currency      string             `json:"currency"`
 }
 
 // BillingPeriod is the half-open interval the document bills, both ends in UTC
@@ -177,6 +204,12 @@ type RelatedCost struct {
 // billed under itself, which is what a top-level project, an orphaned one, and
 // one no relation touched all are.
 //
+// The adjuster applies the pricing adjustments of a project's relations to the
+// document it is billed on, and nil renders every document unadjusted. The walk
+// starts at the project the statement is keyed to, so an attributed project's
+// own relations reach no statement: its costs are billed on its root's
+// statement, and only the root's relations adjust them.
+//
 // Rendering nothing is not an error: a period without usage and without rated
 // resources yields no statements.
 func Build(
@@ -185,6 +218,7 @@ func Build(
 	rated rating.Result,
 	projects []source.Project,
 	res attribution.Resolution,
+	adjuster *adjustments.Adjuster,
 ) (BuildResult, error) {
 	if len(usage) == 0 && len(rated.Resources) == 0 {
 		return BuildResult{}, nil
@@ -249,7 +283,7 @@ func Build(
 			})
 			// A cloud is one installation of one platform, so the resources of a
 			// pair cannot disagree on which one that is.
-			documentOf(documents, own.key, own.key.projectID, items[0].Platform).add(items)
+			documentOf(documents, own.key, own.key.projectID, items[0].Platform, uuid.Nil).add(items)
 			continue
 		}
 
@@ -260,7 +294,8 @@ func Build(
 			// can be keyed to, and its costs stay on their own project's statement
 			// rather than on a document named after nobody.
 			if root, known := byID[attributed.Root]; known {
-				document := documentOf(documents, ownerKey{root.Cloud, root.ExternalID}, root.ExternalID, root.Platform)
+				document := documentOf(
+					documents, ownerKey{root.Cloud, root.ExternalID}, root.ExternalID, root.Platform, root.ID)
 				document.related = append(document.related, related{
 					key: own.key,
 					cost: RelatedCost{
@@ -275,12 +310,12 @@ func Build(
 			}
 		}
 
-		documentOf(documents, own.key, own.project.ExternalID, own.project.Platform).add(items)
+		documentOf(documents, own.key, own.project.ExternalID, own.project.Platform, own.project.ID).add(items)
 	}
 
 	result.Statements = make([]Statement, 0, len(documents))
 	for _, document := range documents {
-		statement, err := document.render(billingPeriod, rated.Currency)
+		statement, err := document.render(billingPeriod, rated.Currency, adjuster)
 		if err != nil {
 			return BuildResult{}, err
 		}
@@ -330,8 +365,13 @@ type builder struct {
 	key       string
 	projectID string
 	platform  string
-	items     []LineItem
-	related   []related
+	// project is the registry id of the project the document is keyed to, and
+	// uuid.Nil for a pair the registry does not hold. The adjustment walk starts
+	// at the project, and a pair the registry does not hold is one no relation
+	// names.
+	project uuid.UUID
+	items   []LineItem
+	related []related
 }
 
 // related is one related-costs entry and the pair of the project it bills,
@@ -408,13 +448,19 @@ func (o *owner) lineItems() []LineItem {
 // The project a document names is the one it is keyed to, so a root reached
 // over an attributed project first is named after the root rather than after
 // whoever arrived with it.
-func documentOf(documents map[ownerKey]*builder, key ownerKey, projectID, platform string) *builder {
+func documentOf(
+	documents map[ownerKey]*builder,
+	key ownerKey,
+	projectID, platform string,
+	project uuid.UUID,
+) *builder {
 	document, held := documents[key]
 	if !held {
 		document = &builder{
 			key:       Key(key.cloud, key.projectID),
 			projectID: projectID,
 			platform:  platform,
+			project:   project,
 			items:     []LineItem{},
 		}
 		documents[key] = document
@@ -432,7 +478,20 @@ func (d *builder) add(items []LineItem) {
 // ordered among themselves, the related entries are ordered here, and the map
 // keys of a period are ordered by encoding/json, so the bytes are a function of
 // the input alone.
-func (d *builder) render(billingPeriod BillingPeriod, currency string) (Statement, error) {
+//
+// The adjustments are applied to the sum of every line the statement bills, its
+// own and the related ones, because that sum is what the customer is invoiced.
+// A walk that collects nothing leaves the four adjustment members nil, and the
+// document is the one an unadjusted build renders. A pair the registry does not
+// hold is billed under its raw project id, which no relation names, so it is
+// rendered unadjusted as well. A relation the walk reaches whose stored
+// adjustments cannot be read fails the build, because the statement would
+// otherwise be billed short of what that relation carries.
+func (d *builder) render(
+	billingPeriod BillingPeriod,
+	currency string,
+	adjuster *adjustments.Adjuster,
+) (Statement, error) {
 	slices.SortFunc(d.related, func(a, b related) int {
 		return cmp.Or(
 			cmp.Compare(a.key.cloud, b.key.cloud),
@@ -453,13 +512,62 @@ func (d *builder) render(billingPeriod BillingPeriod, currency string) (Statemen
 		document.RelatedCosts = append(document.RelatedCosts, entry.cost)
 		total = total.Add(entry.cost.Total.Decimal)
 	}
+
+	if adjuster != nil && d.project != uuid.Nil {
+		outcome, err := adjuster.Adjust(d.project, bases(d.items, document.RelatedCosts))
+		if err != nil {
+			return Statement{}, fmt.Errorf("adjusting the statement of %s: %w", d.key, err)
+		}
+		if len(outcome.Lines) > 0 {
+			baseCost := money.NewAmount(total)
+			netCost := money.NewAmount(outcome.NetCost)
+			kickbackTotal := money.NewAmount(outcome.KickbackTotal)
+			document.BaseCost = &baseCost
+			document.Adjustments = outcome.Lines
+			document.NetCost = &netCost
+			document.KickbackTotal = &kickbackTotal
+			total = outcome.NetCost
+		}
+	}
 	document.Total = money.NewAmount(total)
 
 	body, err := json.Marshal(document)
 	if err != nil {
 		return Statement{}, fmt.Errorf("marshalling the statement of %s: %w", d.key, err)
 	}
-	return Statement{Key: d.key, Document: body, Total: total, Currency: currency}, nil
+	return Statement{
+		Key:         d.key,
+		Document:    body,
+		Total:       total,
+		Currency:    currency,
+		Adjustments: document.Adjustments,
+	}, nil
+}
+
+// bases is every rated line the statement bills, its own and those of the
+// projects attributed to it, as the amounts an adjustment is scoped against. A
+// related line carries the platform and the resource type it was rated under,
+// so an adjustment scoped to a platform reaches the lines of that platform
+// wherever on the document they sit.
+func bases(items []LineItem, related []RelatedCost) []adjustments.Base {
+	collected := make([]adjustments.Base, 0, len(items))
+	for _, item := range items {
+		collected = append(collected, adjustments.Base{
+			Platform:     item.Platform,
+			ResourceType: item.ResourceType,
+			Amount:       item.Total.Decimal,
+		})
+	}
+	for _, cost := range related {
+		for _, item := range cost.LineItems {
+			collected = append(collected, adjustments.Base{
+				Platform:     item.Platform,
+				ResourceType: item.ResourceType,
+				Amount:       item.Total.Decimal,
+			})
+		}
+	}
+	return collected
 }
 
 // periodOf renders one rated record and the draft it rates, and returns the

--- a/internal/engine/statements/statements_test.go
+++ b/internal/engine/statements/statements_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/attribution"
 	"github.com/b42labs/tally/internal/engine/metering"
 	"github.com/b42labs/tally/internal/engine/pricing"
@@ -90,8 +91,16 @@ const (
 )
 
 // infrastructureTenant is the attributing relation type of the concept's
-// example.
-const infrastructureTenant = "infrastructure_tenant"
+// example, and managedBy the relation type its pricing adjustments hang off.
+const (
+	infrastructureTenant = "infrastructure_tenant"
+	managedBy            = "managed_by"
+)
+
+// adjustmentDepth is how many levels the adjustment walk of a case takes. The
+// cases below name a partner one edge away, so any depth of at least one
+// resolves them.
+const adjustmentDepth = 3
 
 // The period the cases bill: March 2026, the one the concept works through.
 var (
@@ -140,6 +149,34 @@ func relation(n, from, to int) source.Relation {
 		TargetID:     projectID(to),
 		RelationType: infrastructureTenant,
 	}
+}
+
+// relationWith is edge n of a given relation type, carrying the metadata a
+// pricing adjustment lives in. Empty metadata is a relation that adjusts
+// nothing, the way a relation created without one is stored.
+func relationWith(n, from, to int, relationType, metadata string) source.Relation {
+	edge := relation(n, from, to)
+	edge.RelationType = relationType
+	if metadata != "" {
+		edge.Metadata = json.RawMessage(metadata)
+	}
+	return edge
+}
+
+// adjusterOver resolves the adjustments of the given relations, which the case
+// expects to hold. A warning means the case built a relation it did not mean
+// to, so it fails there rather than on the numbers it produces.
+func adjusterOver(t *testing.T, relations []source.Relation, projects []source.Project) *adjustments.Adjuster {
+	t.Helper()
+
+	adjuster, warnings, err := adjustments.New(relations, projects, adjustmentDepth)
+	if err != nil {
+		t.Fatalf("adjustments.New() error = %v, want nil", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("adjustments.New() warnings = %+v, want none", warnings)
+	}
+	return adjuster
 }
 
 // resource is one candidate of the period.
@@ -201,7 +238,23 @@ func build(
 ) statements.BuildResult {
 	t.Helper()
 
-	result, err := statements.Build(periodFrom, periodTo, usage, rating.Rate(model, usage), projects, res)
+	return buildAdjusted(t, model, usage, projects, res, nil)
+}
+
+// buildAdjusted renders the same period with an adjuster over the project
+// graph, which is what a run hands in once it has resolved the adjustments of
+// the period.
+func buildAdjusted(
+	t *testing.T,
+	model pricing.Model,
+	usage []metering.ResourceUsage,
+	projects []source.Project,
+	res attribution.Resolution,
+	adjuster *adjustments.Adjuster,
+) statements.BuildResult {
+	t.Helper()
+
+	result, err := statements.Build(periodFrom, periodTo, usage, rating.Rate(model, usage), projects, res, adjuster)
 	if err != nil {
 		t.Fatalf("Build() error = %v, want nil", err)
 	}
@@ -278,6 +331,74 @@ func assertUsage(t *testing.T, period statements.Period, metric, want string) {
 		return
 	}
 	assertDecimal(t, "usage "+metric, quantity.Decimal, want)
+}
+
+// assertAmount holds one of the document's optional amount members against the
+// text it is expected to spell. A member the document does not carry fails the
+// case: the four adjustment members are rendered together or not at all.
+func assertAmount(t *testing.T, name string, got *money.Amount, want string) {
+	t.Helper()
+
+	if got == nil {
+		t.Errorf("%s is missing, want %s", name, want)
+		return
+	}
+	assertDecimal(t, name, got.Decimal, want)
+}
+
+// assertMemberOrder holds the marshalled document against the order the concept
+// prints its members in. The order is a property of the bytes, so it is read
+// off them: a decoded document carries the members in the order the Go type
+// declares them whatever the bytes held. Each name is searched for behind the
+// one ahead of it, so a name a nested object carries as well is not what the
+// next one is placed against.
+func assertMemberOrder(t *testing.T, body []byte, members ...string) {
+	t.Helper()
+
+	rest := body
+	for _, member := range members {
+		name := []byte(`"` + member + `":`)
+		at := bytes.Index(rest, name)
+		if at < 0 {
+			t.Fatalf("the document holds no %q behind the members ahead of it:\n%s", member, body)
+		}
+		rest = rest[at+len(name):]
+	}
+}
+
+// assertUnadjusted holds a statement against carrying no adjustment at all:
+// none of the four document members, no member name in the bytes, and no line
+// on the statement itself.
+func assertUnadjusted(t *testing.T, statement statements.Statement) {
+	t.Helper()
+
+	if statement.Adjustments != nil {
+		t.Errorf("Adjustments of %s = %+v, want none", statement.Key, statement.Adjustments)
+	}
+	document := documentOf(t, statement)
+	if document.BaseCost != nil || document.Adjustments != nil ||
+		document.NetCost != nil || document.KickbackTotal != nil {
+		t.Errorf("the document of %s decodes adjustment members, want none:\n%s", statement.Key, statement.Document)
+	}
+	for _, member := range []string{"base_cost", "adjustments", "net_cost", "kickback_total"} {
+		if bytes.Contains(statement.Document, []byte(`"`+member+`":`)) {
+			t.Errorf("the document of %s renders %q, want it left out:\n%s", statement.Key, member, statement.Document)
+		}
+	}
+}
+
+// powerCycleUsage is the usage of the concept's worked example, one instance
+// that ran for ten days, was shut off for ten and ran for the rest of March. It
+// is rated at 128.45, which is what the adjustment cases start from.
+func powerCycleUsage() []metering.ResourceUsage {
+	return []metering.ResourceUsage{{
+		Resource: resource(openstackCloud, "openstack", "instance", "abc-123"),
+		Drafts: []metering.UsageDraft{
+			draft("active", "proj-456", 240, m1Large(map[string]any{"egress_gb": float64(18.0)})),
+			draft("shutoff", "proj-456", 240, m1Large(map[string]any{"egress_gb": float64(0)})),
+			draft("active", "proj-456", 264, m1Large(map[string]any{"egress_gb": float64(22.5)})),
+		},
+	}}
 }
 
 // TestBuildRelatedCostsGolden renders the concept's related-costs example: a
@@ -430,6 +551,232 @@ func TestBuildPowerCycleDocument(t *testing.T) {
 	if !bytes.Equal(statement.Document, want) {
 		t.Errorf("Document =\n%s\nwant\n%s", statement.Document, want)
 	}
+}
+
+// TestBuildAdjustedDocument bills the concept's worked example through the
+// reseller of Phase 5: proj-456 is managed by a partner whose relation carries
+// a discount of 15 percent and a kickback of 10 percent on everything the
+// period was rated at. The document shows what it was rated at, what each
+// adjustment came to and what the customer pays, and its total is the net cost.
+func TestBuildAdjustedDocument(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "proj-456"),
+		project(2, "partner", "partner", "partner-corp"),
+	}
+	relations := []source.Relation{relationWith(1, 1, 2, managedBy, `{"pricing_adjustments":[
+		{"type": "discount", "rate": "0.15", "scope": "all", "description": "reseller discount"},
+		{"type": "kickback", "rate": "0.10", "scope": "all"}
+	]}`)}
+
+	result := buildAdjusted(t, mustParse(t, conceptModel), powerCycleUsage(), projects,
+		attribution.Resolve(projects, nil), adjusterOver(t, relations, projects))
+
+	statement := statementOf(t, result, "os-prod/proj-456")
+	assertDecimal(t, "Total", statement.Total, "109.18")
+	if len(statement.Adjustments) != 2 {
+		t.Fatalf("Statement.Adjustments = %d, want 2, the discount and the kickback", len(statement.Adjustments))
+	}
+
+	document := documentOf(t, statement)
+	assertAmount(t, "base_cost", document.BaseCost, "128.45")
+	assertAmount(t, "net_cost", document.NetCost, "109.18")
+	assertAmount(t, "kickback_total", document.KickbackTotal, "10.92")
+	// The total is what the customer pays, so the kickback the partner is owed
+	// sits beside it rather than in it.
+	assertDecimal(t, "document total", document.Total.Decimal, "109.18")
+
+	if len(document.Adjustments) != 2 {
+		t.Fatalf("adjustments = %d, want 2", len(document.Adjustments))
+	}
+	lines := []struct {
+		name        string
+		kind        string
+		rate        string
+		base        string
+		amount      string
+		description string
+	}{
+		// 15 percent of the rated total is 19.2675, rounded half away from zero.
+		{"the discount off the rated total", "discount", "0.15", "128.45", "-19.27", "reseller discount"},
+		// The kickback is rated on the net cost, 10.918 of it, and leaves it be.
+		{"the kickback off the net cost", "kickback", "0.10", "109.18", "10.92", ""},
+	}
+	for i, want := range lines {
+		t.Run(want.name, func(t *testing.T) {
+			line := document.Adjustments[i]
+			if line.Type != want.kind {
+				t.Errorf("type = %q, want %q", line.Type, want.kind)
+			}
+			if line.RelationType != managedBy || line.RelationTarget != "partner-corp" {
+				t.Errorf("the line names %s/%s, want %s/partner-corp",
+					line.RelationType, line.RelationTarget, managedBy)
+			}
+			if line.RelationID != relationID(1).String() {
+				t.Errorf("relation_id = %q, want %q", line.RelationID, relationID(1))
+			}
+			if line.Scope != "all" {
+				t.Errorf("scope = %q, want all", line.Scope)
+			}
+			if line.Description != want.description {
+				t.Errorf("description = %q, want %q", line.Description, want.description)
+			}
+			assertDecimal(t, "rate", line.Rate.Decimal, want.rate)
+			assertDecimal(t, "base", line.Base.Decimal, want.base)
+			assertDecimal(t, "amount", line.Amount.Decimal, want.amount)
+			// The statement carries the lines the document shows, which is what
+			// the run stores as its adjustment records.
+			if got := statement.Adjustments[i].Amount.StringFixed(2); got != want.amount {
+				t.Errorf("Statement.Adjustments[%d] = %s, want %s", i, got, want.amount)
+			}
+		})
+	}
+
+	assertMemberOrder(t, statement.Document,
+		"billing_period", "project_id", "platform", "line_items", "related_costs",
+		"base_cost", "adjustments", "net_cost", "kickback_total", "total", "currency")
+}
+
+// TestBuildAdjustsRelatedCosts adjusts a statement over the costs of the
+// project attributed to it. The workers of the shoot are billed on team-alpha's
+// document as a related cost, so a discount scoped to the OpenStack instances
+// reaches them: the customer pays one document, however many projects the lines
+// under it were metered in.
+//
+// The second half hangs the same discount off the tenant's own relation. The
+// walk starts at the project the statement is keyed to, which the tenant is
+// not, so nothing reaches the document and it renders the bytes an unadjusted
+// build renders.
+func TestBuildAdjustsRelatedCosts(t *testing.T) {
+	projects := []source.Project{
+		project(1, gardenerCloud, "gardener", "team-alpha"),
+		project(2, openstackCloud, "openstack", "shoot-abc-os-tenant"),
+		project(3, "partner", "partner", "partner-corp"),
+	}
+	usage := []metering.ResourceUsage{
+		{
+			Resource: resource(gardenerCloud, "gardener", "shoot", "shoot-abc"),
+			Drafts: []metering.UsageDraft{
+				draft("active", "team-alpha", 744, map[string]any{"worker_count": float64(3)}),
+			},
+		},
+		{
+			Resource: resource(openstackCloud, "openstack", "instance", "worker-1"),
+			Drafts: []metering.UsageDraft{
+				draft("active", "shoot-abc-os-tenant", 744, map[string]any{
+					"vcpus":   float64(8),
+					"ram_gb":  float64(16),
+					"disk_gb": float64(160),
+				}),
+			},
+		},
+	}
+	const discount = `{"pricing_adjustments": [{"type": "discount", "rate": "0.10", "scope": "openstack.instance"}]}`
+
+	model := mustParse(t, conceptModel)
+	res := attribution.Resolve(projects, []source.Relation{relation(1, 1, 2)})
+
+	adjusted := buildAdjusted(t, model, usage, projects, res,
+		adjusterOver(t, []source.Relation{relationWith(2, 1, 3, managedBy, discount)}, projects))
+
+	statement := statementOf(t, adjusted, "gardener-prod/team-alpha")
+	assertDecimal(t, "Total", statement.Total, "491.04")
+	document := documentOf(t, statement)
+	assertAmount(t, "base_cost", document.BaseCost, "520.80")
+	assertAmount(t, "net_cost", document.NetCost, "491.04")
+	assertAmount(t, "kickback_total", document.KickbackTotal, "0.00")
+	if len(document.Adjustments) != 1 {
+		t.Fatalf("adjustments = %d, want 1, the discount", len(document.Adjustments))
+	}
+	// The shoot is out of scope and the tenant's worker is in it, although the
+	// worker is billed here as a related cost rather than as a line of its own.
+	assertDecimal(t, "base", document.Adjustments[0].Base.Decimal, "297.60")
+	assertDecimal(t, "amount", document.Adjustments[0].Amount.Decimal, "-29.76")
+
+	unreached := buildAdjusted(t, model, usage, projects, res,
+		adjusterOver(t, []source.Relation{relationWith(2, 2, 3, managedBy, discount)}, projects))
+
+	untouched := statementOf(t, unreached, "gardener-prod/team-alpha")
+	assertDecimal(t, "Total of the statement the walk does not reach", untouched.Total, "520.80")
+	assertUnadjusted(t, untouched)
+	want := statementOf(t, build(t, model, usage, projects, res), "gardener-prod/team-alpha")
+	if !bytes.Equal(untouched.Document, want.Document) {
+		t.Errorf("Document =\n%s\nwant the bytes of a build without an adjuster\n%s",
+			untouched.Document, want.Document)
+	}
+}
+
+// TestBuildWithoutAdjustmentsIsByteIdentical renders the concept's worked
+// example three ways that adjust nothing. A statement no adjustment reaches
+// carries none of the four members, so the document is the fixture byte for
+// byte and an operator reading it sees what Phase 3 renders.
+func TestBuildWithoutAdjustmentsIsByteIdentical(t *testing.T) {
+	projects := []source.Project{
+		project(1, openstackCloud, "openstack", "proj-456"),
+		project(2, "partner", "partner", "partner-corp"),
+	}
+	want, err := os.ReadFile(filepath.Join("testdata", "power_cycle.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		adjuster *adjustments.Adjuster
+	}{
+		{name: "no adjuster at all", adjuster: nil},
+		{name: "an adjuster over no relations", adjuster: adjusterOver(t, nil, projects)},
+		{
+			name: "a relation that carries no metadata",
+			adjuster: adjusterOver(t,
+				[]source.Relation{relationWith(1, 1, 2, managedBy, "")}, projects),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildAdjusted(t, mustParse(t, conceptModel), powerCycleUsage(), projects,
+				attribution.Resolve(projects, nil), tc.adjuster)
+
+			statement := statementOf(t, result, "os-prod/proj-456")
+			assertDecimal(t, "Total", statement.Total, "128.45")
+			assertUnadjusted(t, statement)
+			if !bytes.Equal(statement.Document, want) {
+				t.Errorf("Document =\n%s\nwant\n%s", statement.Document, want)
+			}
+		})
+	}
+}
+
+// TestBuildUnregisteredProjectIsNotAdjusted bills drafts under a project id no
+// registry row matches. The pair is billed standalone, and there is no project
+// to walk from: the discount of a registered project that carries the same
+// external id in another cloud is not that pair's, and an external id is unique
+// per cloud only.
+func TestBuildUnregisteredProjectIsNotAdjusted(t *testing.T) {
+	projects := []source.Project{
+		project(1, gardenerCloud, "gardener", "proj-456"),
+		project(2, "partner", "partner", "partner-corp"),
+	}
+	usage := []metering.ResourceUsage{{
+		Resource: resource(openstackCloud, "openstack", "instance", "abc-123"),
+		Drafts:   []metering.UsageDraft{draft("active", "proj-456", 240, m1Large(nil))},
+	}}
+	relations := []source.Relation{relationWith(1, 1, 2, managedBy,
+		`{"pricing_adjustments": [{"type": "discount", "rate": "0.5", "scope": "all"}]}`)}
+
+	result := buildAdjusted(t, mustParse(t, conceptModel), usage, projects,
+		attribution.Resolve(projects, nil), adjusterOver(t, relations, projects))
+
+	if got := keys(result); !reflect.DeepEqual(got, []string{"os-prod/proj-456"}) {
+		t.Fatalf("statement keys = %v, want only os-prod/proj-456, billed under its raw id", got)
+	}
+	unregistered := []statements.UnregisteredProject{
+		{Cloud: openstackCloud, ProjectID: "proj-456", Resources: 1},
+	}
+	if !reflect.DeepEqual(result.Unregistered, unregistered) {
+		t.Errorf("Unregistered = %+v, want %+v", result.Unregistered, unregistered)
+	}
+	assertDecimal(t, "Total", result.Statements[0].Total, "48.00")
+	assertUnadjusted(t, result.Statements[0])
 }
 
 // TestBuildPartialHours renders drafts that did not run for whole hours. Hours
@@ -802,7 +1149,7 @@ func TestBuildEmptyInputs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := statements.Build(periodFrom, periodTo, tc.usage, tc.rated, nil, attribution.Resolution{})
+			result, err := statements.Build(periodFrom, periodTo, tc.usage, tc.rated, nil, attribution.Resolution{}, nil)
 			if err != nil {
 				t.Fatalf("Build() error = %v, want nil", err)
 			}
@@ -825,7 +1172,7 @@ func TestBuildReservedTotalMetric(t *testing.T) {
 	model := mustParse(t, reservedModel)
 
 	_, err := statements.Build(periodFrom, periodTo, usage, rating.Rate(model, usage), projects,
-		attribution.Resolve(projects, nil))
+		attribution.Resolve(projects, nil), nil)
 
 	if err == nil {
 		t.Fatalf("Build() error = nil, want the reserved metric refused")
@@ -872,7 +1219,7 @@ func TestBuildAlignmentErrors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := statements.Build(periodFrom, periodTo, tc.usage, tc.rated, nil, attribution.Resolution{})
+			_, err := statements.Build(periodFrom, periodTo, tc.usage, tc.rated, nil, attribution.Resolution{}, nil)
 			if err == nil {
 				t.Fatalf("Build() error = nil, want the misaligned resource refused")
 			}

--- a/internal/engine/store/migrate_test.go
+++ b/internal/engine/store/migrate_test.go
@@ -23,9 +23,10 @@ var chainVersions = func() []int64 {
 	return versions
 }()
 
-// wantTables is every table migration 0001 creates, sorted. Goose's own
+// wantTables is every table the embedded chain creates, sorted. Goose's own
 // bookkeeping table is not part of the schema and the queries below exclude it.
 var wantTables = []string{
+	"adjustment_records",
 	"billing_periods",
 	"correction_deltas",
 	"pricing_models",
@@ -63,7 +64,7 @@ func TestMigrate(t *testing.T) {
 		defer s.Close()
 
 		if tables := publicTables(t, s); !slices.Equal(tables, wantTables) {
-			t.Errorf("tables = %v, want the seven of the schema %v", tables, wantTables)
+			t.Errorf("tables = %v, want the eight of the schema %v", tables, wantTables)
 		}
 	})
 
@@ -82,8 +83,11 @@ func TestMigrate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("MigrateDownTo(0) error = %v, want nil", err)
 		}
-		if !slices.Equal(rolledBack, chainVersions) {
-			t.Errorf("MigrateDownTo(0) = %v, want %v", rolledBack, chainVersions)
+		// Newest first, the order a rollback has to run in.
+		want := slices.Clone(chainVersions)
+		slices.Reverse(want)
+		if !slices.Equal(rolledBack, want) {
+			t.Errorf("MigrateDownTo(0) = %v, want %v", rolledBack, want)
 		}
 		if tables := publicTables(t, db.Store); len(tables) != 0 {
 			t.Errorf("tables after the rollback = %v, want an empty schema", tables)
@@ -387,13 +391,14 @@ func seedRun(t *testing.T, s *store.Store) string {
 
 // records holds one seeded row per table the record trigger guards.
 type records struct {
-	usage     string
-	rated     string
-	statement string
-	delta     string
+	usage      string
+	rated      string
+	statement  string
+	delta      string
+	adjustment string
 }
 
-// seedRecords writes one row into each of the four tables the record trigger
+// seedRecords writes one row into each of the five tables the record trigger
 // guards, all of them belonging to runID. The tag keeps two sets of the same run
 // apart: project_statements holds at most one row per (run_id, project_id), so a
 // second set needs a project of its own.
@@ -445,6 +450,18 @@ func seedRecords(t *testing.T, s *store.Store, runID, tag string) records {
 		 RETURNING id`, runID, resource, project).Scan(&seeded.delta); err != nil {
 		t.Fatalf("seeding the %s correction delta: %v", tag, err)
 	}
+
+	// The relation an adjustment came from lives in the reporting database, so
+	// relation_id is provenance rather than a foreign key and any id serves here.
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO adjustment_records (run_id, project_id, relation_id, relation_type,
+		                                 relation_target, type, scope, rate, base,
+		                                 amount, currency)
+		 VALUES ($1, $2, gen_random_uuid(), 'managed_by', $3, 'discount', 'all',
+		         0.150000, 12.00, -1.80, 'EUR')
+		 RETURNING id`, runID, project, "partner-"+tag).Scan(&seeded.adjustment); err != nil {
+		t.Fatalf("seeding the %s adjustment record: %v", tag, err)
+	}
 	return seeded
 }
 
@@ -464,7 +481,7 @@ func (g guardedRow) deleteRow() string {
 	return "DELETE FROM " + g.table + " WHERE id = $1"
 }
 
-// guarded is the seeded set as the four rows the tests work through.
+// guarded is the seeded set as the five rows the tests work through.
 // rated_records comes first because its foreign key points at usage_records:
 // deleting the set in this order is the only order that works.
 func (r records) guarded() []guardedRow {
@@ -498,6 +515,15 @@ func (r records) guarded() []guardedRow {
 			                                       dimension, old_amount, new_amount, delta, currency)
 			         VALUES ($1, $1, 'os-prod-eu1', 'openstack', 'instance', 'instance-added',
 			                 'project-added', 'minutes', 10.00, 4210.00, 4200.00, 'EUR')`,
+		},
+		{
+			table: "adjustment_records", id: r.adjustment,
+			update: `UPDATE adjustment_records SET amount = amount + 1 WHERE id = $1`,
+			insert: `INSERT INTO adjustment_records (run_id, project_id, relation_id, relation_type,
+			                                        relation_target, type, scope, rate, base,
+			                                        amount, currency)
+			         VALUES ($1, 'project-added', gen_random_uuid(), 'managed_by', 'partner-added',
+			                 'discount', 'all', 0.150000, 4200.00, -630.00, 'EUR')`,
 		},
 	}
 }

--- a/internal/engine/store/queries.sql
+++ b/internal/engine/store/queries.sql
@@ -261,6 +261,17 @@ FROM correction_deltas
 WHERE run_id = $1
 ORDER BY cloud, platform, resource_type, resource_id, project_id, dimension;
 
+-- The adjustments a run applied, in a total order over the rows one run writes:
+-- a project's adjustments come from distinct relations, and one relation
+-- contributes at most one line per type and scope. A correction diffs these
+-- rows against its own, which is what the order is for.
+-- name: ListAdjustmentRecords :many
+SELECT id, run_id, project_id, relation_id, relation_type, relation_target,
+       beneficiary, type, scope, rate, base, amount, currency
+FROM adjustment_records
+WHERE run_id = $1
+ORDER BY project_id, relation_id, type, scope, rate, amount;
+
 -- The record writes of a run, over the COPY protocol: a month of metering is
 -- tens of thousands of rows, and one round trip per row is what that costs.
 -- All three name id rather than leaving it to the column default, because COPY
@@ -279,4 +290,11 @@ VALUES ($1, $2, $3, $4, $5, $6);
 -- name: CreateCorrectionDeltas :copyfrom
 INSERT INTO correction_deltas (id, run_id, corrects_run_id, cloud, platform, resource_type, resource_id,
                                project_id, dimension, old_amount, new_amount, delta, currency)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+
+-- The adjustment rows of a run, over the same protocol and naming id for the
+-- same reason: COPY evaluates no defaults.
+-- name: CreateAdjustmentRecords :copyfrom
+INSERT INTO adjustment_records (id, run_id, project_id, relation_id, relation_type, relation_target,
+                                beneficiary, type, scope, rate, base, amount, currency)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);

--- a/internal/engine/store/queries_test.go
+++ b/internal/engine/store/queries_test.go
@@ -8,7 +8,9 @@
 // current numbers.
 //
 // The queries a correction is built from are held here too: which run it takes
-// as its baseline, the key it diffs by, and the delta rows it writes.
+// as its baseline, the key it diffs by, the delta rows it writes, and the
+// adjustment records a run writes its applied adjustments into, which a
+// correction diffs against its own.
 //
 // The reads an export loads a run through are held here as well: the run row
 // itself, taken without a lock, and the two listings whose ordering is what
@@ -24,11 +26,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 	"github.com/b42labs/tally/internal/engine/store/storetest"
 )
+
+// checkViolation is the SQLSTATE a refused CHECK comes back as.
+const checkViolation = "23514"
 
 // TestRunEndsRequireARunningRun holds CompleteRun and FailRun to the status they
 // move from. A run whose process is still metering can be failed underneath it
@@ -589,6 +595,200 @@ func TestListCorrectionDeltas(t *testing.T) {
 	})
 }
 
+// TestCreateAdjustmentRecords holds the copy of the adjustments a run applied.
+// A kickback row is what a partner is paid from, so the rate, the base it was
+// taken on and the beneficiary have to come back exactly as they went in.
+func TestCreateAdjustmentRecords(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	run := openRun(t, db, "running")
+	// The relation lives in the reporting database, so the column is provenance
+	// rather than a foreign key and the id is made up here.
+	relation := pgtype.UUID{Bytes: uuid.New(), Valid: true}
+
+	type stored struct {
+		typ, rate, base, amount, currency string
+		beneficiary                       pgtype.Text
+		relationID                        pgtype.UUID
+	}
+
+	t.Run("copies the adjustments of a run", func(t *testing.T) {
+		partner := pgtype.Text{String: "partner-corp", Valid: true}
+		records := []sqlcgen.CreateAdjustmentRecordsParams{
+			adjustmentRecord(t, run, relation, "tenant-a", "discount", "0.150000",
+				"100.00", "-15.00", pgtype.Text{}),
+			adjustmentRecord(t, run, relation, "tenant-a", "kickback", "0.100000",
+				"85.00", "8.50", partner),
+		}
+
+		copied, err := q.CreateAdjustmentRecords(t.Context(), records)
+		if err != nil {
+			t.Fatalf("CreateAdjustmentRecords() error = %v, want nil", err)
+		}
+		if copied != 2 {
+			t.Fatalf("CreateAdjustmentRecords() copied %d rows, want 2", copied)
+		}
+
+		rows, err := db.Store.Pool().Query(t.Context(),
+			`SELECT type, rate::text, base::text, amount::text, currency, beneficiary, relation_id
+			 FROM adjustment_records WHERE run_id = $1 ORDER BY type`, run)
+		if err != nil {
+			t.Fatalf("reading the adjustments back: %v", err)
+		}
+		defer rows.Close()
+
+		var got []stored
+		for rows.Next() {
+			var row stored
+			if err := rows.Scan(&row.typ, &row.rate, &row.base, &row.amount,
+				&row.currency, &row.beneficiary, &row.relationID); err != nil {
+				t.Fatalf("reading an adjustment back: %v", err)
+			}
+			got = append(got, row)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("reading the adjustments back: %v", err)
+		}
+		// The discount carries no beneficiary: only a kickback is owed to someone
+		// other than the project the statement belongs to.
+		want := []stored{
+			{"discount", "0.150000", "100.00", "-15.00", "EUR", pgtype.Text{}, relation},
+			{"kickback", "0.100000", "85.00", "8.50", "EUR", partner, relation},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("the stored adjustments are %v, want %v", got, want)
+		}
+	})
+
+	t.Run("copies nothing for an empty batch", func(t *testing.T) {
+		copied, err := q.CreateAdjustmentRecords(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("CreateAdjustmentRecords() error = %v, want nil", err)
+		}
+		if copied != 0 {
+			t.Errorf("CreateAdjustmentRecords() copied %d rows, want 0", copied)
+		}
+	})
+}
+
+// TestAdjustmentBeneficiaryIsKickbacksOnly holds the invariant the migration
+// header states against the database rather than against the one writer that
+// keeps it. What a partner is paid is the sum of the amounts under a
+// beneficiary, so a beneficiary on a discount row is a payout of the customer's
+// own rebate, and a kickback without one is a payout that reaches nobody.
+// Neither can be corrected in place: a finalized run's rows are immutable.
+func TestAdjustmentBeneficiaryIsKickbacksOnly(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	run := openRun(t, db, "running")
+	relation := pgtype.UUID{Bytes: uuid.New(), Valid: true}
+	partner := pgtype.Text{String: "partner-corp", Valid: true}
+
+	cases := []struct {
+		name   string
+		record sqlcgen.CreateAdjustmentRecordsParams
+	}{
+		{
+			name: "a discount that names a beneficiary",
+			record: adjustmentRecord(t, run, relation, "tenant-a", "discount", "0.150000",
+				"100.00", "-15.00", partner),
+		},
+		{
+			name: "a kickback that names none",
+			record: adjustmentRecord(t, run, relation, "tenant-a", "kickback", "0.100000",
+				"85.00", "8.50", pgtype.Text{}),
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := q.CreateAdjustmentRecords(t.Context(),
+				[]sqlcgen.CreateAdjustmentRecordsParams{testCase.record})
+
+			var pgErr *pgconn.PgError
+			if !errors.As(err, &pgErr) {
+				t.Fatalf("CreateAdjustmentRecords() error = %v, want a Postgres error", err)
+			}
+			if pgErr.Code != checkViolation {
+				t.Errorf("CreateAdjustmentRecords() error code = %s, want %s", pgErr.Code, checkViolation)
+			}
+		})
+	}
+}
+
+// TestListAdjustmentRecords pins the total order the adjustments of a run come
+// back in. The rows land through a copy, which keeps no order of its own, so a
+// correction diffing its adjustments against the corrected run's needs the
+// order to come from the statement.
+func TestListAdjustmentRecords(t *testing.T) {
+	db := storetest.NewDB(t)
+	q := sqlcgen.New(db.Store.Pool())
+
+	run := openRun(t, db, "completed")
+	// Two relation ids that sort the way their names read, so the case can assert
+	// the position relation_id holds in the order.
+	first := pgtype.UUID{Bytes: uuid.MustParse("11111111-1111-1111-1111-111111111111"), Valid: true}
+	second := pgtype.UUID{Bytes: uuid.MustParse("22222222-2222-2222-2222-222222222222"), Valid: true}
+
+	// Written in none of the orders the case asserts. Every pair of neighbours in
+	// the wanted order below differs in one key column, so each of the six is read.
+	seedAdjustmentRecord(t, db, run, first, "tenant-b", "discount", "all", "0.100000", "-10.00")
+	seedAdjustmentRecord(t, db, run, second, "tenant-a", "discount", "all", "0.100000", "-5.00")
+	seedAdjustmentRecord(t, db, run, first, "tenant-a", "kickback", "all", "0.100000", "5.00")
+	seedAdjustmentRecord(t, db, run, first, "tenant-a", "discount", "openstack", "0.100000", "-3.00")
+	seedAdjustmentRecord(t, db, run, first, "tenant-a", "discount", "all", "0.200000", "-8.00")
+	seedAdjustmentRecord(t, db, run, first, "tenant-a", "discount", "all", "0.100000", "-1.00")
+	seedAdjustmentRecord(t, db, run, first, "tenant-a", "discount", "all", "0.100000", "-2.00")
+
+	// A second run of the next month, so the filter has something to leave out.
+	other := openRun(t, db, "completed")
+	seedAdjustmentRecord(t, db, other, first, "tenant-a", "discount", "all", "0.100000", "-99.00")
+
+	type record struct {
+		projectID, typ, scope, rate, amount string
+		relationID                          pgtype.UUID
+	}
+
+	t.Run("reads the adjustments of one run in the stored order", func(t *testing.T) {
+		rows, err := q.ListAdjustmentRecords(t.Context(), run)
+		if err != nil {
+			t.Fatalf("ListAdjustmentRecords() error = %v, want nil", err)
+		}
+		got := make([]record, 0, len(rows))
+		for _, row := range rows {
+			got = append(got, record{
+				row.ProjectID, row.Type, row.Scope,
+				amountText(t, row.Rate), amountText(t, row.Amount), row.RelationID,
+			})
+		}
+		want := []record{
+			{"tenant-a", "discount", "all", "0.100000", "-2.00", first},
+			{"tenant-a", "discount", "all", "0.100000", "-1.00", first},
+			{"tenant-a", "discount", "all", "0.200000", "-8.00", first},
+			{"tenant-a", "discount", "openstack", "0.100000", "-3.00", first},
+			{"tenant-a", "kickback", "all", "0.100000", "5.00", first},
+			{"tenant-a", "discount", "all", "0.100000", "-5.00", second},
+			{"tenant-b", "discount", "all", "0.100000", "-10.00", first},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ListAdjustmentRecords() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("reports nothing for a run that adjusted nothing", func(t *testing.T) {
+		empty := openRun(t, db, "completed")
+
+		rows, err := q.ListAdjustmentRecords(t.Context(), empty)
+		if err != nil {
+			t.Fatalf("ListAdjustmentRecords() error = %v, want nil", err)
+		}
+		if len(rows) != 0 {
+			t.Errorf("ListAdjustmentRecords() = %v, want no rows", rows)
+		}
+	})
+}
+
 // runSeed is the run a case starts from: its kind, the status it carries, the
 // run it corrects where it is a correction, and the time it started. An
 // invalid correctsRunID is the NULL a run that corrects nothing stores, and a
@@ -708,6 +908,31 @@ func seedCorrectionDelta(
 	}
 }
 
+// seedAdjustmentRecord writes one applied adjustment under a run. The columns
+// the listing orders by are what a case passes; base is one fixed amount,
+// because nothing here reads it. The beneficiary follows the type rather than
+// the caller, because the table admits one on a kickback row alone.
+func seedAdjustmentRecord(
+	t *testing.T,
+	db storetest.DB,
+	runID, relationID pgtype.UUID,
+	projectID, typ, scope, rate, amount string,
+) {
+	t.Helper()
+
+	if _, err := db.Store.Pool().Exec(t.Context(),
+		`INSERT INTO adjustment_records (run_id, project_id, relation_id, relation_type,
+		                                 relation_target, beneficiary, type, scope, rate, base,
+		                                 amount, currency)
+		 VALUES ($1, $2, $3, 'managed_by', 'partner-corp',
+		         CASE WHEN $4::text = 'kickback' THEN 'partner-corp' END,
+		         $4, $5, $6, 100.00, $7, 'EUR')`,
+		runID, projectID, relationID, typ, scope,
+		numeric(t, rate), numeric(t, amount)); err != nil {
+		t.Fatalf("seeding the %s adjustment of %s: %v", typ, projectID, err)
+	}
+}
+
 // correctionDelta is one delta row as a case hands it to the copy.
 func correctionDelta(
 	t *testing.T,
@@ -733,8 +958,35 @@ func correctionDelta(
 	}
 }
 
-// numeric is an amount on its way into a NUMERIC(14,2) column. It reaches the
-// column as text rather than through a float (roadmap/00-conventions.md
+// adjustmentRecord is one applied adjustment as a case hands it to the copy.
+// beneficiary is the caller's, because it is set on kickback rows alone.
+func adjustmentRecord(
+	t *testing.T,
+	runID, relationID pgtype.UUID,
+	projectID, typ, rate, base, amount string,
+	beneficiary pgtype.Text,
+) sqlcgen.CreateAdjustmentRecordsParams {
+	t.Helper()
+
+	return sqlcgen.CreateAdjustmentRecordsParams{
+		ID:             pgtype.UUID{Bytes: uuid.New(), Valid: true},
+		RunID:          runID,
+		ProjectID:      projectID,
+		RelationID:     relationID,
+		RelationType:   "managed_by",
+		RelationTarget: "partner-corp",
+		Beneficiary:    beneficiary,
+		Type:           typ,
+		Scope:          "all",
+		Rate:           numeric(t, rate),
+		Base:           numeric(t, base),
+		Amount:         numeric(t, amount),
+		Currency:       "EUR",
+	}
+}
+
+// numeric is an amount or a rate on its way into a NUMERIC column. It reaches
+// the column as text rather than through a float (roadmap/00-conventions.md
 // section 6).
 func numeric(t *testing.T, amount string) pgtype.Numeric {
 	t.Helper()

--- a/internal/engine/store/sqlcgen/copyfrom.go
+++ b/internal/engine/store/sqlcgen/copyfrom.go
@@ -9,6 +9,52 @@ import (
 	"context"
 )
 
+// iteratorForCreateAdjustmentRecords implements pgx.CopyFromSource.
+type iteratorForCreateAdjustmentRecords struct {
+	rows                 []CreateAdjustmentRecordsParams
+	skippedFirstNextCall bool
+}
+
+func (r *iteratorForCreateAdjustmentRecords) Next() bool {
+	if len(r.rows) == 0 {
+		return false
+	}
+	if !r.skippedFirstNextCall {
+		r.skippedFirstNextCall = true
+		return true
+	}
+	r.rows = r.rows[1:]
+	return len(r.rows) > 0
+}
+
+func (r iteratorForCreateAdjustmentRecords) Values() ([]interface{}, error) {
+	return []interface{}{
+		r.rows[0].ID,
+		r.rows[0].RunID,
+		r.rows[0].ProjectID,
+		r.rows[0].RelationID,
+		r.rows[0].RelationType,
+		r.rows[0].RelationTarget,
+		r.rows[0].Beneficiary,
+		r.rows[0].Type,
+		r.rows[0].Scope,
+		r.rows[0].Rate,
+		r.rows[0].Base,
+		r.rows[0].Amount,
+		r.rows[0].Currency,
+	}, nil
+}
+
+func (r iteratorForCreateAdjustmentRecords) Err() error {
+	return nil
+}
+
+// The adjustment rows of a run, over the same protocol and naming id for the
+// same reason: COPY evaluates no defaults.
+func (q *Queries) CreateAdjustmentRecords(ctx context.Context, arg []CreateAdjustmentRecordsParams) (int64, error) {
+	return q.db.CopyFrom(ctx, []string{"adjustment_records"}, []string{"id", "run_id", "project_id", "relation_id", "relation_type", "relation_target", "beneficiary", "type", "scope", "rate", "base", "amount", "currency"}, &iteratorForCreateAdjustmentRecords{rows: arg})
+}
+
 // iteratorForCreateCorrectionDeltas implements pgx.CopyFromSource.
 type iteratorForCreateCorrectionDeltas struct {
 	rows                 []CreateCorrectionDeltasParams

--- a/internal/engine/store/sqlcgen/models.go
+++ b/internal/engine/store/sqlcgen/models.go
@@ -8,6 +8,22 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type AdjustmentRecord struct {
+	ID             pgtype.UUID
+	RunID          pgtype.UUID
+	ProjectID      string
+	RelationID     pgtype.UUID
+	RelationType   string
+	RelationTarget string
+	Beneficiary    pgtype.Text
+	Type           string
+	Scope          string
+	Rate           pgtype.Numeric
+	Base           pgtype.Numeric
+	Amount         pgtype.Numeric
+	Currency       string
+}
+
 type BillingPeriod struct {
 	PeriodFrom     pgtype.Timestamptz
 	PeriodTo       pgtype.Timestamptz

--- a/internal/engine/store/sqlcgen/queries.sql.go
+++ b/internal/engine/store/sqlcgen/queries.sql.go
@@ -72,6 +72,22 @@ func (q *Queries) ConsecutiveFailedRuns(ctx context.Context, periodFrom pgtype.T
 	return i, err
 }
 
+type CreateAdjustmentRecordsParams struct {
+	ID             pgtype.UUID
+	RunID          pgtype.UUID
+	ProjectID      string
+	RelationID     pgtype.UUID
+	RelationType   string
+	RelationTarget string
+	Beneficiary    pgtype.Text
+	Type           string
+	Scope          string
+	Rate           pgtype.Numeric
+	Base           pgtype.Numeric
+	Amount         pgtype.Numeric
+	Currency       string
+}
+
 type CreateCorrectionDeltasParams struct {
 	ID            pgtype.UUID
 	RunID         pgtype.UUID
@@ -427,6 +443,52 @@ func (q *Queries) LatestFinalizedRun(ctx context.Context, periodFrom pgtype.Time
 		&i.StartedAt,
 	)
 	return i, err
+}
+
+const listAdjustmentRecords = `-- name: ListAdjustmentRecords :many
+SELECT id, run_id, project_id, relation_id, relation_type, relation_target,
+       beneficiary, type, scope, rate, base, amount, currency
+FROM adjustment_records
+WHERE run_id = $1
+ORDER BY project_id, relation_id, type, scope, rate, amount
+`
+
+// The adjustments a run applied, in a total order over the rows one run writes:
+// a project's adjustments come from distinct relations, and one relation
+// contributes at most one line per type and scope. A correction diffs these
+// rows against its own, which is what the order is for.
+func (q *Queries) ListAdjustmentRecords(ctx context.Context, runID pgtype.UUID) ([]AdjustmentRecord, error) {
+	rows, err := q.db.Query(ctx, listAdjustmentRecords, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AdjustmentRecord
+	for rows.Next() {
+		var i AdjustmentRecord
+		if err := rows.Scan(
+			&i.ID,
+			&i.RunID,
+			&i.ProjectID,
+			&i.RelationID,
+			&i.RelationType,
+			&i.RelationTarget,
+			&i.Beneficiary,
+			&i.Type,
+			&i.Scope,
+			&i.Rate,
+			&i.Base,
+			&i.Amount,
+			&i.Currency,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listBillingPeriods = `-- name: ListBillingPeriods :many

--- a/migrations/engine/0002_adjustment_records.sql
+++ b/migrations/engine/0002_adjustment_records.sql
@@ -1,0 +1,50 @@
+-- The applied pricing adjustments of a run: one row per adjustment a run put on
+-- a project statement, with the relation it came from, the rate, the amount the
+-- rate was applied to and the signed amount it produced.
+--
+-- The normative specification is roadmap/05-phase-5-commercial-pricing.md,
+-- WP 5.3 and decision D8. The rows exist beside the statement documents because
+-- a kickback is settled per beneficiary across all of a run's projects, and a
+-- sum over JSONB documents is not a query the reporting side can serve.
+--
+-- The table is a run artifact like the records of migration 0001, so it carries
+-- the same forbid_finalized_mutation trigger: what a run pays out is the sum
+-- over these rows, and a finalized run is immutable (guardrail 7 of
+-- roadmap/00-conventions.md).
+--
+-- Two columns go past the roadmap's table. They are named here rather than
+-- added silently, per guardrail 10 of roadmap/00-conventions.md: relation_type
+-- and relation_target hold the kind of relation the adjustment was collected
+-- from and the external id it points at, so a record and a credit-note line
+-- name that relation without a second lookup in the reporting database.
+-- beneficiary stays what D8 defines, a partner's external id, and it is set on
+-- kickback rows alone.
+
+-- +goose Up
+CREATE TABLE adjustment_records (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id          UUID NOT NULL REFERENCES runs(id),
+    project_id      TEXT NOT NULL,             -- the statement key, as project_statements.project_id
+    relation_id     UUID NOT NULL,             -- provenance: project_relations.id in the reporting database
+    relation_type   TEXT NOT NULL,
+    relation_target TEXT NOT NULL,             -- the target's external id
+    beneficiary     TEXT,                      -- the partner's external id, kickbacks only
+    type            TEXT NOT NULL,             -- surcharge | discount | project_discount | kickback
+    scope           TEXT NOT NULL,
+    rate            NUMERIC(8,6) NOT NULL,
+    base            NUMERIC(14,2) NOT NULL,    -- the amount the rate was applied to
+    amount          NUMERIC(14,2) NOT NULL,    -- signed: discounts negative
+    currency        TEXT NOT NULL,
+    -- What a partner is paid is a sum over the rows idx_adjustments_run serves,
+    -- and that sum reads a beneficiary as a kickback. A beneficiary on any other
+    -- type turns a customer's discount into a payout, on rows a finalized run
+    -- holds immutable, so the invariant the header states is checked here rather
+    -- than left to the one writer in internal/engine/runs/store.go.
+    CHECK ((type = 'kickback') = (beneficiary IS NOT NULL))
+);
+CREATE INDEX idx_adjustments_run ON adjustment_records (run_id, beneficiary);
+CREATE TRIGGER trg_adjustment_immutable BEFORE INSERT OR UPDATE OR DELETE ON adjustment_records
+    FOR EACH ROW EXECUTE FUNCTION forbid_finalized_mutation();
+
+-- +goose Down
+DROP TABLE adjustment_records;

--- a/migrations/engine/embed.go
+++ b/migrations/engine/embed.go
@@ -16,4 +16,4 @@ var FS embed.FS
 // binary built from this tree expects.
 //
 // Adding a migration means raising this; a test fails otherwise.
-const Version int64 = 1
+const Version int64 = 2


### PR DESCRIPTION
Closes #56

The engine's statement stage now resolves pricing adjustments from the project graph and applies them. For every statement of a registered project the run walks the project's outgoing adjustment-carrying relations breadth-first (`managed_by,member_of`, depth 3 by default), reads the `pricing_adjustments` each relation carries, applies them once each in the order surcharge, discount, project discount, kickback, and renders `base_cost`, one `adjustments` line per applied adjustment, `net_cost` and `kickback_total` onto the statement document — `total` becomes the net cost. Every applied adjustment is also stored as one row of the new `adjustment_records` table, under the same immutability trigger as the other run artifacts. A correction re-applies the adjustments on its re-metered amounts, stores its own full set of records, diffs them against the baseline's and renders the differences onto the credit note beside the rated deltas. A statement no adjustment reaches renders byte for byte what Phase 3 rendered.

## The change set, in commit order

**`1507650` Add the typed pricing adjustments to `internal/core/adjustment`.** The package gains what the engine reads the array by: `TypeSurcharge`/`TypeDiscount`/`TypeProjectDiscount`/`TypeKickback`, `TypeOrder` (the D3 application order), `ScopeAll`, the `Adjustment` struct with its rate as a `decimal.Decimal`, `Parse`, `FromMetadata` and `ScopeMatches` (the D5 scope grammar: `all`, a bare platform, or `platform.resource_type`, compared exactly). `Parse` calls `Validate` first, so a refused document still comes back as the `*InvalidError` the API renders field errors from. `ValidateMetadata` is now `FromMetadata` with both values dropped, so the Reporting API path of #55 is unchanged and every case of `TestValidateMetadata` keeps passing.

**`e1f998c` Render adjustment rates at six places with `money.Rate`.** `RatePlaces = 6` joins `AmountPlaces` and `QuantityPlaces`, and `Rate`/`NewRate`/`(Rate) MarshalJSON` render `StringFixed(6)`, shaped like `Quantity`. Without the wrapper the encoder decides whether `0.15` reaches an export as `0.15` or `0.150000`; a rate now carries a type the way an amount does.

**`723a308` Carry relation metadata through the engine's read seam.** `ListRelationsOverlapping` selects `metadata` beside the six columns it read already, and `source.Relation` gains `Metadata json.RawMessage`, which `Snapshot.Relations` copies through. Nothing else in the query changes, so `attribution.Resolve` takes the same relations in the same order. `sqlcgen` regenerated by `make generate`.

**`6d8dc66` Configure the adjustment relation types and walk depth.** `TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES` (default `managed_by,member_of`) and `TALLY_ENGINE_ADJUSTMENT_DEPTH` (default `3`) join the constant block, `EnvNames`, `.env.example` and the Kubernetes base manifest. The explicitly empty type list is the one switch that turns adjustments off; a stray comma is refused, and a depth below 1 is refused. No type is refused here — the lists are independent, and a type in both is walked by attribution and by adjustment resolution.

**`01c5244` Add `internal/engine/adjustments`: resolve and apply adjustments.** `New` parses the graph once per run into edges indexed by source project; `Adjust(project, bases)` walks it breadth-first from the statement's project, one visit per relation, bounded by the depth, and returns the `Outcome`: base cost, the lines in D3 order (ties broken by relation id, then array position), net cost and kickback total. A surcharge is computed on the base, a discount and a project discount on the running net, a kickback on the running net without changing it. Each line is rounded once by `money.Round2` (D7) and then apportioned back over the `(platform, resource type)` buckets its scope covers, the last bucket taking the remainder, so the shares sum to the line exactly and every later base is a sum of two-place amounts. A kickback whose relation target is not a `partner` project is dropped and reported as `WarningKickbackTargetNotPartner`; the relation's other adjustments still apply.

**`eb11d82` Add the `adjustment_records` table with migration 0002.** One row per applied adjustment, with `run_id`, the statement key, the relation and its target, `beneficiary` (kickbacks only, enforced by a `CHECK ((type = 'kickback') = (beneficiary IS NOT NULL))`), type, scope, rate, base, amount and currency; `idx_adjustments_run (run_id, beneficiary)` serves the per-partner sum #57 needs, and `forbid_finalized_mutation` makes the rows immutable once the run is finalized. `migrations/engine` pins version 2. The store writes them with `CreateAdjustmentRecords` (a copy-from like the other record writes) and reads them back with `ListAdjustmentRecords` in one total order per run, which is what a correction diffs against. `TestMigrate`'s rollback assertion now compares against the reversed chain, which a one-migration chain could not tell apart.

**`d97782d` Render adjustments onto the statement document.** `statements.Build` takes an `*adjustments.Adjuster` as its seventh argument. Where one is given, the document renders `base_cost`, the `adjustments` array, `net_cost` and `kickback_total` between the related costs and the total, and `total` becomes the net cost — what the customer pays and what `project_statements.total` stores. The same lines travel on `Statement.Adjustments` for the run to store. A statement no adjustment reaches carries none of the four members and renders the bytes it renders without an adjuster. The run passes `nil` here; the wiring lands two commits later.

**`e7dbf5d` Diff adjustment records and render them on credit notes.** The rated diff is keyed by resource and dimension, which an adjustment is neither, so `AdjustmentAmounts`/`DiffAdjustments` key on the statement, the relation, and the element's type, scope and rate. A note that carries changes shows `base_delta`, `adjustments`, `net_delta` and `kickback_delta` beside its line items, and its total is the net delta. An adjustment delta creates the note of its statement key where no rated delta did; a key the registry does not hold is refused. A note no adjustment delta reached renders unchanged, and `BuildCreditNotes` with `nil` adjustment deltas behaves as before.

**`8c1f143` Apply adjustments in regular and correction runs.** The adjuster is built once per run from the adjustment-carrying relations the snapshot reads beside the attributing ones; an empty type list leaves it `nil`, which is adjustments off. The lines it puts on the statements become the run's adjustment records, written in the one write transaction after the statements. A correction re-applies the adjustments on its re-metered amounts, stores its own records and diffs them against the baseline's, which is where its credit notes take their adjustment deltas from. `runs.stats` gains `adjustment_records` and `adjustment_warnings`; a correction's gains `adjustment_deltas`.

**`bc4763c` Cover adjusted runs and corrections with integration tests.** `TestExecute` gains seven cases over a run that resolves adjustments — the reseller numbers on the stored document and on the records (base 5.76, discount -0.86, net 4.90, kickback 0.49, the partner named as beneficiary on the kickback row alone), a relation closed inside the period applying where one closed before it does not (D4), an empty type list leaving the document byte for byte what it was, a kickback to a meta-project dropped with a warning, a run failed on a relation whose adjustments the schema refuses, a run refused before its first insert on an adjustment past the column, and a superseded run's records kept beside those of the run that replaced it. `TestCorrect` gains the chain over an adjusted month: a late power cycle credited through the discount and the kickback computed off it, an adjustment a correction applies for the first time, a correction that finds nothing twice and stores its own records anyway, and the two baselines a correction is refused over (an amount that is not a number, one in another currency).

**`94d8694` Wire the adjustment settings into `tally-engine` and the golden suite.** `run`, `correct` and the tick's executor pass the configured types and depth, so a deployment's `TALLY_ENGINE_ADJUSTMENT_*` settings reach the engine. `run` prints `applied N pricing adjustments` after the metered line, `correct` prints the adjustment deltas beside the rated ones, and the recorded-warnings line counts the adjustment pass. The golden fixture meters every case with `managed_by,member_of` and depth 3 and refuses an adjustment warning; `virtual_relations` carries edges of both types without adjustments, so the suite proves that resolving them leaves the Phase 3 bytes unchanged.

## Proof

`internal/engine/adjustments/adjustments_test.go` (848 lines) covers the walk (depth bounds, one visit per relation, cycles, diamonds), the D3 order and its tie-breaks, the D5 scope grammar over nested scopes, the single rounding and the apportionment invariants, the non-partner kickback warning, and the refusals. `adjustment_test.go`, `money_test.go`, `config_test.go`, `statements_test.go`, `corrections_test.go`, `queries_test.go` and `migrate_test.go` cover their own units; `runs_integration_test.go`, `correct_integration_test.go` and `main_test.go` cover the cases listed above end to end. `TestGolden`, `TestExportGolden` and `TestLoadCarriesAStoredDocumentThroughJSONB` pass unchanged — an unadjusted document exports to the same bytes.

## Where the diff diverges from the issue (guardrail 10)

- **The new document members carry no currency suffix.** They are `base_cost`, `adjustments[].base`, `adjustments[].amount`, `net_cost` and `kickback_total`, with the currency in the document's existing `currency` member. The concept's Phase 5 example (`README.md:936-962`) spells `base_cost_eur`, `amount_eur`, `base_eur`, `net_cost_eur` and `kickback_eur`, and WP 5.3 says the document "extends the concept's output example exactly". The Phase 3 document already renders `total` rather than `total_eur` (`README.md:1080-1081`), and a suffix that names one currency on a document that carries its own would be the drift.
- **A kickback on a relation whose target is not a `partner` project is skipped, not applied.** The run records `adjustment_kickback_target_not_partner` in `runs.stats`, naming the relation and its target, and the relation's other adjustments apply as usual. This keeps `adjustment_records.beneficiary` what D8 says it is — a partner's external id — so the kickback report of #57 never names a customer as a payee.
- **`adjustment_records` gains `relation_type` and `relation_target`,** which WP 5.3's table does not list, so a record and a credit-note line can name the relation they came from without a second lookup in the reporting database. `beneficiary` stays as the roadmap defines it. The migration header says so in place.
- **Corrections do not pick up adjustment effects "without further work",** as the Meta Issue's split text has it. `corrections.Diff` diffs rated amounts per resource and dimension, and an adjustment is neither, so this branch diffs adjustment records explicitly on their own key and renders the differences onto the note.
- **The pseudocode's "running net per scope partition" is fixed arithmetic here.** It is not defined for nested scopes (`all` beside `openstack.instance`), so the running net is tracked per `(platform, resource type)` bucket, an adjustment's amount is one rounding of its scoped sum times its rate, and that rounded amount is apportioned over the buckets it covers.
- **A relation whose stored `pricing_adjustments` the schema refuses fails at `Adjust`, not at `New`.** `project_relations.metadata` is a free-form document a tenant writes, and refusing it at construction would let one stale relation of a project this run bills nothing from fail every run and every tick of the deployment. It is refused by the first statement whose walk reaches it, so a relation that adjusts nothing bills nothing and breaks nothing.
- **Three integration-test cases moved offsets.** "refuses a period that is not finalized" moves to -25..-27 and "refuses a month it does not know" to -21, because the new adjusted-month cases use `thirtyOneDayMonth(4)` and `thirtyOneDayMonth(5)`, which reach -8..-10 depending on the wall clock.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
