### PR TITLE
Publish a seeded, clock-accelerated month of OpenStack notifications onto RabbitMQ from a simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,28 @@ SERVICES := tally-reporting tally-engine
 # CronJob, so it belongs there beside the Reporting API. IMAGES is everything
 # `images` builds: the collector image is built and publishable, but it runs
 # beside the broker of an OpenStack control plane rather than in the dev cluster.
-IMAGES := $(SERVICES) tally-openstack-collector
+# The simulator is on the producing side of the same kind of broker, and
+# `simulator-up` starts one for it on the developer's machine.
+IMAGES := $(SERVICES) tally-openstack-collector tally-openstack-simulator
+
+# The images the stack runs, which is what `simulator-up` builds. It is not
+# IMAGES: the Reporting API is deployed into the cluster by `up`, which loads it
+# there and applies the migration chain, so building it here would leave a tag
+# nothing loads and a schema nobody applied. After a change to the Reporting API
+# or to the migrations, run `make up` again rather than this.
+SIM_IMAGES := tally-openstack-collector tally-openstack-simulator
+
+# The simulator stack, deploy/compose/compose.yaml: a broker, the collector, and
+# the simulator, run beside the dev cluster rather than in it. The four SIM_
+# values below are what `simulator-up` writes into the .env file compose reads.
+# A factor of 744 puts a 31-day month on the bus in an hour.
+SIM_CLOUD ?= os-sim
+SIM_SEED ?= 1
+SIM_FACTOR ?= 744
+# No default: the target refuses to run until a month is named, because any
+# month guessed here would be as wrong as another.
+SIM_PERIOD ?=
+COMPOSE := docker compose -f deploy/compose/compose.yaml
 
 # Every kubectl call names the cluster explicitly. Creating a kind cluster
 # switches the current context, but reusing an existing one does not, so an
@@ -55,7 +76,8 @@ TALLY_DEV_ENGINE_DB_URL ?= postgres://tally:tally-dev-password@db.tally.127-0-0-
 VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' deploy/kubernetes/base/vmalert/vmalert.yaml | head -n1)
 ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
 
-.PHONY: up down dev ca test lint fmt check-alerting migrate generate images
+.PHONY: up down dev ca test lint fmt check-alerting migrate generate images \
+	simulator-up simulator-down
 
 ## up: create the kind cluster, install the add-ons, and deploy the dev overlay
 up:
@@ -135,6 +157,46 @@ down:
 ## dev: rebuild and redeploy on change
 dev:
 	tilt up
+
+# The stack needs a dev cluster from `make up`. Nothing here creates one, and
+# the credential step below is where a missing one fails, with the admin CLI's
+# connection error.
+#
+# That credential is issued fresh on every run because the cluster may have been
+# recreated since the last one, and a new database knows none of the tokens the
+# old one handed out. A stale token is quiet: the Reporting API answers 401, the
+# collector keeps the events and retries the batch once per flush, and the only
+# sign of it is a line in the collector's log.
+## simulator-up: run the simulator, the collector, and a broker against the dev cluster
+simulator-up:
+	@[ -n '$(SIM_PERIOD)' ] || { echo 'ERROR: set SIM_PERIOD to the past month to simulate, e.g. make simulator-up SIM_PERIOD=2026-07' >&2; exit 1; }
+	$(MAKE) images IMAGES='$(SIM_IMAGES)'
+	@echo '==> writing the dev CA to tally-ca.crt'
+	$(MAKE) -s ca > tally-ca.crt
+	@echo '==> issuing an ingest credential for $(SIM_CLOUD)'
+	@token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud '$(SIM_CLOUD)' --description 'openstack simulator')"; printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_OSC_TOKEN=%s\n' '$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' "$$token" > deploy/compose/.env
+	$(COMPOSE) up -d
+	@echo
+	@echo 'Simulator stack is up:'
+	@echo '  http://127.0.0.1:15672                          broker UI, guest/guest'
+	@echo '  http://127.0.0.1:8090/metrics                   collector'
+	@echo '  http://127.0.0.1:8091/clock                     simulator control'
+	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1  Reporting API'
+	@echo
+	@echo "Finish the month at once with:"
+	@echo "  curl -X PUT -d '{\"factor\": 0}' http://127.0.0.1:8091/clock"
+
+# Dropping the volumes empties the outbox and the broker's queue, so the next
+# `simulator-up` starts from nothing rather than delivering what the last run
+# left behind. The dev reporting database is not part of that: the events of the
+# last run stay ingested, and no subcommand of tally-reporting-admin deletes
+# them. Running the same period again under another seed or another cloud adds a
+# second, disjoint set of rows beside the first, and `make down && make up` is
+# what drops them.
+## simulator-down: stop the simulator stack and drop its volumes
+simulator-down:
+	$(COMPOSE) down --volumes
+	rm -f deploy/compose/.env
 
 ## ca: print the dev CA certificate, for curl --cacert and browser trust
 ca:

--- a/cmd/tally-openstack-simulator/.env.example
+++ b/cmd/tally-openstack-simulator/.env.example
@@ -1,0 +1,41 @@
+# OpenStack notification simulator configuration.
+#
+# Every variable is read from the environment with the TALLY_ prefix
+# (roadmap/00-conventions.md section 8). Secrets also accept the *_FILE
+# convention, which is how a Kubernetes Secret volume reaches the process
+# without the value appearing in a pod spec:
+# TALLY_SIM_AMQP_URL_FILE=/run/secrets/tally/amqp-url
+# Setting a secret and its *_FILE companion at the same time is an error.
+#
+# The simulator has two subcommands. run generates a month from a seed and
+# publishes it, writes it to --out, or both; it is the only one that reads
+# TALLY_SIM_CLOUD. replay publishes a notifications.jsonl an earlier run wrote
+# and reads the broker variables alone, because the recorded notifications
+# carry the cloud already.
+
+# Log level: DEBUG, INFO, WARN, ERROR. Both subcommands read it.
+TALLY_LOG_LEVEL=INFO
+
+# Address the control endpoint binds. Loopback by default: the endpoint carries
+# no credential and PUT /clock changes the pace of a run, so a bind on every
+# interface is something a deployment asks for. The compose stack sets 0.0.0.0
+# because it publishes the port on the host's 127.0.0.1 itself.
+TALLY_SIM_HTTP_ADDR=127.0.0.1
+
+# Port the control endpoint listens on. It serves GET /healthz and GET /clock,
+# and PUT /clock sets the factor the rest of the month is paced at. Both
+# subcommands serve it, for the length of the publishing and no longer.
+TALLY_SIM_HTTP_PORT=8080
+
+# AMQP URL of the broker the notifications are published to. It carries the
+# broker password, so it supports TALLY_SIM_AMQP_URL_FILE. Empty by default: run
+# is then in file mode and requires --out, while replay refuses to start without
+# a broker. A broker that is not on this machine is refused unless
+# --allow-remote-broker is passed: a collector books what a run publishes as
+# real usage, and nothing deletes those events again.
+TALLY_SIM_AMQP_URL=
+
+# Cloud the generated month belongs to. Required by run, with no default: it is
+# the salt of every generated identifier and the cloud of events.jsonl, and a
+# guessed one books usage to the wrong cloud. replay does not read it.
+TALLY_SIM_CLOUD=

--- a/cmd/tally-openstack-simulator/commands.go
+++ b/cmd/tally-openstack-simulator/commands.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/b42labs/tally/internal/providers/openstack/simulator"
+)
+
+// defaultFactor is the pacing a run takes when nobody asks for another one: 744
+// virtual seconds per wall second puts a 31-day month on the bus in an hour,
+// which is long enough to watch a collector work and short enough to sit
+// through.
+const defaultFactor = 744
+
+// defaultWaitForCollector is how long a run waits for the collector to appear
+// on its queue before it publishes. A topic exchange drops what no queue is
+// bound to, so a month published into an empty broker is a month lost; two
+// minutes cover a collector that is still starting.
+const defaultWaitForCollector = 2 * time.Minute
+
+// The confirmation both subcommands ask for before they dial a broker that is
+// not on this machine. What a run puts on a broker is booked as real usage by
+// whatever collector consumes it, so the flag is what turns a copied production
+// URL from a typo into a decision; simulator.EnsureLocalBroker holds the rest of
+// the reason.
+const (
+	allowRemoteBrokerFlag  = "allow-remote-broker"
+	allowRemoteBrokerUsage = "publish to a broker that is not on this machine, " +
+		"knowing that a collector books what a run publishes as real usage"
+)
+
+// newRunCmd builds the run subcommand.
+func newRunCmd() *cobra.Command {
+	var opts simulator.RunOptions
+	// Not a field of RunOptions: what it decides happens before the run begins,
+	// when the broker is dialled, and the run itself never reads it.
+	var allowRemoteBroker bool
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Generate a month of notifications and publish or write it",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// The configuration is read when the subcommand runs rather than when
+			// the tree is built, so building the tree, and with it --help, needs no
+			// environment at all.
+			cfg, err := simulator.Load()
+			if err != nil {
+				return fmt.Errorf("loading the configuration: %w", err)
+			}
+			if err := cfg.ValidateRun(); err != nil {
+				return fmt.Errorf("checking the configuration: %w", err)
+			}
+			// The flags are checked before the broker is dialled: a mistyped period
+			// or a negative factor is the operator's own mistake, and reporting it
+			// here costs neither a connection nor a wait.
+			if _, _, err := opts.Validate(); err != nil {
+				return err
+			}
+
+			logger := newLogger(cmd.OutOrStdout(), cfg)
+
+			// A run without a broker URL is file mode: the month is written out and
+			// nothing is dialled, which is what makes a month on a machine with no
+			// broker possible at all.
+			var publisher *simulator.Publisher
+			if cfg.AMQPURL != "" {
+				connected, closePublisher, err := connect(cfg, allowRemoteBroker, logger)
+				if err != nil {
+					return err
+				}
+				defer closePublisher()
+				publisher = connected
+			}
+			return simulator.Run(cmd.Context(), cfg, opts, publisher, logger)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Period, "period", "",
+		"billing month to simulate, YYYY-MM; it must have ended")
+	cmd.Flags().Uint64Var(&opts.Seed, "seed", 1, "seed of the month's shape")
+	cmd.Flags().Float64Var(&opts.Factor, "factor", defaultFactor,
+		"virtual seconds per wall second; 0 publishes as fast as the broker confirms")
+	cmd.Flags().StringVar(&opts.Out, "out", "",
+		"directory to write notifications.jsonl and events.jsonl to")
+	cmd.Flags().DurationVar(&opts.WaitForCollector, "wait-for-collector", defaultWaitForCollector,
+		"how long to wait for a consumer on the collector's queue before publishing; 0 disables the wait")
+	cmd.Flags().BoolVar(&allowRemoteBroker, allowRemoteBrokerFlag, false, allowRemoteBrokerUsage)
+	_ = cmd.MarkFlagRequired("period")
+	return cmd
+}
+
+// newReplayCmd builds the replay subcommand.
+func newReplayCmd() *cobra.Command {
+	var opts simulator.ReplayOptions
+	var allowRemoteBroker bool
+
+	cmd := &cobra.Command{
+		Use:   "replay",
+		Short: "Publish a recorded notifications.jsonl",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Read here rather than while the tree is built, for the reason run
+			// states.
+			cfg, err := simulator.Load()
+			if err != nil {
+				return fmt.Errorf("loading the configuration: %w", err)
+			}
+			// A replay has no file mode, so the broker is asked for before anything
+			// else: the recorded month is already a file, and publishing it is the
+			// whole of what this subcommand does.
+			if err := cfg.ValidateReplay(); err != nil {
+				return fmt.Errorf("checking the configuration: %w", err)
+			}
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			logger := newLogger(cmd.OutOrStdout(), cfg)
+
+			publisher, closePublisher, err := connect(cfg, allowRemoteBroker, logger)
+			if err != nil {
+				return err
+			}
+			defer closePublisher()
+			return simulator.Replay(cmd.Context(), cfg, opts, publisher, logger)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.In, "in", "", "path of a notifications.jsonl written by run --out")
+	cmd.Flags().Float64Var(&opts.Factor, "factor", defaultFactor,
+		"virtual seconds per wall second; 0 publishes as fast as the broker confirms")
+	cmd.Flags().DurationVar(&opts.WaitForCollector, "wait-for-collector", defaultWaitForCollector,
+		"how long to wait for a consumer on the collector's queue before publishing; 0 disables the wait")
+	cmd.Flags().BoolVar(&allowRemoteBroker, allowRemoteBrokerFlag, false, allowRemoteBrokerUsage)
+	_ = cmd.MarkFlagRequired("in")
+	return cmd
+}
+
+// newLogger builds the logger both subcommands log through and makes it the
+// process default. The default is what the control endpoint writes its factor
+// changes through, so leaving it unset would put those lines on stderr,
+// unstructured and at a level nobody chose.
+func newLogger(out io.Writer, cfg simulator.Config) *slog.Logger {
+	logger := slog.New(slog.NewJSONHandler(out, &slog.HandlerOptions{
+		Level: cfg.SlogLevel(),
+	})).With("service", "tally-openstack-simulator")
+	slog.SetDefault(logger)
+	return logger
+}
+
+// connect dials the broker cfg names and returns it together with the function
+// that gives the connection back. The close error is logged rather than
+// returned, because by the time it runs the answer the caller waits for is the
+// one about the month.
+//
+// Which broker it is gets checked here rather than deeper down because this is
+// the last point before the dial, and a month published onto the wrong broker
+// is one nothing takes back.
+func connect(cfg simulator.Config, allowRemoteBroker bool, logger *slog.Logger) (*simulator.Publisher, func(), error) {
+	if !allowRemoteBroker {
+		if err := simulator.EnsureLocalBroker(cfg.AMQPURL); err != nil {
+			return nil, nil, err
+		}
+	}
+	publisher, err := simulator.Connect(cfg.AMQPURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return publisher, func() {
+		if err := publisher.Close(); err != nil {
+			logger.Error("closing the broker connection failed", "error", err)
+		}
+	}, nil
+}

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -1,0 +1,60 @@
+// Command tally-openstack-simulator publishes one simulated month of OpenStack
+// notifications.
+//
+// The run subcommand generates the month from --seed and --period and publishes
+// it onto the broker TALLY_SIM_AMQP_URL names, at --factor virtual seconds per
+// wall second. With --out it writes the month to notifications.jsonl and
+// events.jsonl instead, and with both it does both. The replay subcommand
+// publishes a notifications.jsonl an earlier run wrote, which puts the same
+// month on a bus again without the generator behind it.
+//
+// The control endpoint on TALLY_SIM_HTTP_PORT changes the factor while a run
+// publishes, so a month that is going out too slowly is sped up without being
+// started over.
+//
+// SIGINT and SIGTERM stop a run cleanly: what went out stays out, and the
+// process ends with exit status 0. Every other failure exits 1.
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	// The tree runs on a context the process's own termination cancels, which is
+	// what a run needs: it spends its whole life inside the publishing loop, and
+	// cancellation is what turns a signal into a stop that keeps the messages
+	// already published rather than a process killed mid-month.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Cobra has already written the error to stderr by the time Execute
+	// returns it.
+	if err := newRootCmd().ExecuteContext(ctx); err != nil {
+		os.Exit(1)
+	}
+}
+
+// newRootCmd assembles the command tree. Nothing in it reads the process's
+// arguments or streams, so a test drives the same tree through SetArgs, SetOut,
+// and SetErr.
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "tally-openstack-simulator",
+		Short: "Publish a simulated month of OpenStack notifications",
+		// A broker that is down is not a usage mistake, and dumping the help text
+		// after one buries the line that says what went wrong.
+		SilenceUsage: true,
+	}
+
+	root.AddCommand(
+		newRunCmd(),
+		newReplayCmd(),
+	)
+	return root
+}

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/providers/openstack"
+	"github.com/b42labs/tally/internal/providers/openstack/simulator"
+)
+
+// endedMonth is a billing month that is over and stays over, which is what the
+// cases that generate one need: a run refuses a month that has not ended.
+const endedMonth = "2026-07"
+
+// simulatedCloud is the cloud the generated months are booked to. It is the
+// salt of every identifier in them, so the cases that compare two runs have to
+// use the same one.
+const simulatedCloud = "os-sim"
+
+// closedBroker is an AMQP URL nothing listens on. It is a usable URL on
+// loopback, so the run gets as far as dialing it and fails there rather than at
+// the parse or at the check of which broker it is.
+const closedBroker = "amqp://guest:guest@127.0.0.1:1/"
+
+// remoteBroker is an AMQP URL of a broker somewhere else, which is the shape of
+// a production URL copied into the simulator's environment.
+const remoteBroker = "amqp://guest:hunter2@rabbit.control-plane.example:5672/"
+
+// nonBillableNotifications is how many notifications of a generated month the
+// collector maps to no event: the ones that are published to describe the
+// month's shape without being billable. notifications.jsonl holds every
+// notification and events.jsonl only the billable ones, so the two files differ
+// by exactly this many lines.
+const nonBillableNotifications = 6
+
+func TestHelpNeedsNoEnvironment(t *testing.T) {
+	blankEnvironment(t)
+
+	// The root and both leaves. Building the tree reads no configuration, so the
+	// help of all of them works on a machine that has none.
+	for _, tc := range []struct {
+		name string
+		path []string
+	}{
+		{"tally-openstack-simulator", nil},
+		{"run", []string{"run"}},
+		{"replay", []string{"replay"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runCLI(t, append(tc.path, "--help")...)
+			if err != nil {
+				t.Fatalf("%s --help error = %v, want nil (stderr %q)", tc.name, err, stderr)
+			}
+			if want := "Usage:"; !strings.Contains(stdout, want) {
+				t.Errorf("stdout = %q, want the usage text, containing %q", stdout, want)
+			}
+		})
+	}
+}
+
+func TestRunRequiresAPeriod(t *testing.T) {
+	useCloud(t)
+
+	_, stderr, err := runCLI(t, "run", "--out", t.TempDir())
+	if err == nil {
+		t.Fatalf("run error = nil, want the missing period reported (stderr %q)", stderr)
+	}
+	if want := `"period"`; !strings.Contains(err.Error(), want) {
+		t.Errorf("run error = %q, want it to contain %q", err, want)
+	}
+}
+
+func TestRunRefusesAPeriodThatHasNotEnded(t *testing.T) {
+	useCloud(t)
+
+	// The month the test runs in, which is the one case where the answer depends
+	// on the clock rather than on the flags.
+	from, to := billingMonth(0)
+	month := from.Format("2006-01")
+
+	_, stderr, err := runCLI(t, "run", "--period", month, "--out", t.TempDir())
+	if err == nil {
+		t.Fatalf("run error = nil, want the running month refused (stderr %q)", stderr)
+	}
+	want := fmt.Sprintf("--period: %s has not ended yet; it ends %s, "+
+		"and the engine warns about a period that has not ended", month, to.Format(time.RFC3339))
+	if err.Error() != want {
+		t.Errorf("run error = %q, want %q", err, want)
+	}
+}
+
+func TestRunRefusesToRunNowhere(t *testing.T) {
+	useCloud(t)
+
+	_, stderr, err := runCLI(t, "run", "--period", endedMonth)
+	if err == nil {
+		t.Fatalf("run error = nil, want the missing destination reported (stderr %q)", stderr)
+	}
+	want := "set TALLY_SIM_AMQP_URL or pass --out: the run has nowhere to publish"
+	if err.Error() != want {
+		t.Errorf("run error = %q, want %q", err, want)
+	}
+}
+
+func TestRunWritesTheMonthInFileMode(t *testing.T) {
+	useCloud(t)
+
+	dir := t.TempDir()
+	if _, stderr, err := runCLI(t,
+		"run", "--period", endedMonth, "--seed", "1", "--out", dir); err != nil {
+		t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+	}
+
+	notifications, notificationLines := readLines(t, filepath.Join(dir, "notifications.jsonl"))
+	for number, raw := range notificationLines {
+		var line simulator.Line
+		if err := json.Unmarshal(raw, &line); err != nil {
+			t.Fatalf("notifications.jsonl line %d: %v", number+1, err)
+		}
+		// The bodies are read by the collector's own decoder, so a body it would
+		// refuse is a month no collector could consume.
+		if _, err := openstack.ParseEnvelope(line.Body); err != nil {
+			t.Fatalf("notifications.jsonl line %d: ParseEnvelope() error = %v, want nil", number+1, err)
+		}
+	}
+
+	events, eventLines := readLines(t, filepath.Join(dir, "events.jsonl"))
+	for number, raw := range eventLines {
+		var e event.Event
+		if err := json.Unmarshal(raw, &e); err != nil {
+			t.Fatalf("events.jsonl line %d: %v", number+1, err)
+		}
+		if err := e.Validate(); err != nil {
+			t.Fatalf("events.jsonl line %d: Validate() error = %v, want nil", number+1, err)
+		}
+		if e.Cloud != simulatedCloud {
+			t.Errorf("events.jsonl line %d: Cloud = %q, want %q", number+1, e.Cloud, simulatedCloud)
+		}
+		if e.Source != event.SourceCollector {
+			t.Errorf("events.jsonl line %d: Source = %q, want %q",
+				number+1, e.Source, event.SourceCollector)
+		}
+	}
+
+	if want := len(eventLines) + nonBillableNotifications; len(notificationLines) != want {
+		t.Errorf("notifications.jsonl has %d lines, want %d: %d events plus the %d non-billable ones",
+			len(notificationLines), want, len(eventLines), nonBillableNotifications)
+	}
+
+	t.Run("is byte-identical on a second run", func(t *testing.T) {
+		second := t.TempDir()
+		if _, stderr, err := runCLI(t,
+			"run", "--period", endedMonth, "--seed", "1", "--out", second); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+
+		for name, first := range map[string][]byte{
+			"notifications.jsonl": notifications,
+			"events.jsonl":        events,
+		} {
+			again, _ := readLines(t, filepath.Join(second, name))
+			if !bytes.Equal(first, again) {
+				t.Errorf("%s differs between two runs of the same seed, period, and cloud", name)
+			}
+		}
+	})
+}
+
+func TestRunRefusesBadInput(t *testing.T) {
+	notADirectory := writeFile(t, t.TempDir(), "notifications.jsonl", "")
+	urlFile := writeFile(t, t.TempDir(), "amqp-url", closedBroker)
+	emptyURLFile := writeFile(t, t.TempDir(), "empty-amqp-url", "")
+
+	for _, tc := range []struct {
+		name string
+		// env is applied over the blanked environment, after the cloud every case
+		// but one needs. A case that names a variable with an empty value blanks
+		// it again.
+		env  map[string]string
+		args []string
+		// want is the whole error, contains a fragment of it. Each case sets one
+		// of the two: the errors that quote a temporary path can only be matched
+		// in part.
+		want     string
+		contains string
+		// absent is a fragment the error must not carry, which is how the case
+		// about a secret checks that the secret stayed out of it.
+		absent string
+	}{
+		{
+			name: "a period that is not a month",
+			args: []string{"--period", "2026-7", "--out", t.TempDir()},
+			want: `--period: "2026-7" is not a YYYY-MM month`,
+		},
+		{
+			name: "a negative factor",
+			// The value is attached with =, because pflag reads a separate -1 as a
+			// flag rather than as the value of --factor.
+			args: []string{"--period", endedMonth, "--factor=-1", "--out", t.TempDir()},
+			want: "--factor: -1 must be zero or positive",
+		},
+		{
+			name: "a negative wait for the collector",
+			args: []string{"--period", endedMonth, "--wait-for-collector=-1s", "--out", t.TempDir()},
+			want: "--wait-for-collector: -1s must be zero or positive",
+		},
+		{
+			name: "a log level in the wrong case",
+			env:  map[string]string{"TALLY_LOG_LEVEL": "info"},
+			args: []string{"--period", endedMonth, "--out", t.TempDir()},
+			want: `loading the configuration: TALLY_LOG_LEVEL: "info" must be DEBUG, INFO, WARN, or ERROR`,
+		},
+		{
+			name: "a broker URL given twice",
+			env: map[string]string{
+				"TALLY_SIM_AMQP_URL":      closedBroker,
+				"TALLY_SIM_AMQP_URL_FILE": urlFile,
+			},
+			args: []string{"--period", endedMonth, "--out", t.TempDir()},
+			want: "loading the configuration: set TALLY_SIM_AMQP_URL or TALLY_SIM_AMQP_URL_FILE, not both",
+		},
+		{
+			name:     "a broker URL file nobody filled",
+			env:      map[string]string{"TALLY_SIM_AMQP_URL_FILE": emptyURLFile},
+			args:     []string{"--period", endedMonth, "--out", t.TempDir()},
+			contains: fmt.Sprintf("TALLY_SIM_AMQP_URL_FILE: file %s is empty", emptyURLFile),
+		},
+		{
+			name: "no cloud",
+			env:  map[string]string{"TALLY_SIM_CLOUD": ""},
+			args: []string{"--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: TALLY_SIM_CLOUD: must be set",
+		},
+		{
+			name:     "a broker URL that is not a URL",
+			env:      map[string]string{"TALLY_SIM_AMQP_URL": "not a url"},
+			args:     []string{"--period", endedMonth},
+			contains: "TALLY_SIM_AMQP_URL is not a usable AMQP URL",
+			// The URL carries the broker password, and the parser formats the whole
+			// input into its own error, so that error is replaced rather than
+			// wrapped.
+			absent: "not a url",
+		},
+		{
+			name:     "a broker that is not on this machine",
+			env:      map[string]string{"TALLY_SIM_AMQP_URL": remoteBroker},
+			args:     []string{"--period", endedMonth},
+			contains: "TALLY_SIM_AMQP_URL names the broker rabbit.control-plane.example, which is not on this machine",
+			// The refusal names the host and nothing else of the URL: the rest of it
+			// is the broker password.
+			absent: "hunter2",
+		},
+		{
+			name: "a factor that is not a number",
+			// pflag parses NaN through strconv, and NaN passes every comparison a
+			// bound is written as, so it has to be refused by name.
+			args: []string{"--period", endedMonth, "--factor=NaN", "--out", t.TempDir()},
+			want: "--factor: NaN must be zero or positive",
+		},
+		{
+			name:     "a broker nothing listens on",
+			env:      map[string]string{"TALLY_SIM_AMQP_URL": closedBroker},
+			args:     []string{"--period", endedMonth},
+			contains: "dialing the broker:",
+		},
+		{
+			name:     "an output directory under a regular file",
+			args:     []string{"--period", endedMonth, "--out", filepath.Join(notADirectory, "sub")},
+			contains: fmt.Sprintf("creating %s:", filepath.Join(notADirectory, "sub")),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			useCloud(t)
+			for name, value := range tc.env {
+				t.Setenv(name, value)
+			}
+
+			_, stderr, err := runCLI(t, append([]string{"run"}, tc.args...)...)
+			if err == nil {
+				t.Fatalf("run error = nil, want a failure (stderr %q)", stderr)
+			}
+			if tc.want != "" && err.Error() != tc.want {
+				t.Errorf("run error = %q, want %q", err, tc.want)
+			}
+			if tc.contains != "" && !strings.Contains(err.Error(), tc.contains) {
+				t.Errorf("run error = %q, want it to contain %q", err, tc.contains)
+			}
+			if tc.absent != "" && strings.Contains(err.Error(), tc.absent) {
+				t.Errorf("run error = %q, want it to keep %q out", err, tc.absent)
+			}
+		})
+	}
+}
+
+func TestReplayRequiresABroker(t *testing.T) {
+	blankEnvironment(t)
+
+	_, stderr, err := runCLI(t, "replay", "--in", filepath.Join(t.TempDir(), "notifications.jsonl"))
+	if err == nil {
+		t.Fatalf("replay error = nil, want the missing broker reported (stderr %q)", stderr)
+	}
+	want := "checking the configuration: TALLY_SIM_AMQP_URL: must be set"
+	if err.Error() != want {
+		t.Errorf("replay error = %q, want %q", err, want)
+	}
+}
+
+func TestReplayRefusesBadInput(t *testing.T) {
+	blankEnvironment(t)
+	t.Setenv("TALLY_SIM_AMQP_URL", closedBroker)
+
+	t.Run("a negative factor", func(t *testing.T) {
+		// The file is never read: the flags are checked before the broker is
+		// dialled, and the dial is what would come first otherwise.
+		_, stderr, err := runCLI(t, "replay", "--in", "x", "--factor=-1")
+		if err == nil {
+			t.Fatalf("replay error = nil, want the negative factor refused (stderr %q)", stderr)
+		}
+		if want := "--factor: -1 must be zero or positive"; err.Error() != want {
+			t.Errorf("replay error = %q, want %q", err, want)
+		}
+	})
+
+	t.Run("a broker that is not on this machine", func(t *testing.T) {
+		t.Setenv("TALLY_SIM_AMQP_URL", remoteBroker)
+
+		_, stderr, err := runCLI(t, "replay", "--in", "x")
+		if err == nil {
+			t.Fatalf("replay error = nil, want the remote broker refused (stderr %q)", stderr)
+		}
+		want := "TALLY_SIM_AMQP_URL names the broker rabbit.control-plane.example, which is not on this machine"
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("replay error = %q, want it to contain %q", err, want)
+		}
+	})
+
+	t.Run("no file to replay", func(t *testing.T) {
+		_, stderr, err := runCLI(t, "replay")
+		if err == nil {
+			t.Fatalf("replay error = nil, want the missing file reported (stderr %q)", stderr)
+		}
+		if want := `"in"`; !strings.Contains(err.Error(), want) {
+			t.Errorf("replay error = %q, want it to contain %q", err, want)
+		}
+	})
+}
+
+// TestEnvExampleListsEveryVariable keeps the example file complete: a variable
+// the CLI reads but nobody documents is one an operator finds out about from a
+// failure.
+func TestEnvExampleListsEveryVariable(t *testing.T) {
+	example, err := os.ReadFile(".env.example")
+	if err != nil {
+		t.Fatalf("reading .env.example: %v", err)
+	}
+
+	for _, name := range simulator.EnvNames {
+		if !strings.Contains(string(example), name) {
+			t.Errorf(".env.example does not mention %s", name)
+		}
+	}
+}
+
+// blankEnvironment blanks every variable the CLI reads, so a value in the
+// developer's shell never reaches the code under test. A variable set to the
+// empty string falls back to its default exactly as an unset one does.
+func blankEnvironment(t *testing.T) {
+	t.Helper()
+
+	for _, name := range simulator.EnvNames {
+		t.Setenv(name, "")
+	}
+}
+
+// useCloud names the cloud a run generates for and blanks every other variable
+// the CLI reads. There is no broker in it, so a run under it is file mode.
+func useCloud(t *testing.T) {
+	t.Helper()
+
+	blankEnvironment(t)
+	t.Setenv("TALLY_SIM_CLOUD", simulatedCloud)
+}
+
+// runCLI executes one command in process and returns its stdout, its stderr,
+// and the error it ended with. It is the same command tree main runs, built
+// over buffers instead of the process's streams.
+func runCLI(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	root := newRootCmd()
+	root.SetArgs(args)
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+
+	err := root.ExecuteContext(t.Context())
+	return stdout.String(), stderr.String(), err
+}
+
+// billingMonth is the UTC billing month offset months from the one the test
+// runs in: 0 is the running month, -2 two months back. The months are derived
+// from the clock rather than written down, because whether a month has ended is
+// what one of the cases is about.
+func billingMonth(offset int) (from, to time.Time) {
+	now := time.Now().UTC()
+	from = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, offset, 0)
+	return from, from.AddDate(0, 1, 0)
+}
+
+// writeFile puts content in a file named name under dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// readLines reads a JSONL file and returns its bytes together with its lines.
+// The bytes are what two runs of the same seed are compared over, and the lines
+// are what each document in them is checked through.
+func readLines(t *testing.T, path string) ([]byte, [][]byte) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	if len(content) == 0 {
+		t.Fatalf("%s is empty", path)
+	}
+	return content, bytes.Split(bytes.TrimSuffix(content, []byte("\n")), []byte("\n"))
+}

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -1,0 +1,106 @@
+# The OpenStack simulator stack.
+#
+# Three containers on the developer's machine: a RabbitMQ broker, the collector
+# image, and the simulator, which publishes a generated month of
+# oslo.messaging notifications onto the broker. The collector consumes them and
+# posts the events into the Reporting API of the kind dev cluster `make up`
+# created, so a month of usage reaches the dev database without an OpenStack
+# deployment anywhere.
+#
+# Every host port below is bound to 127.0.0.1 and lies above 1024. Docker
+# Desktop publishes a privileged port only through a helper that is not
+# installed on every Mac, and a mapping without an address publishes on every
+# interface the machine has; deploy/kind/kind.yaml states the same rule for the
+# cluster's own ports.
+#
+# The values interpolated below come from deploy/compose/.env, which
+# `make simulator-up` writes and git ignores. It carries the cloud, the period,
+# the seed, the factor, and the ingest token issued for that cloud.
+#
+# A named volume of one of these images belongs under /home/nonroot; the
+# collector's outbox below says why.
+name: tally-simulator
+
+services:
+  # The bus. The management UI shows the queue the collector binds and how far
+  # behind it is, which is where a stalled pipeline becomes visible.
+  rabbitmq:
+    # Pinned to a version and a digest, the way deploy/kind/kind.yaml pins the
+    # node image: a floating tag re-resolves on every pull, so the broker the
+    # stack runs would be whatever the registry published under it last.
+    image: rabbitmq:4.3.5-management-alpine@sha256:e2f08f846de10bb09649a8b020f286ed362a8f72ee45e5a8d043851f1533fda8
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    # Both other services wait on this, so neither dials a broker that is still
+    # starting.
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      retries: 12
+
+  # The collector image, running unmodified: nothing in it knows the
+  # notifications it consumes are generated.
+  collector:
+    image: tally-openstack-collector:dev
+    # `make images` builds the tag locally and no registry carries it.
+    pull_policy: never
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      TALLY_OSC_AMQP_URL: amqp://guest:guest@rabbitmq:5672/
+      TALLY_OSC_CLOUD: ${TALLY_SIM_CLOUD}
+      TALLY_OSC_REPORTING_URL: https://api.tally.127-0-0-1.nip.io:8443
+      TALLY_OSC_TOKEN: ${TALLY_OSC_TOKEN}
+      TALLY_OSC_BUFFER_PATH: /home/nonroot/outbox.db
+      # The dev CA is in no root store the distroless image carries, and the
+      # sender is a plain http.Client, so this file is what makes the Gateway's
+      # certificate verify.
+      SSL_CERT_FILE: /etc/tally/tally-ca.crt
+    # Maps the Gateway's host name to the host, so the container reaches the
+    # kind port published on the host's 127.0.0.1:8443. Verified on this
+    # project's Docker Desktop.
+    extra_hosts:
+      - "api.tally.127-0-0-1.nip.io:host-gateway"
+    volumes:
+      - "../../tally-ca.crt:/etc/tally/tally-ca.crt:ro"
+      # The outbox sits under /home/nonroot because the image runs as nonroot
+      # (uid 65532) and Docker gives a fresh named volume the ownership of the
+      # directory it is mounted over, which for /home/nonroot in the distroless
+      # image is uid 65532. A volume mounted at a path the image does not carry
+      # is root-owned, and the collector cannot open its outbox in it.
+      - "outbox:/home/nonroot"
+    ports:
+      # /metrics, /readyz, /healthz
+      - "127.0.0.1:8090:8080"
+
+  # The producing side. It generates the month from the seed and the period and
+  # publishes it in the wall time the factor compresses it into.
+  simulator:
+    image: tally-openstack-simulator:dev
+    pull_policy: never
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      TALLY_SIM_AMQP_URL: amqp://guest:guest@rabbitmq:5672/
+      TALLY_SIM_CLOUD: ${TALLY_SIM_CLOUD}
+      # The control endpoint binds loopback unless it is told otherwise, and
+      # loopback inside the container is reachable from nothing. The port below
+      # is what publishes it, on the host's 127.0.0.1 alone.
+      TALLY_SIM_HTTP_ADDR: 0.0.0.0
+    # --allow-remote-broker is the confirmation the binary asks for before it
+    # dials a broker that is not on its own machine. The broker here is the
+    # container next door, and what it carries is thrown away with the stack; a
+    # URL that named a control plane's broker would put a month of invented usage
+    # into that deployment's billing data, which is why the flag has to be typed.
+    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--allow-remote-broker"]
+    ports:
+      # the control endpoint: GET /clock, PUT /clock, GET /healthz
+      - "127.0.0.1:8091:8080"
+
+volumes:
+  # Everything the collector has consumed and not yet delivered lives here and
+  # nowhere else.
+  outbox: {}

--- a/deploy/compose/compose_test.go
+++ b/deploy/compose/compose_test.go
@@ -1,0 +1,277 @@
+// This file pins the compose stack to what the two binaries in it read. Every
+// mismatch it looks for fails quietly. A variable no binary reads leaves the
+// container starting on the default the variable was meant to replace, a buffer
+// path outside the outbox volume puts the undelivered events in the writable
+// layer that `docker compose down` drops, a missing extra_hosts entry sends
+// every flush to a name the container's resolver does not know, and a host port
+// Docker Desktop cannot publish fails the whole stack rather than the service
+// that asked for it. The test reads the YAML from disk and starts no container.
+package compose_test
+
+import (
+	"maps"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
+	"github.com/b42labs/tally/internal/providers/openstack/simulator"
+)
+
+const (
+	composePath = "compose.yaml"
+
+	// The services, by the names the rest of this file refers to them by.
+	rabbitmqService  = "rabbitmq"
+	collectorService = "collector"
+	simulatorService = "simulator"
+
+	// The volume the collector's outbox lives on, and the file the dev CA is
+	// mounted from.
+	outboxVolume = "outbox"
+	caSource     = "../../tally-ca.crt"
+
+	// The Reporting API of the dev cluster as the collector reaches it: the name
+	// is mapped to the host by extra_hosts, and kind publishes the Gateway's
+	// https port there.
+	gatewayHost  = "api.tally.127-0-0-1.nip.io"
+	reportingURL = "https://" + gatewayHost + ":8443"
+
+	// Every variable Tally itself reads carries this prefix. The environment maps
+	// below also hold variables of the base image, which no EnvNames list knows.
+	tallyPrefix = "TALLY_"
+
+	// The address every published port binds, and the lowest port Docker Desktop
+	// publishes without the privileged-port helper.
+	loopback           = "127.0.0.1"
+	lowestUnprivileged = 1024
+)
+
+// composeFile is the part of the stack these tests assert over. yaml.v3 ignores
+// every field not named here.
+type composeFile struct {
+	Name     string
+	Services map[string]service
+	Volumes  map[string]any
+}
+
+type service struct {
+	Image       string
+	PullPolicy  string `yaml:"pull_policy"`
+	Ports       []string
+	Environment map[string]string
+	Volumes     []string
+	ExtraHosts  []string `yaml:"extra_hosts"`
+	Command     []string
+	DependsOn   map[string]struct {
+		Condition string
+	} `yaml:"depends_on"`
+}
+
+func TestComposeRunsTheThreeServices(t *testing.T) {
+	// The three are the pipeline: the simulator publishes onto the broker, the
+	// collector consumes from it. A renamed or dropped service leaves compose
+	// starting a stack with one end of that missing, and it starts cleanly. Both
+	// Tally images are built locally, so a pull policy other than never sends
+	// compose to a registry that carries neither.
+	file := loadCompose(t)
+
+	names := slices.Sorted(maps.Keys(file.Services))
+	want := []string{collectorService, rabbitmqService, simulatorService}
+	if !slices.Equal(names, want) {
+		t.Fatalf("services = %v, want %v", names, want)
+	}
+
+	images := map[string]string{
+		collectorService: "tally-openstack-collector:dev",
+		simulatorService: "tally-openstack-simulator:dev",
+	}
+	for name, image := range images {
+		svc := file.Services[name]
+		if svc.Image != image {
+			t.Errorf("%s image = %q, want %q, which is the tag make images builds", name, svc.Image, image)
+		}
+		if svc.PullPolicy != "never" {
+			t.Errorf("%s pull_policy = %q, want %q; the image exists on this machine alone", name, svc.PullPolicy, "never")
+		}
+	}
+	if image := file.Services[rabbitmqService].Image; !strings.HasPrefix(image, "rabbitmq:") {
+		t.Errorf("%s image = %q, want a rabbitmq: tag", rabbitmqService, image)
+	}
+
+	for _, name := range []string{collectorService, simulatorService} {
+		dependency, ok := file.Services[name].DependsOn[rabbitmqService]
+		if !ok {
+			t.Errorf("%s does not depend on %s, so it dials a broker that may not exist yet", name, rabbitmqService)
+			continue
+		}
+		if condition := "service_healthy"; dependency.Condition != condition {
+			t.Errorf("%s depends on %s with condition %q, want %q; a started container is not yet a broker that answers",
+				name, rabbitmqService, dependency.Condition, condition)
+		}
+	}
+
+	if _, ok := file.Volumes[outboxVolume]; !ok {
+		t.Errorf("volumes = %v, want the %q volume declared, which is what makes the outbox outlive the container",
+			file.Volumes, outboxVolume)
+	}
+}
+
+func TestCollectorEnvironmentIsWhatTheCollectorReads(t *testing.T) {
+	// The collector reads its configuration from the environment and ignores
+	// what it does not know, so a misspelled variable is a default in place of a
+	// setting: no broker, no cloud, or an outbox in the container.
+	svc := serviceNamed(t, loadCompose(t), collectorService)
+
+	for name := range svc.Environment {
+		if strings.HasPrefix(name, tallyPrefix) && !slices.Contains(openstack.EnvNames, name) {
+			t.Errorf("%s is set although the collector reads no variable of that name (openstack.EnvNames), so its value never arrives", name)
+		}
+	}
+
+	outbox := mountFrom(t, svc, outboxVolume)
+	if path := svc.Environment["TALLY_OSC_BUFFER_PATH"]; !strings.HasPrefix(path, outbox.target+"/") {
+		t.Errorf("TALLY_OSC_BUFFER_PATH = %q, want a path under %q, where the %s volume is mounted; anywhere else the events the collector has not delivered go with the container",
+			path, outbox.target, outboxVolume)
+	}
+
+	ca := mountFrom(t, svc, caSource)
+	if path := svc.Environment["SSL_CERT_FILE"]; path != ca.target {
+		t.Errorf("SSL_CERT_FILE = %q, want %q, where %s is mounted; without it the sender rejects the Gateway's certificate on every flush",
+			path, ca.target, caSource)
+	}
+	if ca.options != "ro" {
+		t.Errorf("the %s mount carries the options %q, want %q; the collector has no reason to write the CA", caSource, ca.options, "ro")
+	}
+
+	if hosts := []string{gatewayHost + ":host-gateway"}; !slices.Equal(svc.ExtraHosts, hosts) {
+		t.Errorf("extra_hosts = %v, want %v; the name is otherwise resolved in the container's network, where the dev cluster is not",
+			svc.ExtraHosts, hosts)
+	}
+	if url := svc.Environment["TALLY_OSC_REPORTING_URL"]; !strings.HasPrefix(url, reportingURL) {
+		t.Errorf("TALLY_OSC_REPORTING_URL = %q, want it to start with %q, which is the name extra_hosts maps and the port kind publishes on the host",
+			url, reportingURL)
+	}
+}
+
+func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
+	// The simulator ignores an unknown variable the same way the collector does,
+	// and a run without the broker in its environment writes the month nowhere
+	// the collector looks.
+	svc := serviceNamed(t, loadCompose(t), simulatorService)
+
+	for name := range svc.Environment {
+		if strings.HasPrefix(name, tallyPrefix) && !slices.Contains(simulator.EnvNames, name) {
+			t.Errorf("%s is set although the simulator reads no variable of that name (simulator.EnvNames), so its value never arrives", name)
+		}
+	}
+
+	if len(svc.Command) == 0 || svc.Command[0] != "run" {
+		t.Fatalf("command = %v, want it to start with %q; the entrypoint's root command prints its help text and exits zero, which is a container that succeeds without publishing a notification",
+			svc.Command, "run")
+	}
+	// The period is required by the binary, but the seed and the factor are not:
+	// dropping either leaves a month that is not the one asked for, published at
+	// a pace nobody chose. Without --allow-remote-broker the container refuses
+	// the broker beside it, which is a stack that starts and publishes nothing.
+	for _, flag := range []string{"--period", "--seed", "--factor", "--allow-remote-broker"} {
+		if !slices.Contains(svc.Command, flag) {
+			t.Errorf("command = %v, want %s among the arguments", svc.Command, flag)
+		}
+	}
+}
+
+func TestHostPortsAreLoopbackAndUnprivileged(t *testing.T) {
+	// Docker Desktop publishes a privileged port only through a helper that is
+	// not installed on every Mac, and a mapping without an address publishes on
+	// every interface the machine has, which puts a broker holding the guest
+	// password on whatever network it is joined to. deploy/kind/kind.yaml holds
+	// the cluster's own ports to the same rule.
+	file := loadCompose(t)
+
+	for name, svc := range file.Services {
+		if len(svc.Ports) == 0 {
+			t.Errorf("%s publishes no port, so this check passes over a service that may still map one later", name)
+		}
+		for _, entry := range svc.Ports {
+			parts := strings.Split(entry, ":")
+			if len(parts) != 3 {
+				t.Errorf("%s port %q, want the address:host:container form; a mapping without an address binds every interface", name, entry)
+				continue
+			}
+			if parts[0] != loopback {
+				t.Errorf("%s port %q binds %q, want %q", name, entry, parts[0], loopback)
+			}
+			port, err := strconv.Atoi(parts[1])
+			if err != nil {
+				t.Errorf("%s port %q: the host port %q is not a number: %v", name, entry, parts[1], err)
+				continue
+			}
+			if port < lowestUnprivileged {
+				t.Errorf("%s port %q publishes on host port %d, want %d or above", name, entry, port, lowestUnprivileged)
+			}
+		}
+	}
+}
+
+// loadCompose decodes the stack from disk.
+func loadCompose(t *testing.T) composeFile {
+	t.Helper()
+
+	raw, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("reading the compose file: %v", err)
+	}
+
+	var file composeFile
+	if err := yaml.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parsing %s, which compose refuses to start: %v", composePath, err)
+	}
+	return file
+}
+
+// serviceNamed returns one service, failing when it is missing rather than
+// asserting over a zero value.
+func serviceNamed(t *testing.T, file composeFile, name string) service {
+	t.Helper()
+
+	svc, ok := file.Services[name]
+	if !ok {
+		t.Fatalf("%s declares no service %q", composePath, name)
+	}
+	return svc
+}
+
+// mount is one entry of a service's volumes list, source:target[:options].
+type mount struct {
+	source  string
+	target  string
+	options string
+}
+
+// mountFrom returns the mount of one source, failing when the service carries
+// none from it.
+func mountFrom(t *testing.T, svc service, source string) mount {
+	t.Helper()
+
+	for _, entry := range svc.Volumes {
+		parts := strings.SplitN(entry, ":", 3)
+		if parts[0] != source {
+			continue
+		}
+		m := mount{source: parts[0]}
+		if len(parts) > 1 {
+			m.target = parts[1]
+		}
+		if len(parts) > 2 {
+			m.options = parts[2]
+		}
+		return m
+	}
+	t.Fatalf("volumes = %v, none of them mounting %s", svc.Volumes, source)
+	return mount{}
+}

--- a/docs/openstack-collector.md
+++ b/docs/openstack-collector.md
@@ -17,6 +17,9 @@ duplicates.
 The collector runs next to the OpenStack control plane, close to its broker.
 `make images` builds its image as `tally-openstack-collector:dev`; `make up`
 deploys only the Tally services into the dev cluster and does not load it.
+`make simulator-up` runs it on the developer's machine beside a broker and a
+simulated month of notifications;
+[`openstack-simulator.md`](openstack-simulator.md) describes that stack.
 
 ## Required OpenStack service settings
 

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -293,7 +293,8 @@ document. The month itself does not move: only what comes after the change runs
 at another speed. A body that is not JSON, one without the member, and one with
 a negative factor all answer 400 with
 `factor must be a JSON object with a number member "factor" that is zero or
-positive`. Any other method on either route answers 405. A run in file mode serves nothing.
+positive`. Any other method on either route answers 405. A run in file mode
+serves nothing.
 
 ## Configuration
 

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -1,0 +1,332 @@
+# OpenStack notification simulator
+
+The simulator is one binary that puts a month of oslo.messaging notifications
+on a RabbitMQ broker the way nova, cinder, neutron, and glance put them there.
+The collector described in [`openstack-collector.md`](openstack-collector.md)
+consumes them unmodified, off its ordinary `tally-notifications` queue, and
+posts the mapped events to the Reporting API, so a month of usage reaches Tally
+with no OpenStack deployment behind it. The month is rendered from a small
+simulated cloud and paced by a virtual clock, so a 31-day month goes out in the
+wall time the factor compresses it into.
+
+It has no fault switches, no oracle to hold a run against, no fake OpenStack
+API, and no metrics endpoint of its own. #65 owns the workloads, the noise, the
+faults, and the oracle; #66 the fake API and the clock seam; #67 the traffic
+series and `/metrics`. The drill #51 cites this simulator as the way a month
+reaches the Reporting API. Octavia notifications wait for #64.
+
+## The world and the workload
+
+The simulated cloud has three projects and one external network. It is small on
+purpose: what a run has to cover is every notification type and every shape of
+resource life, not a realistic tenant count.
+
+The flavor catalog holds four entries: `m1.small` with 1 vCPU, 2048 MB of
+memory, and a 20 GB root disk; `m1.medium` with 2, 4096, and 40; `m1.large`
+with 4, 8192, and 40 GB root plus 40 GB ephemeral; `m1.xlarge` with 8, 16384,
+and 160. `m1.large` is the only one with ephemeral disk, and the first instance
+of every project runs on it, so every month exercises the mapping's sum of root
+and ephemeral disk.
+
+A volume carries one of the types `ssd`, `hdd`, and `standard`. The first two
+appear under `type_modifiers` in `pricing/2026-03.yaml` and `standard` does
+not, so a month prices both paths. Image sizes are drawn at quarter-gibibyte
+steps from 1 GiB to 4 GiB, which keeps the mapping's division into gibibytes on
+exact decimals.
+
+Instances run on `compute-01` to `compute-04` and keep the host they were
+created on. Cinder publishes as `storage-01@ceph`, neutron as `neutron-01`, and
+glance as `glance-01`. Floating addresses come from `203.0.113.0/24`, the
+documentation range of RFC 5737, drawn as a permutation so that no address is
+handed out twice inside a month.
+
+Every project gets:
+
+- two images, each announced by an unsized `image.create` and uploaded 30 to
+  120 seconds later by an `image.upload`. The second image is deleted in the
+  last week of the month.
+- four instances, created within the first six hours, each with one to three
+  power cycles. A resize always falls on the first instance and on any other
+  with probability 1/2; a shelve always on the second and on any other with
+  probability 1/3. The first instance is deleted in the last ten days of the
+  month, together with its floating IP and its volumes.
+- one or two volumes per instance. The second instance's first volume always
+  resizes and retypes.
+- one floating IP per instance. The third instance's is released mid-month,
+  while the instance behind it lives on.
+- one spare volume, transferred to the next project.
+
+The workload renders 18 oslo notification types.
+
+| Notification | Exchange | Billable |
+| --- | --- | --- |
+| `compute.instance.create.end` | `nova` | yes |
+| `compute.instance.delete.end` | `nova` | yes |
+| `compute.instance.resize.end` | `nova` | yes |
+| `compute.instance.finish_resize.end` | `nova` | yes |
+| `compute.instance.power_off.end` | `nova` | yes |
+| `compute.instance.power_on.end` | `nova` | yes |
+| `compute.instance.shelve_offload.end` | `nova` | yes |
+| `compute.instance.unshelve.end` | `nova` | yes |
+| `volume.create.end` | `cinder` | yes |
+| `volume.delete.end` | `cinder` | yes |
+| `volume.resize.end` | `cinder` | yes |
+| `volume.retype` | `cinder` | yes |
+| `volume.transfer.accept.end` | `cinder` | yes |
+| `floatingip.create.end` | `neutron` | yes |
+| `floatingip.delete.end` | `neutron` | yes |
+| `image.create` | `glance` | no |
+| `image.upload` | `glance` | yes |
+| `image.delete` | `glance` | yes |
+
+`image.create` is rendered in the unsized form glance emits before an upload,
+and the mapping skips it on purpose: the `image.upload` that follows is the
+first notification with a size to bill.
+
+The forced steps (the resize on the first instance, the shelve on the second,
+the resize and retype of the second instance's first volume) are what make
+every seed render every type rather than most of them. The test suite holds
+seeds 1 to 5 over July 2026 against the recorded samples under
+[`internal/providers/openstack/testdata/golden/notifications/`](../internal/providers/openstack/testdata/golden/notifications),
+so a sample the catalog does not render fails the suite. The octavia
+notifications of #64 are such a sample.
+
+## Determinism
+
+The shape of a month (what happens, when, and with which sizes) is a function
+of `--seed` alone. The identifiers (the project and user ids, the resource ids,
+the floating addresses, the message ids) are a function of the seed together
+with the period and the cloud.
+
+The same seed, period, and cloud therefore publish byte-identical
+notifications, and a rerun costs nothing at the far end: the collector books
+the oslo message id as the event's `event_id`, and the Reporting API stores an
+event once per (`event_id`, `timestamp`), which
+[`openstack-collector.md`](openstack-collector.md) describes. Another cloud or
+another month publishes fresh resources under fresh message ids, so two
+collectors fed by two simulated clouds never collide on `event_id` at one
+Reporting API.
+
+Between two months of the same length the notifications sit at the same offsets
+from the month start. The transitions anchored on the month's end (the second
+image's delete and the first instance's) move with its length.
+
+## Running a month against the dev cluster
+
+The stack posts into the Reporting API of the kind dev cluster, so `make up`
+comes first. Then:
+
+```sh
+make simulator-up SIM_PERIOD=2026-07
+```
+
+`SIM_CLOUD` defaults to `os-sim`, `SIM_SEED` to 1, and `SIM_FACTOR` to 744. A
+factor of 744 puts a 31-day month on the bus in an hour.
+
+The target builds the collector and the simulator image, writes the dev CA to
+`tally-ca.crt`, issues an ingest credential for `SIM_CLOUD` with
+`tally-reporting-admin create-ingest-credential`, writes the cloud, the period,
+the seed, the factor, and that token into `deploy/compose/.env`, and starts the
+three containers of
+[`../deploy/compose/compose.yaml`](../deploy/compose/compose.yaml): the broker,
+the collector image, and the simulator.
+
+It does not rebuild what runs in the cluster and applies no migration: loading
+the Reporting API image into kind and applying the migration chain are both
+`make up`. After a change to the Reporting API or to the migrations, run
+`make up` again before this target; otherwise the stack posts into the image and
+the schema the last `make up` left there.
+
+The period has to lie in the past. `run` refuses a month that has not ended,
+because the engine warns about a period that has not ended, and a simulated
+month reaching into the future would carry that warning into every run over it.
+
+Four URLs come out of the stack:
+
+- `http://127.0.0.1:15672`, the broker's management UI, guest/guest
+- `http://127.0.0.1:8090/metrics`, the collector
+- `http://127.0.0.1:8091/clock`, the simulator's control endpoint
+- `https://api.tally.127-0-0-1.nip.io:8443/api/v1`, the Reporting API
+
+Every host port is bound to `127.0.0.1` and lies above 1024;
+`deploy/kind/kind.yaml` states why. The collector's container reaches the
+cluster through `extra_hosts`, which maps `api.tally.127-0-0-1.nip.io` to
+`host-gateway`, and `tally-ca.crt` is mounted read-only at the path
+`SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify.
+
+The simulator waits for a consumer on the collector's `tally-notifications`
+queue before its first publish, because a topic exchange drops what no queue is
+bound to and a month published into an empty broker is a month lost.
+`--wait-for-collector` bounds that wait, two minutes by default, and `0`
+disables it. A wait that runs out ends the run with an error naming the fix:
+start the collector first, or pass `--wait-for-collector 0` to publish anyway.
+
+Finish the month at once instead of waiting the factor out:
+
+```sh
+curl -X PUT -d '{"factor": 0}' http://127.0.0.1:8091/clock
+```
+
+Build a backlog on the durable queue and drain it again:
+
+```sh
+docker compose -f deploy/compose/compose.yaml stop collector
+docker compose -f deploy/compose/compose.yaml start collector
+```
+
+The messages are persistent, so a backlog survives a broker restart as well.
+
+A publish the broker does not confirm ends the run with exit status 1. Rerun it
+with the same seed, period, and cloud: that renders the same message ids, and
+ingestion deduplicates whatever was already delivered. SIGINT and SIGTERM stop
+a run with exit status 0, and what went out stays out.
+
+`make simulator-down` removes the containers, the outbox volume, and
+`deploy/compose/.env`, so the next `simulator-up` starts from a stack that
+carries nothing of the last one. It resets the stack and not the dev reporting
+database: what a run already delivered stays ingested, and no subcommand of
+`tally-reporting-admin` deletes an event. Running the same period again under
+another seed or another cloud therefore adds a second, disjoint set of rows
+beside the first and inflates the usage the API reports. To start the period
+over, drop the ingested data first with `make down && make up`, or with
+
+```sh
+TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable' \
+  go run ./cmd/tally-reporting-admin migrate-down-to 0
+make migrate
+```
+
+`simulator-up` issues a fresh ingest credential every time on purpose: the dev
+cluster may have been recreated since the last one, and a collector holding a
+token the database no longer knows retries forever.
+
+The month's resources are readable through the Reporting API with an admin
+token:
+
+```sh
+token="$(TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable' \
+  go run ./cmd/tally-reporting-admin create-api-token --role admin \
+  --description 'openstack simulator')"
+curl --cacert tally-ca.crt -H "Authorization: Bearer $token" \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources?cloud=os-sim'
+```
+
+## What the collector shows
+
+Seed 1 over `2026-07` renders 180 notifications, 174 of them billable. The
+other six are the unsized `image.create`, one per image of the three projects.
+
+`curl http://127.0.0.1:8090/readyz` answers 200 once the collector holds its
+broker connection and its outbox. On `http://127.0.0.1:8090/metrics`:
+
+- `tally_collector_consumed_total` grows per event type while the month goes
+  out.
+- `tally_collector_skipped_total{event_type="image.create"}` ends at 6 for that
+  seed and period.
+- `tally_collector_unparseable_total` stays 0. Anything else is a rendered body
+  the collector could not read.
+- `tally_collector_delivered_total` rises above 0 within two minutes at factor
+  744. A counter that stays at 0 means the events sit in the outbox and the
+  Reporting API is not taking them.
+
+`docker compose -f deploy/compose/compose.yaml logs collector` shows neither an
+`x509` error nor a `401` when the CA and the token are right.
+
+## File mode and replay
+
+`run --out DIR` writes the whole month before it publishes anything, so a run
+interrupted halfway still leaves a complete month on disk. With no broker
+configured it writes the files and publishes nothing:
+
+```sh
+TALLY_SIM_CLOUD=os-sim tally-openstack-simulator run \
+  --period 2026-07 --seed 1 --out /tmp/m
+```
+
+`notifications.jsonl` holds one line per notification with the `exchange` and
+the `routing_key` it goes out under and the `body` it carries. That body is the
+oslo envelope: an `oslo.version` of `2.0` and the notification itself as a JSON
+string under `oslo.message`, which is the double encoding a real deployment
+puts on the bus.
+
+```json
+{"exchange":"glance","routing_key":"notifications.info","body":{"oslo.message":"{\"event_type\":\"image.upload\",\"message_id\":\"6b6ed551-3eb5-4bea-b319-091466e44e7d\",\"payload\":{\"id\":\"72d2d72f-464a-424a-b045-587732b7a432\",\"owner\":\"d5a8024946ddf673277b9e2490643a2c\",\"size\":3489660928,\"status\":\"active\"},\"publisher_id\":\"image.glance-01\",\"timestamp\":\"2026-07-01 00:25:25.000000\"}","oslo.version":"2.0"}}
+```
+
+`events.jsonl` holds one canonical event per billable notification, computed by
+the collector's own parser and mapping table rather than by the simulator's
+idea of them. For seed 1 the first file therefore has six more lines than the
+second. A broker and `--out` combine: a run does both.
+
+`replay --in FILE --factor N` publishes a captured file onto a broker, with the
+virtual clock started at the first line's timestamp, so a month needs neither
+the generator nor the seed that produced it. The message ids are the recorded
+ones, so a second replay of the same file is deduplicated at ingest. A line
+whose timestamp lies before the previous one is published at once, which is
+what lets a file that is not perfectly sorted replay whole.
+
+`ReadStream` reads the file before the first message goes out and refuses an
+empty file, a line that is not JSON, and a body without a timestamp. A replay
+that would fail halfway through a month fails with nothing published.
+
+## The control endpoint
+
+Both subcommands serve a control endpoint on `TALLY_SIM_HTTP_ADDR` and
+`TALLY_SIM_HTTP_PORT` while they publish and no longer: pacing is the only thing
+it changes, and there is nothing to pace before the first notification or after
+the last one. It carries no credential, so what keeps it out of reach is the
+address it binds: loopback, unless a deployment names another one. In the
+compose stack it binds `0.0.0.0` inside the container, where loopback would be
+reachable from nothing, and the container's port 8080 is published on the host's
+`127.0.0.1:8091`. Within that reach the worst a caller does is make the run go
+at another speed.
+
+`GET /healthz` answers `ok`. `GET /clock` answers the document of that moment:
+
+```json
+{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":180,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+```
+
+`PUT /clock` with a body of `{"factor": N}`, where N is zero or positive,
+rebases the clock on the virtual instant it has reached and answers the same
+document. The month itself does not move: only what comes after the change runs
+at another speed. A body that is not JSON, one without the member, and one with
+a negative factor all answer 400 with
+`factor must be a JSON object with a number member "factor" that is zero or
+positive`. Any other method on either route answers 405. A run in file mode serves nothing.
+
+## Configuration
+
+[`../cmd/tally-openstack-simulator/.env.example`](../cmd/tally-openstack-simulator/.env.example)
+lists every variable with its default and its meaning.
+
+| Variable | Default | Read by | Purpose |
+| --- | --- | --- | --- |
+| `TALLY_LOG_LEVEL` | `INFO` | both | slog threshold: `DEBUG`, `INFO`, `WARN`, or `ERROR`, matched exactly. |
+| `TALLY_SIM_HTTP_ADDR` | `127.0.0.1` | both, while publishing | address the control endpoint binds. It carries no credential, so a bind on every interface is a deployment's own decision; the compose stack sets `0.0.0.0` because it publishes the port on the host's loopback itself. |
+| `TALLY_SIM_HTTP_PORT` | `8080` | both, while publishing | port of the control endpoint. |
+| `TALLY_SIM_AMQP_URL` | none | `run` optional, `replay` required | broker the notifications are published to. It carries the broker password, so it also accepts `TALLY_SIM_AMQP_URL_FILE`; setting both is an error. |
+| `TALLY_SIM_CLOUD` | none | `run` | cloud the month belongs to: the salt of every generated identifier and the cloud of `events.jsonl`. |
+
+An empty `TALLY_SIM_AMQP_URL` puts `run` in file mode, where `--out` is what it
+writes to instead, and `replay` refuses to start without one.
+
+The broker is the one setting that reaches off this machine, and what a run puts
+on it is not a test message. The exchanges, the declare arguments, and the shape
+of every notification are the ones a real deployment carries, the wire format
+names no cloud, and a collector books what it consumes under its own
+`TALLY_OSC_CLOUD` whatever `TALLY_SIM_CLOUD` said. A month published onto a
+production broker is therefore a month of invented usage in that deployment's
+billing data, and it stays there: ingestion deduplicates a second run into
+nothing, and no subcommand of `tally-reporting-admin` deletes an event. Both
+subcommands refuse a broker that is not on the machine they run on for that
+reason, and `--allow-remote-broker` is the confirmation that lets one through.
+The compose stack passes it, because its broker is the container next door.
+
+`run` takes `--period` (required, `YYYY-MM`), `--seed` (1), `--factor` (744),
+`--out` (empty), `--wait-for-collector` (two minutes), and
+`--allow-remote-broker` (off). `replay` takes `--in` (required), `--factor`
+(744), `--wait-for-collector` (two minutes), and `--allow-remote-broker` (off).
+
+`TALLY_METRICS_ENABLED` is not read: the simulator exports no metrics, and #67
+owns the endpoint that would serve them.

--- a/internal/providers/openstack/simulator/clock.go
+++ b/internal/providers/openstack/simulator/clock.go
@@ -1,0 +1,153 @@
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+// Clock maps wall time to the virtual time of the simulated month, so that a
+// month of notifications is emitted in the minutes an operator is willing to
+// wait for it. Everything the simulator paces reads its time here rather than
+// from time.Now, which is what lets the factor be raised or lowered while a run
+// is in flight.
+//
+// The factor is a float64 because it scales durations and never touches a usage
+// quantity or a price. The forbidigo rules in .golangci.yml that keep floats
+// off the money paths are about those quantities, not about how fast the
+// simulation runs.
+type Clock struct {
+	mu       sync.Mutex
+	base     time.Time     // virtual instant at baseWall
+	baseWall time.Time     // wall instant the base was taken at
+	factor   float64       // virtual seconds per wall second; 0 is unbounded
+	changed  chan struct{} // closed and replaced on every SetFactor
+	now      func() time.Time
+}
+
+// NewClock starts a clock at start, running at factor virtual seconds per wall
+// second. now is the wall clock it reads: production passes time.Now, and a
+// test passes a function it advances by hand so that a month-long factor is
+// asserted without waiting for real time.
+func NewClock(start time.Time, factor float64, now func() time.Time) *Clock {
+	return &Clock{
+		base:     start,
+		baseWall: now(),
+		factor:   factor,
+		changed:  make(chan struct{}),
+		now:      now,
+	}
+}
+
+// Now is the virtual instant the clock currently stands at.
+func (c *Clock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.nowLocked()
+}
+
+// nowLocked is Now with the lock already held, which is what SetFactor needs to
+// read the old factor's virtual now and rebase on it in one critical section.
+// At factor 0 the elapsed wall time scales to nothing, so the virtual clock
+// stands still however long the process runs.
+func (c *Clock) nowLocked() time.Time {
+	elapsed := c.now().Sub(c.baseWall)
+	return c.base.Add(time.Duration(float64(elapsed) * c.factor))
+}
+
+// Factor is the virtual seconds the clock currently covers per wall second.
+func (c *Clock) Factor() float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.factor
+}
+
+// SetFactor changes how fast virtual time runs from this instant on. The clock
+// rebases on the virtual now it has reached under the old factor, so a change
+// never moves the simulated month itself: only what comes after it runs at a
+// different speed. Closing changed wakes every SleepUntil, because the wall
+// deadline each of them computed no longer answers to the new factor.
+//
+// A negative factor is refused rather than clamped: it would run the simulated
+// month backwards, and every consumer of the notifications reads their
+// timestamps as moving forward. NaN is refused beside it, because it compares
+// false against every bound, including this one: it would reach the arithmetic
+// below and turn every virtual instant the clock reports into a duration
+// nothing can wait for.
+func (c *Clock) SetFactor(factor float64) error {
+	if math.IsNaN(factor) || factor < 0 {
+		return fmt.Errorf("factor %g must be zero or positive", factor)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.base = c.nowLocked()
+	c.baseWall = c.now()
+	c.factor = factor
+	close(c.changed)
+	c.changed = make(chan struct{})
+	return nil
+}
+
+// snapshot reads the three values a wait is planned from in one locked read. A
+// factor change landing between them would otherwise leave the waiter holding a
+// deadline computed under one factor and a changed channel that has already
+// been closed for it, so the wake never arrives.
+func (c *Clock) snapshot() (now time.Time, factor float64, changed <-chan struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.nowLocked(), c.factor, c.changed
+}
+
+// maxWait bounds one wall wait. A very small factor makes the exact wait longer
+// than a time.Duration holds, and converting an out-of-range float64 to an
+// integer is implementation-defined: it yields either a non-positive duration,
+// which fires at once and turns the wait into a spin, or a saturated one, which
+// never fires at all. Waking early costs nothing, because the loop recomputes
+// what is left of the distance.
+const maxWait = time.Hour
+
+// wallWait is the wall time the remaining virtual distance costs at factor,
+// bounded by maxWait. The factor is above zero here: SleepUntil returns before
+// it reaches this at factor 0, and SetFactor refuses everything below it.
+func wallWait(remaining time.Duration, factor float64) time.Duration {
+	if exact := float64(remaining) / factor; exact < float64(maxWait) {
+		return time.Duration(exact)
+	}
+	return maxWait
+}
+
+// SleepUntil waits until the virtual clock reaches virtual, and reports ctx's
+// error when the context ends first. At factor 0 it returns at once: virtual
+// time does not advance then, so waiting for it would never end, and the run
+// goes as fast as the broker takes the notifications.
+//
+// The wait is recomputed on every wake because the factor decides what the
+// remaining virtual distance costs in wall time. A change mid-wait invalidates
+// the deadline, which is why the timer and the changed channel are selected on
+// together. A distance that costs more wall time than maxWait is covered in
+// several waits for the same reason.
+func (c *Clock) SleepUntil(ctx context.Context, virtual time.Time) error {
+	for {
+		now, factor, changed := c.snapshot()
+		if factor == 0 || !now.Before(virtual) {
+			return nil
+		}
+
+		timer := time.NewTimer(wallWait(virtual.Sub(now), factor))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		case <-changed:
+			timer.Stop()
+		}
+	}
+}

--- a/internal/providers/openstack/simulator/clock_test.go
+++ b/internal/providers/openstack/simulator/clock_test.go
@@ -1,0 +1,171 @@
+package simulator
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+// clockStart is the first instant of the simulated month the clock tests run
+// over, and 744 is the factor that covers a 31 day month in one hour.
+var clockStart = time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+// wake is how long a test waits for a sleeper before calling it hung. It is far
+// above the wake it asserts, so the bound fails a clock that never returns
+// rather than a machine that is busy.
+const wake = time.Second
+
+// awaited returns what the sleeper reported, or fails the test when it is still
+// waiting after wake.
+func awaited(t *testing.T, done <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(wake):
+		t.Fatal("SleepUntil() has not returned, want it woken")
+		return nil
+	}
+}
+
+func TestClockAdvancesAtTheFactor(t *testing.T) {
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+
+	wall = wall.Add(time.Second)
+
+	want := clockStart.Add(744 * time.Second)
+	if got := clock.Now(); !got.Equal(want) {
+		t.Errorf("Now() = %s, want %s", got, want)
+	}
+}
+
+func TestSetFactorRebases(t *testing.T) {
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+
+	wall = wall.Add(time.Second)
+	atChange := clockStart.Add(744 * time.Second)
+
+	if err := clock.SetFactor(10); err != nil {
+		t.Fatalf("SetFactor(10) error = %v, want nil", err)
+	}
+	if got := clock.Now(); !got.Equal(atChange) {
+		t.Errorf("Now() at the change = %s, want %s, because a change moves nothing already reached", got, atChange)
+	}
+	if got := clock.Factor(); got != 10 {
+		t.Errorf("Factor() = %g, want 10", got)
+	}
+
+	wall = wall.Add(time.Second)
+
+	want := atChange.Add(10 * time.Second)
+	if got := clock.Now(); !got.Equal(want) {
+		t.Errorf("Now() = %s, want %s", got, want)
+	}
+}
+
+func TestSetFactorRefusesANegativeFactor(t *testing.T) {
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+
+	err := clock.SetFactor(-1)
+	if err == nil {
+		t.Fatal("SetFactor(-1) error = nil, want an error")
+	}
+	if want := "factor -1 must be zero or positive"; err.Error() != want {
+		t.Errorf("SetFactor(-1) error = %q, want %q", err.Error(), want)
+	}
+	if got := clock.Factor(); got != 744 {
+		t.Errorf("Factor() = %g, want 744, because a refused change leaves the clock alone", got)
+	}
+}
+
+func TestSetFactorRefusesNaN(t *testing.T) {
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+
+	err := clock.SetFactor(math.NaN())
+	if err == nil {
+		t.Fatal("SetFactor(NaN) error = nil, want an error")
+	}
+	if want := "factor NaN must be zero or positive"; err.Error() != want {
+		t.Errorf("SetFactor(NaN) error = %q, want %q", err.Error(), want)
+	}
+	if got := clock.Factor(); got != 744 {
+		t.Errorf("Factor() = %g, want 744, because a refused change leaves the clock alone", got)
+	}
+}
+
+func TestWallWaitIsBounded(t *testing.T) {
+	// A wait that is not bounded is not a slow wait: the conversion of a float
+	// that a time.Duration cannot hold is implementation-defined, and the two
+	// answers it gives are a wait that fires at once, which spins a core over a
+	// month that publishes nothing, and one of some three hundred years.
+	for _, tc := range []struct {
+		name      string
+		remaining time.Duration
+		factor    float64
+		want      time.Duration
+	}{
+		{"real time at factor 1", time.Minute, 1, time.Minute},
+		{"a month-in-an-hour factor", 744 * time.Second, 744, time.Second},
+		{"a distance past the bound", 30 * 24 * time.Hour, 1, maxWait},
+		{"a factor that overflows the conversion", time.Hour, 1e-7, maxWait},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wallWait(tc.remaining, tc.factor); got != tc.want {
+				t.Errorf("wallWait(%s, %g) = %s, want %s", tc.remaining, tc.factor, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSleepUntilReturnsAtOnceWhenUnbounded(t *testing.T) {
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 0, func() time.Time { return wall })
+
+	done := make(chan error, 1)
+	go func() { done <- clock.SleepUntil(t.Context(), clockStart.Add(time.Hour)) }()
+
+	if err := awaited(t, done); err != nil {
+		t.Errorf("SleepUntil() error = %v, want nil at factor 0", err)
+	}
+}
+
+func TestSleepUntilWakesOnAFactorChange(t *testing.T) {
+	clock := NewClock(clockStart, 1, time.Now)
+
+	done := make(chan error, 1)
+	go func() { done <- clock.SleepUntil(t.Context(), clockStart.Add(time.Hour)) }()
+
+	// At factor 1 the sleeper is an hour of wall time from its target, so it is
+	// still waiting when the factor drops and only the change can wake it.
+	time.Sleep(50 * time.Millisecond)
+	if err := clock.SetFactor(0); err != nil {
+		t.Fatalf("SetFactor(0) error = %v, want nil", err)
+	}
+
+	if err := awaited(t, done); err != nil {
+		t.Errorf("SleepUntil() error = %v, want nil once the factor is 0", err)
+	}
+}
+
+func TestSleepUntilReturnsTheContextError(t *testing.T) {
+	clock := NewClock(clockStart, 1, time.Now)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- clock.SleepUntil(ctx, clockStart.Add(time.Hour)) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	if err := awaited(t, done); !errors.Is(err, context.Canceled) {
+		t.Errorf("SleepUntil() error = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/providers/openstack/simulator/config.go
+++ b/internal/providers/openstack/simulator/config.go
@@ -1,0 +1,183 @@
+// Package simulator publishes one simulated month of oslo.messaging
+// notifications. It renders a seeded month of nova, cinder, neutron, and glance
+// notifications onto a RabbitMQ broker, or into files when no broker is
+// configured, and a virtual clock decides how much wall time that month costs.
+//
+// The notifications are the ones a real deployment publishes, so the collector
+// in internal/providers/openstack consumes them unmodified: the simulator sits
+// on the producing side of the bus and nothing on the consuming side knows it
+// is there.
+//
+// This file parses the simulator's environment configuration. Configuration
+// comes from the environment alone, prefixed TALLY_, and secrets also accept
+// the *_FILE convention; the normative specification is
+// roadmap/00-conventions.md section 8.
+package simulator
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/caarlos0/env/v11"
+)
+
+// fileSuffix names the companion variable of a secret: the value of
+// TALLY_SIM_AMQP_URL is read from the file at TALLY_SIM_AMQP_URL_FILE when that
+// variable holds a path.
+const fileSuffix = "_FILE"
+
+// The variables this package reads. They are named here because the errors
+// quote them: an operator gets the variable to fix, not a Go field name.
+const (
+	envLogLevel = "TALLY_LOG_LEVEL"
+	envHTTPAddr = "TALLY_SIM_HTTP_ADDR"
+	envHTTPPort = "TALLY_SIM_HTTP_PORT"
+	envAMQPURL  = "TALLY_SIM_AMQP_URL"
+	envCloud    = "TALLY_SIM_CLOUD"
+)
+
+// EnvNames is every variable this package reads, including the *_FILE companion
+// of the secret. Tests blank all of them, so a value in the developer's shell
+// never reaches the code under test.
+var EnvNames = []string{
+	envLogLevel,
+	envHTTPAddr,
+	envHTTPPort,
+	envAMQPURL,
+	envAMQPURL + fileSuffix,
+	envCloud,
+}
+
+// loopback is the address the control endpoint binds unless a deployment names
+// another one. It is the default of TALLY_SIM_HTTP_ADDR and the answer for a
+// Config that never went through Load.
+const loopback = "127.0.0.1"
+
+// logLevels maps the accepted values of TALLY_LOG_LEVEL to their slog level.
+// The match is exact: a lower-case "info" is a typo, and silently accepting it
+// would hide the mistake behind a working service.
+var logLevels = map[string]slog.Level{
+	"DEBUG": slog.LevelDebug,
+	"INFO":  slog.LevelInfo,
+	"WARN":  slog.LevelWarn,
+	"ERROR": slog.LevelError,
+}
+
+// Config is the simulator's resolved configuration. Every field is final by the
+// time Load returns: a file-backed broker URL holds the file's content, and the
+// log level is one this package accepts.
+type Config struct {
+	// LogLevel is the slog threshold, one of DEBUG, INFO, WARN, or ERROR. Both
+	// subcommands read it.
+	LogLevel string `env:"TALLY_LOG_LEVEL" envDefault:"INFO"`
+	// HTTPAddr is the address the control endpoint binds. It defaults to loopback
+	// because the endpoint carries no credential and PUT /clock changes the pace
+	// of a run: a simulator on a host beside a control plane would otherwise
+	// answer everybody on the management network. A deployment that means to
+	// publish the port sets 0.0.0.0, which is what the compose stack does.
+	HTTPAddr string `env:"TALLY_SIM_HTTP_ADDR" envDefault:"127.0.0.1"`
+	// HTTPPort is the port the control endpoint listens on. It is served only
+	// while the simulator publishes, because there is nothing to control once the
+	// month is over.
+	HTTPPort int `env:"TALLY_SIM_HTTP_PORT" envDefault:"8080"`
+	// AMQPURL is the broker the notifications are published to. It carries the
+	// broker password, so it supports the *_FILE convention. Empty puts run in
+	// file mode, where the month is written out instead of published.
+	AMQPURL string `env:"TALLY_SIM_AMQP_URL"`
+	// Cloud is read by run alone: it is the salt of every generated identifier
+	// and the cloud of events.jsonl. It has no default because a guessed cloud
+	// silently books usage to the wrong one.
+	Cloud string `env:"TALLY_SIM_CLOUD"`
+}
+
+// Load reads the environment, resolves the file-backed broker URL, and checks
+// the log level. It does not check whether the required values are present:
+// which ones are required depends on the subcommand, which is what ValidateRun
+// and ValidateReplay decide.
+func Load() (Config, error) {
+	cfg, err := env.ParseAs[Config]()
+	if err != nil {
+		return Config{}, fmt.Errorf("parsing the environment: %w", err)
+	}
+
+	if cfg.AMQPURL, err = resolveFileSecret(envAMQPURL, cfg.AMQPURL); err != nil {
+		return Config{}, err
+	}
+
+	if _, ok := logLevels[cfg.LogLevel]; !ok {
+		return Config{}, fmt.Errorf("%s: %q must be DEBUG, INFO, WARN, or ERROR", envLogLevel, cfg.LogLevel)
+	}
+
+	return cfg, nil
+}
+
+// resolveFileSecret applies the *_FILE convention to one variable: when its
+// companion holds a path, the file's content becomes the value. Kubernetes
+// writes Secret volumes with a trailing newline, so one is trimmed. An empty
+// file is rejected because it usually means the secret was never populated,
+// which would otherwise surface much later as an authentication failure.
+func resolveFileSecret(name, value string) (string, error) {
+	fileVar := name + fileSuffix
+	path := os.Getenv(fileVar)
+	if path == "" {
+		return value, nil
+	}
+	if value != "" {
+		return "", fmt.Errorf("set %s or %s, not both", name, fileVar)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", fileVar, err)
+	}
+	secret := strings.TrimSuffix(string(content), "\n")
+	if secret == "" {
+		return "", fmt.Errorf("%s: file %s is empty", fileVar, path)
+	}
+	return secret, nil
+}
+
+// ValidateRun is the gate of the subcommand that generates the month. It asks
+// for the cloud alone: the broker is optional because run --out writes the
+// month to files and never connects to one.
+func (c Config) ValidateRun() error {
+	if c.Cloud == "" {
+		return fmt.Errorf("%s: must be set", envCloud)
+	}
+	return nil
+}
+
+// ValidateReplay is the gate of the subcommand that publishes an already
+// generated month. Replaying carries the cloud in the recorded notifications,
+// so the broker is all it needs.
+func (c Config) ValidateReplay() error {
+	if c.AMQPURL == "" {
+		return fmt.Errorf("%s: must be set", envAMQPURL)
+	}
+	return nil
+}
+
+// ControlAddr is the address the control endpoint listens on. An empty
+// HTTPAddr, which is a Config that never went through Load, binds loopback
+// rather than every interface: the endpoint carries no credential, so the wider
+// bind is a choice a deployment makes and not one a zero value falls into.
+func (c Config) ControlAddr() string {
+	addr := c.HTTPAddr
+	if addr == "" {
+		addr = loopback
+	}
+	return net.JoinHostPort(addr, strconv.Itoa(c.HTTPPort))
+}
+
+// SlogLevel is the slog level that LogLevel names. A Config that never went
+// through Load, and so carries an unchecked level, logs at info.
+func (c Config) SlogLevel() slog.Level {
+	if level, ok := logLevels[c.LogLevel]; ok {
+		return level
+	}
+	return slog.LevelInfo
+}

--- a/internal/providers/openstack/simulator/control.go
+++ b/internal/providers/openstack/simulator/control.go
@@ -1,0 +1,143 @@
+package simulator
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Progress is how far a run has got: the simulated period it publishes and the
+// notifications it has already put on the bus. The run hands it to the control
+// endpoint through a callback rather than a copy, so a caller reading /clock
+// sees the counts of that moment instead of the counts the endpoint was built
+// with.
+type Progress struct {
+	// From and To bound the simulated month, the period the virtual clock runs
+	// through.
+	From time.Time
+	To   time.Time
+	// Published is how many notifications the run has published so far, of Total
+	// in the whole month.
+	Published int
+	Total     int
+}
+
+// clockDocument is what /clock answers. The instants are RFC 3339 in UTC
+// because the reader is a person or a script watching a run, and a zoneless
+// timestamp would leave both guessing which zone the simulator ran in.
+type clockDocument struct {
+	VirtualNow string  `json:"virtual_now"`
+	Factor     float64 `json:"factor"`
+	Published  int     `json:"published"`
+	Total      int     `json:"total"`
+	PeriodFrom string  `json:"period_from"`
+	PeriodTo   string  `json:"period_to"`
+}
+
+// badFactorBody is the single answer every refused PUT /clock gets. One answer
+// covers a body that is not JSON, one without the member, and one whose factor
+// is negative, because what the caller has to do about it is the same in all
+// three.
+const badFactorBody = `factor must be a JSON object with a number member "factor" that is zero or positive`
+
+// factorBodyMax bounds the body of PUT /clock. The request carries one number,
+// so a kilobyte is far more than it needs, and the bound keeps the endpoint
+// from reading whatever an unauthenticated caller sends.
+const factorBodyMax = 1 << 10
+
+// NewControlMux builds the routes the simulator serves while it publishes:
+// /healthz for the compose health check, and /clock to read and change how fast
+// the simulated month runs.
+//
+// The endpoint changes pacing and nothing else. It cannot alter the month, the
+// notifications, or where they go, which is why it carries no credential. What
+// keeps it from answering anybody is where it is bound: TALLY_SIM_HTTP_ADDR is
+// loopback unless a deployment says otherwise, and the compose stack publishes
+// its port on 127.0.0.1. Within that reach the worst a caller does is make
+// somebody's demo run at a different speed.
+//
+// It takes no logger because the command sets the default one, and the only
+// line it writes is the factor change.
+func NewControlMux(clock *Clock, progress func() Progress) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		writeText(w, http.StatusOK, "ok")
+	})
+
+	mux.HandleFunc("GET /clock", func(w http.ResponseWriter, _ *http.Request) {
+		writeDocument(w, document(clock, progress))
+	})
+
+	mux.HandleFunc("PUT /clock", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			// The pointer is what tells a missing member from a factor of 0, and 0
+			// is a value the clock accepts: it stops virtual time and lets the run
+			// publish as fast as the broker takes it.
+			Factor *float64 `json:"factor"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, factorBodyMax)).Decode(&body); err != nil {
+			writeText(w, http.StatusBadRequest, badFactorBody)
+			return
+		}
+		if body.Factor == nil {
+			writeText(w, http.StatusBadRequest, badFactorBody)
+			return
+		}
+		if err := clock.SetFactor(*body.Factor); err != nil {
+			writeText(w, http.StatusBadRequest, badFactorBody)
+			return
+		}
+
+		slog.Info("the factor changed", "factor", *body.Factor)
+		writeDocument(w, document(clock, progress))
+	})
+
+	return mux
+}
+
+// document reads the state both /clock routes answer with. The clock and the
+// progress are read here rather than held, so the answer is of the instant the
+// request arrived.
+func document(clock *Clock, progress func() Progress) clockDocument {
+	p := progress()
+	return clockDocument{
+		VirtualNow: instant(clock.Now()),
+		Factor:     clock.Factor(),
+		Published:  p.Published,
+		Total:      p.Total,
+		PeriodFrom: instant(p.From),
+		PeriodTo:   instant(p.To),
+	}
+}
+
+// instant renders a time the way the document reports it.
+func instant(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// writeText answers in plain text, the way the collector's probes answer: what
+// reads /healthz is a health check that looks at the status, and a refused PUT
+// says in one sentence what a usable body is.
+func writeText(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+}
+
+// writeDocument answers with the clock document. The encoding is done before
+// the status is written so that a failure can still be reported as one, though
+// with two strings, a float, and two ints there is nothing here that fails to
+// marshal.
+func writeDocument(w http.ResponseWriter, doc clockDocument) {
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		writeText(w, http.StatusInternalServerError, "the clock could not be encoded")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(encoded)
+}

--- a/internal/providers/openstack/simulator/control_test.go
+++ b/internal/providers/openstack/simulator/control_test.go
@@ -1,0 +1,204 @@
+package simulator
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// controlProgress is what the run reports to the endpoint under test. The two
+// counts differ so that a document that swapped published for total fails
+// rather than reading the same either way.
+var controlProgress = Progress{
+	From:      clockStart,
+	To:        time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	Published: 12,
+	Total:     231,
+}
+
+// controlServer serves the endpoint over a clock whose wall time is frozen, so
+// the virtual now the document reports is the month's first instant however
+// long the test takes. The clock comes back with the server because what a
+// request did to the factor is asserted on it.
+func controlServer(t *testing.T) (*Clock, *httptest.Server) {
+	t.Helper()
+
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+	server := httptest.NewServer(NewControlMux(clock, func() Progress { return controlProgress }))
+	t.Cleanup(server.Close)
+	return clock, server
+}
+
+// request sends one request to the endpoint and returns the status, the content
+// type, and the body of the answer.
+func request(t *testing.T, server *httptest.Server, method, path, body string) (int, string, string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, server.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building %s %s: %v", method, path, err)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	answer, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the answer to %s %s: %v", method, path, err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), string(answer)
+}
+
+// decodeDocument reads the clock document out of an answer's body.
+func decodeDocument(t *testing.T, body string) clockDocument {
+	t.Helper()
+
+	var doc clockDocument
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("decoding %q: %v", body, err)
+	}
+	return doc
+}
+
+func TestClockEndpointReportsTheState(t *testing.T) {
+	_, server := controlServer(t)
+
+	status, contentType, body := request(t, server, http.MethodGet, "/clock", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Errorf("GET /clock Content-Type = %q, want it to start with application/json", contentType)
+	}
+
+	doc := decodeDocument(t, body)
+	want := clockDocument{
+		VirtualNow: "2026-07-01T00:00:00Z",
+		Factor:     744,
+		Published:  12,
+		Total:      231,
+		PeriodFrom: "2026-07-01T00:00:00Z",
+		PeriodTo:   "2026-08-01T00:00:00Z",
+	}
+	if doc != want {
+		t.Errorf("GET /clock document = %+v, want %+v", doc, want)
+	}
+
+	status, contentType, body = request(t, server, http.MethodGet, "/healthz", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /healthz = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if body != "ok" {
+		t.Errorf("GET /healthz body = %q, want %q", body, "ok")
+	}
+	if !strings.HasPrefix(contentType, "text/plain") {
+		t.Errorf("GET /healthz Content-Type = %q, want it to start with text/plain", contentType)
+	}
+}
+
+// TestClockEndpointSetsTheFactor uses 0 as the new factor, which is the one
+// value a missing member would otherwise be taken for, and the one an operator
+// reaches for to let a run finish as fast as the broker takes it.
+func TestClockEndpointSetsTheFactor(t *testing.T) {
+	clock, server := controlServer(t)
+
+	status, _, body := request(t, server, http.MethodPut, "/clock", `{"factor": 0}`)
+	if status != http.StatusOK {
+		t.Fatalf("PUT /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if got := decodeDocument(t, body).Factor; got != 0 {
+		t.Errorf("PUT /clock document factor = %g, want 0", got)
+	}
+	if got := clock.Factor(); got != 0 {
+		t.Errorf("Factor() after PUT /clock = %g, want 0", got)
+	}
+
+	status, _, body = request(t, server, http.MethodGet, "/clock", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if got := decodeDocument(t, body).Factor; got != 0 {
+		t.Errorf("GET /clock factor after the change = %g, want 0", got)
+	}
+}
+
+func TestClockEndpointRefusesABadBody(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "a body that is not JSON", body: "not json"},
+		{name: "an object without the member", body: "{}"},
+		{name: "a negative factor", body: `{"factor": -5}`},
+		{name: "a factor that is not a number", body: `{"factor": "fast"}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clock, server := controlServer(t)
+
+			status, contentType, body := request(t, server, http.MethodPut, "/clock", c.body)
+			if status != http.StatusBadRequest {
+				t.Fatalf("PUT /clock %s = %d, want %d (body %q)",
+					c.body, status, http.StatusBadRequest, body)
+			}
+			if !strings.HasPrefix(contentType, "text/plain") {
+				t.Errorf("PUT /clock Content-Type = %q, want it to start with text/plain", contentType)
+			}
+			if body != badFactorBody {
+				t.Errorf("PUT /clock body = %q, want %q", body, badFactorBody)
+			}
+			// The refusal leaves the run at the pace it was started with, rather
+			// than at some pace the bad body was read as.
+			if got := clock.Factor(); got != 744 {
+				t.Errorf("Factor() after the refusal = %g, want 744", got)
+			}
+		})
+	}
+}
+
+// TestClockEndpointRefusesOtherMethods holds the routes to the method they were
+// registered with: the mux answers 405 itself, so neither handler ever sees a
+// request it was not written for.
+func TestClockEndpointRefusesOtherMethods(t *testing.T) {
+	_, server := controlServer(t)
+
+	status, _, body := request(t, server, http.MethodPost, "/clock", `{"factor": 1}`)
+	if status != http.StatusMethodNotAllowed {
+		t.Errorf("POST /clock = %d, want %d (body %q)", status, http.StatusMethodNotAllowed, body)
+	}
+
+	status, _, body = request(t, server, http.MethodDelete, "/healthz", "")
+	if status != http.StatusMethodNotAllowed {
+		t.Errorf("DELETE /healthz = %d, want %d (body %q)", status, http.StatusMethodNotAllowed, body)
+	}
+}
+
+func TestControlAddrBindsLoopbackUnlessAskedOtherwise(t *testing.T) {
+	// The endpoint carries no credential and PUT /clock changes the pace of a
+	// run, so the address it binds is what keeps it out of reach. A bind on every
+	// interface is a deployment's own decision, and a Config that never went
+	// through Load does not fall into it.
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"the default Load resolves", Config{HTTPAddr: loopback, HTTPPort: 8080}, "127.0.0.1:8080"},
+		{"a Config that never went through Load", Config{HTTPPort: 8080}, "127.0.0.1:8080"},
+		{"the address a published deployment sets", Config{HTTPAddr: "0.0.0.0", HTTPPort: 8080}, "0.0.0.0:8080"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.ControlAddr(); got != tc.want {
+				t.Errorf("ControlAddr() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providers/openstack/simulator/mapping_test.go
+++ b/internal/providers/openstack/simulator/mapping_test.go
@@ -1,0 +1,96 @@
+package simulator
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/b42labs/tally/internal/core/testkit"
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+func TestEveryBillableTransitionMapsToAnEvent(t *testing.T) {
+	for _, transition := range generateMonth(t, 1, july2026, testCloud) {
+		notification := parse(t, render(t, transition))
+
+		mapped, ok := openstack.MapNotification(notification, testCloud)
+		if ok != transition.Billable {
+			t.Errorf("MapNotification(%s) mapped = %v, want %v",
+				transition.EventType, ok, transition.Billable)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		raw, err := json.Marshal(mapped)
+		if err != nil {
+			t.Fatalf("encoding the event of %s: %v", transition.EventType, err)
+		}
+		testkit.AssertValidEvent(t, raw)
+
+		if mapped.ResourceID != transition.ResourceID {
+			t.Errorf("%s booked resource %q, want %q",
+				transition.EventType, mapped.ResourceID, transition.ResourceID)
+		}
+		if mapped.ProjectID != transition.ProjectID {
+			t.Errorf("%s booked project %q, want %q",
+				transition.EventType, mapped.ProjectID, transition.ProjectID)
+		}
+		if !mapped.Timestamp.Equal(transition.At) {
+			t.Errorf("%s booked %s, want %s", transition.EventType, mapped.Timestamp, transition.At)
+		}
+		if mapped.Cloud != testCloud {
+			t.Errorf("%s booked cloud %q, want %q", transition.EventType, mapped.Cloud, testCloud)
+		}
+	}
+}
+
+// TestEveryRecordedNotificationTypeIsRendered is the drift guard between the
+// collector's fixtures and the simulator. A type that was recorded from a real
+// deployment but never rendered is one a run leaves untested, whatever the seed
+// an operator picks, so the forced steps of the workload are held against the
+// whole fixture set rather than against one month.
+func TestEveryRecordedNotificationTypeIsRendered(t *testing.T) {
+	entries, err := os.ReadDir(sampleDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", sampleDir, err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("%s holds no recorded notifications, want the collector's fixtures", sampleDir)
+	}
+
+	var recorded []string
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(sampleDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", entry.Name(), err)
+		}
+		if eventType := parse(t, body).EventType; !slices.Contains(recorded, eventType) {
+			recorded = append(recorded, eventType)
+		}
+	}
+	slices.Sort(recorded)
+	if len(recorded) == 0 {
+		t.Fatalf("%s holds no readable notification, want the collector's fixtures", sampleDir)
+	}
+
+	for seed := uint64(1); seed <= 5; seed++ {
+		var rendered []string
+		for _, transition := range generateMonth(t, seed, july2026, testCloud) {
+			if !slices.Contains(rendered, transition.EventType) {
+				rendered = append(rendered, transition.EventType)
+			}
+		}
+		for _, eventType := range recorded {
+			if !slices.Contains(rendered, eventType) {
+				t.Errorf("seed %d renders no %s, want every recorded type in every month", seed, eventType)
+			}
+		}
+	}
+}

--- a/internal/providers/openstack/simulator/publish.go
+++ b/internal/providers/openstack/simulator/publish.go
@@ -9,12 +9,12 @@ import (
 	amqp091 "github.com/rabbitmq/amqp091-go"
 )
 
-// CollectorQueue is the queue the collector consumes from, which is what the
+// collectorQueue is the queue the collector consumes from, which is what the
 // wait for a consumer looks at. It repeats queueName in
 // internal/providers/openstack/osloamqp.go, which is unexported and stays so:
 // the queue belongs to the collector, and naming it here keeps the collector
 // package from exporting anything for the sake of a simulator.
-const CollectorQueue = "tally-notifications"
+const collectorQueue = "tally-notifications"
 
 // serviceExchanges are the exchanges a stock deployment publishes
 // notifications on, one per service. They are also the default of the

--- a/internal/providers/openstack/simulator/publish.go
+++ b/internal/providers/openstack/simulator/publish.go
@@ -1,0 +1,198 @@
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	amqp091 "github.com/rabbitmq/amqp091-go"
+)
+
+// CollectorQueue is the queue the collector consumes from, which is what the
+// wait for a consumer looks at. It repeats queueName in
+// internal/providers/openstack/osloamqp.go, which is unexported and stays so:
+// the queue belongs to the collector, and naming it here keeps the collector
+// package from exporting anything for the sake of a simulator.
+const CollectorQueue = "tally-notifications"
+
+// serviceExchanges are the exchanges a stock deployment publishes
+// notifications on, one per service. They are also the default of the
+// collector's TALLY_OSC_EXCHANGES, so a simulator and a collector that were
+// both left at their defaults meet on all four.
+var serviceExchanges = []string{"nova", "cinder", "neutron", "glance"}
+
+// probeInterval is how long AwaitConsumer waits between two looks at the
+// collector's queue. It is short enough that a collector started a moment later
+// is noticed at once, and long enough that a minute of waiting costs the broker
+// little.
+const probeInterval = 500 * time.Millisecond
+
+// EnsureLocalBroker refuses a broker that is not on the machine the simulator
+// runs on.
+//
+// What a run publishes is well-formed billing data. The exchanges, the declare
+// arguments, and the shape of every notification are the ones a real deployment
+// carries, and the wire format holds no cloud, so a collector on the far side
+// of a production broker books a simulated month as real usage under its own
+// TALLY_OSC_CLOUD, whatever TALLY_SIM_CLOUD said. An operator who copies a
+// production TALLY_OSC_AMQP_URL into TALLY_SIM_AMQP_URL to try the simulator
+// against the real broker writes a month of invented usage into the production
+// database: ingestion deduplicates a second run into nothing, and no
+// subcommand of tally-reporting-admin deletes what the first one wrote.
+//
+// A broker on loopback cannot be that one, so it is dialled without asking.
+// Every other broker is a decision, which is what --allow-remote-broker is: the
+// compose stack passes it because its broker is a container beside the
+// simulator, and an operator on a jump host has to type it.
+func EnsureLocalBroker(url string) error {
+	uri, err := amqp091.ParseURI(url)
+	if err != nil {
+		// The same answer Connect gives, for the reason it gives there: the parse
+		// error carries the whole input, password and all.
+		return fmt.Errorf("%s is not a usable AMQP URL", envAMQPURL)
+	}
+	if uri.Host == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(uri.Host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("%s names the broker %s, which is not on this machine: a run publishes "+
+		"notifications that a collector books as real usage and nothing deletes again; "+
+		"pass --allow-remote-broker when that broker is one to simulate against", envAMQPURL, uri.Host)
+}
+
+// Publisher is the simulator's side of the bus: one connection and one channel
+// in confirm mode, so every published notification is waited on until the
+// broker has taken responsibility for it. A run that reported a message
+// published while the broker dropped it would leave the collector short of
+// events with nothing to point at.
+type Publisher struct {
+	conn    *amqp091.Connection
+	channel *amqp091.Channel
+}
+
+// Connect dials the broker, opens the confirming channel, and declares the
+// service exchanges.
+//
+// The declares are what make the collector's connection work at all: the
+// collector declares the same exchanges passively (connect in
+// internal/providers/openstack/osloamqp.go), so on a fresh broker, where no
+// OpenStack service has ever published, its declare fails and it reconnects
+// until somebody declares them. The arguments are the ones the services use,
+// and the ones declareExchanges in
+// internal/providers/openstack/amqp_integration_test.go uses: a durable topic
+// exchange that is neither auto-deleted nor internal. A declare that differed
+// in any of them would be refused by a broker that already carries the
+// service's exchange.
+func Connect(url string) (*Publisher, error) {
+	// The parse error is thrown away rather than wrapped, the way connect in
+	// internal/providers/openstack/osloamqp.go throws it away: net/url formats
+	// the whole input into that one error, password and all, and the simulator
+	// writes what it returns to the log. What Dial reports afterwards carries the
+	// host and the port alone.
+	if _, err := amqp091.ParseURI(url); err != nil {
+		return nil, fmt.Errorf("%s is not a usable AMQP URL", envAMQPURL)
+	}
+	conn, err := amqp091.Dial(url)
+	if err != nil {
+		return nil, fmt.Errorf("dialing the broker: %w", err)
+	}
+	channel, err := conn.Channel()
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("opening a channel: %w", err)
+	}
+	if err := channel.Confirm(false); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("enabling publisher confirms: %w", err)
+	}
+	for _, exchange := range serviceExchanges {
+		if err := channel.ExchangeDeclare(exchange, "topic",
+			true, false, false, false, nil); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("declaring the exchange %s: %w", exchange, err)
+		}
+	}
+	return &Publisher{conn: conn, channel: channel}, nil
+}
+
+// AwaitConsumer waits until queue has at least one consumer, or until timeout
+// has passed. A timeout of zero skips the wait.
+//
+// The wait is what keeps a run from publishing into nothing: a topic exchange
+// drops every message no queue is bound to, and on a fresh broker the
+// collector's queue does not exist until the collector has connected once and
+// bound it. The consumer count rather than the queue's existence is the signal,
+// because the collector declares, binds, and only then registers its consumer:
+// a queue that has one is a collector that has finished connecting.
+func (p *Publisher) AwaitConsumer(ctx context.Context, queue string, timeout time.Duration) error {
+	if timeout == 0 {
+		return nil
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		// Every probe takes a channel of its own because a passive declare of a
+		// queue that does not exist closes the channel it ran on with a 404, and
+		// the publishing channel has to survive the wait.
+		channel, err := p.conn.Channel()
+		if err != nil {
+			return fmt.Errorf("opening a channel: %w", err)
+		}
+		q, err := channel.QueueDeclarePassive(queue, true, false, false, false, nil)
+		if err == nil {
+			_ = channel.Close()
+			if q.Consumers >= 1 {
+				return nil
+			}
+		}
+
+		timer := time.NewTimer(probeInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("no consumer on the queue %s appeared within %s; "+
+		"start the collector first, or pass --wait-for-collector 0 to publish anyway", queue, timeout)
+}
+
+// Publish puts one notification on an exchange and returns once the broker has
+// confirmed it. The confirm is waited on per message rather than in batches,
+// which is what lets the run report the count it published and stop at the
+// first message the broker refused.
+//
+// The message is persistent because the collector's queue is durable: a backlog
+// that piled up there while the collector was stopped is meant to survive a
+// broker restart, and a transient message would be gone with it.
+func (p *Publisher) Publish(ctx context.Context, exchange, routingKey string, body []byte) error {
+	confirmation, err := p.channel.PublishWithDeferredConfirmWithContext(ctx, exchange, routingKey,
+		false, false, amqp091.Publishing{
+			ContentType:  "application/json",
+			DeliveryMode: amqp091.Persistent,
+			Body:         body,
+		})
+	if err != nil {
+		return fmt.Errorf("publishing to %s: %w", exchange, err)
+	}
+	ok, err := confirmation.WaitContext(ctx)
+	if err != nil {
+		return fmt.Errorf("publishing to %s: %w", exchange, err)
+	}
+	if !ok {
+		return fmt.Errorf("the broker did not confirm a message on %s", exchange)
+	}
+	return nil
+}
+
+// Close ends the connection to the broker, and the channel with it.
+func (p *Publisher) Close() error {
+	if err := p.conn.Close(); err != nil {
+		return fmt.Errorf("closing the broker connection: %w", err)
+	}
+	return nil
+}

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -43,10 +43,10 @@ const (
 	pollDeadline = 30 * time.Second
 )
 
-// testOutboxMax is the outbox bound the collector runs under here. A simulated
-// month is thousands of notifications and nothing drains the outbox during a
-// test, so the bound is far above what one month produces: a consumer that
-// paused on backpressure would stall the run rather than fail it.
+// testOutboxMax is the outbox bound the collector runs under here. Nothing
+// drains the outbox during a test, so the bound is far above the few hundred
+// notifications one month produces: a consumer that paused on backpressure
+// would stall the run rather than fail it.
 const testOutboxMax = 100_000
 
 // startBroker runs a RabbitMQ container for the test and returns the URL it is

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -1,0 +1,451 @@
+package simulator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+// The broker these tests run against. Every test starts one of its own, because
+// the collector's queue name is fixed and two tests on one broker would consume
+// each other's month.
+const (
+	brokerImage = "rabbitmq:4-alpine"
+	brokerPort  = "5672/tcp"
+	// The port listens well before the broker accepts a connection on it, so the
+	// wait is on RabbitMQ's own boot marker instead.
+	brokerReadyLog = "Server startup complete"
+)
+
+// How a test waits for something it cannot be notified of: how often it looks
+// and how long it keeps looking. They are the collector's own
+// (internal/providers/openstack/amqp_integration_test.go), so a simulated month
+// is given as long to arrive as a hand-published notification is.
+const (
+	pollInterval = 25 * time.Millisecond
+	pollDeadline = 30 * time.Second
+)
+
+// testOutboxMax is the outbox bound the collector runs under here. A simulated
+// month is thousands of notifications and nothing drains the outbox during a
+// test, so the bound is far above what one month produces: a consumer that
+// paused on backpressure would stall the run rather than fail it.
+const testOutboxMax = 100_000
+
+// startBroker runs a RabbitMQ container for the test and returns the URL it is
+// reachable under, together with the stop that terminates it. The stop also runs
+// at the end of the test, so a test that never calls it leaves nothing behind.
+func startBroker(t *testing.T) (string, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	container, err := testcontainers.Run(ctx, brokerImage,
+		testcontainers.WithExposedPorts(brokerPort),
+		testcontainers.WithWaitStrategy(wait.ForLog(brokerReadyLog)),
+	)
+	stop := sync.OnceFunc(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Errorf("terminating the broker container: %v", err)
+		}
+	})
+	t.Cleanup(stop)
+	if err != nil {
+		t.Fatalf("starting the broker container: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("reading the container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, brokerPort)
+	if err != nil {
+		t.Fatalf("reading the mapped broker port: %v", err)
+	}
+	// The guest account is the image's own, and the container is reachable only
+	// through its ephemeral host port for the length of one test.
+	return fmt.Sprintf("amqp://guest:guest@%s/", net.JoinHostPort(host, port.Port())), stop
+}
+
+// connect dials the broker the way a run does and closes the connection when the
+// test ends.
+func connect(t *testing.T, url string) *Publisher {
+	t.Helper()
+
+	publisher, err := Connect(url)
+	if err != nil {
+		t.Fatalf("Connect() error = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+	return publisher
+}
+
+// startCollector runs the collector's own consumer against the broker, into an
+// outbox and a registry of its own, until the test ends. It is the collector as
+// the pipeline runs it: the same consumer, the same buffer, and the same
+// counters, so what a test asserts is what a deployment would see.
+//
+// The returned stop waits for the consumer's loop to return before it closes the
+// outbox, so nothing the collector logs outlives the test and nothing touches a
+// closed handle.
+func startCollector(t *testing.T, url string) (*openstack.Outbox, *prometheus.Registry, func()) {
+	t.Helper()
+
+	outbox, err := openstack.OpenOutbox(filepath.Join(t.TempDir(), "outbox.db"))
+	if err != nil {
+		t.Fatalf("OpenOutbox() error = %v, want nil", err)
+	}
+
+	reg := prometheus.NewRegistry()
+	m := openstack.NewMetrics(reg,
+		func() float64 { return float64(outbox.Depth()) },
+		outbox.OldestBufferedSeconds)
+	consumer := openstack.NewConsumer(openstack.Config{
+		AMQPURL:         url,
+		Exchanges:       collectorExchanges,
+		Topics:          []string{collectorTopic},
+		Cloud:           testCloud,
+		Prefetch:        10,
+		BufferMaxEvents: testOutboxMax,
+	}, outbox, m, testLogger(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := consumer.Run(ctx); err != nil {
+			t.Errorf("Run() error = %v, want nil", err)
+		}
+	}()
+
+	stop := sync.OnceFunc(func() {
+		cancel()
+		<-done
+		if err := outbox.Close(); err != nil {
+			t.Errorf("closing the outbox: %v", err)
+		}
+	})
+	t.Cleanup(stop)
+	return outbox, reg, stop
+}
+
+// testLogger writes the simulator's and the collector's log through the test, so
+// that a failing test carries the publishes and reconnects that led to it.
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+
+	return slog.New(slog.NewTextHandler(testWriter{t: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(strings.TrimSuffix(string(p), "\n"))
+	return len(p), nil
+}
+
+// waitFor polls until condition holds, and fails the test naming what it waited
+// for when it never does.
+func waitFor(t *testing.T, why string, condition func() bool) {
+	t.Helper()
+
+	for deadline := time.Now().Add(pollDeadline); time.Now().Before(deadline); {
+		if condition() {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out after %v waiting until %s", pollDeadline, why)
+}
+
+// counterValue reads one counter out of the collector's registry, through the
+// exposition rather than through the instrument, since the instruments belong to
+// the collector package. A family or a child that was never touched reads 0,
+// which is what a test asserting that nothing was skipped needs. An empty
+// labelName addresses the unlabeled counter.
+func counterValue(t *testing.T, reg *prometheus.Registry, name, labelName, labelValue string) float64 {
+	t.Helper()
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v, want nil", err)
+	}
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelName == "" && len(metric.GetLabel()) == 0 {
+				return metric.GetCounter().GetValue()
+			}
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == labelName && label.GetValue() == labelValue {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// storedEventIDs lists the event ids the outbox holds, sorted so that a test
+// compares sets rather than the order the consumer happened to buffer in.
+func storedEventIDs(t *testing.T, outbox *openstack.Outbox, n int) []string {
+	t.Helper()
+
+	rows, err := outbox.Batch(t.Context(), n)
+	if err != nil {
+		t.Fatalf("Batch(%d) error = %v, want nil", n, err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, decodeEventID(t, row.EventJSON))
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// billableMessageIDs lists the message ids of the notifications the collector
+// records an event for, sorted. They are the event ids the outbox has to end up
+// with, because ingestion books an event under the message id it arrived as.
+func billableMessageIDs(t *testing.T, schedule Schedule) []string {
+	t.Helper()
+
+	ids := make([]string, 0, len(schedule))
+	for _, transition := range schedule.Billable() {
+		ids = append(ids, transition.MessageID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// eventIDsOf lists the event ids an events.jsonl holds, sorted. It is what the
+// run wrote down as its expectation, held against what the collector produced.
+func eventIDsOf(t *testing.T, path string) []string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	ids := []string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		if line == "" {
+			continue
+		}
+		ids = append(ids, decodeEventID(t, []byte(line)))
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// decodeEventID reads the event id of one recorded event.
+func decodeEventID(t *testing.T, eventJSON []byte) string {
+	t.Helper()
+
+	var stored struct {
+		EventID string `json:"event_id"`
+	}
+	if err := json.Unmarshal(eventJSON, &stored); err != nil {
+		t.Fatalf("decoding an event: %v", err)
+	}
+	return stored.EventID
+}
+
+// TestRunPublishesWhatTheCollectorConsumes drives a whole simulated month
+// through a real broker into the collector's own consumer. It is what the
+// simulator exists for: the month it generates has to be a month the unmodified
+// collector maps, buffers, and counts, and the events.jsonl it writes has to say
+// the same thing the outbox ends up holding.
+func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
+	url, _ := startBroker(t)
+	// The publisher connects first, because its declares are what the collector's
+	// passive ones find: a consumer started against a fresh broker reconnects
+	// until the exchanges exist.
+	publisher := connect(t, url)
+	outbox, reg, _ := startCollector(t, url)
+
+	out := t.TempDir()
+	err := Run(t.Context(), Config{Cloud: testCloud, HTTPPort: 0}, RunOptions{
+		Period:           "2026-07",
+		Seed:             1,
+		Factor:           0,
+		Out:              out,
+		WaitForCollector: pollDeadline,
+	}, publisher, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	want := billableMessageIDs(t, generateMonth(t, 1, july2026, testCloud))
+	waitFor(t, "every billable notification is buffered", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
+		t.Errorf("buffered event ids = %v, want %v", got, want)
+	}
+	// The file the run wrote is its statement of what the collector would produce,
+	// so it is held against what the collector did produce rather than trusted.
+	if got := eventIDsOf(t, filepath.Join(out, "events.jsonl")); !slices.Equal(got, want) {
+		t.Errorf("the event ids in events.jsonl = %v, want %v", got, want)
+	}
+
+	// The month carries one image.create per image, six in all, and the mapping
+	// skips every one of them because an announced image has no size yet. Nothing
+	// else in the month may go unrecorded: a notification the collector cannot
+	// parse is one the simulator rendered wrong.
+	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 6 {
+		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 6", got)
+	}
+	if got := counterValue(t, reg, "tally_collector_unparseable_total", "", ""); got != 0 {
+		t.Errorf("tally_collector_unparseable_total = %v, want 0", got)
+	}
+}
+
+// TestReplayPublishesACapturedMonth runs the two halves the drill uses: a run
+// that only writes files, and a replay that puts that file on a broker later.
+// What comes out of the collector has to be the same month either way, because
+// a recorded month is what a drill replays when it has no generator at hand.
+func TestReplayPublishesACapturedMonth(t *testing.T) {
+	out := t.TempDir()
+	err := Run(t.Context(), Config{Cloud: testCloud}, RunOptions{
+		Period: "2026-07",
+		Seed:   1,
+		Factor: 0,
+		Out:    out,
+	}, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() in file mode error = %v, want nil", err)
+	}
+
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, _, _ := startCollector(t, url)
+
+	replayErr := Replay(t.Context(), Config{HTTPPort: 0}, ReplayOptions{
+		In:               filepath.Join(out, "notifications.jsonl"),
+		Factor:           0,
+		WaitForCollector: pollDeadline,
+	}, publisher, testLogger(t))
+	if replayErr != nil {
+		t.Fatalf("Replay() error = %v, want nil", replayErr)
+	}
+
+	want := billableMessageIDs(t, generateMonth(t, 1, july2026, testCloud))
+	waitFor(t, "every replayed notification is buffered", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
+		t.Errorf("buffered event ids = %v, want %v", got, want)
+	}
+
+	t.Run("reports a missing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "notifications.jsonl")
+		err := Replay(t.Context(), Config{HTTPPort: 0}, ReplayOptions{In: path}, publisher, testLogger(t))
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("Replay() error = %v, want it to wrap fs.ErrNotExist", err)
+		}
+		if prefix := "reading " + path + ": "; !strings.HasPrefix(err.Error(), prefix) {
+			t.Errorf("Replay() error = %q, want it to start with %q", err, prefix)
+		}
+	})
+}
+
+// TestRunWaitsForTheCollector covers the wait on both settings, against a broker
+// nothing consumes from. The wait is what keeps a demo from publishing a month
+// into a topic exchange no queue is bound to, where every notification is
+// dropped without a trace.
+func TestRunWaitsForTheCollector(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+
+	t.Run("publishes at once when the wait is disabled", func(t *testing.T) {
+		// The bound is a context rather than a bare timeout, so a run that does
+		// wait is stopped and waited for instead of left behind logging into a
+		// finished test.
+		ctx, cancel := context.WithTimeout(t.Context(), pollDeadline)
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- Run(ctx, Config{Cloud: testCloud}, RunOptions{
+				Period:           "2026-07",
+				Seed:             2,
+				WaitForCollector: 0,
+			}, publisher, testLogger(t))
+		}()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Run() error = %v, want nil", err)
+			}
+		case <-ctx.Done():
+			<-done
+			t.Fatalf("Run() did not finish within %v with the wait disabled", pollDeadline)
+		}
+	})
+
+	t.Run("refuses to publish into nothing", func(t *testing.T) {
+		const wait = 2 * time.Second
+		err := Run(t.Context(), Config{Cloud: testCloud}, RunOptions{
+			Period:           "2026-07",
+			Seed:             2,
+			WaitForCollector: wait,
+		}, publisher, testLogger(t))
+
+		want := "no consumer on the queue tally-notifications appeared within 2s; " +
+			"start the collector first, or pass --wait-for-collector 0 to publish anyway"
+		if err == nil || err.Error() != want {
+			t.Fatalf("Run() error = %v, want %q", err, want)
+		}
+
+		// And it published nothing while it waited: a collector started now binds
+		// its queue and finds it empty, however long it looks.
+		outbox, _, _ := startCollector(t, url)
+		for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+			if depth := outbox.Depth(); depth != 0 {
+				t.Fatalf("Depth() = %d, want 0: the refused run published anyway", depth)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
+}
+
+// TestConnectFailsWhenTheBrokerIsGone is the error an operator meets most: the
+// broker in the compose stack is not up yet, or not up any more. Connect has to
+// say which of its steps failed, because a run that reported an unadorned
+// network error would leave them guessing between the broker and the URL.
+func TestConnectFailsWhenTheBrokerIsGone(t *testing.T) {
+	url, stop := startBroker(t)
+	stop()
+
+	publisher, err := Connect(url)
+	if err == nil {
+		_ = publisher.Close()
+		t.Fatal("Connect() error = nil, want a failed dial")
+	}
+	if !strings.Contains(err.Error(), "dialing the broker") {
+		t.Errorf("Connect() error = %q, want it to name the dial", err)
+	}
+}

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -1,0 +1,338 @@
+package simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// timestampLayout is how oslo writes a notification timestamp: no zone, six
+// fractional digits. It is the first layout the collector tries, so a rendered
+// notification carries the same timestamp form a recorded one does.
+const timestampLayout = "2006-01-02 15:04:05.000000"
+
+// The distances a payload reports between a resource's request and the instant
+// it was ready. Nova and cinder both write a created_at that precedes the
+// notification, and repeating that shape keeps a simulated payload from being
+// the one payload where the two timestamps are equal.
+const (
+	instanceBoot    = 30 * time.Second
+	volumeProvision = 8 * time.Second
+)
+
+// The constants glance and cinder repeat in every notification of the simulated
+// cloud. They are the ones the recorded samples carry.
+const (
+	imageDiskFormat        = "qcow2"
+	imageContainerFormat   = "bare"
+	imageVisibility        = "private"
+	imageMinDiskGB         = 5
+	imageMinRAMMB          = 512
+	imageVirtualSizeFactor = 5
+	volumeReplication      = "disabled"
+)
+
+// stamp renders an instant the way a service writes it. It goes through UTC
+// first, because the layout carries no zone and every reader of those digits,
+// the collector included, takes them for UTC.
+func stamp(t time.Time) string {
+	return t.UTC().Format(timestampLayout)
+}
+
+// Render turns a transition into the message body an OpenStack service would
+// publish for it.
+//
+// The body has two layers, and the inner one travels as a string rather than as
+// a nested object. That is what oslo does, and reproducing it is the whole
+// point: the collector decodes the body twice, so a simulator that nested the
+// notification would produce something only the simulator could read.
+func Render(t Transition) ([]byte, error) {
+	inner, err := json.Marshal(map[string]any{
+		"message_id":   t.MessageID,
+		"event_type":   t.EventType,
+		"publisher_id": t.PublisherID,
+		"priority":     "INFO",
+		"timestamp":    stamp(t.At),
+		// Services differ in which of the two they set. Setting both is what a
+		// deployment running several releases side by side looks like on the bus.
+		"_context_project_id": t.ProjectID,
+		"_context_tenant_id":  t.ProjectID,
+		"_context_user_id":    t.UserID,
+		"payload":             t.Payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rendering %s: %w", t.EventType, err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"oslo.version": "2.0",
+		"oslo.message": string(inner),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rendering %s: %w", t.EventType, err)
+	}
+	return body, nil
+}
+
+// instanceCreatePayload describes a server nova has just booted. It is the
+// widest of the compute payloads: it names the flavor three times over and the
+// image the server was booted from, none of which the later notifications
+// repeat in full.
+func instanceCreatePayload(p *project, inst *instance, cloud string) map[string]any {
+	return map[string]any{
+		"instance_id":        inst.id,
+		"tenant_id":          p.id,
+		"user_id":            p.userID,
+		"display_name":       inst.name,
+		"state":              "active",
+		"state_description":  "",
+		"vcpus":              inst.flavor.vcpus,
+		"memory_mb":          inst.flavor.memoryMB,
+		"root_gb":            inst.flavor.rootGB,
+		"ephemeral_gb":       inst.flavor.ephemeralGB,
+		"disk_gb":            inst.flavor.rootGB + inst.flavor.ephemeralGB,
+		"instance_type":      inst.flavor.name,
+		"instance_type_id":   inst.flavor.typeID,
+		"instance_flavor_id": inst.flavor.flavorID,
+		"host":               inst.host,
+		"availability_zone":  availabilityZone,
+		"image_ref_url":      fmt.Sprintf("http://glance.%s.example:9292/images/%s", cloud, inst.imageID),
+		"created_at":         stamp(inst.createdAt.Add(-instanceBoot)),
+		"launched_at":        stamp(inst.createdAt),
+	}
+}
+
+// instanceDeletePayload describes a destroyed server. It reports no
+// state_description, which is the one member the other compute payloads carry
+// and this one does not.
+func instanceDeletePayload(p *project, inst *instance, at time.Time) map[string]any {
+	return map[string]any{
+		"instance_id":   inst.id,
+		"tenant_id":     p.id,
+		"user_id":       p.userID,
+		"display_name":  inst.name,
+		"state":         "deleted",
+		"vcpus":         inst.flavor.vcpus,
+		"memory_mb":     inst.flavor.memoryMB,
+		"root_gb":       inst.flavor.rootGB,
+		"ephemeral_gb":  inst.flavor.ephemeralGB,
+		"instance_type": inst.flavor.name,
+		"host":          inst.host,
+		"created_at":    stamp(inst.createdAt.Add(-instanceBoot)),
+		"deleted_at":    stamp(at),
+		"terminated_at": stamp(at),
+	}
+}
+
+// instanceResizePayload describes a server that changed flavor. Both halves of
+// a resize carry the same members and differ in the state alone, which is why
+// one builder serves them: nova announces the new size twice, and the mapping
+// books both under one event type.
+func instanceResizePayload(p *project, inst *instance, state string) map[string]any {
+	return map[string]any{
+		"instance_id":       inst.id,
+		"tenant_id":         p.id,
+		"user_id":           p.userID,
+		"display_name":      inst.name,
+		"state":             state,
+		"state_description": "",
+		"vcpus":             inst.flavor.vcpus,
+		"memory_mb":         inst.flavor.memoryMB,
+		"root_gb":           inst.flavor.rootGB,
+		"ephemeral_gb":      inst.flavor.ephemeralGB,
+		"instance_type":     inst.flavor.name,
+		"instance_type_id":  inst.flavor.typeID,
+		"host":              inst.host,
+		"availability_zone": availabilityZone,
+		"created_at":        stamp(inst.createdAt.Add(-instanceBoot)),
+		"launched_at":       stamp(inst.createdAt),
+	}
+}
+
+// instancePowerPayload describes a server that was powered off or on. A power
+// state change costs nova the shortest payload of them all: no disk, no zone,
+// and no timestamps, because none of them changed.
+func instancePowerPayload(p *project, inst *instance, state string) map[string]any {
+	return map[string]any{
+		"instance_id":       inst.id,
+		"tenant_id":         p.id,
+		"user_id":           p.userID,
+		"display_name":      inst.name,
+		"state":             state,
+		"state_description": "",
+		"vcpus":             inst.flavor.vcpus,
+		"memory_mb":         inst.flavor.memoryMB,
+		"instance_type":     inst.flavor.name,
+		"host":              inst.host,
+	}
+}
+
+// instanceShelvePayload describes a server that was shelved or brought back. It
+// reports the disk a power change leaves out, since a shelved server keeps its
+// image on disk while it holds no memory.
+func instanceShelvePayload(p *project, inst *instance, state string) map[string]any {
+	return map[string]any{
+		"instance_id":       inst.id,
+		"tenant_id":         p.id,
+		"user_id":           p.userID,
+		"display_name":      inst.name,
+		"state":             state,
+		"state_description": "",
+		"vcpus":             inst.flavor.vcpus,
+		"memory_mb":         inst.flavor.memoryMB,
+		"root_gb":           inst.flavor.rootGB,
+		"ephemeral_gb":      inst.flavor.ephemeralGB,
+		"instance_type":     inst.flavor.name,
+		"host":              inst.host,
+	}
+}
+
+// floatingIPCreatePayload describes an allocated address. Neutron nests the
+// resource one level down, and it reports both the older tenant_id and the
+// newer project_id, which is why the mapping reads the address through a path
+// instead of a member name.
+func floatingIPCreatePayload(p *project, fip *floatingIP, networkID string) map[string]any {
+	return map[string]any{
+		"floatingip": map[string]any{
+			"id":                  fip.id,
+			"tenant_id":           p.id,
+			"project_id":          p.id,
+			"floating_ip_address": fip.address,
+			"floating_network_id": networkID,
+			// An address is allocated before it is associated with a port, so it
+			// points at nothing yet and is down.
+			"fixed_ip_address": nil,
+			"port_id":          nil,
+			"router_id":        nil,
+			"status":           "DOWN",
+			"description":      "",
+		},
+	}
+}
+
+// floatingIPDeletePayload describes a released address. Neutron names the id
+// and nothing else, so the project the address was billed to comes from the
+// request context.
+func floatingIPDeletePayload(fip *floatingIP) map[string]any {
+	return map[string]any{"floatingip_id": fip.id}
+}
+
+// imageCreatePayload describes an image glance has accepted but has no bits
+// for. Both size members are null, which is what makes this the one
+// notification the simulator emits that the mapping skips.
+func imageCreatePayload(p *project, img *image) map[string]any {
+	return map[string]any{
+		"id":               img.id,
+		"owner":            p.id,
+		"name":             img.name,
+		"status":           "queued",
+		"size":             nil,
+		"virtual_size":     nil,
+		"disk_format":      imageDiskFormat,
+		"container_format": imageContainerFormat,
+		"visibility":       imageVisibility,
+		"protected":        false,
+		"created_at":       stamp(img.createdAt),
+		"updated_at":       stamp(img.createdAt),
+	}
+}
+
+// imageUploadPayload describes an image that now has content. It is the
+// notification the image is billed from, because it is the first one to report
+// a size.
+func imageUploadPayload(p *project, img *image, at time.Time) map[string]any {
+	return map[string]any{
+		"id":               img.id,
+		"owner":            p.id,
+		"name":             img.name,
+		"status":           "active",
+		"size":             img.size,
+		"virtual_size":     img.size * imageVirtualSizeFactor,
+		"disk_format":      imageDiskFormat,
+		"container_format": imageContainerFormat,
+		"checksum":         strings.ReplaceAll(img.id, "-", ""),
+		"min_disk":         imageMinDiskGB,
+		"min_ram":          imageMinRAMMB,
+		"visibility":       imageVisibility,
+		"protected":        false,
+		"created_at":       stamp(img.createdAt),
+		"updated_at":       stamp(at),
+	}
+}
+
+// imageDeletePayload describes a removed image. Glance still reports the size
+// it had, which is what lets the projection close the record with the size it
+// was billed at.
+func imageDeletePayload(p *project, img *image, at time.Time) map[string]any {
+	return map[string]any{
+		"id":               img.id,
+		"owner":            p.id,
+		"name":             img.name,
+		"status":           "deleted",
+		"size":             img.size,
+		"disk_format":      imageDiskFormat,
+		"container_format": imageContainerFormat,
+		"deleted":          true,
+		"deleted_at":       stamp(at),
+	}
+}
+
+// volumeCreatePayload describes a volume cinder has provisioned. It is
+// available at this point: an attach follows for most of them, and cinder
+// reports that one under a type the collector does not map.
+func volumeCreatePayload(p *project, vol *volume) map[string]any {
+	return map[string]any{
+		"volume_id":          vol.id,
+		"tenant_id":          p.id,
+		"user_id":            p.userID,
+		"display_name":       vol.name,
+		"status":             "available",
+		"size":               vol.sizeGB,
+		"volume_type":        vol.volumeType,
+		"availability_zone":  availabilityZone,
+		"host":               volumeHost,
+		"replication_status": volumeReplication,
+		"created_at":         stamp(vol.createdAt.Add(-volumeProvision)),
+		"launched_at":        stamp(vol.createdAt),
+	}
+}
+
+// volumeDeletePayload describes a removed volume, with the size and type it
+// carried when it went.
+func volumeDeletePayload(p *project, vol *volume, at time.Time) map[string]any {
+	return map[string]any{
+		"volume_id":    vol.id,
+		"tenant_id":    p.id,
+		"user_id":      p.userID,
+		"display_name": vol.name,
+		"status":       "deleted",
+		"size":         vol.sizeGB,
+		"volume_type":  vol.volumeType,
+		"host":         volumeHost,
+		"created_at":   stamp(vol.createdAt.Add(-volumeProvision)),
+		"deleted_at":   stamp(at),
+	}
+}
+
+// volumeStatePayload describes a volume whose size, type, or owner changed.
+// Cinder reports the same members for all three, each already carrying the new
+// value, which is why one builder serves a resize, a retype, and an accepted
+// transfer alike.
+func volumeStatePayload(p *project, vol *volume) map[string]any {
+	status := "available"
+	if vol.attached {
+		status = "in-use"
+	}
+	return map[string]any{
+		"volume_id":    vol.id,
+		"tenant_id":    p.id,
+		"user_id":      p.userID,
+		"display_name": vol.name,
+		"status":       status,
+		"size":         vol.sizeGB,
+		"volume_type":  vol.volumeType,
+		"host":         volumeHost,
+		"created_at":   stamp(vol.createdAt.Add(-volumeProvision)),
+	}
+}

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -1,0 +1,149 @@
+package simulator
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+// sampleDir holds the notifications recorded from a real deployment. They are
+// the collector's fixtures, and the simulator is held against them rather than
+// against fixtures of its own: a simulator that drifts from them produces a
+// month the collector was never written for.
+var sampleDir = filepath.Join("..", "testdata", "golden", "notifications")
+
+// render renders a transition or fails the test.
+func render(t *testing.T, transition Transition) []byte {
+	t.Helper()
+
+	body, err := Render(transition)
+	if err != nil {
+		t.Fatalf("Render(%s) error = %v, want nil", transition.EventType, err)
+	}
+	return body
+}
+
+// parse runs a body through the collector's own decoder or fails the test.
+func parse(t *testing.T, body []byte) openstack.Notification {
+	t.Helper()
+
+	notification, err := openstack.ParseEnvelope(body)
+	if err != nil {
+		t.Fatalf("ParseEnvelope(%s) error = %v, want nil", body, err)
+	}
+	return notification
+}
+
+// sampleName turns an event type into the file it was recorded in: both the
+// dots and the underscores of the type are hyphens there.
+var sampleName = strings.NewReplacer(".", "-", "_", "-")
+
+// sampleFile names the recorded notification of an event type. image.create is
+// recorded twice, with and without a size, and the simulator emits only the
+// form without one.
+func sampleFile(eventType string) string {
+	if eventType == "image.create" {
+		return "image-create-without-size.json"
+	}
+	return sampleName.Replace(eventType) + ".json"
+}
+
+// memberShape is a payload's structure as its sorted member names, with a
+// nested object's members named under their parent. Neutron nests its resource
+// one level down, so comparing the top level alone would let a floating IP
+// payload pass with nothing in it.
+func memberShape(payload map[string]any) []string {
+	names := make([]string, 0, len(payload))
+	for name, value := range payload {
+		nested, ok := value.(map[string]any)
+		if !ok {
+			names = append(names, name)
+			continue
+		}
+		for _, inner := range memberShape(nested) {
+			names = append(names, name+"."+inner)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// missingFrom returns the names of want that names does not carry.
+func missingFrom(names, want []string) []string {
+	var missing []string
+	for _, name := range want {
+		if !slices.Contains(names, name) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func TestRenderParsesWithTheCollector(t *testing.T) {
+	for _, transition := range generateMonth(t, 1, july2026, testCloud) {
+		notification := parse(t, render(t, transition))
+
+		if notification.MessageID != transition.MessageID {
+			t.Errorf("%s message id = %q, want %q",
+				transition.EventType, notification.MessageID, transition.MessageID)
+		}
+		if notification.EventType != transition.EventType {
+			t.Errorf("event type = %q, want %q", notification.EventType, transition.EventType)
+		}
+		if !notification.Timestamp.Equal(transition.At) {
+			t.Errorf("%s timestamp = %s, want %s",
+				transition.EventType, notification.Timestamp, transition.At)
+		}
+		if notification.ContextProjectID != transition.ProjectID {
+			t.Errorf("%s context project = %q, want %q",
+				transition.EventType, notification.ContextProjectID, transition.ProjectID)
+		}
+		if notification.ContextTenantID != transition.ProjectID {
+			t.Errorf("%s context tenant = %q, want %q",
+				transition.EventType, notification.ContextTenantID, transition.ProjectID)
+		}
+	}
+}
+
+func TestRenderedPayloadsCarryTheRecordedMembers(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, transition := range generateMonth(t, 1, july2026, testCloud) {
+		if seen[transition.EventType] {
+			continue
+		}
+		seen[transition.EventType] = true
+
+		body, err := os.ReadFile(filepath.Join(sampleDir, sampleFile(transition.EventType)))
+		if err != nil {
+			t.Fatalf("reading the recorded %s: %v", transition.EventType, err)
+		}
+		got := memberShape(parse(t, render(t, transition)).Payload)
+		want := memberShape(parse(t, body).Payload)
+
+		if !slices.Equal(got, want) {
+			t.Errorf("%s payload members = %v, want %v (rendered and not recorded: %v; recorded and not rendered: %v)",
+				transition.EventType, got, want, missingFrom(want, got), missingFrom(got, want))
+		}
+	}
+}
+
+func TestRenderReportsAMarshalError(t *testing.T) {
+	// A channel is the one thing encoding/json refuses outright, which is how a
+	// payload builder that put an unencodable value in a member would surface.
+	_, err := Render(Transition{
+		EventType: "compute.instance.create.end",
+		Payload:   map[string]any{"bad": make(chan int)},
+	})
+	if err == nil {
+		t.Fatal("Render() error = nil, want the marshal failure reported")
+	}
+
+	const prefix = "rendering compute.instance.create.end: "
+	if !strings.HasPrefix(err.Error(), prefix) {
+		t.Errorf("Render() error = %q, want it to start with %q", err, prefix)
+	}
+}

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -1,0 +1,382 @@
+package simulator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/b42labs/tally/internal/engine/period"
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+// The bounds the control server is served under. They are the collector's, in
+// cmd/tally-openstack-collector/main.go, and they are here for the same
+// reasons.
+const (
+	// readHeaderTimeout bounds how long a client may take to send its request
+	// headers, which keeps a stalled connection from holding a slot.
+	readHeaderTimeout = 5 * time.Second
+	// readTimeout bounds the whole request, headers and body together.
+	readTimeout = 30 * time.Second
+	// writeTimeout bounds the response. Without it a client that stops reading
+	// holds its handler goroutine for as long as it likes.
+	writeTimeout = 60 * time.Second
+	// idleTimeout bounds a kept-alive connection between requests. Go derives it
+	// from readTimeout when it is zero, and a zero readTimeout clears the read
+	// deadline entirely, so idle connections would pile up.
+	idleTimeout = 120 * time.Second
+	// shutdownTimeout is what an in-flight request gets once the month is over.
+	// It is short because the only caller is somebody watching the run.
+	shutdownTimeout = 10 * time.Second
+)
+
+// outDirMode is the mode the output directory is created with. The files in it
+// are read by whoever runs the simulator and by a replay, and they carry no
+// secret.
+const outDirMode = 0o755
+
+// RunOptions is what a run needs beyond its environment: which month to
+// generate from which seed, how fast to publish it, and where it goes. The
+// flags of the run subcommand map onto it one to one, which is why the errors
+// quote flag names rather than field names.
+type RunOptions struct {
+	// Period is the billing month to generate, as YYYY-MM.
+	Period string
+	// Seed decides the shape of the simulated cloud.
+	Seed uint64
+	// Factor is how many virtual seconds pass per wall second. Zero is
+	// unbounded: the month goes out as fast as the broker takes it.
+	Factor float64
+	// Out is the directory notifications.jsonl and events.jsonl are written to.
+	// Empty writes nothing.
+	Out string
+	// WaitForCollector is how long to wait for a consumer on the collector's
+	// queue before the first notification goes out. Zero disables the wait.
+	WaitForCollector time.Duration
+}
+
+// Validate checks the options and returns the month Period names.
+//
+// It exists so the command refuses a mistyped flag before it dials the broker,
+// which is where a run would otherwise notice. Run calls it again itself,
+// because an exported function cannot rely on its caller having done so.
+func (o RunOptions) Validate() (from, to time.Time, err error) {
+	from, to, err = period.Parse(o.Period)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("--period: %w", err)
+	}
+	// The one place the simulator reads the wall clock. A month that has not
+	// ended is one the engine marks with runs.WarningPeriodNotEnded
+	// (internal/engine/runs/runs.go) whenever it is billed, so a simulated month
+	// reaching into the future would put that warning on every drill run over it.
+	if to.After(time.Now()) {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"--period: %s has not ended yet; it ends %s, and the engine warns about a period that has not ended",
+			o.Period, to.Format(time.RFC3339))
+	}
+	if err := validatePacing(o.Factor, o.WaitForCollector); err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	return from, to, nil
+}
+
+// ReplayOptions is what a replay needs: the file to publish and the pacing to
+// publish it under. The month itself comes from the file, so there is no seed
+// and no period here.
+type ReplayOptions struct {
+	// In is the notifications.jsonl a run wrote.
+	In string
+	// Factor is how many virtual seconds pass per wall second. Zero is
+	// unbounded.
+	Factor float64
+	// WaitForCollector is how long to wait for a consumer on the collector's
+	// queue before the first notification goes out. Zero disables the wait.
+	WaitForCollector time.Duration
+}
+
+// Validate checks the pacing options, the way RunOptions.Validate does. The
+// file is not opened here: reading it is the replay's own first step, and a
+// check that opened it would either read the month twice or leave a handle
+// behind.
+func (o ReplayOptions) Validate() error {
+	return validatePacing(o.Factor, o.WaitForCollector)
+}
+
+// validatePacing checks the two options both subcommands take. Both are
+// durations or rates that only make sense forwards: a negative factor runs the
+// month backwards, and a negative wait is a wait nobody can serve. NaN is
+// refused with the negative factor, for the reason Clock.SetFactor gives: it
+// passes every comparison a bound is written as.
+func validatePacing(factor float64, wait time.Duration) error {
+	if math.IsNaN(factor) || factor < 0 {
+		return fmt.Errorf("--factor: %g must be zero or positive", factor)
+	}
+	if wait < 0 {
+		return fmt.Errorf("--wait-for-collector: %s must be zero or positive", wait)
+	}
+	return nil
+}
+
+// queued is one notification ready for the bus: the addressing it goes out
+// under, the bytes, and the virtual instant the clock releases it at. The whole
+// month is turned into these before the first one is published, so a rendering
+// error ends the run with nothing published rather than halfway through.
+type queued struct {
+	exchange   string
+	routingKey string
+	eventType  string
+	messageID  string
+	at         time.Time
+	body       []byte
+}
+
+// Run generates one month of notifications and publishes it, writes it to
+// files, or both.
+//
+// The publisher is dialled by the caller rather than here. That is what lets a
+// caller have the service exchanges declared before a collector starts: the
+// collector declares them passively and reconnects until somebody has declared
+// them, and a collector started first spends the run reconnecting. A nil
+// publisher is file mode, where the month is written out and nothing reaches a
+// bus.
+//
+// Both files are complete before the first notification is published, so a run
+// that is interrupted halfway still leaves a whole month on disk to replay.
+//
+// A cancelled context is a clean stop: what went out stays out, and Run returns
+// nil, so SIGINT and SIGTERM leave exit status 0 the way they do for the
+// collector. A failed publish is an error instead, and what an operator does
+// about it is rerun the same seed, period and cloud: that renders the same
+// message ids, and ingestion deduplicates whatever was already delivered.
+func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	from, to, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	if publisher == nil && opts.Out == "" {
+		return errors.New("set " + envAMQPURL + " or pass --out: the run has nowhere to publish")
+	}
+
+	schedule, err := Generate(opts.Seed, from, to, cfg.Cloud)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("starting",
+		"seed", opts.Seed,
+		"period", opts.Period,
+		"cloud", cfg.Cloud,
+		"factor", opts.Factor,
+		"transitions", len(schedule),
+		"billable", len(schedule.Billable()),
+		"broker", publisher != nil,
+		"out", opts.Out)
+
+	if opts.Out != "" {
+		if err := os.MkdirAll(opts.Out, outDirMode); err != nil {
+			return fmt.Errorf("creating %s: %w", opts.Out, err)
+		}
+		if err := WriteStream(filepath.Join(opts.Out, "notifications.jsonl"), schedule); err != nil {
+			return err
+		}
+		if err := WriteEvents(filepath.Join(opts.Out, "events.jsonl"), cfg.Cloud, schedule); err != nil {
+			return err
+		}
+	}
+
+	if publisher == nil {
+		logger.Info("completed", "published", 0, "total", len(schedule))
+		return nil
+	}
+
+	lines := make([]queued, 0, len(schedule))
+	for _, transition := range schedule {
+		body, err := Render(transition)
+		if err != nil {
+			return err
+		}
+		lines = append(lines, queued{
+			exchange:   transition.Exchange,
+			routingKey: routingKey,
+			eventType:  transition.EventType,
+			messageID:  transition.MessageID,
+			at:         transition.At,
+			body:       body,
+		})
+	}
+	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines)
+}
+
+// Replay publishes a month a run recorded, in the order the file holds it.
+//
+// The publisher is dialled by the caller, as it is for Run, and for the same
+// reason. A replay has no file mode: the month already exists as a file, so a
+// nil publisher leaves it nothing to do.
+//
+// A cancelled context is a clean stop and a failed publish is an error, the way
+// Run treats them: the recorded message ids are the ones the run published, so
+// a repeated replay is deduplicated by ingestion.
+func Replay(ctx context.Context, cfg Config, opts ReplayOptions, publisher *Publisher, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+	// ValidateReplay refuses a missing broker URL long before this, so reaching
+	// here without a publisher is a caller of this package rather than an
+	// operator. It is still answered rather than dereferenced.
+	if publisher == nil {
+		return errors.New("set " + envAMQPURL + ": a replay has nowhere to publish")
+	}
+
+	read, err := ReadStream(opts.In)
+	if err != nil {
+		return err
+	}
+
+	lines := make([]queued, 0, len(read))
+	for number, line := range read {
+		// ReadStream already parsed every body, so this cannot fail; parsing it
+		// again is how the timestamp, the type and the id are read out of it
+		// without ReadStream having to carry a second form of each line.
+		notification, err := openstack.ParseEnvelope(line.Body)
+		if err != nil {
+			return fmt.Errorf("%s: line %d: %w", opts.In, number+1, err)
+		}
+		lines = append(lines, queued{
+			exchange:   line.Exchange,
+			routingKey: line.RoutingKey,
+			eventType:  notification.EventType,
+			messageID:  notification.MessageID,
+			at:         notification.Timestamp,
+			body:       line.Body,
+		})
+	}
+
+	from, to := lines[0].at, lines[len(lines)-1].at
+	logger.Info("starting",
+		"in", opts.In,
+		"factor", opts.Factor,
+		"transitions", len(lines),
+		"from", from.Format(time.RFC3339),
+		"to", to.Format(time.RFC3339))
+
+	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines)
+}
+
+// broadcast puts the lines on the bus in the order they stand in, paced by a
+// virtual clock that starts at from, and serves the control endpoint while it
+// does.
+//
+// The endpoint is served for the length of the publishing and no longer,
+// because pacing is the only thing it changes and there is nothing to pace
+// before the first notification or after the last one.
+//
+// Lines go out in their own order rather than in timestamp order. One whose
+// instant lies before the previous one is published at once, because SleepUntil
+// returns immediately when the clock has already passed it, so a recorded file
+// that is not perfectly sorted still replays whole.
+func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *slog.Logger,
+	factor float64, wait time.Duration, from, to time.Time, lines []queued,
+) error {
+	if err := publisher.AwaitConsumer(ctx, collectorQueue, wait); err != nil {
+		if ctx.Err() != nil {
+			logger.Info("stopped", "published", 0, "total", len(lines))
+			return nil
+		}
+		return err
+	}
+
+	// The endpoint carries no credential, so it binds the address the
+	// configuration names rather than every interface the machine has: on
+	// loopback by default, and on 0.0.0.0 where a deployment publishes the port
+	// on purpose, as the compose stack does. A configured port of 0 lets the
+	// operating system pick one, which is what a test uses to run several
+	// simulators at once.
+	listener, err := net.Listen("tcp", cfg.ControlAddr())
+	if err != nil {
+		return fmt.Errorf("serving HTTP: %w", err)
+	}
+
+	clock := NewClock(from, factor, time.Now)
+	var published atomic.Int64
+	progress := func() Progress {
+		return Progress{From: from, To: to, Published: int(published.Load()), Total: len(lines)}
+	}
+	server := &http.Server{
+		Handler:           NewControlMux(clock, progress),
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+	// The channel is buffered so that the serving goroutine ends even when
+	// nothing reads from it.
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(listener) }()
+	// Every path out of here closes the endpoint, including the one that reports
+	// a failed publish. A shutdown that fails is logged rather than returned: the
+	// month is over by then, and the error the caller wants is the one about the
+	// month.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Error("shutting the control endpoint down failed", "error", err)
+		}
+	}()
+
+	port := cfg.HTTPPort
+	if addr, ok := listener.Addr().(*net.TCPAddr); ok {
+		port = addr.Port
+	}
+	logger.Info("listening", "port", port)
+
+	for _, line := range lines {
+		err := clock.SleepUntil(ctx, line.at)
+		if err == nil {
+			err = publisher.Publish(ctx, line.exchange, line.routingKey, line.body)
+		}
+		if err != nil {
+			if ctx.Err() != nil {
+				logger.Info("stopped", "published", published.Load(), "total", len(lines))
+				return nil
+			}
+			return err
+		}
+		published.Add(1)
+		logger.Debug("published",
+			"event_type", line.eventType,
+			"exchange", line.exchange,
+			"message_id", line.messageID,
+			"timestamp", line.at.Format(time.RFC3339))
+	}
+
+	// A control endpoint that never came up is reported here rather than while
+	// the month runs: the month is what the operator asked for, and losing the
+	// pacing endpoint is no reason to stop publishing it.
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serving HTTP: %w", err)
+		}
+	default:
+	}
+
+	logger.Info("completed", "published", published.Load(), "total", len(lines))
+	return nil
+}

--- a/internal/providers/openstack/simulator/stream.go
+++ b/internal/providers/openstack/simulator/stream.go
@@ -1,0 +1,174 @@
+package simulator
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+// Line is one line of notifications.jsonl: the message body a service put on
+// the bus, together with the addressing it was published under. The addressing
+// travels with the body because the body does not carry it: an exchange is
+// what decides which queue a notification reaches, and a replay that guessed it
+// would publish a month no collector receives.
+type Line struct {
+	// Exchange is the service exchange the notification belongs on, one of nova,
+	// cinder, neutron, and glance.
+	Exchange string `json:"exchange"`
+	// RoutingKey is the topic the notification was published under.
+	RoutingKey string `json:"routing_key"`
+	// Body is the oslo envelope as Render produced it, kept as raw JSON so a
+	// replay republishes the very bytes the run generated rather than a
+	// re-encoding of them.
+	Body json.RawMessage `json:"body"`
+}
+
+// WriteStream writes the schedule to path as one notification per line,
+// creating the file or truncating what is already there.
+//
+// It is what lets a generated month outlive the process that generated it: the
+// file holds every notification with the exchange and the routing key it was
+// meant for, so replay puts the same month on a broker again without the
+// generator, and without the seed that produced it.
+func WriteStream(path string, schedule Schedule) (err error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	// The close is what reports the write the file system deferred, such as a
+	// full disk, so its error is not dropped. An error already on its way says
+	// more about what went wrong and keeps its place.
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("writing %s: %w", path, closeErr)
+		}
+	}()
+
+	writer := bufio.NewWriter(file)
+	encoder := json.NewEncoder(writer)
+	for _, transition := range schedule {
+		body, renderErr := Render(transition)
+		if renderErr != nil {
+			return renderErr
+		}
+		if encodeErr := encoder.Encode(Line{
+			Exchange:   transition.Exchange,
+			RoutingKey: routingKey,
+			Body:       body,
+		}); encodeErr != nil {
+			return fmt.Errorf("writing %s: %w", path, encodeErr)
+		}
+	}
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// WriteEvents writes the events the collector is expected to record for the
+// schedule to path, one per line, creating the file or truncating what is
+// already there. The cloud is the one the events are booked to.
+//
+// It states what a run expects of the collector. notifications.jsonl says what
+// was published, this file says what ingestion has to hold once the month is
+// consumed, and a drill compares the two without mapping the notifications a
+// second time by hand.
+//
+// A transition the schedule marks billable and the mapping claims nothing for
+// fails the write. The workload decides billable from its own catalog and the
+// collector decides it from its mapping table, so a type added to one and not
+// the other drifts the two apart. Failing here is what catches that drift
+// outside the test suite, on whatever month an operator generates, instead of
+// writing a file that quietly expects fewer events than the month holds.
+func WriteEvents(path, cloud string, schedule Schedule) (err error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("writing %s: %w", path, closeErr)
+		}
+	}()
+
+	writer := bufio.NewWriter(file)
+	encoder := json.NewEncoder(writer)
+	for _, transition := range schedule.Billable() {
+		body, renderErr := Render(transition)
+		if renderErr != nil {
+			return renderErr
+		}
+		// The event comes from the collector's own decoder and mapping rather than
+		// from the transition, so this file holds what the collector produces and
+		// not what the simulator believes it produces.
+		notification, parseErr := openstack.ParseEnvelope(body)
+		if parseErr != nil {
+			return fmt.Errorf("writing %s: %w", path, parseErr)
+		}
+		mapped, ok := openstack.MapNotification(notification, cloud)
+		if !ok {
+			return fmt.Errorf("transition %s at %s is marked billable but the mapping claims nothing for it",
+				transition.EventType, transition.At.UTC().Format(time.RFC3339))
+		}
+
+		if encodeErr := encoder.Encode(mapped); encodeErr != nil {
+			return fmt.Errorf("writing %s: %w", path, encodeErr)
+		}
+	}
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// ReadStream reads the notifications of a stream file back, in the order they
+// stand in the file, which is the order they were published in.
+//
+// Every body goes through the collector's own envelope parser here rather than
+// at publication time. A file that holds something other than notifications, or
+// a notification without a usable timestamp, is refused before the first
+// message reaches the broker, instead of halfway through a replay that has
+// already published part of a month.
+//
+// The routing key of a line is read from the line and not assumed. A month
+// recorded against one deployment may have been published under a topic this
+// build no longer defaults to, and a replay has to reach the queue the
+// recording did.
+func ReadStream(path string) ([]Line, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	// An instance create renders past what bufio.Scanner reads with by default,
+	// so the limit is raised to a megabyte. A longer line is a file this package
+	// did not write, and it is reported rather than silently cut in half.
+	scanner.Buffer(make([]byte, 0, 64<<10), 1<<20)
+
+	var lines []Line
+	for number := 1; scanner.Scan(); number++ {
+		var line Line
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			return nil, fmt.Errorf("%s: line %d: %w", path, number, err)
+		}
+		if _, err := openstack.ParseEnvelope(line.Body); err != nil {
+			return nil, fmt.Errorf("%s: line %d: %w", path, number, err)
+		}
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("%s holds no notifications", path)
+	}
+	return lines, nil
+}

--- a/internal/providers/openstack/simulator/stream_test.go
+++ b/internal/providers/openstack/simulator/stream_test.go
@@ -1,0 +1,255 @@
+package simulator
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/event"
+)
+
+// streamFileMode is what the tests write a stream file with by hand. It is the
+// mode os.Create gives the files this package writes, minus the umask.
+const streamFileMode = 0o600
+
+// encodeLine marshals one stream line or fails the test.
+func encodeLine(t *testing.T, line Line) []byte {
+	t.Helper()
+
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		t.Fatalf("encoding the line: %v", err)
+	}
+	return encoded
+}
+
+// writeLines writes the lines to a stream file of their own and returns its
+// path. It is how the tests build a file ReadStream has to refuse, which
+// WriteStream cannot produce.
+func writeLines(t *testing.T, lines ...[]byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "notifications.jsonl")
+	var content bytes.Buffer
+	for _, line := range lines {
+		content.Write(line)
+		content.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, content.Bytes(), streamFileMode); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// readLines returns the lines of a file. The event stream is read this way
+// rather than through ReadStream, which decodes the notification stream.
+func readLines(t *testing.T, path string) [][]byte {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	trimmed := bytes.TrimSuffix(content, []byte("\n"))
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return bytes.Split(trimmed, []byte("\n"))
+}
+
+func TestStreamRoundTrips(t *testing.T) {
+	schedule := generateMonth(t, 1, july2026, testCloud)
+	path := filepath.Join(t.TempDir(), "notifications.jsonl")
+
+	if err := WriteStream(path, schedule); err != nil {
+		t.Fatalf("WriteStream() error = %v, want nil", err)
+	}
+	lines, err := ReadStream(path)
+	if err != nil {
+		t.Fatalf("ReadStream() error = %v, want nil", err)
+	}
+
+	if len(lines) != len(schedule) {
+		t.Fatalf("ReadStream() returned %d lines, want the schedule's %d", len(lines), len(schedule))
+	}
+	for i, line := range lines {
+		transition := schedule[i]
+		if line.Exchange != transition.Exchange {
+			t.Errorf("line %d exchange = %q, want %q", i+1, line.Exchange, transition.Exchange)
+		}
+		if line.RoutingKey != collectorTopic {
+			t.Errorf("line %d routing key = %q, want %q", i+1, line.RoutingKey, collectorTopic)
+		}
+		if want := render(t, transition); !bytes.Equal(line.Body, want) {
+			t.Errorf("line %d body = %s, want %s", i+1, line.Body, want)
+		}
+	}
+}
+
+func TestWriteEventsWritesOneLinePerBillableTransition(t *testing.T) {
+	schedule := generateMonth(t, 1, july2026, testCloud)
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+
+	if err := WriteEvents(path, testCloud, schedule); err != nil {
+		t.Fatalf("WriteEvents() error = %v, want nil", err)
+	}
+
+	billable := schedule.Billable()
+	documents := readLines(t, path)
+	if len(documents) != len(billable) {
+		t.Fatalf("events.jsonl holds %d lines, want one per billable transition, which is %d",
+			len(documents), len(billable))
+	}
+
+	got := make(map[string]struct{}, len(documents))
+	for i, document := range documents {
+		var recorded event.Event
+		if err := json.Unmarshal(document, &recorded); err != nil {
+			t.Fatalf("decoding line %d: %v", i+1, err)
+		}
+		if err := recorded.Validate(); err != nil {
+			t.Errorf("line %d: Validate() error = %v, want nil", i+1, err)
+		}
+		if recorded.Cloud != testCloud {
+			t.Errorf("line %d cloud = %q, want %q", i+1, recorded.Cloud, testCloud)
+		}
+		if recorded.Source != event.SourceCollector {
+			t.Errorf("line %d source = %q, want %q", i+1, recorded.Source, event.SourceCollector)
+		}
+		got[recorded.EventID] = struct{}{}
+	}
+
+	// The event id is the notification's message id, which is what a redelivery
+	// is deduplicated by, so the two sets have to name the same notifications.
+	want := make(map[string]struct{}, len(billable))
+	for _, transition := range billable {
+		want[transition.MessageID] = struct{}{}
+	}
+	if !maps.Equal(got, want) {
+		t.Errorf("events.jsonl holds %d event ids, want the %d billable message ids",
+			len(got), len(want))
+	}
+}
+
+func TestWriteEventsReportsAnUnmappedBillableTransition(t *testing.T) {
+	// A reboot is a notification nova publishes and the collector's table holds
+	// no entry for, which is what a workload catalog that drifted from the
+	// mapping looks like from here.
+	const instanceID = "3f1a9c62-8b45-4d07-9e13-6c2a5f8b41d0"
+	transition := Transition{
+		At:          time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC),
+		EventType:   "compute.instance.reboot.end",
+		Exchange:    "nova",
+		Billable:    true,
+		MessageID:   "b7d4e1a0-52c9-4f68-8a3b-1e05d9c7f264",
+		PublisherID: "compute.compute-01",
+		ProjectID:   "9c4d2f81a5b3476e8d17f0a2c6b93e54",
+		UserID:      "2e8b7a0c34d54f19b6c8a1e50f37d942",
+		ResourceID:  instanceID,
+		Payload:     map[string]any{"instance_id": instanceID},
+	}
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+
+	err := WriteEvents(path, testCloud, Schedule{transition})
+
+	const want = "transition compute.instance.reboot.end at 2026-07-03T10:00:00Z " +
+		"is marked billable but the mapping claims nothing for it"
+	if err == nil || err.Error() != want {
+		t.Fatalf("WriteEvents() error = %v, want %q", err, want)
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("stat %s: %v", path, statErr)
+	}
+	if info.Size() != 0 {
+		t.Errorf("%s holds %d bytes, want the failed write to have put nothing in it", path, info.Size())
+	}
+}
+
+func TestReadStreamReportsAnEmptyFile(t *testing.T) {
+	path := writeLines(t)
+
+	_, err := ReadStream(path)
+
+	want := path + " holds no notifications"
+	if err == nil || err.Error() != want {
+		t.Fatalf("ReadStream() error = %v, want %q", err, want)
+	}
+}
+
+func TestReadStreamNamesTheBadLine(t *testing.T) {
+	schedule := generateMonth(t, 1, july2026, testCloud)
+	valid := make([][]byte, 2)
+	for i := range valid {
+		valid[i] = encodeLine(t, Line{
+			Exchange:   schedule[i].Exchange,
+			RoutingKey: collectorTopic,
+			Body:       render(t, schedule[i]),
+		})
+	}
+
+	t.Run("a line that is not a stream line", func(t *testing.T) {
+		path := writeLines(t, valid[0], []byte("not json"))
+
+		_, err := ReadStream(path)
+
+		prefix := path + ": line 2: "
+		if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+			t.Fatalf("ReadStream() error = %v, want it to start with %q", err, prefix)
+		}
+	})
+
+	t.Run("a notification without a timestamp", func(t *testing.T) {
+		// The envelope is built by hand because Render always writes a timestamp,
+		// while a recording taken off a real bus may hold a notification that
+		// carries none.
+		const untimed = `{"oslo.version":"2.0",` +
+			`"oslo.message":"{\"message_id\":\"x\",\"event_type\":\"image.upload\",\"payload\":{}}"}`
+		path := writeLines(t, valid[0], valid[1], encodeLine(t, Line{
+			Exchange:   "glance",
+			RoutingKey: collectorTopic,
+			Body:       json.RawMessage(untimed),
+		}))
+
+		_, err := ReadStream(path)
+
+		want := path + ": line 3: the oslo notification has no timestamp"
+		if err == nil || err.Error() != want {
+			t.Fatalf("ReadStream() error = %v, want %q", err, want)
+		}
+	})
+}
+
+func TestReadStreamReportsAMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notifications.jsonl")
+
+	_, err := ReadStream(path)
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadStream() error = %v, want it to report a missing file", err)
+	}
+	prefix := "reading " + path + ": "
+	if !strings.HasPrefix(err.Error(), prefix) {
+		t.Errorf("ReadStream() error = %q, want it to start with %q", err, prefix)
+	}
+}
+
+func TestWriteStreamReportsAnUnwritablePath(t *testing.T) {
+	// A --out whose directory was never created is what an operator hits, and
+	// the error names the file rather than the syscall that refused it.
+	path := filepath.Join(t.TempDir(), "absent", "notifications.jsonl")
+
+	err := WriteStream(path, generateMonth(t, 1, july2026, testCloud))
+
+	prefix := "writing " + path + ": "
+	if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+		t.Fatalf("WriteStream() error = %v, want it to start with %q", err, prefix)
+	}
+}

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -1,0 +1,565 @@
+package simulator
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math/rand/v2"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/b42labs/tally/internal/engine/period"
+)
+
+// Transition is one lifecycle step of the simulated cloud: what happened, when,
+// and everything the notification about it needs. It is the simulator's own
+// form, one level above the wire, so that a month can be sorted, counted, and
+// asserted on before any of it is serialized.
+type Transition struct {
+	// At is the virtual instant the notification is published at. It lies
+	// inside the generated month.
+	At time.Time
+	// EventType is the type the emitting service would use, such as
+	// "compute.instance.create.end".
+	EventType string
+	// Exchange is the notification exchange the type belongs on. A deployment
+	// gives each service its own, and the collector binds its queue to all four.
+	Exchange string
+	// Billable reports whether the collector's mapping records an event for this
+	// notification. It is false only for the image.create that precedes an
+	// upload: that one carries no size yet, and the mapping skips it on purpose.
+	Billable bool
+	// MessageID is the oslo message id, which the Reporting API deduplicates on.
+	// It is drawn after the month is sorted, so the ids run in the order the
+	// notifications are published.
+	MessageID string
+	// PublisherID names the service instance that emitted the notification.
+	PublisherID string
+	// ProjectID is the project the request ran in. It becomes both
+	// _context_project_id and _context_tenant_id, since services differ in which
+	// of the two they set and the collector reads either.
+	ProjectID string
+	// UserID is the user the request ran as, which becomes _context_user_id.
+	UserID string
+	// ResourceID is the resource the transition is about. The rendered payload
+	// carries it under whatever member the emitting service names it in, so this
+	// field is what a test holds the mapping's result against.
+	ResourceID string
+	// Payload is the service's description of the resource, ready to be
+	// marshalled as the notification's payload.
+	Payload map[string]any
+}
+
+// Schedule is one month of transitions in publication order.
+type Schedule []Transition
+
+// Billable returns the transitions the collector records an event for. It is
+// what a run counts its expected events by: the rest reaches the collector and
+// is skipped there, so counting the whole schedule would overstate the month.
+func (s Schedule) Billable() []Transition {
+	billable := make([]Transition, 0, len(s))
+	for _, transition := range s {
+		if transition.Billable {
+			billable = append(billable, transition)
+		}
+	}
+	return billable
+}
+
+// routingKey is the topic every notification is published under. oslo puts the
+// topic in the routing key itself rather than as a prefix of one, and it is the
+// key the collector binds its queue with.
+const routingKey = "notifications.info"
+
+// imageCreateType is the one type the simulator emits that the mapping skips.
+// Glance announces an image before its bits are uploaded, so that first
+// notification has no size to bill, and the upload that follows is what the
+// image is booked from.
+const imageCreateType = "image.create"
+
+// exchangeFor names the exchange a type is published on. The four are the
+// service exchanges of nova, cinder, neutron, and glance. A type outside them
+// is one this package does not generate, and it is reported as the empty
+// exchange rather than guessed at, because a wrong exchange is a notification
+// no bound queue receives.
+func exchangeFor(eventType string) string {
+	switch {
+	case strings.HasPrefix(eventType, "compute."):
+		return "nova"
+	case strings.HasPrefix(eventType, "volume."):
+		return "cinder"
+	case strings.HasPrefix(eventType, "floatingip."):
+		return "neutron"
+	case strings.HasPrefix(eventType, "image."):
+		return "glance"
+	default:
+		return ""
+	}
+}
+
+// The size of the simulated cloud. It is small on purpose: what a run has to
+// cover is every notification type and every shape of resource life, not a
+// realistic tenant count.
+const (
+	projectCount        = 3
+	imagesPerProject    = 2
+	instancesPerProject = 4
+	// addressPoolSize is how many host addresses the floating network holds. A
+	// /24 with its network and broadcast addresses left out is 254, and drawing
+	// the month's addresses as a permutation of it keeps any two of them apart.
+	addressPoolSize = 254
+)
+
+// day is the unit most of the workload's spans are stated in.
+const day = 24 * time.Hour
+
+// The fixed distances inside a delete sequence. A deployment tears a server
+// down in this order, and the gaps are what keep the notifications about one
+// resource a second or more apart.
+const (
+	releaseLead      = 10 * time.Second
+	volumeDeleteLead = 60 * time.Second
+	volumeDeleteGap  = 10 * time.Second
+	resizeDuration   = 60 * time.Second
+)
+
+// shapeStream is the second half of the shape generator's state. It is a
+// constant so that the shape of a month depends on the seed alone.
+const shapeStream = 1
+
+// Generate builds one month of the simulated cloud's lifecycle transitions,
+// sorted by their instant.
+//
+// The month runs on two generators. The shape generator draws everything that
+// decides what happens and when, and it is seeded by the seed alone: the same
+// seed describes the same cloud whichever period or deployment it is run for.
+// The identifier generator draws every id, and it is seeded by the seed
+// together with the cloud and the billing month, so the same seed on another
+// cloud or in another month publishes fresh resources and fresh message ids
+// while the same triple republishes the very notifications ingestion has
+// already deduplicated.
+//
+// Splitting them is what makes both properties hold at once. Identifiers are
+// drawn in a fixed order before the first transition is generated, so how many
+// of them a month costs depends on the shape and never on the salt, and a month
+// keeps its shape when the cloud changes.
+func Generate(seed uint64, from, to time.Time, cloud string) (Schedule, error) {
+	// A caller that reached here without going through period.Parse is caught
+	// before it produces a month that no billing period covers.
+	month := time.Date(from.UTC().Year(), from.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+	if !from.Equal(month) || !to.Equal(month.AddDate(0, 1, 0)) {
+		return nil, fmt.Errorf("%q is not a UTC month", from.Format(time.RFC3339))
+	}
+
+	shape := rand.New(rand.NewPCG(seed, shapeStream))
+	identifiers := idReader{src: rand.New(rand.NewPCG(seed, identifierSalt(cloud, month)))}
+
+	g := newGenerator(shape, identifiers, month, month.AddDate(0, 1, 0), cloud)
+	g.run()
+	if len(g.schedule) == 0 {
+		return nil, errors.New("the generated month holds no transitions")
+	}
+
+	slices.SortStableFunc(g.schedule, func(a, b Transition) int { return a.At.Compare(b.At) })
+	// The message ids come last so that they run in publication order, which is
+	// what a dumped month reads like when it is compared against a real bus.
+	for i := range g.schedule {
+		g.schedule[i].MessageID = identifiers.nextUUID()
+	}
+	return g.schedule, nil
+}
+
+// identifierSalt mixes the cloud and the billing month into the identifier
+// generator's state. Without it, two clouds fed the same seed would publish
+// notifications carrying the same message ids, and ingestion would take the
+// second cloud's month for a redelivery of the first one's.
+func identifierSalt(cloud string, from time.Time) uint64 {
+	digest := fnv.New64a()
+	// A hash.Hash never fails a write, which is why the error is not examined.
+	_, _ = digest.Write([]byte(cloud + "\x00" + period.Format(from)))
+	return digest.Sum64()
+}
+
+// idReader draws bytes from the identifier generator. uuid takes an io.Reader
+// and math/rand/v2's generator is not one, so this adapter puts every
+// identifier of a month on one stream, in one order, and therefore makes them
+// reproducible.
+type idReader struct {
+	src *rand.Rand
+}
+
+// Read fills p and never fails. A trailing partial block costs a whole draw, so
+// how many draws a buffer costs depends on its length alone.
+func (r idReader) Read(p []byte) (int, error) {
+	var block [8]byte
+	for offset := 0; offset < len(p); offset += len(block) {
+		binary.LittleEndian.PutUint64(block[:], r.src.Uint64())
+		copy(p[offset:], block[:])
+	}
+	return len(p), nil
+}
+
+// nextUUID draws one identifier in the form nova, cinder, neutron, and glance
+// name their resources. The reader cannot fail, so Must never panics.
+func (r idReader) nextUUID() string {
+	return uuid.Must(uuid.NewRandomFromReader(r)).String()
+}
+
+// nextHexID draws one identifier in the 32 character form keystone hands out
+// project and user ids in.
+func (r idReader) nextHexID() string {
+	var raw [16]byte
+	_, _ = r.Read(raw[:])
+	return hex.EncodeToString(raw[:])
+}
+
+// generator is one month under construction: the draws that shape it, the world
+// they populated, and the transitions so far.
+type generator struct {
+	shape *rand.Rand
+	from  time.Time
+	to    time.Time
+	cloud string
+
+	// networkID is the external network the month's addresses come from. There
+	// is one per month, the way a deployment has one.
+	networkID string
+	// addresses is the month's address pool as a permutation, and assigned is
+	// how much of it has been handed out. Taking them in order means no address
+	// is used twice inside a month.
+	addresses []int
+	assigned  int
+
+	projects []*project
+	schedule Schedule
+}
+
+// newGenerator draws every identifier of the month and returns the generator
+// that walks the world they name. The order of the draws is fixed here and
+// finished before the first transition is generated, which is what keeps the
+// number of identifiers a function of the shape alone.
+func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cloud string) *generator {
+	g := &generator{shape: shape, from: from, to: to, cloud: cloud}
+
+	g.networkID = identifiers.nextUUID()
+	g.addresses = identifiers.src.Perm(addressPoolSize)
+
+	for range projectCount {
+		g.projects = append(g.projects, &project{id: identifiers.nextHexID()})
+	}
+	for index, p := range g.projects {
+		p.userID = identifiers.nextHexID()
+		for i := range imagesPerProject {
+			p.images = append(p.images, &image{id: identifiers.nextUUID(), name: imageNames[i]})
+		}
+		for i := range instancesPerProject {
+			p.instances = append(p.instances, &instance{
+				id:   identifiers.nextUUID(),
+				name: fmt.Sprintf("%s-%02d", instanceNames[i], index+1),
+			})
+		}
+		for _, inst := range p.instances {
+			// The volume count is the one draw the identifier pass takes from the
+			// shape, because how many volumes exist is part of the shape and how
+			// many identifiers they cost follows from it.
+			for i := range 1 + shape.IntN(2) {
+				inst.volumes = append(inst.volumes, &volume{
+					id:   identifiers.nextUUID(),
+					name: fmt.Sprintf("%s-data-%d", inst.name, i+1),
+				})
+			}
+		}
+		for _, inst := range p.instances {
+			inst.fip = &floatingIP{id: identifiers.nextUUID()}
+		}
+		p.spare = &volume{
+			id:   identifiers.nextUUID(),
+			name: fmt.Sprintf("handover-%02d", index+1),
+		}
+	}
+	return g
+}
+
+// run generates every project's month. The phases are ordered the way a tenant
+// works: the images come first because an instance boots from one, the volumes
+// and addresses follow the instances they belong to, and the tear-down comes
+// last.
+func (g *generator) run() {
+	for index, p := range g.projects {
+		g.images(p)
+		g.instances(p)
+		g.volumes(p)
+		g.floatingIPs(p)
+		g.deleteFirstInstance(p)
+		g.spareVolume(p, g.projects[(index+1)%len(g.projects)])
+	}
+}
+
+// emit records one transition. The project is the one the request ran in, which
+// is the owner everywhere except on a transfer, where the accepting project
+// makes the request that moves the volume to itself.
+func (g *generator) emit(at time.Time, eventType, publisherID, resourceID string,
+	requester *project, payload map[string]any,
+) {
+	g.schedule = append(g.schedule, Transition{
+		At:          at,
+		EventType:   eventType,
+		Exchange:    exchangeFor(eventType),
+		Billable:    eventType != imageCreateType,
+		PublisherID: publisherID,
+		ProjectID:   requester.id,
+		UserID:      requester.userID,
+		ResourceID:  resourceID,
+		Payload:     payload,
+	})
+}
+
+// images gives a project its two images and deletes the second one before the
+// month is over, so that every month carries an image that lives through it and
+// one that does not. Each image is announced before it has content and uploaded
+// shortly after, which is the pair the mapping's skip rule is written for.
+func (g *generator) images(p *project) {
+	for index, img := range p.images {
+		img.createdAt = g.from.Add(span(g.shape, 0, 2*time.Hour))
+		uploadedAt := img.createdAt.Add(span(g.shape, 30*time.Second, 120*time.Second))
+		// Every quarter gibibyte from one to four.
+		img.size = int64(4+g.shape.IntN(13)) * quarterGiB
+
+		g.emit(img.createdAt, imageCreateType, imagePublisher, img.id, p, imageCreatePayload(p, img))
+		g.emit(uploadedAt, "image.upload", imagePublisher, img.id, p,
+			imageUploadPayload(p, img, uploadedAt))
+
+		if index == len(p.images)-1 {
+			deletedAt := g.to.Add(-span(g.shape, day, 7*day))
+			g.emit(deletedAt, "image.delete", imagePublisher, img.id, p,
+				imageDeletePayload(p, img, deletedAt))
+		}
+	}
+}
+
+// instances boots the project's servers. The first one is deleted inside the
+// month and every other one outlives it, so a month always holds both a
+// resource the projection closes and resources it carries forward.
+func (g *generator) instances(p *project) {
+	for index, inst := range p.instances {
+		inst.flavor = largeFlavor
+		if index > 0 {
+			inst.flavor = flavors[g.shape.IntN(len(flavors))]
+		}
+		inst.host = computeHosts[g.shape.IntN(len(computeHosts))]
+		inst.createdAt = g.from.Add(span(g.shape, 2*time.Hour, 6*time.Hour))
+		inst.imageID = p.images[g.shape.IntN(len(p.images))].id
+
+		g.emit(inst.createdAt, "compute.instance.create.end", computePublisher(inst), inst.id, p,
+			instanceCreatePayload(p, inst, g.cloud))
+
+		// The end bounds what the instance may still report, so the delete
+		// instant is drawn here rather than in the tear-down phase that uses it.
+		end := g.to
+		if index == 0 {
+			inst.deletedAt = g.to.Add(-span(g.shape, day, 10*day))
+			end = inst.deletedAt
+		}
+		g.lifetime(p, inst, index, end)
+	}
+}
+
+// lifetime walks one instance through the month: power cycles first, then a
+// resize, then a shelve, each a gap apart. The first instance always resizes
+// and the second always shelves, which is what makes every seed produce every
+// recorded notification type instead of most of them.
+//
+// A step whose last notification would fall at or after the instance's end
+// stops the walk. Dropping the rest with it is what keeps a deleted instance
+// from reporting anything after its delete, and a step from straddling the
+// month's end with only its first half inside the period.
+func (g *generator) lifetime(p *project, inst *instance, index int, end time.Time) {
+	cursor := inst.createdAt.Add(span(g.shape, time.Hour, 3*day))
+
+	for range 1 + g.shape.IntN(3) {
+		poweredOnAt := cursor.Add(span(g.shape, 2*time.Hour, 48*time.Hour))
+		if !poweredOnAt.Before(end) {
+			return
+		}
+		g.emit(cursor, "compute.instance.power_off.end", computePublisher(inst), inst.id, p,
+			instancePowerPayload(p, inst, "stopped"))
+		g.emit(poweredOnAt, "compute.instance.power_on.end", computePublisher(inst), inst.id, p,
+			instancePowerPayload(p, inst, "active"))
+		cursor = poweredOnAt.Add(span(g.shape, time.Hour, 3*day))
+	}
+
+	if index == 0 || g.shape.IntN(2) == 0 {
+		finishedAt := cursor.Add(resizeDuration)
+		if !finishedAt.Before(end) {
+			return
+		}
+		// Both halves of a resize report the flavor the instance is moving to,
+		// and every notification after them reports it as well.
+		inst.flavor = otherFlavor(g.shape, inst.flavor)
+		g.emit(cursor, "compute.instance.resize.end", computePublisher(inst), inst.id, p,
+			instanceResizePayload(p, inst, "resized"))
+		g.emit(finishedAt, "compute.instance.finish_resize.end", computePublisher(inst), inst.id, p,
+			instanceResizePayload(p, inst, "active"))
+		cursor = finishedAt.Add(span(g.shape, time.Hour, 3*day))
+	}
+
+	if index == 1 || g.shape.IntN(3) == 0 {
+		unshelvedAt := cursor.Add(span(g.shape, day, 5*day))
+		if !unshelvedAt.Before(end) {
+			return
+		}
+		g.emit(cursor, "compute.instance.shelve_offload.end", computePublisher(inst), inst.id, p,
+			instanceShelvePayload(p, inst, "shelved_offloaded"))
+		g.emit(unshelvedAt, "compute.instance.unshelve.end", computePublisher(inst), inst.id, p,
+			instanceShelvePayload(p, inst, "active"))
+	}
+}
+
+// volumes gives every instance its one or two volumes. The attach itself is not
+// a notification the collector maps, so the world records it and every later
+// notification about the volume reports the in-use status cinder would.
+func (g *generator) volumes(p *project) {
+	for index, inst := range p.instances {
+		for i, vol := range inst.volumes {
+			vol.createdAt = inst.createdAt.Add(span(g.shape, 30*time.Second, 300*time.Second))
+			vol.sizeGB = volumeSizesGB[g.shape.IntN(len(volumeSizesGB))]
+			vol.volumeType = volumeTypes[g.shape.IntN(len(volumeTypes))]
+
+			g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, p,
+				volumeCreatePayload(p, vol))
+			vol.attached = true
+
+			// The first instance's volumes are deleted with it and report nothing
+			// in between, which is the shortest volume life a month holds.
+			if index > 0 {
+				g.changeVolume(p, vol, index == 1 && i == 0)
+			}
+		}
+	}
+}
+
+// changeVolume grows a volume and moves it to another type, each on its own
+// draw unless the volume is the forced one. Forcing the second instance's first
+// volume is what puts a volume.resize.end and a volume.retype into every month
+// whatever the seed draws.
+func (g *generator) changeVolume(p *project, vol *volume, forced bool) {
+	resizes := forced || g.shape.IntN(2) == 0
+	retypes := forced || g.shape.IntN(3) == 0
+
+	var resizedAt time.Time
+	if resizes {
+		resizedAt = g.from.Add(span(g.shape, 3*day, 20*day))
+		vol.sizeGB *= 2
+		g.emit(resizedAt, "volume.resize.end", volumePublisher, vol.id, p, volumeStatePayload(p, vol))
+	}
+	if retypes {
+		retypedAt := g.from.Add(span(g.shape, 3*day, 20*day))
+		// Both instants are drawn from the same span, so a retype that would land
+		// on or before the resize is pushed past it: two notifications about one
+		// resource in the same second are two the projection cannot order.
+		if resizes && !retypedAt.After(resizedAt) {
+			retypedAt = resizedAt.Add(time.Second)
+		}
+		vol.volumeType = otherVolumeType(g.shape, vol.volumeType)
+		g.emit(retypedAt, "volume.retype", volumePublisher, vol.id, p, volumeStatePayload(p, vol))
+	}
+}
+
+// floatingIPs gives every instance an address. The third instance's is released
+// mid-month, which is a floating IP that is billed for part of the period
+// without the instance behind it being deleted.
+func (g *generator) floatingIPs(p *project) {
+	for index, inst := range p.instances {
+		fip := inst.fip
+		fip.address = floatingPrefix + strconv.Itoa(1+g.addresses[g.assigned])
+		g.assigned++
+
+		createdAt := inst.createdAt.Add(span(g.shape, 10*time.Second, 60*time.Second))
+		g.emit(createdAt, "floatingip.create.end", networkPublisher, fip.id, p,
+			floatingIPCreatePayload(p, fip, g.networkID))
+
+		if index == 2 {
+			releasedAt := g.from.Add(span(g.shape, 8*day, 22*day))
+			g.emit(releasedAt, "floatingip.delete.end", networkPublisher, fip.id, p,
+				floatingIPDeletePayload(fip))
+		}
+	}
+}
+
+// deleteFirstInstance tears the first instance down in the order a deployment
+// does: the address is released, the server is destroyed, and the volumes that
+// were attached to it follow one after another.
+func (g *generator) deleteFirstInstance(p *project) {
+	inst := p.instances[0]
+
+	g.emit(inst.deletedAt.Add(-releaseLead), "floatingip.delete.end", networkPublisher,
+		inst.fip.id, p, floatingIPDeletePayload(inst.fip))
+	g.emit(inst.deletedAt, "compute.instance.delete.end", computePublisher(inst), inst.id, p,
+		instanceDeletePayload(p, inst, inst.deletedAt))
+
+	for i, vol := range inst.volumes {
+		deletedAt := inst.deletedAt.Add(volumeDeleteLead + time.Duration(i)*volumeDeleteGap)
+		g.emit(deletedAt, "volume.delete.end", volumePublisher, vol.id, p,
+			volumeDeletePayload(p, vol, deletedAt))
+	}
+}
+
+// spareVolume creates the volume that changes hands and hands it to the next
+// project. A transfer is the one event that moves a resource from one project
+// to another, and both halves of the month have to be billed to the right one.
+func (g *generator) spareVolume(p, accepting *project) {
+	vol := p.spare
+	vol.createdAt = g.from.Add(span(g.shape, 2*time.Hour, 6*time.Hour))
+	vol.sizeGB = volumeSizesGB[g.shape.IntN(len(volumeSizesGB))]
+	vol.volumeType = volumeTypes[g.shape.IntN(len(volumeTypes))]
+	g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, p, volumeCreatePayload(p, vol))
+
+	// The accepting project makes the request and owns the volume from here on,
+	// so it is the project in the payload as well as in the request context.
+	acceptedAt := g.from.Add(span(g.shape, 10*day, 20*day))
+	g.emit(acceptedAt, "volume.transfer.accept.end", volumePublisher, vol.id, accepting,
+		volumeStatePayload(accepting, vol))
+}
+
+// span draws a duration from [lo, hi) at whole second granularity. Every
+// instant of a month is a whole number of seconds after midnight because of it,
+// which is what lets a step that ends before an instance's end stay a full
+// second before it: the projection orders events by their timestamp, and two in
+// the same second are two it cannot order.
+func span(shape *rand.Rand, lo, hi time.Duration) time.Duration {
+	return lo + time.Duration(shape.Int64N(int64((hi-lo)/time.Second)))*time.Second
+}
+
+// otherFlavor draws a flavor that is not the current one. The draw is over one
+// entry less than the catalog and the collision is mapped onto the last entry,
+// which keeps every other flavor equally likely.
+func otherFlavor(shape *rand.Rand, current flavor) flavor {
+	drawn := shape.IntN(len(flavors) - 1)
+	if flavors[drawn].name == current.name {
+		drawn = len(flavors) - 1
+	}
+	return flavors[drawn]
+}
+
+// otherVolumeType draws a type that is not the current one, the way
+// otherFlavor does. A retype onto the type the volume already has would be a
+// notification that changes nothing.
+func otherVolumeType(shape *rand.Rand, current string) string {
+	drawn := shape.IntN(len(volumeTypes) - 1)
+	if volumeTypes[drawn] == current {
+		drawn = len(volumeTypes) - 1
+	}
+	return volumeTypes[drawn]
+}
+
+// computePublisher is the publisher id of the compute an instance runs on. oslo
+// publishes a nova notification under the service name and the host.
+func computePublisher(inst *instance) string {
+	return "compute." + inst.host
+}

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -1,0 +1,216 @@
+package simulator
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The months the workload tests generate. July and May are both 31 days long,
+// so a comparison between them holds every instant at the same offset, while
+// June is a day shorter and moves the ones anchored on the month's end.
+var (
+	july2026 = time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	june2026 = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	may2026  = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// testCloud is the cloud the generated months are salted with.
+const testCloud = "os-test"
+
+// collectorTopic and collectorExchanges are what the collector binds its queue
+// to out of the box: the defaults of TALLY_OSC_TOPICS and TALLY_OSC_EXCHANGES
+// in internal/providers/openstack/config.go. A simulator that addressed
+// anything else would publish a month no collector receives.
+const collectorTopic = "notifications.info"
+
+var collectorExchanges = []string{"nova", "cinder", "neutron", "glance"}
+
+// generateMonth generates one month or fails the test. Every test takes its
+// schedule through it, so a generation error is reported once and in one form.
+func generateMonth(t *testing.T, seed uint64, from time.Time, cloud string) Schedule {
+	t.Helper()
+
+	schedule, err := Generate(seed, from, from.AddDate(0, 1, 0), cloud)
+	if err != nil {
+		t.Fatalf("Generate(%d, %s, %q) error = %v, want nil", seed, from.Format(time.RFC3339), cloud, err)
+	}
+	return schedule
+}
+
+// requireDisjoint fails the test when the two schedules share a value of the
+// field, which is what salting the identifiers is supposed to rule out.
+func requireDisjoint(t *testing.T, field string, first, second Schedule, of func(Transition) string) {
+	t.Helper()
+
+	seen := make(map[string]struct{}, len(first))
+	for _, transition := range first {
+		seen[of(transition)] = struct{}{}
+	}
+	for _, transition := range second {
+		if _, ok := seen[of(transition)]; ok {
+			t.Errorf("both schedules carry the %s %q, want them disjoint", field, of(transition))
+			return
+		}
+	}
+}
+
+func TestGenerateIsDeterministic(t *testing.T) {
+	first := generateMonth(t, 7, july2026, testCloud)
+	second := generateMonth(t, 7, july2026, testCloud)
+
+	if len(first) != len(second) {
+		t.Fatalf("the same seed produced %d and %d transitions, want the same month twice",
+			len(first), len(second))
+	}
+	for i := range first {
+		before, after := render(t, first[i]), render(t, second[i])
+		if !bytes.Equal(before, after) {
+			t.Fatalf("transition %d differs between two runs of the same seed:\n%s\n%s", i, before, after)
+		}
+	}
+}
+
+func TestGenerateSaltsIdentifiersWithPeriodAndCloud(t *testing.T) {
+	t.Run("another cloud keeps the shape and renames everything", func(t *testing.T) {
+		first := generateMonth(t, 7, july2026, "os-a")
+		second := generateMonth(t, 7, july2026, "os-b")
+
+		if len(first) != len(second) {
+			t.Fatalf("two clouds produced %d and %d transitions, want the shape to be the seed's alone",
+				len(first), len(second))
+		}
+		for i := range first {
+			if first[i].EventType != second[i].EventType {
+				t.Errorf("transition %d is %s on one cloud and %s on the other, want the same shape",
+					i, first[i].EventType, second[i].EventType)
+			}
+			if !first[i].At.Equal(second[i].At) {
+				t.Errorf("transition %d is at %s on one cloud and %s on the other, want the same shape",
+					i, first[i].At, second[i].At)
+			}
+			if len(first[i].Payload) != len(second[i].Payload) {
+				t.Errorf("transition %d carries %d payload members on one cloud and %d on the other",
+					i, len(first[i].Payload), len(second[i].Payload))
+			}
+		}
+		requireDisjoint(t, "message id", first, second, func(tr Transition) string { return tr.MessageID })
+		requireDisjoint(t, "resource id", first, second, func(tr Transition) string { return tr.ResourceID })
+		requireDisjoint(t, "project id", first, second, func(tr Transition) string { return tr.ProjectID })
+	})
+
+	t.Run("another month of the same length keeps every offset", func(t *testing.T) {
+		july := generateMonth(t, 7, july2026, testCloud)
+		may := generateMonth(t, 7, may2026, testCloud)
+
+		if len(july) != len(may) {
+			t.Fatalf("two 31 day months produced %d and %d transitions, want the same shape",
+				len(july), len(may))
+		}
+		for i := range july {
+			if july[i].EventType != may[i].EventType {
+				t.Errorf("transition %d is %s in July and %s in May, want the same shape",
+					i, july[i].EventType, may[i].EventType)
+			}
+			inJuly, inMay := july[i].At.Sub(july2026), may[i].At.Sub(may2026)
+			if inJuly != inMay {
+				t.Errorf("transition %d sits %s into July and %s into May, want the same offset",
+					i, inJuly, inMay)
+			}
+		}
+		requireDisjoint(t, "message id", july, may, func(tr Transition) string { return tr.MessageID })
+	})
+
+	t.Run("a shorter month renames everything as well", func(t *testing.T) {
+		// June is a day shorter than July, so the transitions anchored on the end
+		// of the month sit at other offsets and the offsets are not compared.
+		july := generateMonth(t, 7, july2026, testCloud)
+		june := generateMonth(t, 7, june2026, testCloud)
+
+		requireDisjoint(t, "message id", july, june, func(tr Transition) string { return tr.MessageID })
+		requireDisjoint(t, "resource id", july, june, func(tr Transition) string { return tr.ResourceID })
+	})
+}
+
+func TestGenerateStaysInsideThePeriod(t *testing.T) {
+	from := july2026
+	to := from.AddDate(0, 1, 0)
+	schedule := generateMonth(t, 1, from, testCloud)
+
+	if routingKey != collectorTopic {
+		t.Errorf("routingKey = %q, want %q, the topic the collector binds by default",
+			routingKey, collectorTopic)
+	}
+
+	last := make(map[string]time.Time, len(schedule))
+	for i, transition := range schedule {
+		if transition.At.Before(from) || !transition.At.Before(to) {
+			t.Errorf("transition %d (%s) is at %s, want it inside [%s, %s)",
+				i, transition.EventType, transition.At, from, to)
+		}
+		if i > 0 && transition.At.Before(schedule[i-1].At) {
+			t.Errorf("transition %d is at %s after %s, want the schedule sorted",
+				i, transition.At, schedule[i-1].At)
+		}
+		if !slices.Contains(collectorExchanges, transition.Exchange) {
+			t.Errorf("%s is published on %q, want one of the exchanges the collector binds: %v",
+				transition.EventType, transition.Exchange, collectorExchanges)
+		}
+		if previous, ok := last[transition.ResourceID]; ok && transition.At.Sub(previous) < time.Second {
+			t.Errorf("resource %s reports %s at %s, %s after its previous transition, want at least a second",
+				transition.ResourceID, transition.EventType, transition.At, transition.At.Sub(previous))
+		}
+		last[transition.ResourceID] = transition.At
+	}
+
+	var want []Transition
+	for _, transition := range schedule {
+		if transition.EventType != "image.create" {
+			want = append(want, transition)
+		}
+	}
+	got := schedule.Billable()
+	if len(got) != len(want) {
+		t.Fatalf("Billable() returned %d of %d transitions, want the %d that are not an image.create",
+			len(got), len(schedule), len(want))
+	}
+	for i := range got {
+		if got[i].MessageID != want[i].MessageID {
+			t.Errorf("Billable()[%d] is %s, want %s", i, got[i].MessageID, want[i].MessageID)
+		}
+	}
+}
+
+func TestGenerateRefusesANonMonth(t *testing.T) {
+	cases := []struct {
+		name string
+		from time.Time
+		to   time.Time
+	}{
+		{
+			name: "a period that starts mid-month",
+			from: time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+			to:   time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "a period that is not the whole month",
+			from: july2026,
+			to:   july2026.AddDate(0, 0, 20),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Generate(1, c.from, c.to, testCloud)
+			if err == nil {
+				t.Fatalf("Generate(1, %s, %s, %q) error = nil, want a refusal",
+					c.from.Format(time.RFC3339), c.to.Format(time.RFC3339), testCloud)
+			}
+			if !strings.HasSuffix(err.Error(), " is not a UTC month") {
+				t.Errorf("Generate() error = %q, want it to end with %q", err, " is not a UTC month")
+			}
+		})
+	}
+}

--- a/internal/providers/openstack/simulator/world.go
+++ b/internal/providers/openstack/simulator/world.go
@@ -1,0 +1,150 @@
+package simulator
+
+import "time"
+
+// flavor is one entry of the simulated nova flavor catalog. It carries all
+// three names nova reports a flavor under, because a notification repeats all
+// of them and the mapping reads the one it is metered by.
+type flavor struct {
+	name        string
+	vcpus       int
+	memoryMB    int
+	rootGB      int
+	ephemeralGB int
+	typeID      int
+	flavorID    string
+}
+
+// flavors is the catalog every simulated instance runs on. The four are the
+// ones a stock nova ships, and m1.large is the flavor the recorded
+// compute.instance.create.end was captured with, down to its flavor id. It is
+// also the only one with ephemeral disk, so a month that always creates an
+// m1.large always exercises the mapping's root_gb plus ephemeral_gb sum.
+//
+// The flavor ids are catalog constants and not salted with the period or the
+// cloud: a flavor outlives a billing month, and two clouds running the same
+// deployment tool have it under the same id.
+var flavors = []flavor{
+	{
+		name: "m1.small", vcpus: 1, memoryMB: 2048, rootGB: 20, ephemeralGB: 0,
+		typeID: 2, flavorID: "1b7f4c20-3e5a-4d18-8f92-2a6c9b0d7e41",
+	},
+	{
+		name: "m1.medium", vcpus: 2, memoryMB: 4096, rootGB: 40, ephemeralGB: 0,
+		typeID: 3, flavorID: "4e6a8d31-5c92-4b07-a13d-8f2b6c4e0a95",
+	},
+	{
+		name: "m1.large", vcpus: 4, memoryMB: 8192, rootGB: 40, ephemeralGB: 40,
+		typeID: 5, flavorID: "8d2c1e40-0b7a-4a3e-9d61-5b8c7a2f1e93",
+	},
+	{
+		name: "m1.xlarge", vcpus: 8, memoryMB: 16384, rootGB: 160, ephemeralGB: 0,
+		typeID: 7, flavorID: "c05a7f92-1d4b-4e63-b872-3a9d5c1e8f04",
+	},
+}
+
+// largeFlavor is the flavor the first instance of every project is created
+// with. Pinning one instance to it is what puts the recorded flavor id and the
+// ephemeral disk into every generated month.
+var largeFlavor = flavors[2]
+
+// volumeTypes are the cinder types a simulated volume carries. ssd and hdd
+// carry a type_modifier in pricing/2026-03.yaml; standard carries none there
+// and is rated at the implicit modifier 1. Drawing from all three is what makes
+// a month price both paths.
+var volumeTypes = []string{"ssd", "hdd", "standard"}
+
+// volumeSizesGB are the sizes a volume is created with, in gibibytes.
+var volumeSizesGB = []int{50, 100, 200}
+
+// quarterGiB is the step image sizes are drawn on. Glance reports bytes and the
+// mapping divides them into gibibytes, so a size that is a whole number of
+// quarter gibibytes turns into an exact decimal instead of a repeating one.
+const quarterGiB = 268435456
+
+// computeHosts are the nova computes the instances of the simulated cloud run
+// on. An instance keeps the host it was created on for its whole life, which is
+// what a deployment without live migration looks like.
+var computeHosts = []string{"compute-01", "compute-02", "compute-03", "compute-04"}
+
+// The publishers and hosts the other three services report. They are the ones
+// the recorded notifications carry, so a rendered notification names the same
+// services an operator sees on a real bus.
+const (
+	volumePublisher  = "volume.storage-01@ceph"
+	volumeHost       = "storage-01@ceph#ceph"
+	networkPublisher = "network.neutron-01"
+	imagePublisher   = "image.glance-01"
+	availabilityZone = "nova"
+	// floatingPrefix is the network the floating addresses come from. It is the
+	// documentation range of RFC 5737, which no deployment routes.
+	floatingPrefix = "203.0.113."
+)
+
+// imageNames and instanceNames are what the resources of a project are called.
+// The names are cosmetic: nothing is metered by them, and they exist so that a
+// dumped month reads like a deployment rather than like a list of ids.
+var (
+	imageNames    = []string{"debian-13-golden", "ubuntu-24.04"}
+	instanceNames = []string{"web", "db", "batch", "cache"}
+)
+
+// project is one tenant of the simulated cloud together with everything it
+// owns. The workload walks it once per month, so the resources are held as
+// pointers: a step changes the resource the next step reports.
+type project struct {
+	id     string
+	userID string
+
+	images    []*image
+	instances []*instance
+	// spare is the volume that is never attached and changes hands inside the
+	// month, which is the only way a resource moves between two projects.
+	spare *volume
+}
+
+// image is one glance image. Its size is the one the upload reports, since the
+// create that comes first has none yet.
+type image struct {
+	id        string
+	name      string
+	size      int64
+	createdAt time.Time
+}
+
+// instance is one nova server. Its flavor is the current one: a resize
+// replaces it, and every notification after that reports the new one.
+type instance struct {
+	id        string
+	name      string
+	host      string
+	flavor    flavor
+	imageID   string
+	createdAt time.Time
+	// deletedAt is when the instance is destroyed, and the zero instant on one
+	// that outlives the month. It is drawn with the create, because it bounds
+	// what the instance may still report.
+	deletedAt time.Time
+	volumes   []*volume
+	fip       *floatingIP
+}
+
+// volume is one cinder volume. attached is what the world knows and cinder
+// reports as the status: the attach itself produces no notification the
+// collector maps, so the volume simply is in use from the moment it is created
+// for an instance.
+type volume struct {
+	id         string
+	name       string
+	sizeGB     int
+	volumeType string
+	attached   bool
+	createdAt  time.Time
+}
+
+// floatingIP is one neutron address. It has no timestamps of its own, because
+// neutron reports neither a created_at nor a deleted_at for one.
+type floatingIP struct {
+	id      string
+	address string
+}


### PR DESCRIPTION
Adds `tally-openstack-simulator`, a development tool that renders one seeded month of oslo.messaging notifications and publishes it onto a RabbitMQ broker the way nova, cinder, neutron and glance would, so the **unmodified** collector consumes them through its ordinary queue and posts the mapped events to the Reporting API. Nothing in `internal/providers/openstack/` outside the new `simulator/` directory changes, and nothing in the collector, the Reporting API or the engine changes at all.

Closes #63

## The change set, in commit order

**`0b84fa0` Add the simulator configuration and virtual clock**
`internal/providers/openstack/simulator/config.go` mirrors the collector's `TALLY_OSC_` shape under `TALLY_SIM_`, down to the `*_FILE` secret convention and the separate gates (`ValidateRun`, `ValidateReplay`); `Load` checks the log level alone, because `run` needs the cloud while `replay` needs the broker. `clock.go` maps wall time to the virtual time of the simulated month at a factor that can change mid-run, which is what every later package paces on.

**`7231a99` Generate and render a simulated month of notifications**
`world.go` fixes the catalog (four flavors, three volume types, the publisher ids and hosts of the recorded samples); `workload.go` draws a month from two `math/rand/v2` generators — the *shape* from the seed alone, the *identifiers* salted with the cloud and the billing month — so one seed describes the same cloud everywhere, while the same seed, period and cloud republish byte-identical notifications that ingest deduplicates. Forced steps (the first instance always resizes, the second always shelves, one volume always resizes and retypes) are what make every seed render all eighteen recorded types plus the unsized `image.create`. `render.go` reproduces the member sets of the recorded samples, inner document travelling as a JSON string, so the collector's mapping reads the payloads it was written for.

**`a540b6c` Write and read the notification and event streams**
`stream.go`: `notifications.jsonl` carries the envelope with its exchange and routing key, so a month reaches a broker again without the generator; `events.jsonl` states what the collector's mapping is expected to make of that month, so a drill holds ingestion against it rather than mapping by hand. A billable transition the mapping claims nothing for fails the write — that catches a workload catalog drifting from the mapping table outside the test suite.

**`ade96f3` Publish onto the broker and serve the control endpoint**
`publish.go` publishes in confirm mode and persistently, and declares the four service exchanges with the arguments the OpenStack services declare them with (the collector declares them *passively*, so on a fresh broker its connection fails until somebody declares them first). A run can wait for a consumer on `tally-notifications` before publishing, because a topic exchange drops every message no queue is bound to. `control.go` serves `GET`/`PUT /clock` and `GET /healthz` — pacing and nothing else.

**`3eeae71` Run and replay a month against a broker**
`simulator.go`: the month is written to disk *before* the first publish, so an interrupted run still leaves a whole month to replay. A cancelled context stops where it stands and returns nil, leaving SIGINT/SIGTERM at exit 0 the way they are for the collector; a failed publish is an error, and the rerun is deduplicated at ingest. The control endpoint is served only while notifications go out. `publish_integration_test.go` holds the simulator against the collector's own `Consumer`, `Outbox` and `Metrics` on a RabbitMQ container: a generated month, a replayed one, both `--wait-for-collector` settings, and a broker that is gone.

**`21d77e5` Add the tally-openstack-simulator command**
`cmd/tally-openstack-simulator/` mirrors `tally-engine`'s tree: `main.go` for main and the root command, `commands.go` for the `run` and `replay` leaves, each loading configuration inside `RunE` so `--help` works with no environment. Flags are checked before the broker is dialled. A `run` without `TALLY_SIM_AMQP_URL` is file mode: it writes to `--out` and dials nothing.

**`ea744a0` Run the broker, collector and simulator through compose**
`deploy/compose/compose.yaml` runs the stack beside the kind cluster and reaches its Reporting API through `host-gateway`, with the dev CA mounted into the collector so the Gateway's certificate verifies. Every host port is bound to `127.0.0.1` and lies above 1024, which is what Docker Desktop publishes without the privileged-port helper. `make simulator-up` builds the images, writes the dev CA and issues a **fresh** ingest credential into `deploy/compose/.env` — the cluster may have been recreated, and a token its database no longer knows shows up as nothing but a retry line in the collector's log. The target refuses to start until `SIM_PERIOD` names a month. `compose_test.go` parses the file and holds it to what the two binaries actually read.

**`5dfd539` Document the OpenStack notification simulator** and **`c4579aa` Tighten two comments of the simulator**
`docs/openstack-simulator.md` covers the simulated world and its workload, the determinism the seed/period/cloud triple gives a month, `make simulator-up`, file mode and replay, the control endpoint, and the configuration. `docs/openstack-collector.md` now points at it. The last commit fixes an over-wide doc line and a comment that called a simulated month "thousands of notifications" when one month renders a few hundred.

## Divergences from the issue

All four came out of the self-review round recorded in [the last elaboration comment on #63](https://github.com/B42Labs/tally/issues/63#issuecomment-5454193331), and all are additive:

- **`TALLY_SIM_HTTP_ADDR` (default `127.0.0.1`)** — the issue's config table has four variables and the listener was `:port`. The control endpoint carries no credential and `PUT /clock` changes the pace of a run, so it now binds loopback unless asked otherwise; compose sets `0.0.0.0` explicitly because it publishes the port on the host's loopback itself.
- **`--allow-remote-broker` on `run` and `replay`** — `EnsureLocalBroker` refuses any broker whose host is not loopback. A mistyped URL would otherwise put a month of invented usage into a real deployment's billing data, and nothing deletes those events again. The refusal names the host only, never the URL that carries the password. Compose passes the flag.
- **`SIM_IMAGES` in the Makefile** — `simulator-up` builds the collector and the simulator only, not the cluster services `make up` loads and migrates; building those here would leave a tag nothing loads and a schema nobody applied.
- **`maxWait`/`wallWait` and NaN rejection in the clock** — a legal but tiny `PUT /clock` factor overflowed the `float64`→`time.Duration` conversion (spinning or a ~292-year timer), and `NaN` passed both `factor < 0` guards.

The broker image in compose is also pinned to a digest (`rabbitmq:4.3.5-management-alpine@sha256:e2f08f84…`), matching `deploy/kind/kind.yaml`'s style, rather than a floating tag.

## Verification state

`go build`, `go vet`, `golangci-lint` and the Go test suites (unit plus the RabbitMQ-container integration tests) pass on the branch. The compose acceptance criteria that need a running `make up` dev cluster are **unverified** — the machine this was implemented on has no kind cluster, so `make simulator-up` was checked through `make -n` and `docker compose config` only. A reviewer with a dev cluster should run `make up && make simulator-up SIM_PERIOD=<past month>` and confirm the collector's log carries no `x509` and no `401`, and that `tally_collector_delivered_total` on `http://127.0.0.1:8090/metrics` rises.

Two known follow-ups, both out of scope here: `publish_integration_test.go` pulls `rabbitmq:4-alpine` on a floating tag (as the pre-existing `amqp_integration_test.go` already does), and octavia has no mapping-table entry yet, so `TestEveryRecordedNotificationTypeIsRendered` will fail the moment #64 lands its samples — which is the intended signal to extend the catalog.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 2ff29db with Claude:claude-opus-5_
