### PR TITLE
Codify volume and loyalty discounts and add the meta-project rollup export

### DIFF
--- a/cmd/tally-engine/commands.go
+++ b/cmd/tally-engine/commands.go
@@ -13,13 +13,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/spf13/cobra"
 
+	"github.com/b42labs/tally/internal/core/project"
 	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/period"
 	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/runs"
 	"github.com/b42labs/tally/internal/engine/scheduler"
+	"github.com/b42labs/tally/internal/engine/source"
 	"github.com/b42labs/tally/internal/engine/store"
 	"github.com/b42labs/tally/internal/engine/store/sqlcgen"
 )
@@ -472,7 +475,7 @@ const (
 
 // newExportCmd builds the export subcommand.
 func newExportCmd() *cobra.Command {
-	var runID, format, out string
+	var runID, format, out, rollup string
 
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -481,10 +484,16 @@ func newExportCmd() *cobra.Command {
 			"json writes run.json and one statement document per project, or one credit note per project " +
 			"for a correction run. csv writes the rated records into rated.csv, and the deltas of a " +
 			"correction into deltas.csv. Both formats write the run's partner settlement beside them, " +
-			"kickbacks.json or kickbacks.csv, empty when the run owes nobody. --out has to be empty or " +
+			"kickbacks.json or kickbacks.csv, empty when the run owes nobody. --rollup member_of or " +
+			"--rollup managed_by writes one rollup document per meta-project or partner beside the " +
+			"statements, rollup-<key>.json or rollup.csv, summing the statements of its members; it reads " +
+			"the membership from the reporting database when the export runs, so " +
+			"TALLY_ENGINE_REPORTING_DB_URL has to be set for it. --out has to be empty or " +
 			"absent, so what it holds afterwards is one run's artifacts and nothing an earlier export of " +
 			"another run left there. Exporting a finalized run twice into a clean directory yields the " +
-			"same files, because a finalized run's records no longer change.",
+			"same files, because a finalized run's records no longer change. A --rollup export is the " +
+			"exception: the membership is read from the registry when the export runs, so two exports " +
+			"differ where a relation was created or closed between them.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			id, err := validateRunID(runID)
@@ -494,23 +503,41 @@ func newExportCmd() *cobra.Command {
 			if err := validateFormat(format); err != nil {
 				return err
 			}
+			if err := validateRollup(rollup); err != nil {
+				return err
+			}
 			if err := validateOut(out); err != nil {
 				return err
 			}
 
 			// Everything an export renders was written to the engine database by
-			// the run, so this reads that one database.
-			db, err := openStore(cmd.Context())
-			if err != nil {
-				return err
+			// the run, so an export reads that one database. A rollup is the one
+			// export that reads the registry as well, because the membership it
+			// sums under lives in the reporting database: a missing reporting url
+			// is refused there rather than after a month of records was read.
+			var pool *pgxpool.Pool
+			var reporting *source.DB
+			if rollup == "" {
+				db, err := openStore(cmd.Context())
+				if err != nil {
+					return err
+				}
+				defer db.Close()
+				pool = db.Pool()
+			} else {
+				dbs, err := openDatabases(cmd.Context())
+				if err != nil {
+					return err
+				}
+				defer dbs.Close()
+				pool, reporting = dbs.engine.Pool(), dbs.reporting
 			}
-			defer db.Close()
 
 			// The run is read before an exporter is built, and an exporter
 			// creates its directory only once it has rendered everything: a run
 			// id no row carries, and a run no export is produced from, leave the
 			// --out directory uncreated.
-			run, err := export.Load(cmd.Context(), db.Pool(), id)
+			run, err := export.Load(cmd.Context(), pool, id)
 			if err != nil {
 				return err
 			}
@@ -522,12 +549,23 @@ func newExportCmd() *cobra.Command {
 			// records were being read is refused rather than written out. What is
 			// left after this is the rendering and the writing, which the row
 			// lock the export deliberately does not take would not cover either.
-			current, err := sqlcgen.New(db.Pool()).GetRun(cmd.Context(), pgtype.UUID{Bytes: id, Valid: true})
+			current, err := sqlcgen.New(pool).GetRun(cmd.Context(), pgtype.UUID{Bytes: id, Valid: true})
 			if err != nil {
 				return fmt.Errorf("re-reading the run %s: %w", id, err)
 			}
 			if current.Status != run.Status {
 				return fmt.Errorf("run %s became %s while it was read, and was not exported", id, current.Status)
+			}
+
+			// The membership is read before the exporter is built, for the reason
+			// the run itself is: a registry read that fails leaves the operator's
+			// --out uncreated rather than holding half an export.
+			if rollup != "" {
+				loaded, err := export.LoadRollup(cmd.Context(), reporting, run, rollup)
+				if err != nil {
+					return err
+				}
+				run.Rollup = &loaded
 			}
 
 			// The format names the implementation. Every consumer of billing
@@ -559,6 +597,9 @@ func newExportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&runID, "run", "", "id of the run to export")
 	cmd.Flags().StringVar(&format, "format", "", "output format: json or csv")
 	cmd.Flags().StringVar(&out, "out", "", "directory the exported files are written to")
+	cmd.Flags().StringVar(&rollup, "rollup", "",
+		"relation type to sum the statements under, member_of or managed_by: "+
+			"one document per meta-project or partner; no rollup when absent")
 	_ = cmd.MarkFlagRequired("run")
 	_ = cmd.MarkFlagRequired("format")
 	_ = cmd.MarkFlagRequired("out")
@@ -779,7 +820,10 @@ func runLines(month string, result runs.Result) []string {
 // directory. The counts say how much of the month is in those files, so a run
 // that billed nobody says so here rather than in a listing of the directory.
 // The partner settlement, kickbacks.json or kickbacks.csv, is written by both
-// formats, so its line stands under either of them.
+// formats, so its line stands under either of them. A run the export summed
+// under a relation type says so on a line of its own, which is what tells an
+// operator whether the meta-projects they asked for were reached at all: a
+// rollup that found no member writes its files and counts nothing.
 func exportLines(month, format, out string, run export.Run) []string {
 	lines := []string{fmt.Sprintf("run %s exported for %s as %s into %s", run.ID, month, format, out)}
 	correction := run.Kind == runs.KindCorrection
@@ -802,12 +846,26 @@ func exportLines(month, format, out string, run export.Run) []string {
 		lines = append(lines,
 			fmt.Sprintf("wrote run.json and %d %s", len(run.Statements), documents),
 			fmt.Sprintf("wrote kickbacks.json with %d %s", len(run.Kickbacks), kickbacks))
+		if run.Rollup != nil {
+			lines = append(lines, fmt.Sprintf("wrote %d rollup documents over %s",
+				len(run.Rollup.Groups), run.Rollup.RelationType))
+		}
 	case formatCSV:
 		lines = append(lines, fmt.Sprintf("wrote rated.csv with %d rated records", len(run.Rated)))
 		if correction {
 			lines = append(lines, fmt.Sprintf("wrote deltas.csv with %d deltas", len(run.Deltas)))
 		}
 		lines = append(lines, fmt.Sprintf("wrote kickbacks.csv with %d %s", len(run.Kickbacks), kickbacks))
+		if run.Rollup != nil {
+			// One row per member rather than per group, which is what the table
+			// holds: a group's total is the sum of its rows.
+			members := 0
+			for _, group := range run.Rollup.Groups {
+				members += len(group.Members)
+			}
+			lines = append(lines, fmt.Sprintf("wrote rollup.csv with %d members over %s",
+				members, run.Rollup.RelationType))
+		}
 	}
 	return lines
 }
@@ -972,6 +1030,20 @@ func validateRunID(value string) (uuid.UUID, error) {
 func validateFormat(value string) error {
 	if value != formatJSON && value != formatCSV {
 		return fmt.Errorf("--format: %q must be %s or %s", value, formatJSON, formatCSV)
+	}
+	return nil
+}
+
+// validateRollup checks a --rollup flag against the relation types a rollup
+// sums under. An absent flag passes: an export without one writes no rollup at
+// all. Any other type points at a project that owns resources and carries a
+// statement of its own, which a rollup under it would leave out.
+func validateRollup(value string) error {
+	if value == "" {
+		return nil
+	}
+	if !project.IsVirtualRelationType(value) {
+		return fmt.Errorf("--rollup: %q must be %s or %s", value, project.RelationMemberOf, project.RelationManagedBy)
 	}
 	return nil
 }

--- a/cmd/tally-engine/main_test.go
+++ b/cmd/tally-engine/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/engine/config"
 	"github.com/b42labs/tally/internal/engine/corrections"
@@ -1104,6 +1105,348 @@ func TestExportCLI(t *testing.T) {
 	})
 }
 
+// TestExportRollupCLI exports a run whose projects are billed under one
+// meta-project. Two of the three are members of it and are given the group's
+// discount, the third is a member of nothing and is billed what it was rated,
+// and the rollup sums the two member statements alone. That a group's total is
+// the sum of the statements it lists, and that a project outside the group is
+// in neither the document nor the table, is what roadmap WP 5.5 asks the tests
+// to prove.
+func TestExportRollupCLI(t *testing.T) {
+	f := newPipelineFixture(t)
+	// The fixture blanks the environment, so the relation types the adjustments
+	// are resolved through are set after it rather than before it.
+	t.Setenv("TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES", "managed_by,member_of")
+
+	from, _ := billingMonth(-3)
+	month := period.Format(from)
+	const (
+		cloud    = "os-cli-rollup"
+		alpha    = "team-alpha"
+		beta     = "team-beta"
+		outsider = "outsider"
+		metaID   = "customer-alpha-rollup"
+	)
+	for _, name := range []string{alpha, beta, outsider} {
+		f.seedProject(t, cloud, name)
+		f.seedInstance(t, cloud, "i-"+name, name, from)
+	}
+	meta := f.seedVirtualProject(t, "meta", metaID)
+	// Valid from a month before the one that is billed, so the membership covers
+	// the whole of it. The third project is left out of the group, which is what
+	// makes it the control the assertions below read.
+	for _, member := range []string{alpha, beta} {
+		f.seedRelation(t, f.projectIDOf(t, cloud, member), meta, "member_of", groupDiscount, from.AddDate(0, -1, 0))
+	}
+
+	stdout, stderr, err := runCLI(t, "run", "--period", month, "--clouds", cloud)
+	if err != nil {
+		t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+	}
+	// One per member of the group, and none for the project outside it.
+	if want := "applied 2 pricing adjustments"; !strings.Contains(stdout, want) {
+		t.Errorf("stdout of run = %q, want it to contain %q", stdout, want)
+	}
+	id := f.completedRun(t, from)
+
+	documents := filepath.Join(t.TempDir(), "json")
+	stdout, stderr, err = runCLI(t, "export",
+		"--run", id.String(), "--format", "json", "--out", documents, "--rollup", "member_of")
+	if err != nil {
+		t.Fatalf("export as json error = %v, want nil (stderr %q)", err, stderr)
+	}
+	want := fmt.Sprintf("run %s exported for %s as json into %s\n"+
+		"wrote run.json and 3 statements\nwrote kickbacks.json with 0 kickbacks\n"+
+		"wrote 1 rollup documents over member_of\n",
+		id, month, documents)
+	if stdout != want {
+		t.Errorf("stdout of export as json = %q, want %q", stdout, want)
+	}
+
+	// Every member inherits the group's 5 percent off what it was rated: 3.84
+	// less the 0.19 the discount comes to is the 3.65 the rollup sums.
+	memberFiles := make(map[string]string, 2)
+	for _, name := range []string{alpha, beta} {
+		file := "statement-" + url.PathEscape(statements.Key(cloud, name)) + ".json"
+		memberFiles[name] = file
+
+		var document statements.Document
+		readJSONFile(t, filepath.Join(documents, file), &document)
+		if document.BaseCost == nil || document.NetCost == nil {
+			t.Fatalf("%s carries no base or net cost, want the group's discount applied to it", file)
+		}
+		if len(document.Adjustments) != 1 {
+			t.Fatalf("%s carries %d adjustments, want the group's one", file, len(document.Adjustments))
+		}
+		line := document.Adjustments[0]
+		for _, tc := range []struct{ what, got, want string }{
+			{"base cost", document.BaseCost.StringFixed(2), "3.84"},
+			{"adjustment type", line.Type, "project_discount"},
+			{"relation type", line.RelationType, "member_of"},
+			{"relation target", line.RelationTarget, metaID},
+			{"rate", line.Rate.StringFixed(6), "0.050000"},
+			{"base", line.Base.StringFixed(2), "3.84"},
+			{"amount", line.Amount.StringFixed(2), "-0.19"},
+			{"net cost", document.NetCost.StringFixed(2), "3.65"},
+			{"total", document.Total.StringFixed(2), "3.65"},
+		} {
+			if tc.got != tc.want {
+				t.Errorf("%s %s = %q, want %q", file, tc.what, tc.got, tc.want)
+			}
+		}
+	}
+
+	// The project no relation reaches is billed the list price: a group discount
+	// is given to its members and to nobody else.
+	var control statements.Document
+	readJSONFile(t, filepath.Join(documents,
+		"statement-"+url.PathEscape(statements.Key(cloud, outsider))+".json"), &control)
+	if control.BaseCost != nil || control.NetCost != nil || control.Adjustments != nil {
+		t.Errorf("the statement of %s carries the adjustments %v, want none", outsider, control.Adjustments)
+	}
+	if got := control.Total.StringFixed(2); got != "3.84" {
+		t.Errorf("the statement of %s totals %s, want the undiscounted 3.84", outsider, got)
+	}
+
+	// The group's document is named after the key of the meta-project, escaped
+	// the way a statement's is, so the literal is pinned beside the rendering.
+	rollupFile := "rollup-" + url.PathEscape(statements.Key("meta", metaID)) + ".json"
+	if want := "rollup-meta%2Fcustomer-alpha-rollup.json"; rollupFile != want {
+		t.Fatalf("the rollup document is named %q, want %q", rollupFile, want)
+	}
+
+	var report rollupReport
+	readJSONFile(t, filepath.Join(documents, rollupFile), &report)
+	for _, tc := range []struct{ what, got, want string }{
+		{"project id", report.ProjectID, metaID},
+		{"platform", report.Platform, "meta"},
+		{"relation type", report.RelationType, "member_of"},
+		{"kind", report.Kind, runs.KindRegular},
+		{"total", report.Total.String(), "7.30"},
+		{"currency", report.Currency, "EUR"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s %s = %q, want %q", rollupFile, tc.what, tc.got, tc.want)
+		}
+	}
+	if report.CorrectsRunID != nil {
+		t.Errorf("%s corrects run %q, want a regular run's rollup to correct nothing", rollupFile, *report.CorrectsRunID)
+	}
+	if len(report.Members) != 2 {
+		t.Fatalf("%s lists %d members, want the two of the group", rollupFile, len(report.Members))
+	}
+	// Every member points at the file its own invoice is in, so an ERP reads the
+	// group and the statements it is made of out of one directory.
+	for i, name := range []string{alpha, beta} {
+		for _, tc := range []struct{ what, got, want string }{
+			{"file", report.Members[i].File, memberFiles[name]},
+			{"cloud", report.Members[i].Cloud, cloud},
+			{"project id", report.Members[i].ProjectID, name},
+			{"total", report.Members[i].Total.String(), "3.65"},
+		} {
+			if tc.got != tc.want {
+				t.Errorf("%s member %d %s = %q, want %q", rollupFile, i, tc.what, tc.got, tc.want)
+			}
+		}
+	}
+
+	// Attribution and billing stay per project, so the group's total has to be
+	// the sum of the member totals rather than a number of its own. It is
+	// checked against both: the totals the document lists, and the digits the
+	// database holds for those two statements.
+	total := decimal.RequireFromString(report.Total.String())
+	listed := decimal.Zero
+	for _, member := range report.Members {
+		listed = listed.Add(decimal.RequireFromString(member.Total.String()))
+	}
+	if !total.Equal(listed) {
+		t.Errorf("%s totals %s, want the %s its members add up to", rollupFile, total, listed)
+	}
+	stored := decimal.RequireFromString(f.statementTotalOf(t, id, statements.Key(cloud, alpha))).
+		Add(decimal.RequireFromString(f.statementTotalOf(t, id, statements.Key(cloud, beta))))
+	if !total.Equal(stored) {
+		t.Errorf("%s totals %s, want the %s the database holds for its members", rollupFile, total, stored)
+	}
+
+	// The index names the group beside the statements, which is how a reader
+	// that walks run.json alone finds the rollup document at all.
+	var index runIndex
+	readJSONFile(t, filepath.Join(documents, "run.json"), &index)
+	if index.Rollup == nil {
+		t.Fatal("run.json names no rollup, want the one the export summed")
+	}
+	if got := index.Rollup.RelationType; got != "member_of" {
+		t.Errorf("run.json rolls up over %q, want %q", got, "member_of")
+	}
+	if len(index.Rollup.Documents) != 1 {
+		t.Fatalf("run.json names %d rollup documents, want the one group the run reached", len(index.Rollup.Documents))
+	}
+	entry := index.Rollup.Documents[0]
+	for _, tc := range []struct{ what, got, want string }{
+		{"file", entry.File, rollupFile},
+		{"cloud", entry.Cloud, "meta"},
+		{"project id", entry.ProjectID, metaID},
+		{"total", entry.Total.String(), "7.30"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("run.json rollup %s = %q, want %q", tc.what, tc.got, tc.want)
+		}
+	}
+	if entry.Members != 2 {
+		t.Errorf("run.json counts %d members under the rollup, want 2", entry.Members)
+	}
+
+	// The project outside the group is nowhere in the group's document: a rollup
+	// sums what is related to its target and says nothing about the rest of the
+	// run.
+	body, err := os.ReadFile(filepath.Join(documents, rollupFile))
+	if err != nil {
+		t.Fatalf("reading %s: %v", rollupFile, err)
+	}
+	if bytes.Contains(body, []byte(outsider)) {
+		t.Errorf("%s names %s, want the group to hold its two members alone", rollupFile, outsider)
+	}
+
+	tables := filepath.Join(t.TempDir(), "csv")
+	stdout, stderr, err = runCLI(t, "export",
+		"--run", id.String(), "--format", "csv", "--out", tables, "--rollup", "member_of")
+	if err != nil {
+		t.Fatalf("export as csv error = %v, want nil (stderr %q)", err, stderr)
+	}
+	want = fmt.Sprintf("run %s exported for %s as csv into %s\n"+
+		"wrote rated.csv with 3 rated records\nwrote kickbacks.csv with 0 kickbacks\n"+
+		"wrote rollup.csv with 2 members over member_of\n",
+		id, month, tables)
+	if stdout != want {
+		t.Errorf("stdout of export as csv = %q, want %q", stdout, want)
+	}
+
+	header, rows := readCSVFile(t, filepath.Join(tables, "rollup.csv"))
+	if len(header) != 12 {
+		t.Fatalf("rollup.csv holds %d columns, want 12", len(header))
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rollup.csv holds %d rows under its header, want one per member", len(rows))
+	}
+	// One row per member rather than per group, each naming the target it is
+	// summed under, so the two rows add up to the group's total.
+	for i, name := range []string{alpha, beta} {
+		for _, tc := range []struct{ column, want string }{
+			{"target_project_id", metaID},
+			{"project_id", name},
+			{"total", "3.65"},
+			{"currency", "EUR"},
+		} {
+			if got := rows[i][tc.column]; got != tc.want {
+				t.Errorf("rollup.csv row %d %s = %q, want %q", i, tc.column, got, tc.want)
+			}
+		}
+	}
+
+	t.Run("writes no rollup without --rollup", func(t *testing.T) {
+		// The same run, exported the way every other export of it is: a rollup is
+		// asked for or it is not written at all, so a reader of an export that
+		// never asked for one finds nothing to read.
+		out := filepath.Join(t.TempDir(), "no-rollup")
+		stdout, stderr, err := runCLI(t, "export", "--run", id.String(), "--format", "json", "--out", out)
+		if err != nil {
+			t.Fatalf("export error = %v, want nil (stderr %q)", err, stderr)
+		}
+		want := fmt.Sprintf("run %s exported for %s as json into %s\n"+
+			"wrote run.json and 3 statements\nwrote kickbacks.json with 0 kickbacks\n",
+			id, month, out)
+		if stdout != want {
+			t.Errorf("stdout = %q, want %q", stdout, want)
+		}
+
+		entries, err := os.ReadDir(out)
+		if err != nil {
+			t.Fatalf("reading %s: %v", out, err)
+		}
+		for _, written := range entries {
+			if strings.HasPrefix(written.Name(), "rollup-") {
+				t.Errorf("the export wrote %s, want no rollup document", written.Name())
+			}
+		}
+		body, err := os.ReadFile(filepath.Join(out, "run.json"))
+		if err != nil {
+			t.Fatalf("reading run.json: %v", err)
+		}
+		if bytes.Contains(body, []byte(`"rollup"`)) {
+			t.Error("run.json names a rollup, want the field absent from an export that summed none")
+		}
+	})
+
+	t.Run("refuses --rollup without the reporting database", func(t *testing.T) {
+		// A rollup is the one export that reads the registry, and the membership
+		// lives in the reporting database. A machine that has only the engine
+		// database is told which variable is missing before a run is read.
+		useDatabase(t, f.engine.URL)
+
+		out := filepath.Join(t.TempDir(), "no-reporting")
+		stdout, _, err := runCLI(t, "export",
+			"--run", id.String(), "--format", "json", "--out", out, "--rollup", "member_of")
+		if err == nil {
+			t.Fatal("export error = nil, want the missing reporting database reported")
+		}
+		if want := "TALLY_ENGINE_REPORTING_DB_URL: must be set"; !strings.Contains(err.Error(), want) {
+			t.Errorf("export error = %q, want it to contain %q", err, want)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an export that wrote nothing", stdout)
+		}
+		if _, err := os.Stat(out); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("os.Stat(%s) error = %v, want it to report a directory that was never created", out, err)
+		}
+	})
+
+	t.Run("refuses a run no row carries with --rollup", func(t *testing.T) {
+		missing := uuid.New()
+		out := filepath.Join(t.TempDir(), "unknown-run")
+
+		stdout, _, err := runCLI(t, "export",
+			"--run", missing.String(), "--format", "json", "--out", out, "--rollup", "member_of")
+		if err == nil {
+			t.Fatal("export error = nil, want the unknown run reported")
+		}
+		if !strings.Contains(err.Error(), missing.String()) {
+			t.Errorf("export error = %q, want it to name the run %s", err, missing)
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an export that wrote nothing", stdout)
+		}
+		if _, err := os.Stat(out); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("os.Stat(%s) error = %v, want it to report a directory that was never created", out, err)
+		}
+	})
+
+	t.Run("reports a reporting database it cannot read", func(t *testing.T) {
+		// The engine database holds no registry, so the rollup fails at the
+		// projects it reads. The membership is read before the exporter is built,
+		// which is what leaves --out uncreated rather than holding statements
+		// beside a rollup that was never summed.
+		t.Setenv("TALLY_ENGINE_REPORTING_DB_URL", f.engine.URL)
+
+		out := filepath.Join(t.TempDir(), "wrong-reporting")
+		stdout, _, err := runCLI(t, "export",
+			"--run", id.String(), "--format", "json", "--out", out, "--rollup", "member_of")
+		if err == nil {
+			t.Fatal("export error = nil, want the unreadable registry reported")
+		}
+		for _, want := range []string{"rolling up run ", id.String(), "listing the projects", `"projects" does not exist`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("export error = %q, want it to contain %q", err, want)
+			}
+		}
+		if stdout != "" {
+			t.Errorf("stdout = %q, want nothing printed by an export that wrote nothing", stdout)
+		}
+		if _, err := os.Stat(out); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("os.Stat(%s) error = %v, want it to report a directory that was never created", out, err)
+		}
+	})
+}
+
 // TestKickbacksCLI reports what a run owes its partners: the month's regular
 // run, the same run named with --run, and the correction that booked a resize
 // afterwards. The correction settles negative numbers because the resize halved
@@ -1504,6 +1847,40 @@ type runIndex struct {
 		File  string      `json:"file"`
 		Total json.Number `json:"total"`
 	} `json:"statements"`
+	// A pointer, so an index that names no rollup at all is told apart from one
+	// whose rollup reached no group.
+	Rollup *struct {
+		RelationType string `json:"relation_type"`
+		Documents    []struct {
+			File      string      `json:"file"`
+			Cloud     string      `json:"cloud"`
+			ProjectID string      `json:"project_id"`
+			Members   int         `json:"members"`
+			Total     json.Number `json:"total"`
+		} `json:"documents"`
+	} `json:"rollup"`
+}
+
+// rollupReport is one rollup-<key>.json, as much of it as the assertions above
+// read. The export package's own tests pin the rest. The amounts are
+// json.Number, so they are compared as the digits the document holds rather
+// than through a float.
+type rollupReport struct {
+	ProjectID    string `json:"project_id"`
+	Platform     string `json:"platform"`
+	RelationType string `json:"relation_type"`
+	Kind         string `json:"kind"`
+	// A pointer, so a regular run's absent field is told apart from the run a
+	// correction's rollup names.
+	CorrectsRunID *string `json:"corrects_run_id"`
+	Members       []struct {
+		File      string      `json:"file"`
+		Cloud     string      `json:"cloud"`
+		ProjectID string      `json:"project_id"`
+		Total     json.Number `json:"total"`
+	} `json:"members"`
+	Total    json.Number `json:"total"`
+	Currency string      `json:"currency"`
 }
 
 // kickbacksReport is the settlement document the kickbacks subcommand prints,
@@ -1663,6 +2040,12 @@ const modelVersion = "v1"
 const resellerAdjustments = `{"pricing_adjustments":[` +
 	`{"type":"discount","rate":"0.15","scope":"all"},` +
 	`{"type":"kickback","rate":"0.10","scope":"all"}]}`
+
+// groupDiscount is the metadata of the relation between a project and the
+// meta-project it belongs to: 5 percent off what the project is rated, which
+// every member of the group is given and nobody outside it. One adjustment, so
+// a member's statement carries exactly one line.
+const groupDiscount = `{"pricing_adjustments":[{"type":"project_discount","rate":"0.05","scope":"all"}]}`
 
 // pipelineFixture is the pair of databases a run works over: the engine
 // database it is written to, and the reporting database it reads its resources
@@ -1921,6 +2304,22 @@ func (f pipelineFixture) statementTotal(t *testing.T, id uuid.UUID) string {
 	return total
 }
 
+// statementTotalOf is the total of one statement of a run, named by the key it
+// was stored under, which is what project_statements.project_id holds.
+// statementTotal reads the one statement of its run, and a run that billed
+// several projects has no single row to read.
+func (f pipelineFixture) statementTotalOf(t *testing.T, id uuid.UUID, key string) string {
+	t.Helper()
+
+	var total string
+	if err := f.engine.Store.Pool().QueryRow(t.Context(),
+		`SELECT total::text FROM project_statements WHERE run_id = $1 AND project_id = $2`,
+		id, key).Scan(&total); err != nil {
+		t.Fatalf("reading the total of the statement %s of the run %s: %v", key, id, err)
+	}
+	return total
+}
+
 // TestTickLinesReportsWhatTheWalkLeftBehind pins the two lines a tick prints
 // beside the steps a month took. Both stand for a month that is not fine while
 // the tick's exit status is zero, so nothing else would say they happened: the
@@ -2061,6 +2460,18 @@ func TestBadCommandLinesAreRefusedWithoutAConfiguration(t *testing.T) {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("export error = %q, want it to name %q", err, want)
 			}
+		}
+	})
+
+	t.Run("export refuses a rollup relation type it does not sum under", func(t *testing.T) {
+		_, _, err := runCLI(t, "export", "--run", runID, "--format", "json", "--out", "./out",
+			"--rollup", "infrastructure_tenant")
+		if err == nil {
+			t.Fatal("export error = nil, want the relation type refused")
+		}
+		want := `--rollup: "infrastructure_tenant" must be member_of or managed_by`
+		if err.Error() != want {
+			t.Errorf("export error = %q, want %q", err, want)
 		}
 	})
 

--- a/docs/group-discounts.md
+++ b/docs/group-discounts.md
@@ -1,0 +1,193 @@
+# Customer-group discounts
+
+A customer that runs several projects is modelled as a meta-project: a registry
+row of platform `meta` that owns no resources and that each of the customer's
+projects points at with a `member_of` relation. That relation carries the
+customer's discount, a `project_discount` in its `pricing_adjustments`, and the
+rating engine applies it to every project the relation reaches. Attribution and
+billing stay per project: each project keeps its own statement, and the group is
+a view over those statements.
+
+This document states the one pattern that expresses such a discount, how its
+rate is changed for a later month, why the engine derives no volume tiers from
+usage, and what the rollup export writes.
+
+## Expressing a group discount
+
+Register the meta-project once:
+
+```bash
+tally-reporting-admin create-meta-project \
+  --external-id customer-alpha \
+  --name "Customer Alpha"
+```
+
+The command prints the new project id on stdout, and that id is what the
+relations name as their target.
+
+Then relate every project of the customer to it. The call leaves the member
+project, `POST /api/v1/projects/{id}/relations`, and carries the discount on the
+relation:
+
+```json
+{
+  "target_id": "<the meta-project id>",
+  "relation_type": "member_of",
+  "metadata": {
+    "pricing_adjustments": [
+      {"type": "project_discount", "rate": "0.05", "scope": "all", "description": "Customer Alpha group discount"}
+    ]
+  }
+}
+```
+
+The rate is a string, never a number. The array is validated against
+`internal/core/adjustment/adjustments_schema.json` when the relation is written,
+and an array the schema refuses is answered 422 with one field error per
+violation.
+
+A run resolves the adjustments of a statement by walking the relation types
+named in `TALLY_ENGINE_ADJUSTMENT_RELATION_TYPES` (default
+`managed_by,member_of`) outward from the statement's project, up to
+`TALLY_ENGINE_ADJUSTMENT_DEPTH` levels (default `3`). The discount sits on the
+relation rather than on a project, so it reaches every member that holds one. A
+`project_discount` applies after every `discount`, on the running net.
+
+The member's statement then carries `base_cost`, one `adjustments` line whose
+`relation_type` is `member_of` and whose `relation_target` is the meta-project's
+external id (`customer-alpha`), and `net_cost`; `total` is the net cost. A
+project rated at 3.84 under a rate of 0.05 gets one line of amount -0.19 and a
+net cost of 3.65.
+
+Relations the meta-project itself holds are part of the same walk. A
+`managed_by` from the meta-project to a partner is at depth 2 from every member
+and reaches all of them, which is how a partner's terms apply to a whole
+customer group.
+
+The one pattern is the `project_discount` on the `member_of` relation. Do not
+put a `discount` on each member's own relations: the rate is then stored once
+per project and drifts apart at the next change. Do not put the adjustment on
+any other relation of the member, because the walk applies whatever it finds and
+the group's terms then depend on relations that mean something else. Do not edit
+statements: a statement is what a run produced from the registry, and a
+finalized month stays reproducible from the relations alone.
+
+## Changing the rate for a later month
+
+The adjustments a relation carries are fixed for its lifetime. A `PATCH` whose
+`pricing_adjustments` differ from the stored ones is answered 409 with the
+detail `the pricing adjustments of a relation are fixed for its lifetime; close
+this relation and create a successor that carries the new ones`.
+
+A rate change effective 2026-04-01 is two calls. First close the current
+relation at the boundary:
+
+```http
+PATCH /api/v1/projects/{id}/relations/{relation_id}
+Content-Type: application/json
+
+{"valid_to": "2026-04-01T00:00:00Z"}
+```
+
+Then create the successor over the same pair and type, valid from the same
+instant and carrying the new rate:
+
+```http
+POST /api/v1/projects/{id}/relations
+Content-Type: application/json
+
+{
+  "target_id": "<the meta-project id>",
+  "relation_type": "member_of",
+  "valid_from": "2026-04-01T00:00:00Z",
+  "metadata": {
+    "pricing_adjustments": [
+      {"type": "project_discount", "rate": "0.08", "scope": "all", "description": "Customer Alpha group discount"}
+    ]
+  }
+}
+```
+
+The successor is created as soon as `valid_to` is set on its predecessor, well
+before the boundary passes. The registry's unique index over (source, target,
+type), `uq_relations_active` in `migrations/reporting/0001_init.sql`, is partial
+and covers open relations only, so a triple whose predecessor is closed is
+created again even while that predecessor is still valid.
+
+`DELETE /api/v1/projects/{id}/relations/{relation_id}` closes a relation at now.
+It is not the call for a rate change, because now is somewhere inside the
+running month.
+
+Close at the month boundary, never mid-month. A relation applies to a whole
+period as soon as its validity overlaps that period at any instant, that is
+`valid_from < period_to AND (valid_to IS NULL OR valid_to > period_from)`
+(decision D4 of phase 3), and so does its successor. A relation closed on
+2026-04-15 and a successor valid from that instant therefore both apply to
+April, and April's statements carry both discounts.
+
+A month that is already finalized is not changed by the successor. A correction
+run re-meters its own period and resolves the relations valid for that period,
+so the relation that covered March keeps applying to March however many
+successors follow it.
+
+## Why volume tiers are not computed
+
+The engine does not derive a rate from the usage of the period it rates. Such a
+rate changes when a late event moves the period's usage across a tier boundary,
+so the same month rates differently depending on when it is rated. A correction
+would then have to re-derive the rate as well as the base it applies to, and
+that is a correction semantics the engine does not have: a correction re-meters
+and re-rates its period with the relations valid for it, and the rate those
+relations carry is stored rather than computed.
+
+Automatic tiering is recorded as a future extension in
+`roadmap/05-phase-5-commercial-pricing.md` (WP 5.5). Until it exists, operations
+sets a tier's rate per period explicitly, through the flow of the section above:
+close the relation at the month boundary, create the successor with the rate the
+next period is owed.
+
+## The meta-project rollup export
+
+An export sums a run's statements under the meta-projects the billed projects
+are members of:
+
+```bash
+tally-engine export --run <id> --format json --out <dir> --rollup member_of
+```
+
+`--rollup managed_by` sums under partners instead. `--format csv` writes the
+table rather than the documents. `TALLY_ENGINE_REPORTING_DB_URL` has to be set
+whenever `--rollup` is passed: an export otherwise reads the engine database
+alone, and the membership lives in the registry.
+
+The json export writes one `rollup-<key>.json` per meta-project beside the
+statements, where `<key>` is the target's cloud and external id escaped the way
+a statement file name is. A virtual project carries its platform as its cloud,
+so `customer-alpha` is written to `rollup-meta%2Fcustomer-alpha.json`. The
+document holds `billing_period`, `project_id`, `platform`, `relation_type`,
+`kind`, `corrects_run_id` (null on a regular run), `members` with `file`,
+`cloud`, `project_id`, `total` and `currency` each, `total` and `currency`.
+`run.json` carries a `rollup` member naming every rollup document with its
+`members` count and its `total`. The csv export writes `rollup.csv` with the
+columns `run_id`, `kind`, `corrects_run_id`, `period_from`, `period_to`,
+`relation_type`, `target_cloud`, `target_project_id`, `cloud`, `project_id`,
+`total` and `currency`, one row per member.
+
+The sum follows the direct `member_of` relations of the period and nothing
+further: a meta-project that is itself a member of a larger one is not followed,
+and its members are summed under it alone. A member is counted once however many
+relations reach the target from it in the period, so a membership closed and
+opened again inside the month is one member rather than two. A project is listed
+under every meta-project it belongs to, so two rollups are not disjoint and
+their totals add up to more than the run billed. Nothing is summed for a project
+the run billed under another project's statement: a project attributed to a root
+through an `infrastructure_tenant` relation has its costs on the root's
+statement, and it is the root's membership that decides where they land. A
+rollup of a correction run sums that run's credit notes. A group's total equals
+the sum of the member totals to the cent, and the statements themselves are
+unchanged by it.
+
+The membership is read from the registry at the moment the export runs rather
+than stored with the run (author's decision of 2026-08-29). Two exports of one
+finalized run therefore differ when a relation was created or closed
+retroactively between them.

--- a/internal/engine/export/csv.go
+++ b/internal/engine/export/csv.go
@@ -14,7 +14,8 @@ import (
 
 // The two files a CSV export writes off the rating. rated.csv is every run's,
 // deltas.csv only a correction's. kickbacks.csv, every run's as well, is named
-// in kickbacks.go beside the renderer that fills it.
+// in kickbacks.go beside the renderer that fills it, and rollup.csv, which a run
+// that carries a rollup writes, in rollup.go beside its own.
 const (
 	ratedFileName  = "rated.csv"
 	deltasFileName = "deltas.csv"
@@ -39,8 +40,10 @@ var (
 
 // CSVFiles writes a run as CSV files into a directory: rated.csv, one row per
 // rated record, kickbacks.csv, one row per kickback the run settles for a
-// partner, and, for a correction run, deltas.csv, one row per delta. It is the
-// BillingExporter an ERP that imports tables rather than documents is fed from.
+// partner, and, for a correction run, deltas.csv, one row per delta. A run that
+// carries a rollup writes rollup.csv on top, one row per member of every group.
+// It is the BillingExporter an ERP that imports tables rather than documents is
+// fed from.
 type CSVFiles struct {
 	// Dir is where the files are written. It is created, with every parent it
 	// needs, when the export has rendered everything.
@@ -57,7 +60,8 @@ type CSVFiles struct {
 // correction with no deltas writes deltas.csv holding its header alone, and a
 // run that owes no partner writes kickbacks.csv holding its header alone: an
 // empty table says the run produced no rows, and a missing file says nothing at
-// all.
+// all. A run that carries a rollup writes rollup.csv after kickbacks.csv, and a
+// rollup with no member writes that header alone under the same rule.
 //
 // The context is not read, for the reason JSONFiles.Export gives.
 func (c CSVFiles) Export(_ context.Context, run Run) error {
@@ -77,6 +81,12 @@ func (c CSVFiles) Export(_ context.Context, run Run) error {
 	if err != nil {
 		return err
 	}
+	var rollup []byte
+	if run.Rollup != nil {
+		if rollup, err = RollupCSV(run); err != nil {
+			return err
+		}
+	}
 
 	if err := prepareDir(c.Dir); err != nil {
 		return err
@@ -86,6 +96,9 @@ func (c CSVFiles) Export(_ context.Context, run Run) error {
 		files = append(files, artifact{name: deltasFileName, body: deltas})
 	}
 	files = append(files, artifact{name: kickbacksCSVFileName, body: kickbacks})
+	if run.Rollup != nil {
+		files = append(files, artifact{name: rollupCSVFileName, body: rollup})
+	}
 	return writeFiles(c.Dir, files)
 }
 

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -25,7 +25,10 @@
 // The normative specification is roadmap/03-phase-3-metering-rating.md, WP
 // 3.10, and, for the partner settlement the writers put beside the statements
 // as kickbacks.json or kickbacks.csv, roadmap/05-phase-5-commercial-pricing.md,
-// WP 5.4.
+// WP 5.4. The rollup an export writes on request, one document per meta-project
+// or partner summing the statements of its members as rollup-{key}.json or
+// rollup.csv, with the membership read from the registry at export time, is WP
+// 5.5 of that phase.
 package export
 
 import (
@@ -101,6 +104,12 @@ type Run struct {
 	// scope, rate, amount, base. A correction's are the differences to the run
 	// it corrects, and a run that owes nobody carries none.
 	Kickbacks []Kickback
+	// Rollup is the meta-project or partner rollup an export writes beside the
+	// statements, and nil for an export without one. Load and LoadKickbacks leave
+	// it nil: the membership comes out of the reporting database rather than out
+	// of the engine's, and the export subcommand sets it from LoadRollup where
+	// --rollup names a relation type.
+	Rollup *Rollup
 }
 
 // RatedRecord is one rated_records row with the usage record it rates: what was

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -103,6 +103,8 @@ const (
 		"resource_type,resource_id,project_id,dimension,old_amount,new_amount,delta,currency"
 	kickbacksHeader = "run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud," +
 		"project_id,relation_id,scope,rate,base,amount,currency"
+	rollupHeader = "run_id,kind,corrects_run_id,period_from,period_to,relation_type," +
+		"target_cloud,target_project_id,cloud,project_id,total,currency"
 )
 
 // The file names the two writers produce over the fixtures.
@@ -115,6 +117,8 @@ const (
 
 	kickbacksJSONFile = "kickbacks.json"
 	kickbacksCSVFile  = "kickbacks.csv"
+
+	rollupCSVFile = "rollup.csv"
 )
 
 // regularRun is the finalized run of the concept's power-cycle month: the
@@ -331,6 +335,138 @@ func kickbackRows(kickbacks []export.Kickback) []kickbackRow {
 			amount:      entry.Amount.StringFixed(2),
 			currency:    entry.Currency,
 		})
+	}
+	return rows
+}
+
+// The registry rows the rollup cases are built over: two meta-projects and a
+// partner, which are the virtual projects a rollup sums under, the three real
+// projects the run bills, and one real project a relation reaches that no
+// rollup may sum under. A relation names both of its ends by id, so the ids are
+// written out rather than generated: a case names which row it meant.
+var (
+	metaAlphaID   = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	metaBetaID    = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	partnerCorpID = uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	teamAlphaID   = uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	teamBetaID    = uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+	drProjectID   = uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	realTargetID  = uuid.MustParse("0a0a0a0a-0a0a-0a0a-0a0a-0a0a0a0a0a0a")
+	// The id of a project no registry snapshot holds, which is what a relation
+	// naming an end the projects do not carry is refused over.
+	strangerID = uuid.MustParse("9b9b9b9b-9b9b-9b9b-9b9b-9b9b9b9b9b9b")
+)
+
+// The relations those rows are related by, one id per edge a case names.
+var (
+	alphaMemberID   = uuid.MustParse("1a1a1a1a-1a1a-1a1a-1a1a-1a1a1a1a1a1a")
+	betaMemberID    = uuid.MustParse("2a2a2a2a-2a2a-2a2a-2a2a-2a2a2a2a2a2a")
+	drMemberID      = uuid.MustParse("3a3a3a3a-3a3a-3a3a-3a3a-3a3a3a3a3a3a")
+	alphaSecondID   = uuid.MustParse("4a4a4a4a-4a4a-4a4a-4a4a-4a4a4a4a4a4a")
+	alphaManagedID  = uuid.MustParse("5a5a5a5a-5a5a-5a5a-5a5a-5a5a5a5a5a5a")
+	alphaStrangerID = uuid.MustParse("6a6a6a6a-6a6a-6a6a-6a6a-6a6a6a6a6a6a")
+)
+
+// The keys of the two statements the rollup cases bill beside drStatementKey,
+// and the instant a membership that was replaced inside the month was closed
+// and its successor opened at.
+const (
+	alphaStatementKey = "os-prod/team-alpha"
+	betaStatementKey  = "os-prod/team-beta"
+)
+
+var midMarch = time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+// billedTotal is one statement a rollup case's run carries: the key it is
+// stored under and the total it bills.
+type billedTotal struct{ key, total string }
+
+// statementsOf is a run's statements as a rollup case names them. A rollup
+// reads the key, the total and the currency and never opens the document, so
+// the stored bytes are the empty object rather than a rendered invoice.
+func statementsOf(billed ...billedTotal) []statements.Statement {
+	entries := make([]statements.Statement, 0, len(billed))
+	for _, entry := range billed {
+		entries = append(entries, statements.Statement{
+			Key:      entry.key,
+			Document: []byte("{}"),
+			Total:    decimal.RequireFromString(entry.total),
+			Currency: currency,
+		})
+	}
+	return entries
+}
+
+// registryProject is one row of the registry snapshot a rollup is built over. A
+// virtual project carries its platform as its cloud, which is what the cases
+// pass for a meta-project and a partner.
+func registryProject(id uuid.UUID, platform, cloud, externalID string) source.Project {
+	return source.Project{ID: id, Platform: platform, Cloud: cloud, ExternalID: externalID}
+}
+
+// relationOf is one relation of the period between two of those rows, open at
+// its end. A case that means a closed one sets ValidTo on what it gets back.
+func relationOf(id, sourceID, targetID uuid.UUID, relationType string) source.Relation {
+	return source.Relation{
+		ID:           id,
+		SourceID:     sourceID,
+		TargetID:     targetID,
+		RelationType: relationType,
+		ValidFrom:    periodFrom,
+	}
+}
+
+// closedAt is that relation ended at an instant, and openedAt is the successor
+// that took over there: the pair a rate change of WP 5.2 leaves behind, and
+// both of them overlap the period the run billed.
+func closedAt(relation source.Relation, at time.Time) source.Relation {
+	relation.ValidTo = &at
+	return relation
+}
+
+func openedAt(relation source.Relation, at time.Time) source.Relation {
+	relation.ValidFrom = at
+	return relation
+}
+
+// rollupGroupRow is one group as a case compares it: every field, with the
+// totals at the scale they are rendered at. Two decimals that are the same
+// number are not the same decimal.Decimal, so the comparison is over what they
+// render as.
+type rollupGroupRow struct {
+	key, cloud, projectID, platform string
+	total, currency                 string
+	members                         []rollupMemberRow
+}
+
+// rollupMemberRow is one member under such a group.
+type rollupMemberRow struct {
+	statementKey, cloud, projectID string
+	total, currency                string
+}
+
+// rollupRows renders what BuildRollup returned, in the order it came back in.
+func rollupRows(groups []export.RollupGroup) []rollupGroupRow {
+	rows := make([]rollupGroupRow, 0, len(groups))
+	for _, group := range groups {
+		row := rollupGroupRow{
+			key:       group.Key,
+			cloud:     group.Cloud,
+			projectID: group.ProjectID,
+			platform:  group.Platform,
+			total:     group.Total.StringFixed(2),
+			currency:  group.Currency,
+		}
+		for _, member := range group.Members {
+			row.members = append(row.members, rollupMemberRow{
+				statementKey: member.StatementKey,
+				cloud:        member.Cloud,
+				projectID:    member.ProjectID,
+				total:        member.Total.StringFixed(2),
+				currency:     member.Currency,
+			})
+		}
+		rows = append(rows, row)
 	}
 	return rows
 }
@@ -1443,6 +1579,532 @@ func TestKickbacksCSVRefusesAFormulaToTheSpreadsheet(t *testing.T) {
 	})
 }
 
+// TestBuildRollup pins what an export sums under a meta-project or a partner.
+// A group's total is the sum of the member totals it lists, so a member counted
+// twice, one left out, or one summed under a target it is not related to is a
+// number the customer reconciles their projects against and does not arrive at.
+func TestBuildRollup(t *testing.T) {
+	cases := []struct {
+		name         string
+		correction   bool
+		billed       []billedTotal
+		relationType string
+		projects     []source.Project
+		relations    []source.Relation
+		want         []rollupGroupRow
+	}{
+		{
+			name: "two meta-projects over the three projects they hold",
+			billed: []billedTotal{
+				{key: drStatementKey, total: "22.32"},
+				{key: alphaStatementKey, total: "520.80"},
+				{key: betaStatementKey, total: "100.00"},
+			},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(metaBetaID, "meta", "meta", "customer-beta"),
+				registryProject(drProjectID, "openstack", "os-dr", "proj-789"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, metaAlphaID, "member_of"),
+				relationOf(drMemberID, drProjectID, metaBetaID, "member_of"),
+			},
+			want: []rollupGroupRow{
+				{
+					key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+					platform: "meta", total: "620.80", currency: currency,
+					members: []rollupMemberRow{
+						{
+							statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+							total: "520.80", currency: currency,
+						},
+						{
+							statementKey: betaStatementKey, cloud: "os-prod", projectID: "team-beta",
+							total: "100.00", currency: currency,
+						},
+					},
+				},
+				{
+					key: "meta/customer-beta", cloud: "meta", projectID: "customer-beta",
+					platform: "meta", total: "22.32", currency: currency,
+					members: []rollupMemberRow{
+						{
+							statementKey: drStatementKey, cloud: "os-dr", projectID: "proj-789",
+							total: "22.32", currency: currency,
+						},
+					},
+				},
+			},
+		},
+		{
+			// The membership was closed mid-month and opened again, which is how WP
+			// 5.2 changes a rate, and both relations overlap the period. Summing the
+			// statement once per relation would bill the customer the project twice.
+			name:         "a membership replaced inside the month is one member",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				closedAt(relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"), midMarch),
+				openedAt(relationOf(alphaSecondID, teamAlphaID, metaAlphaID, "member_of"), midMarch),
+			},
+			want: []rollupGroupRow{{
+				key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+				platform: "meta", total: "520.80", currency: currency,
+				members: []rollupMemberRow{{
+					statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+					total: "520.80", currency: currency,
+				}},
+			}},
+		},
+		{
+			// The two groups sum to 1041.60 over a run that billed 520.80: the
+			// rollups of one export are not disjoint, and adding them up is not a
+			// second reading of the month.
+			name:         "a project of two meta-projects is summed under both",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(metaBetaID, "meta", "meta", "customer-beta"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamAlphaID, metaBetaID, "member_of"),
+			},
+			want: []rollupGroupRow{
+				{
+					key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+					platform: "meta", total: "520.80", currency: currency,
+					members: []rollupMemberRow{{
+						statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+						total: "520.80", currency: currency,
+					}},
+				},
+				{
+					key: "meta/customer-beta", cloud: "meta", projectID: "customer-beta",
+					platform: "meta", total: "520.80", currency: currency,
+					members: []rollupMemberRow{{
+						statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+						total: "520.80", currency: currency,
+					}},
+				},
+			},
+		},
+		{
+			name:         "a managed_by rollup sums under the partner",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "managed_by",
+			projects: []source.Project{
+				registryProject(partnerCorpID, "partner", "partner", "partner-corp"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaManagedID, teamAlphaID, partnerCorpID, "managed_by"),
+			},
+			want: []rollupGroupRow{{
+				key: "partner/partner-corp", cloud: "partner", projectID: "partner-corp",
+				platform: "partner", total: "520.80", currency: currency,
+				members: []rollupMemberRow{{
+					statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+					total: "520.80", currency: currency,
+				}},
+			}},
+		},
+		{
+			// team-beta is related to customer-beta and the run billed it nothing,
+			// so customer-beta is no group at all: a document reporting a total of
+			// zero would read as a customer that used nothing rather than as one
+			// this month has no statements for.
+			name:         "a member the run billed nothing opens no group",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(metaBetaID, "meta", "meta", "customer-beta"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, metaBetaID, "member_of"),
+			},
+			want: []rollupGroupRow{{
+				key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+				platform: "meta", total: "520.80", currency: currency,
+				members: []rollupMemberRow{{
+					statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+					total: "520.80", currency: currency,
+				}},
+			}},
+		},
+		{
+			// proj-real is not virtual, and the run billed team-beta nothing, so the
+			// relation reaching it adds no member and is not judged for it either: a
+			// registry row of a project this run has no statement for refuses no
+			// month it has no part in.
+			name:         "a relation to a project which is not virtual the run billed nothing for",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(realTargetID, "openstack", "os-prod", "proj-real"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, realTargetID, "member_of"),
+			},
+			want: []rollupGroupRow{{
+				key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+				platform: "meta", total: "520.80", currency: currency,
+				members: []rollupMemberRow{{
+					statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+					total: "520.80", currency: currency,
+				}},
+			}},
+		},
+		{
+			name:         "a registry that relates none of the billed projects",
+			billed:       []billedTotal{{key: alphaStatementKey, total: "520.80"}},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			want: []rollupGroupRow{},
+		},
+		{
+			name:         "a run that billed nobody over three memberships",
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(metaBetaID, "meta", "meta", "customer-beta"),
+				registryProject(drProjectID, "openstack", "os-dr", "proj-789"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, metaAlphaID, "member_of"),
+				relationOf(drMemberID, drProjectID, metaBetaID, "member_of"),
+			},
+			want: []rollupGroupRow{},
+		},
+		{
+			// The credit notes of a correction are stored under the keys the
+			// statements were, so a rollup of one sums to what the customer is owed
+			// back rather than to what they were billed.
+			name:       "a correction sums its credits to a negative total",
+			correction: true,
+			billed: []billedTotal{
+				{key: alphaStatementKey, total: "-24.00"},
+				{key: betaStatementKey, total: "-1.50"},
+			},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, metaAlphaID, "member_of"),
+			},
+			want: []rollupGroupRow{{
+				key: "meta/customer-alpha", cloud: "meta", projectID: "customer-alpha",
+				platform: "meta", total: "-25.50", currency: currency,
+				members: []rollupMemberRow{
+					{
+						statementKey: alphaStatementKey, cloud: "os-prod", projectID: "team-alpha",
+						total: "-24.00", currency: currency,
+					},
+					{
+						statementKey: betaStatementKey, cloud: "os-prod", projectID: "team-beta",
+						total: "-1.50", currency: currency,
+					},
+				},
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			run := regularRun(t)
+			if c.correction {
+				run = correctionRun(t)
+			}
+			run.Statements = statementsOf(c.billed...)
+
+			rollup, err := export.BuildRollup(run, c.relationType, c.projects, c.relations)
+			if err != nil {
+				t.Fatalf("BuildRollup() error = %v, want nil", err)
+			}
+			if rollup.RelationType != c.relationType {
+				t.Errorf("RelationType = %q, want %q", rollup.RelationType, c.relationType)
+			}
+			// Non-nil whatever the registry held, so a reader renders an empty list
+			// rather than a null: a run that rolls up to nothing said so.
+			if rollup.Groups == nil {
+				t.Fatalf("Groups = nil, want an empty list")
+			}
+			if got := rollupRows(rollup.Groups); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("BuildRollup() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuildRollupRefusals pins what a rollup nothing can be summed from
+// reports. Every one of them would otherwise produce a document that reads like
+// a total: a customer's projects under a partner's name, a group missing the
+// member whose registry row was not read, one under a project that carries a
+// statement of its own, or two currencies added together.
+func TestBuildRollupRefusals(t *testing.T) {
+	cases := []struct {
+		name         string
+		billed       []statements.Statement
+		relationType string
+		projects     []source.Project
+		relations    []source.Relation
+		wantErr      string
+		exact        bool
+	}{
+		{
+			name:         "a relation type that reaches no virtual project",
+			relationType: "infrastructure_tenant",
+			wantErr:      `the rollup relation type "infrastructure_tenant" is not member_of or managed_by`,
+			exact:        true,
+		},
+		{
+			name:    "no relation type at all",
+			wantErr: `the rollup relation type "" is not member_of or managed_by`,
+			exact:   true,
+		},
+		{
+			name:         "a relation of another type among the ones handed in",
+			billed:       statementsOf(billedTotal{key: alphaStatementKey, total: "520.80"}),
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(partnerCorpID, "partner", "partner", "partner-corp"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaManagedID, teamAlphaID, partnerCorpID, "managed_by"),
+			},
+			wantErr: "is of type managed_by, and the rollup is over member_of",
+		},
+		{
+			name:         "a relation whose source the registry snapshot does not hold",
+			billed:       statementsOf(billedTotal{key: alphaStatementKey, total: "520.80"}),
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, strangerID, metaAlphaID, "member_of"),
+			},
+			wantErr: "names the project " + strangerID.String() + ", which the registry snapshot does not hold",
+		},
+		{
+			name:         "a relation whose target the registry snapshot does not hold",
+			billed:       statementsOf(billedTotal{key: alphaStatementKey, total: "520.80"}),
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaStrangerID, teamAlphaID, strangerID, "member_of"),
+			},
+			wantErr: "names the project " + strangerID.String() + ", which the registry snapshot does not hold",
+		},
+		{
+			// proj-real owns resources and carries a statement of its own, which a
+			// group under it would leave out of the total it reports.
+			name:         "a relation that reaches a project which is not virtual",
+			billed:       statementsOf(billedTotal{key: alphaStatementKey, total: "520.80"}),
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(realTargetID, "openstack", "os-prod", "proj-real"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, realTargetID, "member_of"),
+			},
+			wantErr: `reaches os-prod/proj-real, whose platform "openstack" is not meta or partner`,
+		},
+		{
+			name: "two members of one meta-project billed in two currencies",
+			billed: []statements.Statement{
+				{
+					Key: alphaStatementKey, Document: []byte("{}"),
+					Total: decimal.RequireFromString("520.80"), Currency: currency,
+				},
+				{
+					Key: betaStatementKey, Document: []byte("{}"),
+					Total: decimal.RequireFromString("100.00"), Currency: "USD",
+				},
+			},
+			relationType: "member_of",
+			projects: []source.Project{
+				registryProject(metaAlphaID, "meta", "meta", "customer-alpha"),
+				registryProject(teamAlphaID, "openstack", "os-prod", "team-alpha"),
+				registryProject(teamBetaID, "openstack", "os-prod", "team-beta"),
+			},
+			relations: []source.Relation{
+				relationOf(alphaMemberID, teamAlphaID, metaAlphaID, "member_of"),
+				relationOf(betaMemberID, teamBetaID, metaAlphaID, "member_of"),
+			},
+			wantErr: "the rollup of meta/customer-alpha holds statements in EUR and in USD",
+			exact:   true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			run := regularRun(t)
+			run.Statements = c.billed
+
+			_, err := export.BuildRollup(run, c.relationType, c.projects, c.relations)
+			if err == nil {
+				t.Fatalf("BuildRollup() error = nil, want %q", c.wantErr)
+			}
+			if c.exact {
+				if got := err.Error(); got != c.wantErr {
+					t.Errorf("BuildRollup() error = %q, want %q", got, c.wantErr)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("BuildRollup() error = %v, want it to hold %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestRollupFileName pins the names a group's document is written under. The
+// key of a target escapes its two halves and the file name escapes that key
+// again, the way a statement's name does, so two targets never meet in one file.
+func TestRollupFileName(t *testing.T) {
+	t.Run("a group is named after the key of its target", func(t *testing.T) {
+		got := export.RollupFileName("meta/customer-alpha")
+		if want := "rollup-meta%2Fcustomer-alpha.json"; got != want {
+			t.Errorf("RollupFileName() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a target that holds a slash keeps it out of the name", func(t *testing.T) {
+		got := export.RollupFileName(statements.Key("meta", "a/b"))
+		if want := "rollup-meta%2Fa%252Fb.json"; got != want {
+			t.Errorf("RollupFileName() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a key past what a file name holds is named after its digest", func(t *testing.T) {
+		// nameMax is what POSIX guarantees a file name holds, and os.CreateTemp
+		// appends a pattern to the name before the rename, so a name has to stay
+		// under it with room to spare.
+		const nameMax = 255
+
+		got := export.RollupFileName(statements.Key("meta", strings.Repeat("p", 500)))
+		if len(got) >= nameMax {
+			t.Errorf("RollupFileName() = %q, which is %d bytes and past the %d a name holds",
+				got, len(got), nameMax)
+		}
+		if !strings.HasPrefix(got, "rollup-") || !strings.HasSuffix(got, ".json") {
+			t.Errorf("RollupFileName() = %q, want it to start with rollup- and end in .json", got)
+		}
+		// The name is a function of the key: exporting one finalized run twice
+		// yields the same file either way.
+		if again := export.RollupFileName(statements.Key("meta", strings.Repeat("p", 500))); again != got {
+			t.Errorf("RollupFileName() = %q on the second call, want the %q of the first", again, got)
+		}
+	})
+}
+
+// TestRollupCSV pins the table a rollup renders. The identifiers come out of an
+// event stream and a registry, and this is the file whoever reports to the
+// customer opens in a spreadsheet, so they carry the prefix that keeps it from
+// evaluating them, for the reason the rated.csv case gives.
+func TestRollupCSV(t *testing.T) {
+	t.Run("a group and the member under it", func(t *testing.T) {
+		run := regularRun(t)
+		run.Rollup = &export.Rollup{
+			RelationType: "member_of",
+			Groups: []export.RollupGroup{{
+				Key:       statements.Key("meta", "-customer"),
+				Cloud:     "meta",
+				ProjectID: "-customer",
+				Platform:  "meta",
+				Members: []export.RollupMember{{
+					StatementKey: statements.Key("os-prod", `=HYPERLINK("x")`),
+					Cloud:        "os-prod",
+					ProjectID:    `=HYPERLINK("x")`,
+					Total:        decimal.RequireFromString("-24.00"),
+					Currency:     currency,
+				}},
+				Total:    decimal.RequireFromString("-24.00"),
+				Currency: currency,
+			}},
+		}
+
+		rows := rollupTable(t, run)
+		if len(rows) != 2 {
+			t.Fatalf("the table holds %d rows, want the header and one member", len(rows))
+		}
+		if got := strings.Join(rows[0], ","); got != rollupHeader {
+			t.Errorf("the header of %s = %q, want %q", rollupCSVFile, got, rollupHeader)
+		}
+		// Column nine is the member's project id and column seven the target's.
+		// Both reach an importer whole, under the apostrophe a spreadsheet reads
+		// as "this is text".
+		if got, want := rows[1][9], `'=HYPERLINK("x")`; got != want {
+			t.Errorf("project_id = %q, want %q", got, want)
+		}
+		if got, want := rows[1][7], "'-customer"; got != want {
+			t.Errorf("target_project_id = %q, want %q", got, want)
+		}
+		// Column ten is the total. It is a number, so it does not go through the
+		// prefix: a leading minus there is what the correction credits.
+		if got, want := rows[1][10], "-24.00"; got != want {
+			t.Errorf("total = %q, want %q", got, want)
+		}
+	})
+
+	empty := []struct {
+		name   string
+		rollup *export.Rollup
+	}{
+		{name: "an export without a rollup"},
+		{name: "a rollup that holds no group", rollup: &export.Rollup{
+			RelationType: "member_of",
+			Groups:       []export.RollupGroup{},
+		}},
+	}
+	for _, c := range empty {
+		t.Run(c.name+" renders the header alone", func(t *testing.T) {
+			run := regularRun(t)
+			run.Rollup = c.rollup
+
+			body, err := export.RollupCSV(run)
+			if err != nil {
+				t.Fatalf("RollupCSV() error = %v, want nil", err)
+			}
+			if got, want := string(body), rollupHeader+"\n"; got != want {
+				t.Errorf("%s = %q, want %q", rollupCSVFile, got, want)
+			}
+		})
+	}
+}
+
 // jsonFiles and csvFiles are the two writers over one directory, as the cases
 // hand them around.
 func jsonFiles(dir string) export.BillingExporter { return export.JSONFiles{Dir: dir} }
@@ -1543,6 +2205,22 @@ func kickbackTable(t *testing.T, run export.Run) [][]string {
 	rows, err := csv.NewReader(bytes.NewReader(body)).ReadAll()
 	if err != nil {
 		t.Fatalf("reading the settlement back: %v", err)
+	}
+	return rows
+}
+
+// rollupTable is one rendered rollup, parsed: the header row and the rows under
+// it, the way kickbackTable parses a settlement.
+func rollupTable(t *testing.T, run export.Run) [][]string {
+	t.Helper()
+
+	body, err := export.RollupCSV(run)
+	if err != nil {
+		t.Fatalf("RollupCSV() error = %v, want nil", err)
+	}
+	rows, err := csv.NewReader(bytes.NewReader(body)).ReadAll()
+	if err != nil {
+		t.Fatalf("reading the rollup back: %v", err)
 	}
 	return rows
 }

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -118,7 +118,9 @@ const (
 	kickbacksJSONFile = "kickbacks.json"
 	kickbacksCSVFile  = "kickbacks.csv"
 
-	rollupCSVFile = "rollup.csv"
+	rollupCSVFile   = "rollup.csv"
+	rollupAlphaFile = "rollup-meta%2Fcustomer-alpha.json"
+	rollupBetaFile  = "rollup-meta%2Fcustomer-beta.json"
 )
 
 // regularRun is the finalized run of the concept's power-cycle month: the
@@ -182,6 +184,57 @@ func correctionRun(t *testing.T) export.Run {
 		Rated:  ratedRecords(),
 		Deltas: deltas(),
 	}
+}
+
+// rollupRun is that month summed under the two meta-projects its projects are
+// members of: customer-alpha, which holds the one project, and customer-beta,
+// which holds both. The two groups share os-prod/proj-456, so a statement that
+// is a member of two groups and a group whose total is the sum of two members
+// are both covered, and the second group's total is a number no statement of the
+// run carries.
+func rollupRun(t *testing.T) export.Run {
+	t.Helper()
+
+	run := regularRun(t)
+	run.Rollup = &export.Rollup{
+		RelationType: "member_of",
+		Groups: []export.RollupGroup{{
+			Key:       statements.Key("meta", "customer-alpha"),
+			Cloud:     "meta",
+			ProjectID: "customer-alpha",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: statementKey,
+				Cloud:        "os-prod",
+				ProjectID:    projectID,
+				Total:        decimal.RequireFromString("128.45"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("128.45"),
+			Currency: currency,
+		}, {
+			Key:       statements.Key("meta", "customer-beta"),
+			Cloud:     "meta",
+			ProjectID: "customer-beta",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: drStatementKey,
+				Cloud:        "os-dr",
+				ProjectID:    "proj-789",
+				Total:        decimal.RequireFromString("22.32"),
+				Currency:     currency,
+			}, {
+				StatementKey: statementKey,
+				Cloud:        "os-prod",
+				ProjectID:    projectID,
+				Total:        decimal.RequireFromString("128.45"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("150.77"),
+			Currency: currency,
+		}},
+	}
+	return run
 }
 
 // ratedRecords is what the month billed the instance for: the three periods the
@@ -523,6 +576,23 @@ func TestExportGolden(t *testing.T) {
 			golden: "correction",
 			files:  []string{ratedFile, deltasFile, kickbacksCSVFile},
 		},
+		{
+			name:   "the JSON writer over a rolled-up run",
+			writer: jsonFiles,
+			run:    rollupRun,
+			golden: "rollup",
+			files: []string{
+				runFile, drStatementFile, statementFile, kickbacksJSONFile,
+				rollupAlphaFile, rollupBetaFile,
+			},
+		},
+		{
+			name:   "the CSV writer over a rolled-up run",
+			writer: csvFiles,
+			run:    rollupRun,
+			golden: "rollup",
+			files:  []string{ratedFile, kickbacksCSVFile, rollupCSVFile},
+		},
 	}
 
 	for _, c := range cases {
@@ -608,6 +678,142 @@ func TestJSONFilesWithoutStatements(t *testing.T) {
 	}
 }
 
+// TestJSONFilesWithoutRollupGroups pins what a run whose rollup reached no
+// target exports: run.json says which relation type it was summed over and
+// carries an empty document list, and no rollup document is written. Whoever
+// asked for the rollup is told the run rolled nothing up, rather than reading a
+// missing member as an export that does not say.
+func TestJSONFilesWithoutRollupGroups(t *testing.T) {
+	dir := t.TempDir()
+	run := regularRun(t)
+	run.Rollup = &export.Rollup{RelationType: "member_of", Groups: []export.RollupGroup{}}
+
+	if err := jsonFiles(dir).Export(t.Context(), run); err != nil {
+		t.Fatalf("Export() error = %v, want nil", err)
+	}
+
+	assertNames(t, dir, []string{runFile, drStatementFile, statementFile, kickbacksJSONFile})
+	body := string(read(t, filepath.Join(dir, runFile)))
+	for _, want := range []string{
+		`"rollup": {`,
+		`"relation_type": "member_of"`,
+		`"documents": []`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("%s =\n%s\nwant it to carry %s", runFile, body, want)
+		}
+	}
+}
+
+// TestRollupOfACorrection pins what a correction's rollup carries: the kind and
+// the run it corrects, so a reader tells a credit from a month's bill without
+// opening a member, and credit notes under it rather than statements, because a
+// correction writes its documents under the other prefix and a group names the
+// file each of its members was written to.
+func TestRollupOfACorrection(t *testing.T) {
+	dir := t.TempDir()
+	run := correctionRun(t)
+	run.Rollup = &export.Rollup{
+		RelationType: "member_of",
+		Groups: []export.RollupGroup{{
+			Key:       statements.Key("meta", "customer-alpha"),
+			Cloud:     "meta",
+			ProjectID: "customer-alpha",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: statementKey,
+				Cloud:        "os-prod",
+				ProjectID:    projectID,
+				Total:        decimal.RequireFromString("-24.00"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("-24.00"),
+			Currency: currency,
+		}},
+	}
+
+	if err := jsonFiles(dir).Export(t.Context(), run); err != nil {
+		t.Fatalf("Export() error = %v, want nil", err)
+	}
+
+	var document struct {
+		Kind          string  `json:"kind"`
+		CorrectsRunID *string `json:"corrects_run_id"`
+		Members       []struct {
+			File  string      `json:"file"`
+			Total json.Number `json:"total"`
+		} `json:"members"`
+		Total json.Number `json:"total"`
+	}
+	if err := json.Unmarshal(read(t, filepath.Join(dir, rollupAlphaFile)), &document); err != nil {
+		t.Fatalf("decoding %s: %v", rollupAlphaFile, err)
+	}
+
+	if document.Kind != runs.KindCorrection {
+		t.Errorf("kind = %q, want %q", document.Kind, runs.KindCorrection)
+	}
+	switch {
+	case document.CorrectsRunID == nil:
+		t.Errorf("corrects_run_id is absent, want %s", regularRunID)
+	case *document.CorrectsRunID != regularRunID.String():
+		t.Errorf("corrects_run_id = %s, want %s", *document.CorrectsRunID, regularRunID)
+	}
+	if len(document.Members) != 1 {
+		t.Fatalf("%s holds %d members, want the one the correction credits",
+			rollupAlphaFile, len(document.Members))
+	}
+	if got := document.Members[0].File; got != creditNoteFile {
+		t.Errorf("the member names the file %q, want %q", got, creditNoteFile)
+	}
+	if got, want := document.Total.String(), "-24.00"; got != want {
+		t.Errorf("total = %s, want %s", got, want)
+	}
+}
+
+// TestJSONFilesRefusesARollupMemberItWroteNoStatementFor pins what an export
+// does with a rollup whose member the run carries no statement for. Nothing
+// binds a rollup to the run it is attached to, so a rollup built over one run
+// and handed to another one's export lands here: the member would name an empty
+// file beside a total that still balances against the members listed inline, and
+// an ERP walking members[].file would find nothing under a group that reads as
+// authoritative. The export is refused instead, and --out stays uncreated the
+// way it does for every other refusal.
+func TestJSONFilesRefusesARollupMemberItWroteNoStatementFor(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "out")
+	run := regularRun(t)
+	run.Rollup = &export.Rollup{
+		RelationType: "member_of",
+		Groups: []export.RollupGroup{{
+			Key:       statements.Key("meta", "customer-alpha"),
+			Cloud:     "meta",
+			ProjectID: "customer-alpha",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: "os-prod/team-beta",
+				Cloud:        "os-prod",
+				ProjectID:    "team-beta",
+				Total:        decimal.RequireFromString("100.00"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("100.00"),
+			Currency: currency,
+		}},
+	}
+
+	err := jsonFiles(dir).Export(t.Context(), run)
+	if err == nil {
+		t.Fatalf("Export() error = nil, want the member no statement was written for")
+	}
+	want := "the rollup of meta/customer-alpha names the member os-prod/team-beta, which run " +
+		run.ID.String() + " wrote no statement for"
+	if got := err.Error(); got != want {
+		t.Errorf("Export() error = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("the output directory exists and holds %v, want nothing written", names(t, dir))
+	}
+}
+
 // TestCSVFilesWithoutRows pins the header-only tables. A run that billed
 // nothing, and a correction that changed nothing, write their files all the
 // same: an empty table says the run produced no rows, and a missing file says
@@ -640,6 +846,21 @@ func TestCSVFilesWithoutRows(t *testing.T) {
 		assertNames(t, dir, []string{deltasFile, kickbacksCSVFile, ratedFile})
 		if got, want := string(read(t, filepath.Join(dir, deltasFile))), deltasHeader+"\n"; got != want {
 			t.Errorf("%s = %q, want %q", deltasFile, got, want)
+		}
+	})
+
+	t.Run("a rollup with no members", func(t *testing.T) {
+		dir := t.TempDir()
+		run := regularRun(t)
+		run.Rollup = &export.Rollup{RelationType: "member_of", Groups: []export.RollupGroup{}}
+
+		if err := csvFiles(dir).Export(t.Context(), run); err != nil {
+			t.Fatalf("Export() error = %v, want nil", err)
+		}
+
+		assertNames(t, dir, []string{kickbacksCSVFile, ratedFile, rollupCSVFile})
+		if got, want := string(read(t, filepath.Join(dir, rollupCSVFile))), rollupHeader+"\n"; got != want {
+			t.Errorf("%s = %q, want %q", rollupCSVFile, got, want)
 		}
 	})
 }
@@ -855,6 +1076,95 @@ func TestJSONFilesNamesTwoStatementsOneFileSystemHoldsAsOneApart(t *testing.T) {
 	}
 }
 
+// TestJSONFilesNamesTwoRollupsOneFileSystemHoldsAsOneApart pins the pair above
+// for two targets rather than two projects. A meta-project id is free text the
+// registry carries, so two of them that differ only in ASCII case are valid
+// input, and the second rename would replace the first group's document while
+// run.json went on naming both: one customer would be reported the other's
+// total. The second document takes its digest name, which no fold collides with.
+func TestJSONFilesNamesTwoRollupsOneFileSystemHoldsAsOneApart(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "out")
+	run := regularRun(t)
+	// In this order rather than sorted: the writer renders the groups the way the
+	// rollup hands them over, and the first of the pair is the one that keeps the
+	// name its key renders.
+	run.Rollup = &export.Rollup{
+		RelationType: "member_of",
+		Groups: []export.RollupGroup{{
+			Key:       statements.Key("meta", "Customer-A"),
+			Cloud:     "meta",
+			ProjectID: "Customer-A",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: drStatementKey,
+				Cloud:        "os-dr",
+				ProjectID:    "proj-789",
+				Total:        decimal.RequireFromString("22.32"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("22.32"),
+			Currency: currency,
+		}, {
+			Key:       statements.Key("meta", "customer-a"),
+			Cloud:     "meta",
+			ProjectID: "customer-a",
+			Platform:  "meta",
+			Members: []export.RollupMember{{
+				StatementKey: statementKey,
+				Cloud:        "os-prod",
+				ProjectID:    projectID,
+				Total:        decimal.RequireFromString("128.45"),
+				Currency:     currency,
+			}},
+			Total:    decimal.RequireFromString("128.45"),
+			Currency: currency,
+		}},
+	}
+
+	if err := jsonFiles(dir).Export(t.Context(), run); err != nil {
+		t.Fatalf("Export() error = %v, want nil", err)
+	}
+
+	var index struct {
+		Rollup struct {
+			Documents []struct {
+				File      string      `json:"file"`
+				ProjectID string      `json:"project_id"`
+				Total     json.Number `json:"total"`
+			} `json:"documents"`
+		} `json:"rollup"`
+	}
+	if err := json.Unmarshal(read(t, filepath.Join(dir, runFile)), &index); err != nil {
+		t.Fatalf("decoding %s: %v", runFile, err)
+	}
+	if len(index.Rollup.Documents) != 2 {
+		t.Fatalf("%s names %d rollup documents, want both of the pair", runFile, len(index.Rollup.Documents))
+	}
+	first, second := index.Rollup.Documents[0], index.Rollup.Documents[1]
+
+	if want := export.RollupFileName(statements.Key("meta", "Customer-A")); first.File != want {
+		t.Errorf("%s names the file %q, want %q", runFile, first.File, want)
+	}
+	if strings.EqualFold(first.File, second.File) {
+		t.Errorf("%s names %q and %q, which are one file on a case-insensitive filesystem",
+			runFile, first.File, second.File)
+	}
+	// Both documents are in the directory beside the statements they sum, and
+	// each target is named by the index rather than by its file.
+	assertNames(t, dir, []string{
+		runFile, kickbacksJSONFile, drStatementFile, statementFile, first.File, second.File,
+	})
+	for i, want := range []struct{ projectID, total string }{
+		{projectID: "Customer-A", total: "22.32"},
+		{projectID: "customer-a", total: "128.45"},
+	} {
+		if entry := index.Rollup.Documents[i]; entry.ProjectID != want.projectID || entry.Total.String() != want.total {
+			t.Errorf("%s names the target %q with the total %s under %q, want %q and %s",
+				runFile, entry.ProjectID, entry.Total, entry.File, want.projectID, want.total)
+		}
+	}
+}
+
 // TestJSONFilesRendersTheAbsentValuesAsNull pins what run.json carries for a run
 // whose row holds NULL under the three nullable columns. A regular run corrects
 // nothing, a run of a period no model priced carries no version, and a run that
@@ -930,6 +1240,13 @@ func TestExportRemovesWhatItWroteWhenAWriteFails(t *testing.T) {
 			run:     correctionRun,
 			blocked: kickbacksCSVFile,
 			removed: deltasFile,
+		},
+		{
+			name:    "the JSON writer over a rollup document that fails",
+			writer:  jsonFiles,
+			run:     rollupRun,
+			blocked: rollupAlphaFile,
+			removed: statementFile,
 		},
 	}
 
@@ -1238,12 +1555,15 @@ func TestExportIntoAWriteProtectedDirectory(t *testing.T) {
 
 // TestExportModes pins the permissions an export carries. A billing artifact
 // names every project of an installation and what it was invoiced, so the
-// directory is the exporting user's own and so is every file in it.
+// directory is the exporting user's own and so is every file in it. The run
+// carries a rollup, which puts the group documents and rollup.csv under the
+// check as well: a group's document names every project under one customer and
+// what each of them was billed.
 func TestExportModes(t *testing.T) {
 	for _, c := range writers() {
 		t.Run(c.name, func(t *testing.T) {
 			dir := filepath.Join(t.TempDir(), "out")
-			if err := c.writer(dir).Export(t.Context(), regularRun(t)); err != nil {
+			if err := c.writer(dir).Export(t.Context(), rollupRun(t)); err != nil {
 				t.Fatalf("Export() error = %v, want nil", err)
 			}
 

--- a/internal/engine/export/json.go
+++ b/internal/engine/export/json.go
@@ -46,7 +46,9 @@ const nameMaxLen = 200
 // its stats, and one entry per document beside the file it was written to, and
 // kickbacks.json, what the run settles for its partners. The settlement is
 // written for every run and carries an empty beneficiary list where the run
-// owes nobody. It is the file implementation of BillingExporter.
+// owes nobody. A run that carries a rollup writes one document per group beside
+// the statements, which run.json names under rollup. It is the file
+// implementation of BillingExporter.
 type JSONFiles struct {
 	// Dir is where the files are written. It is created, with every parent it
 	// needs, when the export has rendered everything.
@@ -134,6 +136,9 @@ type runDocument struct {
 	CompletedAt    *string          `json:"completed_at"`
 	Stats          json.RawMessage  `json:"stats"`
 	Statements     []statementEntry `json:"statements"`
+	// Rollup is absent from the index of an export that summed nothing under a
+	// meta-project or a partner, which is every export no rollup was asked for.
+	Rollup *rollupIndex `json:"rollup,omitempty"`
 }
 
 // statementEntry is one document in the index: the file it was written to, the
@@ -148,12 +153,33 @@ type statementEntry struct {
 	Currency  string       `json:"currency"`
 }
 
+// rollupIndex is what the index says about the rollup: the relation type the
+// run was summed over, and one entry per group. The document list is empty
+// rather than absent where the rollup reached no group, which is what says the
+// run rolled nothing up.
+type rollupIndex struct {
+	RelationType string        `json:"relation_type"`
+	Documents    []rollupEntry `json:"documents"`
+}
+
+// rollupEntry is one group in the index: the file it was written to, the
+// virtual project it sums under, how many members it holds, and their total.
+type rollupEntry struct {
+	File      string       `json:"file"`
+	Cloud     string       `json:"cloud"`
+	ProjectID string       `json:"project_id"`
+	Members   int          `json:"members"`
+	Total     money.Amount `json:"total"`
+	Currency  string       `json:"currency"`
+}
+
 // Export writes the run's documents, its settlement and its index into Dir.
 // Everything is rendered before the directory is touched, so a statement whose
 // key or whose stored document is refused leaves no directory and no file
 // behind, and a write that fails takes the documents before it with it: an
 // export that reports an error wrote nothing, rather than every document up to
-// the bad one.
+// the bad one. The group documents of a run that carries a rollup are written
+// between the statements and the settlement.
 //
 // run.json is written last, after every document it names and the settlement
 // beside them are on stable storage, so a reader that picks the index up finds
@@ -192,6 +218,11 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 	}
 
 	documents := make(map[string][]byte, len(run.Statements))
+	// The name every statement was written under, keyed by its statement key. A
+	// rollup names the file of each of its members, and the name a document took
+	// is not always the one its key renders: a member that pointed at the name
+	// instead would point at a file the digest fallback below moved.
+	written := make(map[string]string, len(run.Statements))
 	// The names the run renders, folded to lower case. A case-insensitive file
 	// system (APFS, SMB, NTFS) resolves two names that differ only in case to
 	// one file, so the second rename would replace the first project's document
@@ -213,6 +244,7 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 		}
 		name := uniqueName(folded, documentPrefix(run.Kind), statement.Key)
 		documents[name] = document
+		written[statement.Key] = name
 		index.Statements = append(index.Statements, statementEntry{
 			File:      name,
 			Cloud:     cloud,
@@ -220,6 +252,35 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 			Total:     money.NewAmount(statement.Total),
 			Currency:  statement.Currency,
 		})
+	}
+
+	if run.Rollup != nil {
+		index.Rollup = &rollupIndex{
+			RelationType: run.Rollup.RelationType,
+			// Non-nil, for the reason the statement list is: a rollup that reached
+			// no group renders an empty list rather than a null.
+			Documents: make([]rollupEntry, 0, len(run.Rollup.Groups)),
+		}
+		// In the order the rollup holds them, which BuildRollup sorted by key.
+		for _, group := range run.Rollup.Groups {
+			body, err := renderRollup(run, *run.Rollup, group, written)
+			if err != nil {
+				return err
+			}
+			// Two targets whose keys differ in ASCII case alone resolve to one file
+			// on APFS, SMB and NTFS, so the second of such a pair takes its digest
+			// name, the way the second of two such statements does.
+			name := uniqueName(folded, rollupPrefix, group.Key)
+			documents[name] = body
+			index.Rollup.Documents = append(index.Rollup.Documents, rollupEntry{
+				File:      name,
+				Cloud:     group.Cloud,
+				ProjectID: group.ProjectID,
+				Members:   len(group.Members),
+				Total:     money.NewAmount(group.Total),
+				Currency:  group.Currency,
+			})
+		}
 	}
 
 	kickbacks, err := KickbacksJSON(run)
@@ -235,14 +296,21 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 	if err := prepareDir(j.Dir); err != nil {
 		return err
 	}
-	files := make([]artifact, 0, len(index.Statements)+1)
+	files := make([]artifact, 0, len(documents)+1)
 	for _, entry := range index.Statements {
 		files = append(files, artifact{name: entry.File, body: documents[entry.File]})
+	}
+	// The rollup documents follow the statements they sum, so a reader that picks
+	// one up finds every invoice it names beside it.
+	if index.Rollup != nil {
+		for _, entry := range index.Rollup.Documents {
+			files = append(files, artifact{name: entry.File, body: documents[entry.File]})
+		}
 	}
 	// The settlement goes in with the documents rather than after the index, so
 	// it is on stable storage before run.json names the month. No document takes
 	// its name away from it: DocumentFileName prefixes every one of them with
-	// statement- or credit-note-.
+	// statement- or credit-note-, and RollupFileName every group's with rollup-.
 	files = append(files, artifact{name: kickbacksJSONFileName, body: kickbacks})
 	return writeIndexedFiles(j.Dir, files, artifact{name: runFileName, body: body})
 }

--- a/internal/engine/export/json.go
+++ b/internal/engine/export/json.go
@@ -53,31 +53,17 @@ type JSONFiles struct {
 	Dir string
 }
 
-// DocumentFileName is the file one statement is written to: the prefix its
-// kind carries, the statement key escaped, and .json.
-//
-// The key is escaped as a whole, and its halves are escaped already, so the
-// slash between them becomes %2F and the percent of an escape inside a half
-// becomes %25. The double escaping is what keeps the names apart: the cloud
-// "os-prod/a" with project "b" and the cloud "os-prod" with project "a/b"
-// render one key each, and escaping those keys once more renders one file name
-// each rather than the same one twice.
-//
-// A key that renders past nameMaxLen is named after its SHA-256 digest instead:
-// the pair such a document bills is read off run.json, which names the cloud and
-// the project id beside every file.
+// DocumentFileName is the file one statement is written to: escapedName under
+// the prefix the run's kind carries, statement- or credit-note-. The key is
+// escaped twice and falls back to its digest past the length a file name holds,
+// for the reasons escapedName gives.
 //
 // The roadmap writes this file as statement-{project}.json. External project
 // ids are unique per cloud only, which is why a statement is stored under a key
 // of both halves, and why the file is named after that key rather than after
 // the project alone (author's decision of 2026-08-24).
 func DocumentFileName(kind, key string) string {
-	name := documentPrefix(kind) + url.PathEscape(key) + ".json"
-	if len(name) <= nameMaxLen {
-		return name
-	}
-	// A key no file system holds a name for is named after its digest instead.
-	return digestFileName(kind, key)
+	return escapedName(documentPrefix(kind), key)
 }
 
 // documentPrefix is the prefix the documents of a run's kind carry.
@@ -88,15 +74,45 @@ func documentPrefix(kind string) string {
 	return statementPrefix
 }
 
-// digestFileName names a document after the SHA-256 of its key: the fallback
-// for the two keys no escaped name serves, the one that renders past
-// nameMaxLen and the one whose name a directory already holds under a different
-// case. run.json carries the cloud and the project id beside every file, so the
-// pair a digest-named document bills is read off the index rather than off the
-// name, and one project id no longer takes the export of the whole month with
-// it.
-func digestFileName(kind, key string) string {
-	return fmt.Sprintf("%s%x.json", documentPrefix(kind), sha256.Sum256([]byte(key)))
+// uniqueName is the file one key is written to under a prefix, held apart from
+// the names rendered before it: escapedName, or digestName where the name it
+// renders is one folded already holds. The name is recorded in folded.
+func uniqueName(folded map[string]bool, prefix, key string) string {
+	name := escapedName(prefix, key)
+	if folded[strings.ToLower(name)] {
+		name = digestName(prefix, key)
+	}
+	folded[strings.ToLower(name)] = true
+	return name
+}
+
+// escapedName is the file one key is written to under a prefix: the prefix, the
+// key escaped, and .json.
+//
+// The key is escaped as a whole, and its halves are escaped already, so the
+// slash between them becomes %2F and the percent of an escape inside a half
+// becomes %25. The double escaping is what keeps the names apart: the cloud
+// "os-prod/a" with project "b" and the cloud "os-prod" with project "a/b"
+// render one key each, and escaping those keys once more renders one file name
+// each rather than the same one twice.
+//
+// A key that renders past nameMaxLen is named after its SHA-256 digest instead:
+// the pair such a name stands for is read off the index that carries it beside
+// the file.
+func escapedName(prefix, key string) string {
+	name := prefix + url.PathEscape(key) + ".json"
+	if len(name) <= nameMaxLen {
+		return name
+	}
+	// A key no file system holds a name for is named after its digest instead.
+	return digestName(prefix, key)
+}
+
+// digestName names a key after its SHA-256 under a prefix: the fallback for the
+// two keys no escaped name serves, the one that renders past nameMaxLen and the
+// one whose name a directory already holds under a different case.
+func digestName(prefix, key string) string {
+	return fmt.Sprintf("%s%x.json", prefix, sha256.Sum256([]byte(key)))
 }
 
 // runDocument is run.json. The field order is the order it is marshalled in.
@@ -195,11 +211,7 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 		if err != nil {
 			return err
 		}
-		name := DocumentFileName(run.Kind, statement.Key)
-		if folded[strings.ToLower(name)] {
-			name = digestFileName(run.Kind, statement.Key)
-		}
-		folded[strings.ToLower(name)] = true
+		name := uniqueName(folded, documentPrefix(run.Kind), statement.Key)
 		documents[name] = document
 		index.Statements = append(index.Statements, statementEntry{
 			File:      name,

--- a/internal/engine/export/rollup.go
+++ b/internal/engine/export/rollup.go
@@ -1,0 +1,286 @@
+package export
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/core/project"
+	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
+)
+
+// The prefix one group's document is named under and the file the table is
+// written to. A rollup document is one per group, the way a statement is one
+// per project, and the table holds every group of the run.
+const (
+	rollupPrefix      = "rollup-"
+	rollupCSVFileName = "rollup.csv"
+)
+
+// rollupHeader is the column order of rollup.csv. The first five columns are
+// the ones every table of an export carries, so a row says which run and which
+// month it belongs to on its own. relation_type says whether the target is a
+// meta-project or a partner, target_cloud and target_project_id name it, and
+// cloud and project_id name the member the total on the row was billed to: a
+// group's total is the sum of its rows rather than a column of its own.
+var rollupHeader = []string{
+	"run_id", "kind", "corrects_run_id", "period_from", "period_to",
+	"relation_type", "target_cloud", "target_project_id", "cloud", "project_id",
+	"total", "currency",
+}
+
+// Rollup is what an export sums under the virtual projects of one relation
+// type: the meta-projects a run's projects are members of, or the partners that
+// manage them.
+type Rollup struct {
+	// RelationType is project.RelationMemberOf or project.RelationManagedBy.
+	RelationType string
+	// Groups is never nil and is ordered by Key. A run none of whose statements
+	// is related to a virtual project rolls up to no group at all.
+	Groups []RollupGroup
+}
+
+// RollupGroup is one meta-project or partner and what the run billed under it.
+type RollupGroup struct {
+	// Key is statements.Key(Cloud, ProjectID) of the target, which is what its
+	// document is named after.
+	Key string
+	// Cloud and ProjectID are the target as the registry holds it. A virtual
+	// project carries its platform as its cloud.
+	Cloud, ProjectID string
+	// Platform is the target's registry platform, meta or partner.
+	Platform string
+	// Members is ordered by StatementKey and holds at least one entry: a target
+	// none of whose members the run billed is no group.
+	Members []RollupMember
+	// Total is the sum of the member totals, and Currency is the currency every
+	// one of them was billed in.
+	Total    decimal.Decimal
+	Currency string
+}
+
+// RollupMember is one project of a group, as the run's statement billed it.
+type RollupMember struct {
+	// StatementKey is the key the run stored the statement under; Cloud and
+	// ProjectID are its two halves as the registry holds them.
+	StatementKey     string
+	Cloud, ProjectID string
+	Total            decimal.Decimal
+	Currency         string
+}
+
+// rollupMemberKey says which member a group already counts: the group's key and
+// the statement key under it.
+type rollupMemberKey struct{ group, member string }
+
+// BuildRollup sums a run's statements under the virtual projects the relations
+// reach. One group is one target: the meta-project or the partner a relation
+// points at, the projects related to it that the run billed, and the sum of what
+// those statements carry. Attribution and billing stay per project, so a group's
+// total is the sum of the member totals it lists rather than a number of its
+// own.
+//
+// The relations are walked one hop each. A member of a meta-project that is
+// itself a member of a second one is counted under the first alone, because a
+// rollup reports what is directly related to a target rather than what a walk
+// reaches from it. A source is counted once per target however many of the
+// given relations reach that target from it, so a membership closed and opened
+// again inside the period is one member rather than two. A source related to two
+// targets is a member of both groups and both sum it: the groups of a rollup are
+// not disjoint, and their totals add up to more than the run billed.
+//
+// A source the run billed no statement for adds nothing, and a target none of
+// whose members the run billed is no group. Such a relation is skipped before
+// its target is judged, so one registry row of a cloud this run never metered
+// refuses no month it has no part in. A target a billed source reaches whose
+// platform is not meta or partner is refused: such a project owns resources and
+// carries a statement of its own, which a rollup under it would leave out, and
+// the document would then report a total that is neither the group's nor the
+// project's.
+func BuildRollup(run Run, relationType string, projects []source.Project, relations []source.Relation) (Rollup, error) {
+	if !project.IsVirtualRelationType(relationType) {
+		return Rollup{}, fmt.Errorf("the rollup relation type %q is not member_of or managed_by", relationType)
+	}
+
+	registry := make(map[uuid.UUID]source.Project, len(projects))
+	for _, entry := range projects {
+		registry[entry.ID] = entry
+	}
+	billed := make(map[string]statements.Statement, len(run.Statements))
+	for _, statement := range run.Statements {
+		billed[statement.Key] = statement
+	}
+
+	groups := make(map[string]*RollupGroup, len(relations))
+	counted := make(map[rollupMemberKey]bool, len(relations))
+	for _, relation := range relations {
+		// The caller asked for one relation type, and a relation of another one
+		// would be summed under a target the type does not reach: a managed_by edge
+		// in a member_of rollup puts a partner's projects under a customer's total.
+		if relation.RelationType != relationType {
+			return Rollup{}, fmt.Errorf("relation %s is of type %s, and the rollup is over %s",
+				relation.ID, relation.RelationType, relationType)
+		}
+		// Both ends have to be among the projects, the way adjustments.New holds
+		// them to the same snapshot: a group is named after its target's cloud and
+		// external id, and a member after its source's.
+		from, held := registry[relation.SourceID]
+		if !held {
+			return Rollup{}, fmt.Errorf("relation %s names the project %s, which the registry snapshot does not hold",
+				relation.ID, relation.SourceID)
+		}
+		target, held := registry[relation.TargetID]
+		if !held {
+			return Rollup{}, fmt.Errorf("relation %s names the project %s, which the registry snapshot does not hold",
+				relation.ID, relation.TargetID)
+		}
+		// A relation whose source the run billed nothing for contributes no member,
+		// so nothing about its target enters a total: it is skipped before it is
+		// judged below, rather than judged and refused over a project the run has
+		// no statement for.
+		key := statements.Key(from.Cloud, from.ExternalID)
+		statement, billedHere := billed[key]
+		if !billedHere {
+			continue
+		}
+		if !project.IsVirtualPlatform(target.Platform) {
+			return Rollup{}, fmt.Errorf(
+				"relation %s reaches %s/%s, whose platform %q is not meta or partner, "+
+					"and a rollup sums under a virtual project alone",
+				relation.ID, target.Cloud, target.ExternalID, target.Platform)
+		}
+		targetKey := statements.Key(target.Cloud, target.ExternalID)
+		if counted[rollupMemberKey{group: targetKey, member: key}] {
+			continue
+		}
+		counted[rollupMemberKey{group: targetKey, member: key}] = true
+
+		group, opened := groups[targetKey]
+		if !opened {
+			group = &RollupGroup{
+				Key:       targetKey,
+				Cloud:     target.Cloud,
+				ProjectID: target.ExternalID,
+				Platform:  target.Platform,
+				Total:     decimal.Zero,
+				Currency:  statement.Currency,
+			}
+			groups[targetKey] = group
+		} else if group.Currency != statement.Currency {
+			// A sum over two currencies is not a total anybody invoices, the way two
+			// currencies under one partner are two entries of a settlement.
+			return Rollup{}, fmt.Errorf("the rollup of %s holds statements in %s and in %s",
+				group.Key, group.Currency, statement.Currency)
+		}
+		group.Members = append(group.Members, RollupMember{
+			StatementKey: key,
+			Cloud:        from.Cloud,
+			ProjectID:    from.ExternalID,
+			Total:        statement.Total,
+			Currency:     statement.Currency,
+		})
+		// The statement totals are two-place amounts the rating rounded already, so
+		// adding them is what keeps the group equal to the lines it lists.
+		group.Total = group.Total.Add(statement.Total)
+	}
+
+	// Non-nil, so a run that rolls up to nothing carries an empty list rather
+	// than a null, the way an export without statements carries one.
+	result := make([]RollupGroup, 0, len(groups))
+	for _, group := range groups {
+		slices.SortFunc(group.Members, func(a, b RollupMember) int {
+			return cmp.Compare(a.StatementKey, b.StatementKey)
+		})
+		result = append(result, *group)
+	}
+	slices.SortFunc(result, func(a, b RollupGroup) int { return cmp.Compare(a.Key, b.Key) })
+	return Rollup{RelationType: relationType, Groups: result}, nil
+}
+
+// LoadRollup reads the membership out of the reporting database and sums the
+// run under it. The relations are the ones of the given type whose validity
+// overlaps the run's period, which is the same overlap query the run resolved
+// its adjustments from.
+//
+// The registry is read when the export runs rather than taken off what the run
+// recorded (author's decision of 2026-08-29, named here per guardrail 10 of
+// roadmap/00-conventions.md). A rollup is therefore a function of the run and of
+// the registry as it stands at that moment, rather than of the run alone: two
+// exports of one finalized run differ where a relation was created or closed
+// retroactively between them.
+func LoadRollup(ctx context.Context, reporting *source.DB, run Run, relationType string) (Rollup, error) {
+	rollup, err := loadRollup(ctx, reporting, run, relationType)
+	if err != nil {
+		return Rollup{}, fmt.Errorf("rolling up run %s over %s: %w", run.ID, relationType, err)
+	}
+	return rollup, nil
+}
+
+// loadRollup is the read LoadRollup wraps: the projects and the relations of one
+// reporting snapshot, and the sum over them.
+func loadRollup(ctx context.Context, reporting *source.DB, run Run, relationType string) (Rollup, error) {
+	snap, err := reporting.Snapshot(ctx)
+	if err != nil {
+		return Rollup{}, err
+	}
+	// The close that ends the snapshot, on a context no cancellation reaches, the
+	// way load ends its own transaction. The error is dropped because there is
+	// nothing a failed rollback of a read-only transaction changes.
+	defer func() { _ = snap.Close(context.WithoutCancel(ctx)) }()
+
+	projects, err := snap.Projects(ctx)
+	if err != nil {
+		return Rollup{}, err
+	}
+	relations, err := snap.Relations(ctx, []string{relationType}, run.PeriodFrom, run.PeriodTo)
+	if err != nil {
+		return Rollup{}, err
+	}
+	return BuildRollup(run, relationType, projects, relations)
+}
+
+// RollupFileName is the file one group is written to: the rollup- prefix, the
+// escaped key of the target and .json. The key is escaped twice and falls back
+// to its digest past the length a file name holds, for the reasons escapedName
+// gives.
+func RollupFileName(key string) string {
+	return escapedName(rollupPrefix, key)
+}
+
+// RollupCSV renders rollup.csv: the header and one row per member of every
+// group, in the order the rollup holds them. Every row carries the run, its kind
+// and its period beside the target it is summed under, the way a row of
+// kickbacks.csv carries them, so a row says which run, which month and which
+// meta-project it belongs to on its own.
+//
+// An export without a rollup and a rollup with no groups both render the header
+// alone: an empty table says the run rolled nothing up, and a missing file says
+// nothing at all.
+func RollupCSV(run Run) ([]byte, error) {
+	rows := [][]string{rollupHeader}
+	if run.Rollup != nil {
+		corrects := correctsOf(run)
+		from, to := instant(run.PeriodFrom), instant(run.PeriodTo)
+
+		for _, group := range run.Rollup.Groups {
+			for _, member := range group.Members {
+				rows = append(rows, []string{
+					run.ID.String(), run.Kind, corrects, from, to,
+					cell(run.Rollup.RelationType), cell(group.Cloud), cell(group.ProjectID),
+					cell(member.Cloud), cell(member.ProjectID),
+					// The total does not go through cell: a leading minus is the sign of
+					// what a correction credits rather than a formula.
+					member.Total.StringFixed(money.AmountPlaces),
+					member.Currency,
+				})
+			}
+		}
+	}
+	return table(run, rollupCSVFileName, rows)
+}

--- a/internal/engine/export/rollup.go
+++ b/internal/engine/export/rollup.go
@@ -253,6 +253,86 @@ func RollupFileName(key string) string {
 	return escapedName(rollupPrefix, key)
 }
 
+// rollupDocument is rollup-<key>.json: which target the group sums under, the
+// period and the kind of the run that produced it, and one entry per member
+// beside the file that member's invoice was written to. Nothing here names the
+// run itself, the way a statement document does not: run.json is the index that
+// ties a file to its run. The field order is the order it is marshalled in.
+type rollupDocument struct {
+	BillingPeriod statements.BillingPeriod `json:"billing_period"`
+	ProjectID     string                   `json:"project_id"`
+	Platform      string                   `json:"platform"`
+	RelationType  string                   `json:"relation_type"`
+	Kind          string                   `json:"kind"`
+	// CorrectsRunID is the run a correction's rollup corrects. A pointer, so a
+	// regular run renders null the way runDocument and kickbacksDocument render
+	// the run they correct: one export's documents say the same thing about an
+	// absent value.
+	CorrectsRunID *string             `json:"corrects_run_id"`
+	Members       []rollupMemberEntry `json:"members"`
+	Total         money.Amount        `json:"total"`
+	Currency      string              `json:"currency"`
+}
+
+// rollupMemberEntry is one member under a group: the file its statement was
+// written to, the pair it bills, and the total that statement carries. The two
+// halves of the key are unescaped, the way the index carries them.
+type rollupMemberEntry struct {
+	File      string       `json:"file"`
+	Cloud     string       `json:"cloud"`
+	ProjectID string       `json:"project_id"`
+	Total     money.Amount `json:"total"`
+	Currency  string       `json:"currency"`
+}
+
+// renderRollup renders one group of a rollup. files is the name every statement
+// of the run was written under, keyed by its statement key: a member names the
+// file its invoice is in rather than the name its key renders to, so a document
+// that had to give its name up to a case-fold collision is still the one the
+// group points at. A member no name was recorded for is refused: an empty
+// pointer beside a total that still balances is worse than no document at all,
+// because an ERP walking members[].file finds nothing and the group reads as
+// authoritative all the same.
+func renderRollup(run Run, rollup Rollup, group RollupGroup, files map[string]string) ([]byte, error) {
+	document := rollupDocument{
+		BillingPeriod: statements.BillingPeriod{
+			From: instant(run.PeriodFrom),
+			To:   instant(run.PeriodTo),
+		},
+		ProjectID:    group.ProjectID,
+		Platform:     group.Platform,
+		RelationType: rollup.RelationType,
+		Kind:         run.Kind,
+		Members:      make([]rollupMemberEntry, 0, len(group.Members)),
+		Total:        money.NewAmount(group.Total),
+		Currency:     group.Currency,
+	}
+	if run.CorrectsRunID != uuid.Nil {
+		corrects := run.CorrectsRunID.String()
+		document.CorrectsRunID = &corrects
+	}
+	for _, member := range group.Members {
+		file, wrote := files[member.StatementKey]
+		if !wrote {
+			return nil, fmt.Errorf("the rollup of %s names the member %s, which run %s wrote no statement for",
+				group.Key, member.StatementKey, run.ID)
+		}
+		document.Members = append(document.Members, rollupMemberEntry{
+			File:      file,
+			Cloud:     member.Cloud,
+			ProjectID: member.ProjectID,
+			Total:     money.NewAmount(member.Total),
+			Currency:  member.Currency,
+		})
+	}
+
+	body, err := marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("rendering %s of run %s: %w", RollupFileName(group.Key), run.ID, err)
+	}
+	return body, nil
+}
+
 // RollupCSV renders rollup.csv: the header and one row per member of every
 // group, in the order the rollup holds them. Every row carries the run, its kind
 // and its period beside the target it is summed under, the way a row of

--- a/internal/engine/export/testdata/golden/rollup/kickbacks.csv
+++ b/internal/engine/export/testdata/golden/rollup/kickbacks.csv
@@ -1,0 +1,1 @@
+run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency

--- a/internal/engine/export/testdata/golden/rollup/kickbacks.json
+++ b/internal/engine/export/testdata/golden/rollup/kickbacks.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "beneficiaries": []
+}

--- a/internal/engine/export/testdata/golden/rollup/rated.csv
+++ b/internal/engine/export/testdata/golden/rollup/rated.csv
@@ -1,0 +1,13 @@
+run_id,kind,corrects_run_id,period_from,period_to,cloud,platform,resource_type,resource_id,project_id,state,from_ts,to_ts,dimension,quantity,amount,currency
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-01T00:00:00Z,2026-03-11T00:00:00Z,disk_gb,80.0000,19.20,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-01T00:00:00Z,2026-03-11T00:00:00Z,egress_gb,18.0000,1.62,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-01T00:00:00Z,2026-03-11T00:00:00Z,ram_gb,8.0000,9.60,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-01T00:00:00Z,2026-03-11T00:00:00Z,vcpus,4.0000,19.20,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,shutoff,2026-03-11T00:00:00Z,2026-03-21T00:00:00Z,disk_gb,80.0000,9.60,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,shutoff,2026-03-11T00:00:00Z,2026-03-21T00:00:00Z,egress_gb,0.0000,0.00,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,shutoff,2026-03-11T00:00:00Z,2026-03-21T00:00:00Z,ram_gb,8.0000,4.80,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,shutoff,2026-03-11T00:00:00Z,2026-03-21T00:00:00Z,vcpus,4.0000,9.60,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-21T00:00:00Z,2026-04-01T00:00:00Z,disk_gb,80.0000,21.12,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-21T00:00:00Z,2026-04-01T00:00:00Z,egress_gb,22.5000,2.03,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-21T00:00:00Z,2026-04-01T00:00:00Z,ram_gb,8.0000,10.56,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,os-prod,openstack,instance,abc-123,proj-456,active,2026-03-21T00:00:00Z,2026-04-01T00:00:00Z,vcpus,4.0000,21.12,EUR

--- a/internal/engine/export/testdata/golden/rollup/rollup-meta%2Fcustomer-alpha.json
+++ b/internal/engine/export/testdata/golden/rollup/rollup-meta%2Fcustomer-alpha.json
@@ -1,0 +1,22 @@
+{
+  "billing_period": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-04-01T00:00:00Z"
+  },
+  "project_id": "customer-alpha",
+  "platform": "meta",
+  "relation_type": "member_of",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "members": [
+    {
+      "file": "statement-os-prod%2Fproj-456.json",
+      "cloud": "os-prod",
+      "project_id": "proj-456",
+      "total": 128.45,
+      "currency": "EUR"
+    }
+  ],
+  "total": 128.45,
+  "currency": "EUR"
+}

--- a/internal/engine/export/testdata/golden/rollup/rollup-meta%2Fcustomer-beta.json
+++ b/internal/engine/export/testdata/golden/rollup/rollup-meta%2Fcustomer-beta.json
@@ -1,0 +1,29 @@
+{
+  "billing_period": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-04-01T00:00:00Z"
+  },
+  "project_id": "customer-beta",
+  "platform": "meta",
+  "relation_type": "member_of",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "members": [
+    {
+      "file": "statement-os-dr%2Fproj-789.json",
+      "cloud": "os-dr",
+      "project_id": "proj-789",
+      "total": 22.32,
+      "currency": "EUR"
+    },
+    {
+      "file": "statement-os-prod%2Fproj-456.json",
+      "cloud": "os-prod",
+      "project_id": "proj-456",
+      "total": 128.45,
+      "currency": "EUR"
+    }
+  ],
+  "total": 150.77,
+  "currency": "EUR"
+}

--- a/internal/engine/export/testdata/golden/rollup/rollup.csv
+++ b/internal/engine/export/testdata/golden/rollup/rollup.csv
@@ -1,0 +1,4 @@
+run_id,kind,corrects_run_id,period_from,period_to,relation_type,target_cloud,target_project_id,cloud,project_id,total,currency
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,member_of,meta,customer-alpha,os-prod,proj-456,128.45,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,member_of,meta,customer-beta,os-dr,proj-789,22.32,EUR
+3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4,regular,,2026-03-01T00:00:00Z,2026-04-01T00:00:00Z,member_of,meta,customer-beta,os-prod,proj-456,128.45,EUR

--- a/internal/engine/export/testdata/golden/rollup/run.json
+++ b/internal/engine/export/testdata/golden/rollup/run.json
@@ -1,0 +1,50 @@
+{
+  "run_id": "3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4",
+  "kind": "regular",
+  "corrects_run_id": null,
+  "period_from": "2026-03-01T00:00:00Z",
+  "period_to": "2026-04-01T00:00:00Z",
+  "status": "finalized",
+  "pricing_version": "2026-03",
+  "clouds": [],
+  "started_at": "2026-04-04T00:00:00Z",
+  "completed_at": "2026-04-04T00:01:00Z",
+  "stats": {},
+  "statements": [
+    {
+      "file": "statement-os-dr%2Fproj-789.json",
+      "cloud": "os-dr",
+      "project_id": "proj-789",
+      "total": 22.32,
+      "currency": "EUR"
+    },
+    {
+      "file": "statement-os-prod%2Fproj-456.json",
+      "cloud": "os-prod",
+      "project_id": "proj-456",
+      "total": 128.45,
+      "currency": "EUR"
+    }
+  ],
+  "rollup": {
+    "relation_type": "member_of",
+    "documents": [
+      {
+        "file": "rollup-meta%2Fcustomer-alpha.json",
+        "cloud": "meta",
+        "project_id": "customer-alpha",
+        "members": 1,
+        "total": 128.45,
+        "currency": "EUR"
+      },
+      {
+        "file": "rollup-meta%2Fcustomer-beta.json",
+        "cloud": "meta",
+        "project_id": "customer-beta",
+        "members": 2,
+        "total": 150.77,
+        "currency": "EUR"
+      }
+    ]
+  }
+}

--- a/internal/engine/export/testdata/golden/rollup/statement-os-dr%2Fproj-789.json
+++ b/internal/engine/export/testdata/golden/rollup/statement-os-dr%2Fproj-789.json
@@ -1,0 +1,34 @@
+{
+  "billing_period": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-04-01T00:00:00Z"
+  },
+  "project_id": "proj-789",
+  "platform": "openstack",
+  "line_items": [
+    {
+      "resource_type": "volume",
+      "resource_id": "vol-789",
+      "platform": "openstack",
+      "description": "200 GB volume",
+      "periods": [
+        {
+          "state": "in-use",
+          "hours": 744.00,
+          "usage": {
+            "disk_gb": 200.0000
+          },
+          "cost": {
+            "disk_gb": 22.32,
+            "total": 22.32
+          },
+          "state_modifier": 1.0000
+        }
+      ],
+      "total": 22.32
+    }
+  ],
+  "related_costs": [],
+  "total": 22.32,
+  "currency": "EUR"
+}

--- a/internal/engine/export/testdata/golden/rollup/statement-os-prod%2Fproj-456.json
+++ b/internal/engine/export/testdata/golden/rollup/statement-os-prod%2Fproj-456.json
@@ -1,0 +1,76 @@
+{
+  "billing_period": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-04-01T00:00:00Z"
+  },
+  "project_id": "proj-456",
+  "platform": "openstack",
+  "line_items": [
+    {
+      "resource_type": "instance",
+      "resource_id": "abc-123",
+      "platform": "openstack",
+      "description": "m1.large instance",
+      "periods": [
+        {
+          "state": "active",
+          "hours": 240.00,
+          "usage": {
+            "disk_gb": 80.0000,
+            "egress_gb": 18.0000,
+            "ram_gb": 8.0000,
+            "vcpus": 4.0000
+          },
+          "cost": {
+            "disk_gb": 19.20,
+            "egress_gb": 1.62,
+            "ram_gb": 9.60,
+            "total": 49.62,
+            "vcpus": 19.20
+          },
+          "state_modifier": 1.0000
+        },
+        {
+          "state": "shutoff",
+          "hours": 240.00,
+          "usage": {
+            "disk_gb": 80.0000,
+            "egress_gb": 0.0000,
+            "ram_gb": 8.0000,
+            "vcpus": 4.0000
+          },
+          "cost": {
+            "disk_gb": 9.60,
+            "egress_gb": 0.00,
+            "ram_gb": 4.80,
+            "total": 24.00,
+            "vcpus": 9.60
+          },
+          "state_modifier": 0.5000
+        },
+        {
+          "state": "active",
+          "hours": 264.00,
+          "usage": {
+            "disk_gb": 80.0000,
+            "egress_gb": 22.5000,
+            "ram_gb": 8.0000,
+            "vcpus": 4.0000
+          },
+          "cost": {
+            "disk_gb": 21.12,
+            "egress_gb": 2.03,
+            "ram_gb": 10.56,
+            "total": 54.83,
+            "vcpus": 21.12
+          },
+          "state_modifier": 1.0000
+        }
+      ],
+      "total": 128.45
+    }
+  ],
+  "related_costs": [],
+  "total": 128.45,
+  "currency": "EUR"
+}


### PR DESCRIPTION
Closes #58

WP 5.5 of `roadmap/05-phase-5-commercial-pricing.md`: one operator document for customer-group discounts, and one export option that sums a run's statements under the meta-projects or partners its projects are related to. No rating mechanics change — the walk that carries a `member_of` discount to every member already exists in `internal/engine/adjustments`, and the rate-change flow already exists in the Reporting API. This issue documents both and adds the rollup beside them.

## The change set, in commit order

**`41b5eef` Split `DocumentFileName` into `escapedName` and `digestName`**

Groundwork. A second family of file names needs what `DocumentFileName` does: the double escaping that keeps two keys apart, the fallback to a digest past `nameMaxLen`, and the digest itself. `escapedName` and `digestName` take the prefix as an argument, `DocumentFileName` becomes `escapedName` under the prefix a run's kind carries, and `uniqueName` holds the two apart from the names an export already rendered. The names a run writes do not change — `TestDocumentFileName` passes unchanged.

**`e84f569` Add the meta-project rollup builder, loader and table** (`internal/engine/export/rollup.go`)

- `BuildRollup(run, relationType, projects, relations)` is the sum itself and does no I/O. It yields `Rollup{RelationType, Groups}` with `Groups` never nil, ordered by `Key`, each `RollupGroup` holding its `Members` ordered by `StatementKey`, a `Total` that is the sum of the member totals it lists, and the target's `Cloud`, `ProjectID` and `Platform`.
- A source is counted once per target however many relations of the period reach it (a relation closed mid-month plus its successor is one member), and a project related to two targets is a member of both — the groups of one rollup are deliberately **not** disjoint, so the group totals can add up to more than the run.
- Refusals: a relation type that is neither `member_of` nor `managed_by`; a relation of the other type than the one being summed; a relation naming a project the snapshot does not hold; a target whose platform is neither `meta` nor `partner` (a group under a real project would omit that project's own statement); two currencies under one target.
- `LoadRollup` reads the projects and the relations overlapping the run's period out of **one** reporting snapshot and hands them to `BuildRollup`, wrapping what the snapshot reports as `rolling up run <id> over <type>: ...`.
- `Rollup *Rollup` goes on `export.Run` after `Kickbacks`. `Load` and `LoadKickbacks` leave it nil, which is what an export without `--rollup` renders from.

**`21949d4` Write rollup documents and `rollup.csv` from the export writers**

- JSON: `rollup-{key}.json` per group, written between the statements and the settlement, each holding the period, the target, the run's kind (and `corrects_run_id` for a correction) and one entry per member naming the file that member's statement or credit note was written to. `run.json` gains a `rollup` member naming the documents with the relation type they were summed over. A key that collides with an earlier name under a case fold takes its digest name, the way a statement does.
- CSV: `rollup.csv` after `kickbacks.csv`, one row per member; a rollup that reached no group writes the header alone, under the same rule as an empty `kickbacks.csv`.
- A run with a nil `Rollup` renders exactly what it rendered before: no `rollup` member in `run.json`, no `rollup-` document, no `rollup.csv`. The `regular` and `correction` golden directories are unchanged byte for byte.

**`1ae56df` Add `--rollup` to `tally-engine export`**

The flag names the relation type (`member_of` or `managed_by`); an unknown value is refused before any configuration is read, with `--rollup: "..." must be member_of or managed_by`. Because the membership lives in the reporting database, an export given the flag opens both databases rather than the engine one alone, and a missing `TALLY_ENGINE_REPORTING_DB_URL` is refused before a run is read. The rollup is loaded after the run's status is re-read and before the exporter is built, so a failing registry read leaves `--out` uncreated. `exportLines` gains one line per format: `wrote N rollup documents over <type>` for json, `wrote N members over <type>` for csv.

**`be77f32` Document customer-group discounts and the rollup export** (`docs/group-discounts.md`)

Four sections: expressing a group discount as a `project_discount` on the `member_of` relation to a meta-project (one place per customer, inherited by every member of the walk); changing the rate for a later month by closing the relation at the month boundary and creating a successor, including the consequence of decision D4 that closing mid-month applies both rates to that month; why volume tiers are not derived from period usage (a rate that is a function of the usage it rates changes when a late event crosses a tier boundary, and correcting that needs semantics the engine does not have); and the rollup export itself.

## Notes for the reviewer

- **The rollup reads the registry at export time, not the run.** This was the author's decision of 2026-08-29, recorded in the issue's non-goals and stated in the document: two exports of one *finalized* run can differ after a relation is created or closed retroactively in between. It is the one documented exception to the export's reproducibility guarantee, and the `export` command's long help says so.
- The rollup carries totals only — no `base_cost`, `net_cost` or `kickback_total` per group. The member statements hold the rest.
- Direct relations only: a meta-project that is itself `member_of` a larger one is not followed.
- No divergences from the issue that I can identify from the commits and the diff. The `DocumentFileName` split landed in `json.go` rather than `files.go`, which is where `DocumentFileName` lives; no roadmap, README, `.env.example` or `deploy/` file is touched, and no environment variable is added.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) fe409b0 with Claude:claude-opus-5_
