### PR TITLE
Simulate Gardener shoots, a CI tenant and the classic tenants under a working-week profile

### DIFF
--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -36,11 +36,11 @@ const remoteBroker = "amqp://guest:hunter2@rabbit.control-plane.example:5672/"
 // nonBillableNotifications is how many notifications of a generated month the
 // collector maps to no event: the ones that are published to describe the
 // month's shape without being billable. They are the unsized image.create of
-// every image, two for each of the three classic projects and one for each of
-// the two Gardener tenants. notifications.jsonl holds every notification and
-// events.jsonl only the billable ones, so the two files differ by exactly this
-// many lines.
-const nonBillableNotifications = 8
+// every image: two for each of the three classic projects, one for each of the
+// two Gardener tenants, and one for the CI tenant. notifications.jsonl holds
+// every notification and events.jsonl only the billable ones, so the two files
+// differ by exactly this many lines.
+const nonBillableNotifications = 9
 
 func TestHelpNeedsNoEnvironment(t *testing.T) {
 	blankEnvironment(t)

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -35,10 +35,12 @@ const remoteBroker = "amqp://guest:hunter2@rabbit.control-plane.example:5672/"
 
 // nonBillableNotifications is how many notifications of a generated month the
 // collector maps to no event: the ones that are published to describe the
-// month's shape without being billable. notifications.jsonl holds every
-// notification and events.jsonl only the billable ones, so the two files differ
-// by exactly this many lines.
-const nonBillableNotifications = 6
+// month's shape without being billable. They are the unsized image.create of
+// every image, two for each of the three classic projects and one for each of
+// the two Gardener tenants. notifications.jsonl holds every notification and
+// events.jsonl only the billable ones, so the two files differ by exactly this
+// many lines.
+const nonBillableNotifications = 8
 
 func TestHelpNeedsNoEnvironment(t *testing.T) {
 	blankEnvironment(t)

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -50,6 +50,11 @@ services:
         condition: service_healthy
     environment:
       TALLY_OSC_AMQP_URL: amqp://guest:guest@rabbitmq:5672/
+      # The simulator publishes the shoots' load balancers on octavia. A topic
+      # exchange copies a message only to the queues bound to it, so a collector
+      # left at its default, the four without octavia, receives no load balancer
+      # from this stack and shows no `octavia.` series in any counter.
+      TALLY_OSC_EXCHANGES: nova,neutron,cinder,glance,octavia
       TALLY_OSC_CLOUD: ${TALLY_SIM_CLOUD}
       TALLY_OSC_REPORTING_URL: https://api.tally.127-0-0-1.nip.io:8443
       TALLY_OSC_TOKEN: ${TALLY_OSC_TOKEN}

--- a/deploy/compose/compose_test.go
+++ b/deploy/compose/compose_test.go
@@ -158,6 +158,22 @@ func TestCollectorEnvironmentIsWhatTheCollectorReads(t *testing.T) {
 	}
 }
 
+func TestCollectorBindsEveryExchangeTheSimulatorPublishesOn(t *testing.T) {
+	// A topic exchange copies a message only to the queues bound to it, so a
+	// notification published on an exchange the collector never binds is dropped
+	// by the broker: no queue, no counter, and no event. The collector's default
+	// binds four of the five the simulator publishes on, which makes the fifth
+	// this stack's to list.
+	svc := serviceNamed(t, loadCompose(t), collectorService)
+
+	bound := strings.Split(svc.Environment["TALLY_OSC_EXCHANGES"], ",")
+	slices.Sort(bound)
+	if want := slices.Sorted(slices.Values(simulator.ServiceExchanges)); !slices.Equal(bound, want) {
+		t.Errorf("TALLY_OSC_EXCHANGES binds %v, want %v, the exchanges the simulator publishes on (simulator.ServiceExchanges); a notification on an unbound exchange reaches no queue and no counter",
+			bound, want)
+	}
+}
+
 func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 	// The simulator ignores an unknown variable the same way the collector does,
 	// and a run without the broker in its environment writes the month nowhere

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -1,40 +1,49 @@
 # OpenStack notification simulator
 
 The simulator is one binary that puts a month of oslo.messaging notifications
-on a RabbitMQ broker the way nova, cinder, neutron, and glance put them there.
-The collector described in [`openstack-collector.md`](openstack-collector.md)
-consumes them unmodified, off its ordinary `tally-notifications` queue, and
-posts the mapped events to the Reporting API, so a month of usage reaches Tally
-with no OpenStack deployment behind it. The month is rendered from a small
-simulated cloud and paced by a virtual clock, so a 31-day month goes out in the
-wall time the factor compresses it into.
+on a RabbitMQ broker the way nova, cinder, neutron, glance, and octavia put
+them there. The collector described in
+[`openstack-collector.md`](openstack-collector.md) consumes them unmodified,
+off its ordinary `tally-notifications` queue, and posts the mapped events to
+the Reporting API, so a month of usage reaches Tally with no OpenStack
+deployment behind it. The month is rendered from a small simulated cloud and
+paced by a virtual clock, so a 31-day month goes out in the wall time the
+factor compresses it into.
 
 It has no fault switches, no oracle to hold a run against, no fake OpenStack
-API, and no metrics endpoint of its own. #65 owns the workloads, the noise, the
-faults, and the oracle; #66 the fake API and the clock seam; #67 the traffic
-series and `/metrics`. The drill #51 cites this simulator as the way a month
-reaches the Reporting API. The collector maps octavia's load balancer
-notifications, but this workload creates no load balancer, so no seed renders one
-until #65 gives it a shoot that does.
+API, and no metrics endpoint of its own. #65 is the meta issue the simulated
+workloads belong to, and this document describes its first stage: #86 owns the
+noise (the notifications the collector does not bill), #87 the oracle, #88 the
+fault switches, and #89 the project registry; #66 the fake API and the clock
+seam; #67 the traffic series and `/metrics`. The drill #51 cites this simulator
+as the way a month reaches the Reporting API. The workload renders octavia's
+three load balancer types from the shoots' load balancers.
 
 ## The world and the workload
 
-The simulated cloud has three projects and one external network. It is small on
-purpose: what a run has to cover is every notification type and every shape of
-resource life, not a realistic tenant count.
+The simulated cloud has three classic projects, two Gardener projects on two
+tenants, one CI tenant, and one external network. It is small on purpose: what
+a run has to cover is every notification type and every shape of resource life,
+not a realistic tenant count. Every tenant of it is addressed by its id alone:
+no notification, payload, or log line of a month carries a tenant name.
 
 The flavor catalog holds four entries: `m1.small` with 1 vCPU, 2048 MB of
 memory, and a 20 GB root disk; `m1.medium` with 2, 4096, and 40; `m1.large`
 with 4, 8192, and 40 GB root plus 40 GB ephemeral; `m1.xlarge` with 8, 16384,
 and 160. `m1.large` is the only one with ephemeral disk, and the first instance
 of every project runs on it, so every month exercises the mapping's sum of root
-and ephemeral disk.
+and ephemeral disk. Beside the catalog stands `c1.large` with 4 vCPUs, 8192 MB
+of memory, and no root disk. It is the flavor of a worker that boots from a
+volume: a server reports the root disk of its flavor whether it boots from one
+or not, so a flavor without root disk keeps the root volume from being billed
+twice, once as disk and once as volume.
 
 A volume carries one of the types `ssd`, `hdd`, and `standard`. The first two
 appear under `type_modifiers` in `pricing/2026-03.yaml` and `standard` does
-not, so a month prices both paths. Image sizes are drawn at quarter-gibibyte
-steps from 1 GiB to 4 GiB, which keeps the mapping's division into gibibytes on
-exact decimals.
+not, so a month prices both paths. A persistent volume claim is created with
+10, 20, or 50 GB, and the root volume of a worker that boots from one is 50 GB
+of `ssd`. Image sizes are drawn at quarter-gibibyte steps from 1 GiB to 4 GiB,
+which keeps the mapping's division into gibibytes on exact decimals.
 
 Instances run on `compute-01` to `compute-04` and keep the host they were
 created on. Cinder publishes as `storage-01@ceph`, neutron as `neutron-01`, and
@@ -42,7 +51,7 @@ glance as `glance-01`. Floating addresses come from `203.0.113.0/24`, the
 documentation range of RFC 5737, drawn as a permutation so that no address is
 handed out twice inside a month.
 
-Every project gets:
+Every classic project gets:
 
 - two images, each announced by an unsized `image.create` and uploaded 30 to
   120 seconds later by an `image.upload`. The second image is deleted in the
@@ -58,7 +67,105 @@ Every project gets:
   while the instance behind it lives on.
 - one spare volume, transferred to the next project.
 
-The workload renders 18 oslo notification types.
+### The Gardener projects
+
+Two Gardener projects run their shoots on two OpenStack tenants. Nothing of the
+Kubernetes side is rendered: what the simulator generates is what the platform
+underneath a shoot creates in OpenStack, the workers of the machine controller,
+the volumes of the CSI driver, and the load balancers of the cloud controller.
+Each tenant uploads one image, `gardenlinux-1592.4`, in the first half hour of
+the month and never deletes it, because the fleet that boots from it is created
+and destroyed all month long. The project names below reach a notification
+through the technical ids of the shoots, `shoot--alpha--api-prod` and the like,
+and the tenants they run on carry no name of their own.
+
+`alpha` runs on a tenant of its own with two shoots:
+
+- `api-prod` on `m1.xlarge`, booted from the tenant image, created in the first
+  hours of the month and alive through it. It rolls its workers once on a
+  working day between 8 and 20 days into the month, takes a second load
+  balancer between 3 and 20 days in, and a third listener on its first balancer
+  between 5 and 25 days in.
+- `api-dev` on `c1.large` from a 50 GB root volume, created in the first hours
+  as well. It hibernates at 19:00 of every day it is awake and wakes at 07:00
+  of every working day. Half the seeds give it a second load balancer.
+
+`beta` runs on the other tenant with one shoot: `batch` on `m1.large`, created
+in the working hours of a day between 2 and 8 days into the month and torn down
+in the working hours of one between 18 and 27 days in.
+
+A shoot's life renders:
+
+- three or four workers, booted seconds apart. A worker that boots from a
+  volume reports its `volume.create.end` 5 to 15 seconds before its
+  `compute.instance.create.end` and carries an empty `image_ref_url`.
+- two or three claims, each of them a `volume.create.end`. On a working day a
+  claim is added with probability 1/3, one is doubled with probability 1/4 (at
+  most twice per claim), and one is deleted with probability 1/5, never the
+  first one.
+- an autoscaler that adds one or two workers in the morning and gives them back
+  in the evening of every working day the shoot is fully alive.
+- a rolling update that boots a replacement and deletes the worker it replaces
+  minutes later.
+- hibernation, which deletes every worker and its root volume and keeps the
+  claims, the balancers, and their addresses.
+- a tear-down in the order the resources depend on each other: address,
+  balancer, workers, claims.
+
+A load balancer renders three notifications. `octavia.loadbalancer.create.end`
+carries no listeners and no pools, a `floatingip.create.end` gives its VIP port
+an address, and an `octavia.loadbalancer.update.end` one to five minutes later
+carries the listeners and the pools, which is what the balancer's size is
+booked from. The address of a balancer is associated from the moment it is
+allocated: it names its `port_id`, its `fixed_ip_address`, and its `router_id`,
+and its status is `ACTIVE`. The classic tenants' addresses are allocated
+unassociated instead, with the three members `null` and the status `DOWN`.
+Every octavia notification carries a `publisher_id` of `null`, the way the
+recorded samples do.
+
+The names are the shapes Gardener's OpenStack extension and the
+machine-controller-manager give the resources they create: the technical id
+`shoot--<project>--<shoot>`, a worker
+`<technical id>-worker-z1-<5 hex>-<5 hex>`, a root volume named after the
+worker it carries, a claim `<technical id>-dynamic-pvc-<volume id>`, a load
+balancer `kube_service_<technical id>_<namespace>_<service>`, and a keypair
+`<technical id>-ssh-publickey`. They are cosmetic: nothing is metered by a name.
+
+The notifications of the network, the subnet, the router, the security group,
+the keypair, and the ports belong to #86, together with the keystone
+notifications and the attach and detach notifications. Three of those
+identifiers are already named by a payload: a load balancer reports its
+`vip_network_id` and its `vip_subnet_id`, and the address of one reports its
+`router_id`. The security group and the keypair are drawn here and read by
+nothing yet: they hold their place in the identifier stream until #86 renders
+the notifications about them.
+
+### The CI tenant
+
+The CI tenant uploads the image `ubuntu-24.04-ci` and boots runners on every
+Monday to Friday of the month: 4 to 8 bursts of 2 to 5 runners each, the
+runners of one burst 1 to 3 seconds apart. A runner runs on `m1.small` or
+`m1.medium`, is called `runner-<8 hex>`, and is deleted 3 to 40 minutes after
+its create. It holds no volume and no address.
+
+### The profile
+
+The Gardener and the CI workload draw their instants on a working-week profile.
+Every hour of the period carries a weight: 10 for a Monday to Friday between
+07:00 and 19:00 UTC, 3 for 05:00 to 07:00 and 19:00 to 23:00 of those days, and
+1 for every other hour, the nights and the weekends. What a machine drives (a
+scale-up, the claim activity, a CI burst) is drawn on those weights. What
+somebody triggers (a shoot's creation and its deletion, the rolling update day,
+a second balancer, a listener) falls on the working hours alone.
+
+The working days are the Mondays to Fridays of the real calendar of the
+simulated period: July 2026 begins on a Wednesday and has 23 of them. The
+profile follows that calendar rather than a synthetic one, which is the author's
+decision of 2026-08-29. The consequence is that the same seed run over another
+month keeps the classic tenants at their offsets from the month start and moves
+the shoot and the CI activity onto that month's working days.
+
+The workload renders 21 oslo notification types.
 
 | Notification | Exchange | Billable |
 | --- | --- | --- |
@@ -80,28 +187,45 @@ The workload renders 18 oslo notification types.
 | `image.create` | `glance` | no |
 | `image.upload` | `glance` | yes |
 | `image.delete` | `glance` | yes |
+| `octavia.loadbalancer.create.end` | `octavia` | yes |
+| `octavia.loadbalancer.update.end` | `octavia` | yes |
+| `octavia.loadbalancer.delete.end` | `octavia` | yes |
 
 `image.create` is rendered in the unsized form glance emits before an upload,
 and the mapping skips it on purpose: the `image.upload` that follows is the
-first notification with a size to bill.
+first notification with a size to bill. A load balancer is billed from its
+update: the create carries no listeners and no pools, and the mapping counts
+both as 0 there.
 
-The forced steps (the resize on the first instance, the shelve on the second,
-the resize and retype of the second instance's first volume) are what make
-every seed render every type rather than most of them. The test suite holds
-seeds 1 to 5 over July 2026 against the recorded samples under
+Billable here means the collector books the notification as an event, not that
+the engine prices it. `pricing/2026-03.yaml`, the model
+`tally-engine pricing import` loads, prices `instance`, `volume`, and
+`floating_ip` and no `loadbalancer`, so a rated month counts every balancer of
+it under `runs.stats.unpriced` instead of billing it. Pricing the resource type
+is a change to that model and not to this simulator.
+
+The forced steps of the classic tenants and of the shoots (the resize on the
+first instance, the shelve on the second, the resize and retype of the second
+instance's first volume, the rolling update of `api-prod`, the tear-down of
+`batch`, and the load balancers) are what make every seed render every type
+rather than most of them. The test suite holds seeds 1 to 5 over July 2026
+against the recorded samples under
 [`internal/providers/openstack/testdata/golden/notifications/`](../internal/providers/openstack/testdata/golden/notifications),
-so a sample the catalog does not render fails the suite. A recorded type this
-workload publishes on no exchange is left out of that check, because no seed can
-reach one: octavia's three load balancer types are recorded there for the
-collector and rendered by nobody. Giving the workload an octavia exchange re-arms
-the check for them.
+so a sample the catalog does not render fails the suite. The check holds the
+octavia types against every seed as well, because every seed's `batch` tears its
+balancer down and every shoot updates the balancers it creates.
 
 ## Determinism
 
-The shape of a month (what happens, when, and with which sizes) is a function
-of `--seed` alone. The identifiers (the project and user ids, the resource ids,
-the floating addresses, the message ids) are a function of the seed together
-with the period and the cloud.
+The shape of the classic tenants (what happens, when, and with which sizes) is
+a function of `--seed` alone. The shape of the Gardener and the CI workload is a
+function of the seed and the period's calendar, because their steps fall on the
+working days of the month. The identifiers (the project and user ids, the
+resource ids, the floating addresses, the message ids) are a function of the
+seed together with the period and the cloud. The identifiers of the resources a
+month churns (the workers, their root volumes, the claims, the load balancers
+with their ports, listeners, pools, and addresses, and the CI runners) come from
+that same salted stream at the moment the resource is created.
 
 The same seed, period, and cloud therefore publish byte-identical
 notifications, and a rerun costs nothing at the far end: the collector books
@@ -112,9 +236,11 @@ another month publishes fresh resources under fresh message ids, so two
 collectors fed by two simulated clouds never collide on `event_id` at one
 Reporting API.
 
-Between two months of the same length the notifications sit at the same offsets
-from the month start. The transitions anchored on the month's end (the second
-image's delete and the first instance's) move with its length.
+Between two months of the same length the classic tenants' notifications sit at
+the same offsets from the month start. The transitions anchored on the month's
+end (the second image's delete and the first instance's) move with its length.
+The activity of the shoots and of the CI tenant follows each month's own
+working days.
 
 ## Running a month against the dev cluster
 
@@ -158,6 +284,15 @@ Every host port is bound to `127.0.0.1` and lies above 1024;
 cluster through `extra_hosts`, which maps `api.tally.127-0-0-1.nip.io` to
 `host-gateway`, and `tally-ca.crt` is mounted read-only at the path
 `SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify.
+
+The collector service of the stack lists five exchanges in
+`TALLY_OSC_EXCHANGES`: `nova,neutron,cinder,glance,octavia`. The simulator
+publishes the shoots' load balancers on `octavia`, and a topic exchange copies a
+message only to the queues bound to it, so a collector left at its default of
+four exchanges receives none of the load balancers and shows no `octavia.`
+series in any of its counters, `tally_collector_skipped_total` included.
+[`openstack-collector.md`](openstack-collector.md), "Exchanges and topics", is
+where that default and the reason it leaves octavia out are described.
 
 The simulator waits for a consumer on the collector's `tally-notifications`
 queue before its first publish, because a topic exchange drops what no queue is
@@ -218,15 +353,17 @@ curl --cacert tally-ca.crt -H "Authorization: Bearer $token" \
 
 ## What the collector shows
 
-Seed 1 over `2026-07` renders 180 notifications, 174 of them billable. The
-other six are the unsized `image.create`, one per image of the three projects.
+Seed 1 over `2026-07` renders 1821 notifications, 1812 of them billable. The
+other nine are the unsized `image.create`, one per image: two per classic
+project, one per Gardener tenant, and one for the CI tenant.
 
 `curl http://127.0.0.1:8090/readyz` answers 200 once the collector holds its
 broker connection and its outbox. On `http://127.0.0.1:8090/metrics`:
 
 - `tally_collector_consumed_total` grows per event type while the month goes
-  out.
-- `tally_collector_skipped_total{event_type="image.create"}` ends at 6 for that
+  out, and carries the three `octavia.loadbalancer.*.end` series among the
+  others.
+- `tally_collector_skipped_total{event_type="image.create"}` ends at 9 for that
   seed and period.
 - `tally_collector_unparseable_total` stays 0. Anything else is a rendered body
   the collector could not read.
@@ -260,7 +397,7 @@ puts on the bus.
 
 `events.jsonl` holds one canonical event per billable notification, computed by
 the collector's own parser and mapping table rather than by the simulator's
-idea of them. For seed 1 the first file therefore has six more lines than the
+idea of them. For seed 1 the first file therefore has nine more lines than the
 second. A broker and `--out` combine: a run does both.
 
 `replay --in FILE --factor N` publishes a captured file onto a broker, with the
@@ -289,7 +426,7 @@ at another speed.
 `GET /healthz` answers `ok`. `GET /clock` answers the document of that moment:
 
 ```json
-{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":180,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":1821,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
 ```
 
 `PUT /clock` with a body of `{"factor": N}`, where N is zero or positive,

--- a/internal/providers/openstack/simulator/ci.go
+++ b/internal/providers/openstack/simulator/ci.go
@@ -1,0 +1,64 @@
+package simulator
+
+import "time"
+
+// The CI tenant is the OpenStack project a build system runs its jobs in. It
+// boots one runner per job and destroys it when the job ends, so a runner's
+// whole life is shorter than the gap between two notifications of a classic
+// tenant. That is the shape the other workloads do not produce: a month of
+// resources that are created and closed inside it, hundreds of them, none of
+// which the projection carries into the next period.
+//
+// A pipeline is started by somebody pushing, so the bursts fall into the
+// working hours of a Monday to Friday of the real calendar and the weekends
+// hold none of them.
+//
+// A runner is called runner-<the first eight hex digits of its instance id>,
+// the way a build system names a throwaway machine after the job it was
+// requested for. The name is cosmetic: nothing is metered by it, and it is
+// there so that a dumped month reads like a deployment rather than like a list
+// of ids.
+
+// ci generates the CI tenant's month. The image comes first because every
+// runner boots from it, and it is the one resource of this tenant that outlives
+// a single job.
+func (g *generator) ci() {
+	g.tenantImage(g.ciTenant)
+
+	for _, d := range workingDays(g.from, g.to) {
+		// A push starts several jobs at once, which is why the day's runners come
+		// in bursts rather than one at a time: the runners of one burst are
+		// requested seconds apart and run side by side.
+		for range 4 + g.shape.IntN(5) {
+			t := drawInstant(g.shape, at(d, 7, 0), at(d, 19, 0))
+			for range 2 + g.shape.IntN(4) {
+				g.runner(t)
+				t = t.Add(span(g.shape, time.Second, 4*time.Second))
+			}
+		}
+	}
+}
+
+// runner boots one runner and destroys it again once its job is over. It holds
+// no volume and no address, and nothing keeps it: the pipeline that asked for
+// it is done with it by the delete, and the month refers to it through neither
+// its name nor its id afterwards.
+func (g *generator) runner(t time.Time) {
+	tenant := g.ciTenant
+	id := g.identifiers.nextUUID()
+	inst := &instance{
+		id:        id,
+		name:      "runner-" + id[:8],
+		flavor:    runnerFlavors[g.shape.IntN(len(runnerFlavors))],
+		host:      computeHosts[g.shape.IntN(len(computeHosts))],
+		imageID:   tenant.images[0].id,
+		createdAt: t,
+	}
+
+	g.emit(t, "compute.instance.create.end", computePublisher(inst), inst.id, tenant,
+		instanceCreatePayload(tenant, inst, g.cloud))
+
+	deletedAt := t.Add(span(g.shape, 3*time.Minute, 40*time.Minute))
+	g.emit(deletedAt, "compute.instance.delete.end", computePublisher(inst), inst.id, tenant,
+		instanceDeletePayload(tenant, inst, deletedAt))
+}

--- a/internal/providers/openstack/simulator/ci.go
+++ b/internal/providers/openstack/simulator/ci.go
@@ -19,6 +19,24 @@ import "time"
 // there so that a dumped month reads like a deployment rather than like a list
 // of ids.
 
+// The shape of one burst: how many runners it holds and how far apart they are
+// requested. runnerGapCeiling is exclusive, the way span draws whole seconds
+// below the duration it is handed.
+const (
+	minBurstRunners  = 2
+	maxBurstRunners  = 5
+	minRunnerGap     = 1 * time.Second
+	runnerGapCeiling = 4 * time.Second
+)
+
+// longestBurst is how long after its first runner the last runner of a burst
+// boots: the gaps of the widest burst, each of them the longest one a draw
+// yields. It is derived from the burst above rather than written out, because
+// the first runner is drawn so that even the last one of its burst comes up
+// before the working hours end, and a burst widened past a constant that stated
+// its own number would push runners past that end unnoticed.
+const longestBurst = (maxBurstRunners - 1) * (runnerGapCeiling - time.Second)
+
 // ci generates the CI tenant's month. The image comes first because every
 // runner boots from it, and it is the one resource of this tenant that outlives
 // a single job.
@@ -30,10 +48,10 @@ func (g *generator) ci() {
 		// in bursts rather than one at a time: the runners of one burst are
 		// requested seconds apart and run side by side.
 		for range 4 + g.shape.IntN(5) {
-			t := drawInstant(g.shape, at(d, 7, 0), at(d, 19, 0))
-			for range 2 + g.shape.IntN(4) {
+			t := drawInstant(g.shape, at(d, officeFrom, 0), at(d, officeTo, 0).Add(-longestBurst))
+			for range minBurstRunners + g.shape.IntN(maxBurstRunners-minBurstRunners+1) {
 				g.runner(t)
-				t = t.Add(span(g.shape, time.Second, 4*time.Second))
+				t = t.Add(span(g.shape, minRunnerGap, runnerGapCeiling))
 			}
 		}
 	}

--- a/internal/providers/openstack/simulator/config.go
+++ b/internal/providers/openstack/simulator/config.go
@@ -1,7 +1,8 @@
 // Package simulator publishes one simulated month of oslo.messaging
-// notifications. It renders a seeded month of nova, cinder, neutron, and glance
-// notifications onto a RabbitMQ broker, or into files when no broker is
-// configured, and a virtual clock decides how much wall time that month costs.
+// notifications. It renders a seeded month of nova, cinder, neutron, glance,
+// and octavia notifications onto a RabbitMQ broker, or into files when no
+// broker is configured, and a virtual clock decides how much wall time that
+// month costs.
 //
 // The notifications are the ones a real deployment publishes, so the collector
 // in internal/providers/openstack consumes them unmodified: the simulator sits

--- a/internal/providers/openstack/simulator/gardener.go
+++ b/internal/providers/openstack/simulator/gardener.go
@@ -1,0 +1,450 @@
+package simulator
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// A Gardener shoot is simulated from the OpenStack side, the way the platform
+// underneath one sees it: the machine controller boots and destroys nova
+// servers, the cloud controller gives every service of type LoadBalancer an
+// octavia load balancer with a floating address, and the CSI driver turns a
+// persistent volume claim into a cinder volume. Nothing here speaks to a
+// Kubernetes API, and nothing of the cluster itself is rendered.
+//
+// Only the billable side of a shoot is generated: the workers, the volumes, the
+// addresses, the image the workers boot from, and the load balancers. The
+// network, the subnet, the router, and the ports are named in the payloads that
+// refer to them. The security group and the keypair are named by nothing yet:
+// they are held for the issue that adds the neutron and keystone side, which is
+// where the notifications about all of them belong.
+//
+// The names are the shapes Gardener's OpenStack extension and the
+// machine-controller-manager give the resources they create: a technical id
+// shoot--<project>--<shoot>, a worker <technical id>-worker-z1-<5 hex>-<5 hex>,
+// a root volume named after the worker it carries, a claim
+// <technical id>-dynamic-pvc-<volume id>, a load balancer
+// kube_service_<technical id>_<namespace>_<service>, and a keypair
+// <technical id>-ssh-publickey. They are cosmetic: nothing is metered by a
+// name, and they are there so that a dumped month reads like a real deployment.
+
+// newGardenerProjects returns the projects a month is generated from, built
+// fresh on every call. A shoot carries the state of the month it is walked
+// through, such as which workers are alive at this moment, so a package
+// variable would hand one Generate call's fleet to the next and the second
+// month would come out a different one.
+//
+// The three shoots are the three shapes a cluster has over a billing month: one
+// that runs the whole month and rolls its workers once, one that hibernates
+// every night and boots its workers from volumes, and one that is created and
+// deleted inside the month.
+func newGardenerProjects() []*gardenerProject {
+	return []*gardenerProject{
+		{
+			name: "alpha",
+			shoots: []*shoot{
+				{name: "api-prod", flavor: xlargeFlavor},
+				{name: "api-dev", flavor: bootVolumeFlavor, bootFromVolume: true, hibernates: true},
+			},
+		},
+		{
+			name:   "beta",
+			shoots: []*shoot{{name: "batch", flavor: largeFlavor, transient: true}},
+		},
+	}
+}
+
+// gardener generates one Gardener project's month. The image comes first
+// because every worker of every shoot boots from it.
+func (g *generator) gardener(gp *gardenerProject) {
+	g.tenantImage(gp.tenant)
+	for _, s := range gp.shoots {
+		g.shoot(gp, s)
+	}
+}
+
+// tenantImage uploads the one image a machine-driven tenant boots its servers
+// from. It is uploaded in the first half hour of the month and never deleted:
+// the fleet on top of it is created and destroyed all month long, and an image
+// that went with one of those steps would leave the next boot without one.
+func (g *generator) tenantImage(p *project) {
+	img := p.images[0]
+	img.createdAt = g.from.Add(span(g.shape, 0, 30*time.Minute))
+	uploadedAt := img.createdAt.Add(span(g.shape, 30*time.Second, 120*time.Second))
+	// Every quarter gibibyte from one to four, the way a classic image is sized.
+	img.size = int64(4+g.shape.IntN(13)) * quarterGiB
+
+	g.emit(img.createdAt, imageCreateType, imagePublisher, img.id, p, imageCreatePayload(p, img))
+	g.emit(uploadedAt, "image.upload", imagePublisher, img.id, p,
+		imageUploadPayload(p, img, uploadedAt))
+}
+
+// shoot creates one cluster and walks it through every day it exists.
+//
+// The one-off steps of the month are drawn before the first of them is
+// generated, because each of them is a day the day loop has to recognise when
+// it reaches it. A transient shoot is created and deleted while its team is at
+// work, and a shoot that outlives the month comes up in the first hours of it,
+// where Gardener's reconciliation would have picked it up.
+func (g *generator) shoot(gp *gardenerProject, s *shoot) {
+	s.baseWorkers = 3 + g.shape.IntN(2)
+	if s.transient {
+		s.createdAt = drawWorkingInstant(g.shape, g.from.Add(2*day), g.from.Add(8*day))
+		s.deletedAt = drawWorkingInstant(g.shape, g.from.Add(18*day), g.from.Add(27*day))
+	} else {
+		s.createdAt = g.from.Add(span(g.shape, time.Hour, 4*time.Hour))
+	}
+	if !s.hibernates && !s.transient {
+		s.rollingUpdateDay = at(drawWorkingInstant(g.shape, g.from.Add(8*day), g.from.Add(20*day)), 0, 0)
+		s.secondBalancerDay = at(drawWorkingInstant(g.shape, g.from.Add(3*day), g.from.Add(20*day)), 0, 0)
+		s.listenerDay = at(drawWorkingInstant(g.shape, g.from.Add(5*day), g.from.Add(25*day)), 0, 0)
+	}
+	// A development cluster publishes a second service or it does not, which is
+	// the one shoot whose balancer count depends on the seed.
+	if s.hibernates && g.shape.IntN(2) == 0 {
+		s.secondBalancerDay = at(drawWorkingInstant(g.shape, g.from.Add(3*day), g.from.Add(20*day)), 0, 0)
+	}
+
+	// The creation sequence: the workers come up seconds apart, the workloads
+	// that claim storage are scheduled once the nodes are ready, and the ingress
+	// controller's load balancer follows within the hour.
+	t := s.createdAt.Add(span(g.shape, 30*time.Second, 90*time.Second))
+	for range s.baseWorkers {
+		g.bootWorker(s, t)
+		t = t.Add(span(g.shape, 3*time.Second, 10*time.Second))
+	}
+	claims := 2 + g.shape.IntN(2)
+	t = s.createdAt.Add(span(g.shape, 5*time.Minute, 30*time.Minute))
+	for range claims {
+		g.createClaim(s, t)
+		t = t.Add(span(g.shape, time.Second, 20*time.Second))
+	}
+	g.createLoadBalancer(s, s.createdAt.Add(span(g.shape, 10*time.Minute, 60*time.Minute)),
+		"kube_service_"+s.technicalID+"_ingress_nginx-ingress-controller", 2, 2)
+
+	for d := at(s.createdAt, 0, 0); d.Before(g.to); d = d.AddDate(0, 0, 1) {
+		g.shootDay(s, d)
+		// The tear-down is the last thing the shoot does, so the days after it
+		// are days it no longer exists on.
+		if s.transient && d.Equal(at(s.deletedAt, 0, 0)) {
+			break
+		}
+	}
+}
+
+// shootDay generates one day of a shoot, in the order the day runs: the cluster
+// wakes up, the autoscaler adds workers for the working hours, the one-off
+// steps of the day happen, the workloads move their claims around, the
+// autoscaler gives the workers back in the evening, and the cluster hibernates
+// or is torn down.
+//
+// Everything the working hours bring is generated only on a day the shoot is
+// fully alive, from the morning to the evening. A day it is created, torn down,
+// or hibernating through is a day the autoscaler and the workloads have no full
+// window on, and rendering their steps into a fraction of one would put load on
+// a cluster that was not there yet.
+func (g *generator) shootDay(s *shoot, d time.Time) {
+	if s.hibernates && !s.awake && workingDay(d) {
+		t := at(d, officeFrom, 0)
+		for range s.baseWorkers {
+			g.bootWorker(s, t)
+			t = t.Add(span(g.shape, 3*time.Second, 10*time.Second))
+		}
+		// The claims outlive the night and are mounted again by the workloads the
+		// new workers run, so cinder reports them in use from the wake-up on.
+		for _, claim := range s.claims {
+			claim.attached = true
+		}
+		s.awake = true
+	}
+
+	alive := s.createdAt.Before(at(d, officeFrom, 0)) &&
+		(s.deletedAt.IsZero() || !s.deletedAt.Before(at(d, officeTo, 0))) && s.awake
+
+	if workingDay(d) && alive {
+		t := drawInstant(g.shape, at(d, 8, 0), at(d, 12, 0))
+		for range 1 + g.shape.IntN(2) {
+			s.added = append(s.added, g.bootWorker(s, t))
+			t = t.Add(span(g.shape, 3*time.Second, 10*time.Second))
+		}
+	}
+
+	// A rolling update replaces the workers of the base pool one at a time: the
+	// new machine is up before the old one goes, which is what keeps the cluster
+	// at its capacity while its nodes are exchanged. The workers the autoscaler
+	// added today are left alone, because they already run the new version.
+	if d.Equal(s.rollingUpdateDay) {
+		t := drawWorkingInstant(g.shape, at(d, 9, 0), at(d, 15, 0))
+		for _, w := range slices.Clone(s.workers) {
+			if slices.Contains(s.added, w) {
+				continue
+			}
+			g.bootWorker(s, t)
+			deletedAt := t.Add(span(g.shape, 2*time.Minute, 5*time.Minute))
+			g.deleteWorker(s, w, deletedAt)
+			t = deletedAt.Add(span(g.shape, time.Minute, 3*time.Minute))
+		}
+	}
+
+	if !s.secondBalancerDay.IsZero() && d.Equal(s.secondBalancerDay) {
+		g.createLoadBalancer(s, drawWorkingInstant(g.shape, at(d, 9, 0), at(d, 17, 0)),
+			"kube_service_"+s.technicalID+"_default_api", 1, 1)
+	}
+
+	// A service that publishes another port gets another listener on the
+	// balancer it already has. Creating the listener sends no notification of
+	// its own, the way octavia notifies on the load balancer alone, so the
+	// balancer's update is where the new count arrives.
+	if !s.listenerDay.IsZero() && d.Equal(s.listenerDay) {
+		lb := s.loadBalancers[0]
+		lb.listenerIDs = append(lb.listenerIDs, g.identifiers.nextUUID())
+		g.emit(drawWorkingInstant(g.shape, at(d, 9, 0), at(d, 17, 0)),
+			"octavia.loadbalancer.update.end", "", lb.id, s.owner.tenant,
+			loadBalancerPayload(s.owner.tenant, s, lb, true))
+	}
+
+	if workingDay(d) && alive {
+		g.claimActivity(s, d)
+	}
+
+	if workingDay(d) && alive && len(s.added) > 0 {
+		t := drawInstant(g.shape, at(d, 16, 0), at(d, 18, 30))
+		for _, w := range slices.Clone(s.added) {
+			g.deleteWorker(s, w, t)
+			t = t.Add(span(g.shape, 10*time.Second, 60*time.Second))
+		}
+		s.added = nil
+	}
+
+	// Hibernation destroys every worker and keeps everything else: the claims
+	// hold the cluster's data over the night and the balancers hold their
+	// addresses, so a hibernating shoot is billed for its storage and its
+	// network throughout and for its servers by the working day.
+	if s.hibernates && s.awake {
+		t := at(d, officeTo, 0)
+		for _, w := range slices.Clone(s.workers) {
+			g.deleteWorker(s, w, t)
+			t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
+		}
+		for _, claim := range s.claims {
+			claim.attached = false
+		}
+		s.awake = false
+	}
+
+	if s.transient && d.Equal(at(s.deletedAt, 0, 0)) {
+		g.tearDown(s)
+	}
+}
+
+// bootWorker creates one worker of the shoot and returns it. A worker that
+// boots from a volume has its root volume provisioned seconds before the server
+// exists, because the image is written to that volume first and the server is
+// booted off it afterwards.
+func (g *generator) bootWorker(s *shoot, t time.Time) *instance {
+	tenant := s.owner.tenant
+	id := g.identifiers.nextUUID()
+	// The machine-controller-manager names a machine after its worker pool and
+	// two short pieces of randomness, which is what these two slices of the
+	// identifier stand in for.
+	name := fmt.Sprintf("%s-worker-z1-%s-%s", s.technicalID, id[:5], id[24:29])
+	w := &instance{
+		id:        id,
+		name:      name,
+		host:      computeHosts[g.shape.IntN(len(computeHosts))],
+		flavor:    s.flavor,
+		createdAt: t,
+	}
+
+	if s.bootFromVolume {
+		vol := &volume{
+			id:         g.identifiers.nextUUID(),
+			name:       name,
+			sizeGB:     rootVolumeSizeGB,
+			volumeType: rootVolumeType,
+			createdAt:  t.Add(-span(g.shape, 5*time.Second, 15*time.Second)),
+		}
+		g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, tenant,
+			volumeCreatePayload(tenant, vol))
+		vol.attached = true
+		w.bootVolume = vol
+	} else {
+		w.imageID = tenant.images[0].id
+	}
+
+	g.emit(t, "compute.instance.create.end", computePublisher(w), w.id, tenant,
+		instanceCreatePayload(tenant, w, g.cloud))
+	s.workers = append(s.workers, w)
+	return w
+}
+
+// deleteWorker destroys one worker, and its root volume with it: a machine that
+// boots from a volume takes that volume when it goes, so the volume is billed
+// for exactly as long as the worker is. Every worker a shoot loses goes through
+// here, whether it is scaled down, rolled, hibernated, or torn down.
+func (g *generator) deleteWorker(s *shoot, w *instance, t time.Time) {
+	tenant := s.owner.tenant
+	g.emit(t, "compute.instance.delete.end", computePublisher(w), w.id, tenant,
+		instanceDeletePayload(tenant, w, t))
+
+	if w.bootVolume != nil {
+		deletedAt := t.Add(span(g.shape, 20*time.Second, 40*time.Second))
+		g.emit(deletedAt, "volume.delete.end", volumePublisher, w.bootVolume.id, tenant,
+			volumeDeletePayload(tenant, w.bootVolume, deletedAt))
+	}
+
+	s.workers = slices.DeleteFunc(s.workers, func(other *instance) bool { return other == w })
+	s.added = slices.DeleteFunc(s.added, func(other *instance) bool { return other == w })
+}
+
+// createClaim provisions one persistent volume claim. The CSI driver names the
+// volume after the claim it stands for, and the volume is in use from the
+// moment it exists: the pod that asked for it is waiting on the mount.
+func (g *generator) createClaim(s *shoot, t time.Time) {
+	tenant := s.owner.tenant
+	id := g.identifiers.nextUUID()
+	vol := &volume{
+		id:         id,
+		name:       s.technicalID + "-dynamic-pvc-" + id,
+		sizeGB:     claimSizesGB[g.shape.IntN(len(claimSizesGB))],
+		volumeType: volumeTypes[g.shape.IntN(len(volumeTypes))],
+		createdAt:  t,
+	}
+
+	g.emit(t, "volume.create.end", volumePublisher, vol.id, tenant, volumeCreatePayload(tenant, vol))
+	vol.attached = true
+	s.claims = append(s.claims, vol)
+}
+
+// claimActivity is what a working day does to a cluster's storage: a workload
+// is deployed and claims a volume, one that ran out of room is expanded, and
+// one whose workload is gone is released. Each of the three happens on a draw
+// of its own, so a day brings any combination of them, none included.
+//
+// A claim created today is no candidate for either of the other two, because a
+// resize or a release of a volume in the hour it was provisioned is not a day
+// in the life of a cluster. The shoot's first claim is never released: it is
+// what carries the state that outlives every workload, and it keeps a month
+// from being a month in which every claim of a shoot is gone by the end.
+func (g *generator) claimActivity(s *shoot, d time.Time) {
+	tenant := s.owner.tenant
+	lo, hi := at(d, 8, 0), at(d, 18, 30)
+
+	if g.shape.IntN(3) == 0 {
+		g.createClaim(s, drawInstant(g.shape, lo, hi))
+	}
+
+	// The volume that grew today is left out of the release below: two
+	// notifications about one volume in the same second are two the projection
+	// cannot order, and a release of what was just expanded says nothing.
+	var grown *volume
+	if g.shape.IntN(4) == 0 {
+		var candidates []*volume
+		for _, vol := range s.claims {
+			// A claim grows at most twice, which is what keeps a month from
+			// doubling one volume into a size no cluster carries.
+			if vol.createdAt.Before(d) && vol.resizes < 2 {
+				candidates = append(candidates, vol)
+			}
+		}
+		if len(candidates) > 0 {
+			t := drawInstant(g.shape, lo, hi)
+			vol := candidates[g.shape.IntN(len(candidates))]
+			vol.sizeGB *= 2
+			vol.resizes++
+			g.emit(t, "volume.resize.end", volumePublisher, vol.id, tenant,
+				volumeStatePayload(tenant, vol))
+			grown = vol
+		}
+	}
+
+	if g.shape.IntN(5) == 0 {
+		var candidates []*volume
+		for _, vol := range s.claims[1:] {
+			if vol.createdAt.Before(d) && vol != grown {
+				candidates = append(candidates, vol)
+			}
+		}
+		if len(candidates) > 0 {
+			t := drawInstant(g.shape, lo, hi)
+			vol := candidates[g.shape.IntN(len(candidates))]
+			g.emit(t, "volume.delete.end", volumePublisher, vol.id, tenant,
+				volumeDeletePayload(tenant, vol, t))
+			s.claims = slices.DeleteFunc(s.claims, func(other *volume) bool { return other == vol })
+		}
+	}
+}
+
+// createLoadBalancer publishes one service of type LoadBalancer: octavia
+// creates the balancer, neutron gives its VIP port a floating address, and the
+// listeners and pools of the service arrive on the update that follows.
+//
+// The update is the notification the balancer's size is booked from. Octavia
+// reports the listeners and the pools on an update alone, and the create is
+// sent before the service's ports are attached, so the create carries a
+// balancer of zero listeners and zero pools.
+func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, listeners, pools int) {
+	tenant := s.owner.tenant
+	lb := &loadBalancer{id: g.identifiers.nextUUID(), name: name, vipPortID: g.identifiers.nextUUID()}
+	for range listeners {
+		lb.listenerIDs = append(lb.listenerIDs, g.identifiers.nextUUID())
+	}
+	for range pools {
+		lb.poolIDs = append(lb.poolIDs, g.identifiers.nextUUID())
+	}
+	// The VIP addresses of a shoot come from its own third octet, so two shoots
+	// on one tenant never report the same address.
+	lb.vipAddress = fmt.Sprintf("10.250.%d.%d", s.index, 10+len(s.loadBalancers))
+	lb.fip = &floatingIP{
+		id:      g.identifiers.nextUUID(),
+		address: floatingPrefix + strconv.Itoa(1+g.addresses[g.assigned]),
+		// The address of a load balancer is associated with its VIP port at once,
+		// which is what makes it the one address of a month that is up from the
+		// moment it is allocated.
+		portID:       lb.vipPortID,
+		fixedAddress: lb.vipAddress,
+		routerID:     s.routerID,
+	}
+	g.assigned++
+	s.loadBalancers = append(s.loadBalancers, lb)
+
+	g.emit(t, "octavia.loadbalancer.create.end", "", lb.id, tenant,
+		loadBalancerPayload(tenant, s, lb, false))
+	allocatedAt := t.Add(span(g.shape, 2*time.Second, 10*time.Second))
+	g.emit(allocatedAt, "floatingip.create.end", networkPublisher, lb.fip.id, tenant,
+		floatingIPCreatePayload(tenant, lb.fip, g.networkID))
+
+	g.emit(t.Add(span(g.shape, 60*time.Second, 300*time.Second)),
+		"octavia.loadbalancer.update.end", "", lb.id, tenant,
+		loadBalancerPayload(tenant, s, lb, true))
+}
+
+// tearDown deletes a shoot in the order Gardener does, which is the order its
+// resources depend on each other in: the services go first, address before
+// balancer, then the workers, then the claims they held. Nothing of the shoot
+// is emitted after the last of them.
+func (g *generator) tearDown(s *shoot) {
+	tenant := s.owner.tenant
+	t := s.deletedAt
+
+	for _, lb := range s.loadBalancers {
+		g.emit(t, "floatingip.delete.end", networkPublisher, lb.fip.id, tenant,
+			floatingIPDeletePayload(lb.fip))
+		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
+		g.emit(t, "octavia.loadbalancer.delete.end", "", lb.id, tenant,
+			loadBalancerPayload(tenant, s, lb, false))
+		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
+	}
+	for _, w := range slices.Clone(s.workers) {
+		g.deleteWorker(s, w, t)
+		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
+	}
+	for _, vol := range s.claims {
+		g.emit(t, "volume.delete.end", volumePublisher, vol.id, tenant,
+			volumeDeletePayload(tenant, vol, t))
+		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
+	}
+	s.claims = nil
+}

--- a/internal/providers/openstack/simulator/mapping_test.go
+++ b/internal/providers/openstack/simulator/mapping_test.go
@@ -82,12 +82,11 @@ func TestEveryRecordedNotificationTypeIsRendered(t *testing.T) {
 
 	// A recorded type the workload publishes on no exchange is one no seed can
 	// render: exchangeFor decides where a transition goes, and it names only the
-	// four services this package generates. Holding such a type against the seeds
-	// would fail the guard for work this package has not taken on. Octavia's load
-	// balancer notifications are the case: the collector maps them and the
-	// workload creates no load balancer, so nothing renders them until #65 gives
-	// it a shoot that does. Naming the exchange there re-arms the guard for them
-	// without an edit here.
+	// services this package generates. Holding such a type against the seeds
+	// would fail the guard for work this package has not taken on. Every type
+	// recorded today has an exchange, octavia's load balancer types among them,
+	// so the filter drops none of them. It stays for the next service the
+	// collector records before the workload renders it.
 	expected := recorded[:0:0]
 	for _, eventType := range recorded {
 		if exchangeFor(eventType) == "" {

--- a/internal/providers/openstack/simulator/profile.go
+++ b/internal/providers/openstack/simulator/profile.go
@@ -1,0 +1,179 @@
+package simulator
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// The working-week profile weighs the hours of the simulated period. The office
+// hours of a Monday to Friday carry ten times the weight of a night or a
+// weekend, and the two hours before and the four after them sit in between,
+// which is what a cloud that people work on looks like. Which days are working
+// days follows the real calendar of the period: July 2026 begins on a
+// Wednesday, and its first weekend is the fourth and the fifth.
+//
+// Every draw the profile makes is taken from the shape generator, so a profile
+// decides what happens and when and never which identifiers a month is built
+// from. Every instant it returns is a whole number of seconds, the way span
+// produces one, because the projection orders events by their timestamp and two
+// in the same second are two it cannot order.
+const (
+	officeWeight = 10
+	fringeWeight = 3
+	quietWeight  = 1
+
+	// The UTC hours the weights are cut at. Office hours run from officeFrom to
+	// officeTo, the fringe around them from fringeFrom to fringeTo, and what is
+	// left of the day is quiet.
+	officeFrom = 7
+	officeTo   = 19
+	fringeFrom = 5
+	fringeTo   = 23
+)
+
+// workingDay reports whether t falls on a Monday to Friday.
+func workingDay(t time.Time) bool {
+	weekday := t.UTC().Weekday()
+	return weekday != time.Saturday && weekday != time.Sunday
+}
+
+// hourWeight is how likely an instant in the hour t lies in is against one in
+// any other hour of the period. The weights are relative to each other, and the
+// quiet ones are never zero: a window that holds nothing but a weekend still
+// yields an instant.
+func hourWeight(t time.Time) int {
+	hour := t.UTC().Hour()
+	switch {
+	case !workingDay(t):
+		return quietWeight
+	case hour >= officeFrom && hour < officeTo:
+		return officeWeight
+	case hour >= fringeFrom && hour < fringeTo:
+		return fringeWeight
+	default:
+		return quietWeight
+	}
+}
+
+// slot is a piece of a window that lies inside one UTC clock hour, together
+// with the whole seconds it holds. hourWeight is constant over a slot, which is
+// what lets a window be weighed piece by piece.
+type slot struct {
+	start   time.Time
+	seconds int64
+}
+
+// slotsOf cuts [lo, hi) at every full UTC hour. The first piece runs from lo to
+// the next full hour and the last one ends at hi, so a window that starts or
+// ends mid-hour keeps the weight of the hours both of its ends lie in. A hi
+// that is not after lo is no range and is cut into nothing.
+func slotsOf(lo, hi time.Time) []slot {
+	var pieces []slot
+	for cursor := lo; cursor.Before(hi); {
+		end := cursor.Truncate(time.Hour).Add(time.Hour)
+		if end.After(hi) {
+			end = hi
+		}
+		pieces = append(pieces, slot{start: cursor, seconds: int64(end.Sub(cursor) / time.Second)})
+		cursor = end
+	}
+	return pieces
+}
+
+// pick draws one of the pieces, each as likely as the weight it carries against
+// the others, and returns it together with what is left of the draw inside it.
+// It reports false when the weights add up to nothing, which is a window the
+// caller has to answer for itself, and it costs no draw at all in that case.
+func pick(shape *rand.Rand, pieces []slot, weight func(slot) int64) (slot, int64, bool) {
+	var total int64
+	for _, piece := range pieces {
+		total += weight(piece)
+	}
+	if total == 0 {
+		return slot{}, 0, false
+	}
+
+	drawn := shape.Int64N(total)
+	for _, piece := range pieces {
+		share := weight(piece)
+		if drawn < share {
+			return piece, drawn, true
+		}
+		drawn -= share
+	}
+	// The draw is below the total the loop subtracts from, so one of the pieces
+	// above holds it and the loop returns before it runs out.
+	return slot{}, 0, false
+}
+
+// drawInstant draws one instant from [lo, hi) on the working-week profile: an
+// office hour of a working day is ten times as likely as a night hour, and the
+// seconds of one hour are equally likely among themselves. It is what a step
+// nobody waits for is placed by, such as a CI job a schedule starts or a
+// machine-driven step of a shoot.
+//
+// A window that holds no whole second is answered with lo and costs no draw at
+// all. A caller that hands one over therefore leaves the generators of the
+// month exactly where they were, and the transitions after it keep their
+// instants.
+func drawInstant(shape *rand.Rand, lo, hi time.Time) time.Time {
+	piece, _, ok := pick(shape, slotsOf(lo, hi), func(piece slot) int64 {
+		return int64(hourWeight(piece.start)) * piece.seconds
+	})
+	if !ok {
+		return lo
+	}
+	// The hours weigh against each other, so the second inside the drawn hour is
+	// a draw of its own.
+	return piece.start.Add(time.Duration(shape.Int64N(piece.seconds)) * time.Second)
+}
+
+// drawWorkingInstant draws one instant from the office hours of [lo, hi), each
+// of their seconds equally likely. It places what somebody triggers: a shoot is
+// created and a pipeline is started while its team is at work, whereas what
+// follows on its own runs at any hour.
+//
+// A window without a single office second falls back to drawInstant, because a
+// caller that has to place a step inside such a window needs an instant rather
+// than a refusal.
+func drawWorkingInstant(shape *rand.Rand, lo, hi time.Time) time.Time {
+	piece, second, ok := pick(shape, slotsOf(lo, hi), func(piece slot) int64 {
+		if hourWeight(piece.start) != officeWeight {
+			return 0
+		}
+		return piece.seconds
+	})
+	if !ok {
+		return drawInstant(shape, lo, hi)
+	}
+	// Every office second weighs the same, so the one draw picks the piece and
+	// the second inside it at once.
+	return piece.start.Add(time.Duration(second) * time.Second)
+}
+
+// workingDays returns the midnight of every Monday to Friday in [from, to), in
+// order. A workload that does something once a day walks them, and it skips the
+// weekends of the real calendar rather than every seventh day counted from the
+// first: July 2026 has 23 of them.
+//
+// A range that holds none is answered with an empty slice and never with nil,
+// so a caller ranges over the result without a check.
+func workingDays(from, to time.Time) []time.Time {
+	from = from.UTC()
+	cursor := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+
+	days := make([]time.Time, 0)
+	for ; cursor.Before(to); cursor = cursor.AddDate(0, 0, 1) {
+		if workingDay(cursor) {
+			days = append(days, cursor)
+		}
+	}
+	return days
+}
+
+// at is the instant a clock time falls on a day. The workloads state the steps
+// they anchor on an hour and a minute of a working day, and this puts them on
+// the UTC calendar the rest of the month is drawn on.
+func at(day time.Time, hour, minute int) time.Time {
+	return time.Date(day.Year(), day.Month(), day.Day(), hour, minute, 0, 0, time.UTC)
+}

--- a/internal/providers/openstack/simulator/profile_test.go
+++ b/internal/providers/openstack/simulator/profile_test.go
@@ -1,0 +1,211 @@
+package simulator
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+)
+
+// The two days of July 2026 the profile is held against. The eighth is a
+// Wednesday and the eleventh a Saturday, which the tests below check before
+// they read a weight off them: a profile that follows the real calendar is only
+// worth testing against days the calendar really has.
+var (
+	wednesday = time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+	saturday  = time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	// mondayOfWeek28 opens the one full Monday to Monday week the draws are
+	// counted over, so a distribution covers five working days and one weekend.
+	mondayOfWeek28 = time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
+)
+
+// profileShape is a shape generator for the profile tests. Pinning the stream
+// keeps a distribution that fails reproducible.
+func profileShape(seed uint64) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, shapeStream))
+}
+
+// requireWeekday fails the test when the day is not the one the case is written
+// for.
+func requireWeekday(t *testing.T, day time.Time, want time.Weekday) {
+	t.Helper()
+
+	if day.Weekday() != want {
+		t.Fatalf("%s is a %s, want a %s: the test days come from the real calendar",
+			day.Format(time.DateOnly), day.Weekday(), want)
+	}
+}
+
+func TestHourWeightFollowsTheWorkingWeek(t *testing.T) {
+	requireWeekday(t, wednesday, time.Wednesday)
+	requireWeekday(t, saturday, time.Saturday)
+
+	cases := []struct {
+		name    string
+		instant time.Time
+		want    int
+	}{
+		{"a working day at midday", at(wednesday, 10, 0), officeWeight},
+		{"the hour before a working day's office hours", at(wednesday, 6, 0), fringeWeight},
+		{"the evening of a working day", at(wednesday, 20, 0), fringeWeight},
+		{"the night of a working day", at(wednesday, 2, 0), quietWeight},
+		{"a Saturday at the same hour as the working week's peak", at(saturday, 10, 0), quietWeight},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hourWeight(c.instant); got != c.want {
+				t.Errorf("hourWeight(%s, a %s) = %d, want %d",
+					c.instant.Format(time.RFC3339), c.instant.Weekday(), got, c.want)
+			}
+		})
+	}
+}
+
+func TestDrawInstantStaysInsideTheWindowOnWholeSeconds(t *testing.T) {
+	shape := profileShape(3)
+	lo := at(wednesday, 16, 0)
+	hi := at(wednesday, 18, 30)
+
+	for i := range 1000 {
+		got := drawInstant(shape, lo, hi)
+
+		if got.Before(lo) || !got.Before(hi) {
+			t.Fatalf("draw %d = %s, want it inside [%s, %s): an instant outside the window is a "+
+				"notification outside the period it was drawn for", i, got, lo, hi)
+		}
+		if !got.Truncate(time.Second).Equal(got) {
+			t.Fatalf("draw %d = %s, want a whole second: the projection orders events by their "+
+				"timestamp, and the rest of the month is drawn on whole seconds", i, got)
+		}
+	}
+}
+
+func TestDrawInstantFavoursWorkingHours(t *testing.T) {
+	requireWeekday(t, mondayOfWeek28, time.Monday)
+
+	shape := profileShape(5)
+	lo := mondayOfWeek28
+	hi := lo.AddDate(0, 0, 7)
+
+	const draws = 10000
+	var office, quiet int
+	for range draws {
+		switch hourWeight(drawInstant(shape, lo, hi)) {
+		case officeWeight:
+			office++
+		case quietWeight:
+			quiet++
+		}
+	}
+
+	// Over a full week the office hours hold about 78 % of the weight and the
+	// nights and weekends about 10 %. A profile that had gone uniform would put
+	// 36 % on the office hours and 46 % on the quiet ones, so the bounds are wide
+	// enough for the draw to wander and still tell the two apart.
+	if office < 7000 {
+		t.Errorf("%d of %d draws landed on an office hour, want at least 7000: the workloads are "+
+			"placed on the working week, not spread over the month", office, draws)
+	}
+	if quiet > 1500 {
+		t.Errorf("%d of %d draws landed on a night or a weekend, want at most 1500: the working "+
+			"week is what makes a simulated month look like a worked one", quiet, draws)
+	}
+}
+
+func TestDrawInstantReturnsLoOnADegenerateWindow(t *testing.T) {
+	lo := at(wednesday, 9, 0)
+
+	cases := []struct {
+		name string
+		hi   time.Time
+	}{
+		{"a window of no length", lo},
+		{"a window that ends before it starts", lo.Add(-time.Hour)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := drawInstant(profileShape(7), lo, c.hi); !got.Equal(lo) {
+				t.Errorf("drawInstant(%s, %s) = %s, want %s: a window with nothing to draw from "+
+					"answers with its own start instead of panicking",
+					lo.Format(time.RFC3339), c.hi.Format(time.RFC3339), got, lo)
+			}
+		})
+	}
+
+	t.Run("it costs no draw", func(t *testing.T) {
+		used, untouched := profileShape(7), profileShape(7)
+		drawInstant(used, lo, lo)
+
+		if got, want := used.Uint64(), untouched.Uint64(); got != want {
+			t.Errorf("the generator that went through a degenerate window yields %d next, want %d: "+
+				"a draw spent here would move every transition after it", got, want)
+		}
+	})
+}
+
+func TestDrawWorkingInstantDrawsWorkingHoursOnly(t *testing.T) {
+	shape := profileShape(11)
+	lo := mondayOfWeek28
+	hi := lo.AddDate(0, 0, 7)
+
+	for i := range 1000 {
+		got := drawWorkingInstant(shape, lo, hi)
+
+		if got.Before(lo) || !got.Before(hi) {
+			t.Fatalf("draw %d = %s, want it inside [%s, %s)", i, got, lo, hi)
+		}
+		if hourWeight(got) != officeWeight {
+			t.Fatalf("draw %d = %s (a %s) has weight %d, want %d: what somebody triggers happens "+
+				"while that somebody is at work", i, got, got.Weekday(), hourWeight(got), officeWeight)
+		}
+	}
+
+	t.Run("a window without a working second falls back", func(t *testing.T) {
+		sunday := time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC)
+		requireWeekday(t, sunday, time.Sunday)
+		night, morning := at(sunday, 0, 0), at(sunday, 6, 0)
+
+		got := drawWorkingInstant(profileShape(13), night, morning)
+		if got.Before(night) || !got.Before(morning) {
+			t.Errorf("drawWorkingInstant over a Sunday night = %s, want an instant inside [%s, %s): "+
+				"a window holding no office hour is answered rather than refused", got, night, morning)
+		}
+	})
+}
+
+func TestWorkingDaysOfJuly2026(t *testing.T) {
+	days := workingDays(july2026, july2026.AddDate(0, 1, 0))
+
+	if len(days) != 23 {
+		t.Fatalf("workingDays(July 2026) returned %d days, want the 23 the calendar has: a workload "+
+			"that runs once a working day runs that often", len(days))
+	}
+	if want := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC); !days[0].Equal(want) {
+		t.Errorf("the first working day is %s, want %s, the Wednesday July 2026 opens on",
+			days[0], want)
+	}
+	if want := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC); !days[len(days)-1].Equal(want) {
+		t.Errorf("the last working day is %s, want %s, the Friday July 2026 ends on",
+			days[len(days)-1], want)
+	}
+	for _, midnight := range days {
+		if !workingDay(midnight) {
+			t.Errorf("%s is a %s, want no weekend among the working days",
+				midnight.Format(time.DateOnly), midnight.Weekday())
+		}
+		if !midnight.Equal(at(midnight, 0, 0)) {
+			t.Errorf("the working day %s is not at midnight UTC, want the day itself so that a "+
+				"caller places its own hours on it", midnight)
+		}
+	}
+
+	empty := workingDays(july2026, july2026)
+	if empty == nil {
+		t.Fatal("workingDays over an empty range returned nil, want an empty slice a caller ranges " +
+			"over without a check")
+	}
+	if len(empty) != 0 {
+		t.Errorf("workingDays over an empty range returned %d days, want none", len(empty))
+	}
+}

--- a/internal/providers/openstack/simulator/publish.go
+++ b/internal/providers/openstack/simulator/publish.go
@@ -16,11 +16,13 @@ import (
 // package from exporting anything for the sake of a simulator.
 const collectorQueue = "tally-notifications"
 
-// serviceExchanges are the exchanges a stock deployment publishes
-// notifications on, one per service. They are also the default of the
-// collector's TALLY_OSC_EXCHANGES, so a simulator and a collector that were
-// both left at their defaults meet on all four.
-var serviceExchanges = []string{"nova", "cinder", "neutron", "glance"}
+// ServiceExchanges are the exchanges the simulator publishes notifications on,
+// one per service, and the ones Connect declares. The collector's default
+// TALLY_OSC_EXCHANGES lists the first four, and a deployment that runs octavia
+// lists the fifth itself (docs/openstack-collector.md, "Exchanges and topics"),
+// so a collector left at its default receives the month without its load
+// balancers.
+var ServiceExchanges = []string{"nova", "cinder", "neutron", "glance", "octavia"}
 
 // probeInterval is how long AwaitConsumer waits between two looks at the
 // collector's queue. It is short enough that a collector started a moment later
@@ -108,7 +110,7 @@ func Connect(url string) (*Publisher, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("enabling publisher confirms: %w", err)
 	}
-	for _, exchange := range serviceExchanges {
+	for _, exchange := range ServiceExchanges {
 		if err := channel.ExchangeDeclare(exchange, "topic",
 			true, false, false, false, nil); err != nil {
 			_ = conn.Close()

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -100,15 +100,21 @@ func connect(t *testing.T, url string) *Publisher {
 	return publisher
 }
 
-// startCollector runs the collector's own consumer against the broker, into an
-// outbox and a registry of its own, until the test ends. It is the collector as
-// the pipeline runs it: the same consumer, the same buffer, and the same
-// counters, so what a test asserts is what a deployment would see.
+// defaultCollectorExchanges are the exchanges a collector binds when nothing
+// sets TALLY_OSC_EXCHANGES: the default of the variable in
+// internal/providers/openstack/config.go.
+var defaultCollectorExchanges = []string{"nova", "neutron", "cinder", "glance"}
+
+// startCollector runs the collector's own consumer against the broker, bound to
+// the exchanges it is given, into an outbox and a registry of its own, until
+// the test ends. It is the collector as the pipeline runs it: the same
+// consumer, the same buffer, and the same counters, so what a test asserts is
+// what a deployment would see.
 //
 // The returned stop waits for the consumer's loop to return before it closes the
 // outbox, so nothing the collector logs outlives the test and nothing touches a
 // closed handle.
-func startCollector(t *testing.T, url string) (*openstack.Outbox, *prometheus.Registry, func()) {
+func startCollector(t *testing.T, url string, exchanges []string) (*openstack.Outbox, *prometheus.Registry, func()) {
 	t.Helper()
 
 	outbox, err := openstack.OpenOutbox(filepath.Join(t.TempDir(), "outbox.db"))
@@ -122,7 +128,7 @@ func startCollector(t *testing.T, url string) (*openstack.Outbox, *prometheus.Re
 		outbox.OldestBufferedSeconds)
 	consumer := openstack.NewConsumer(openstack.Config{
 		AMQPURL:         url,
-		Exchanges:       collectorExchanges,
+		Exchanges:       exchanges,
 		Topics:          []string{collectorTopic},
 		Cloud:           testCloud,
 		Prefetch:        10,
@@ -283,7 +289,7 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 	// passive ones find: a consumer started against a fresh broker reconnects
 	// until the exchanges exist.
 	publisher := connect(t, url)
-	outbox, reg, _ := startCollector(t, url)
+	outbox, reg, _ := startCollector(t, url, ServiceExchanges)
 
 	out := t.TempDir()
 	err := Run(t.Context(), Config{Cloud: testCloud, HTTPPort: 0}, RunOptions{
@@ -310,15 +316,81 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 		t.Errorf("the event ids in events.jsonl = %v, want %v", got, want)
 	}
 
-	// The month carries one image.create per image, six in all, and the mapping
-	// skips every one of them because an announced image has no size yet. Nothing
-	// else in the month may go unrecorded: a notification the collector cannot
-	// parse is one the simulator rendered wrong.
-	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 6 {
-		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 6", got)
+	// The month carries one image.create per image, eight in all: two for each of
+	// the three classic projects and one for each of the two Gardener tenants.
+	// The mapping skips every one of them because an announced image has no size
+	// yet. Nothing else in the month may go unrecorded: a notification the
+	// collector cannot parse is one the simulator rendered wrong.
+	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 8 {
+		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 8", got)
 	}
 	if got := counterValue(t, reg, "tally_collector_unparseable_total", "", ""); got != 0 {
 		t.Errorf("tally_collector_unparseable_total = %v, want 0", got)
+	}
+}
+
+// TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers is what a
+// deployment that runs octavia and left TALLY_OSC_EXCHANGES alone gets. A topic
+// exchange copies a message only to the queues bound to it, so the octavia
+// notifications of the month reach a collector bound to the other four
+// exchanges neither as an event nor as a skip: they are dropped at the broker,
+// and nothing in the collector counts them.
+func TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers(t *testing.T) {
+	url, _ := startBroker(t)
+	// The publisher declares all five, so the octavia exchange exists and takes
+	// its messages whether a queue is bound to it or not.
+	publisher := connect(t, url)
+	outbox, reg, _ := startCollector(t, url, defaultCollectorExchanges)
+
+	err := Run(t.Context(), Config{Cloud: testCloud, HTTPPort: 0}, RunOptions{
+		Period:           "2026-07",
+		Seed:             1,
+		Factor:           0,
+		Out:              t.TempDir(),
+		WaitForCollector: pollDeadline,
+	}, publisher, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	billable := generateMonth(t, 1, july2026, testCloud).Billable()
+	want := make([]string, 0, len(billable))
+	for _, transition := range billable {
+		if transition.Exchange != "octavia" {
+			want = append(want, transition.MessageID)
+		}
+	}
+	slices.Sort(want)
+	if len(want) == len(billable) {
+		t.Fatalf("the month carries no billable notification on the octavia exchange, want the load " +
+			"balancers of the shoots: a month without one holds nothing back from this collector")
+	}
+
+	waitFor(t, "every notification off the four default exchanges is buffered", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
+		t.Errorf("buffered event ids = %v, want %v", got, want)
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v, want nil", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "tally_collector_skipped_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() != "event_type" || !strings.HasPrefix(label.GetValue(), "octavia.") {
+					continue
+				}
+				t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want the type in no counter "+
+					"at all: a message the broker drops is one the collector never sees",
+					label.GetValue(), metric.GetCounter().GetValue())
+			}
+		}
 	}
 }
 
@@ -340,7 +412,7 @@ func TestReplayPublishesACapturedMonth(t *testing.T) {
 
 	url, _ := startBroker(t)
 	publisher := connect(t, url)
-	outbox, _, _ := startCollector(t, url)
+	outbox, _, _ := startCollector(t, url, ServiceExchanges)
 
 	replayErr := Replay(t.Context(), Config{HTTPPort: 0}, ReplayOptions{
 		In:               filepath.Join(out, "notifications.jsonl"),
@@ -422,7 +494,7 @@ func TestRunWaitsForTheCollector(t *testing.T) {
 
 		// And it published nothing while it waited: a collector started now binds
 		// its queue and finds it empty, however long it looks.
-		outbox, _, _ := startCollector(t, url)
+		outbox, _, _ := startCollector(t, url, ServiceExchanges)
 		for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
 			if depth := outbox.Depth(); depth != 0 {
 				t.Fatalf("Depth() = %d, want 0: the refused run published anyway", depth)

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -316,13 +316,14 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 		t.Errorf("the event ids in events.jsonl = %v, want %v", got, want)
 	}
 
-	// The month carries one image.create per image, eight in all: two for each of
-	// the three classic projects and one for each of the two Gardener tenants.
-	// The mapping skips every one of them because an announced image has no size
-	// yet. Nothing else in the month may go unrecorded: a notification the
-	// collector cannot parse is one the simulator rendered wrong.
-	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 8 {
-		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 8", got)
+	// The month carries one image.create per image, nine in all: two for each of
+	// the three classic projects, one for each of the two Gardener tenants, and
+	// one for the CI tenant. The mapping skips every one of them because an
+	// announced image has no size yet. Nothing else in the month may go
+	// unrecorded: a notification the collector cannot parse is one the simulator
+	// rendered wrong.
+	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 9 {
+		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 9", got)
 	}
 	if got := counterValue(t, reg, "tally_collector_unparseable_total", "", ""); got != 0 {
 		t.Errorf("tally_collector_unparseable_total = %v, want 0", got)

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -48,10 +48,17 @@ func stamp(t time.Time) string {
 // point: the collector decodes the body twice, so a simulator that nested the
 // notification would produce something only the simulator could read.
 func Render(t Transition) ([]byte, error) {
+	// octavia publishes a null publisher, the way the recorded samples carry it.
+	// Every other service names the instance the notification came from.
+	var publisher any
+	if t.PublisherID != "" {
+		publisher = t.PublisherID
+	}
+
 	inner, err := json.Marshal(map[string]any{
 		"message_id":   t.MessageID,
 		"event_type":   t.EventType,
-		"publisher_id": t.PublisherID,
+		"publisher_id": publisher,
 		"priority":     "INFO",
 		"timestamp":    stamp(t.At),
 		// Services differ in which of the two they set. Setting both is what a
@@ -80,6 +87,13 @@ func Render(t Transition) ([]byte, error) {
 // image the server was booted from, none of which the later notifications
 // repeat in full.
 func instanceCreatePayload(p *project, inst *instance, cloud string) map[string]any {
+	// A server booted from a volume names no image, because the image was
+	// written to the volume before the server existed.
+	imageURL := ""
+	if inst.bootVolume == nil {
+		imageURL = fmt.Sprintf("http://glance.%s.example:9292/images/%s", cloud, inst.imageID)
+	}
+
 	return map[string]any{
 		"instance_id":        inst.id,
 		"tenant_id":          p.id,
@@ -97,7 +111,7 @@ func instanceCreatePayload(p *project, inst *instance, cloud string) map[string]
 		"instance_flavor_id": inst.flavor.flavorID,
 		"host":               inst.host,
 		"availability_zone":  availabilityZone,
-		"image_ref_url":      fmt.Sprintf("http://glance.%s.example:9292/images/%s", cloud, inst.imageID),
+		"image_ref_url":      imageURL,
 		"created_at":         stamp(inst.createdAt.Add(-instanceBoot)),
 		"launched_at":        stamp(inst.createdAt),
 	}
@@ -193,6 +207,16 @@ func instanceShelvePayload(p *project, inst *instance, state string) map[string]
 // newer project_id, which is why the mapping reads the address through a path
 // instead of a member name.
 func floatingIPCreatePayload(p *project, fip *floatingIP, networkID string) map[string]any {
+	// An address is allocated before it is associated with a port, so it points
+	// at nothing yet and is down. The VIP port of a load balancer is the
+	// exception: that address is associated the moment it is created.
+	var fixedAddress, portID, routerID any
+	status := "DOWN"
+	if fip.portID != "" {
+		fixedAddress, portID, routerID = fip.fixedAddress, fip.portID, fip.routerID
+		status = "ACTIVE"
+	}
+
 	return map[string]any{
 		"floatingip": map[string]any{
 			"id":                  fip.id,
@@ -200,13 +224,11 @@ func floatingIPCreatePayload(p *project, fip *floatingIP, networkID string) map[
 			"project_id":          p.id,
 			"floating_ip_address": fip.address,
 			"floating_network_id": networkID,
-			// An address is allocated before it is associated with a port, so it
-			// points at nothing yet and is down.
-			"fixed_ip_address": nil,
-			"port_id":          nil,
-			"router_id":        nil,
-			"status":           "DOWN",
-			"description":      "",
+			"fixed_ip_address":    fixedAddress,
+			"port_id":             portID,
+			"router_id":           routerID,
+			"status":              status,
+			"description":         "",
 		},
 	}
 }
@@ -335,4 +357,88 @@ func volumeStatePayload(p *project, vol *volume) map[string]any {
 		"host":         volumeHost,
 		"created_at":   stamp(vol.createdAt.Add(-volumeProvision)),
 	}
+}
+
+// listenerSpecs are the listeners a load balancer gets, in the order a shoot
+// adds them. A service publishes one port after another, so a balancer that
+// carries two listeners carries the first two of these.
+var listenerSpecs = []struct {
+	name     string
+	protocol string
+	port     int
+}{
+	{name: "http", protocol: "HTTP", port: 80},
+	{name: "https", protocol: "TERMINATED_HTTPS", port: 443},
+	{name: "metrics", protocol: "TCP", port: 9100},
+}
+
+// loadBalancerPayload describes one octavia load balancer. Octavia reports the
+// listeners and the pools on an update alone, which is why the collector books
+// a balancer's size from the update: the create carries a size of zero
+// listeners and zero pools, and the delete carries neither member at all.
+func loadBalancerPayload(p *project, s *shoot, lb *loadBalancer, withMembers bool) map[string]any {
+	payload := map[string]any{
+		"admin_state_up":    true,
+		"description":       "",
+		"loadbalancer_id":   lb.id,
+		"name":              lb.name,
+		"project_id":        p.id,
+		"vip_address":       lb.vipAddress,
+		"vip_network_id":    s.networkID,
+		"vip_port_id":       lb.vipPortID,
+		"vip_qos_policy_id": nil,
+		"vip_subnet_id":     s.subnetID,
+		"vip_sg_ids":        []any{},
+		"additional_vips":   []any{},
+	}
+	if !withMembers {
+		return payload
+	}
+
+	// Both members are slices even when they hold nothing, because the mapping
+	// counts the array and a null is not one it can count.
+	listeners := make([]any, 0, len(lb.listenerIDs))
+	for index, id := range lb.listenerIDs {
+		// A balancer that carries more listeners than the catalog names takes the
+		// catalog from the front again. The mapping books the count and nothing
+		// else of a listener, so a repeated name and port cost the month nothing,
+		// where reaching past the catalog would end the run in this renderer with
+		// the balancer that outgrew it named nowhere.
+		spec := listenerSpecs[index%len(listenerSpecs)]
+		// A listener points at the pool behind it, and a balancer with fewer
+		// pools than listeners has them share one. One with no pool at all points
+		// its listeners at nothing, the way octavia reports a listener whose
+		// default pool was never created, rather than ending the run here.
+		var poolID any
+		if len(lb.poolIDs) > 0 {
+			poolID = lb.poolIDs[index%len(lb.poolIDs)]
+		}
+		listeners = append(listeners, map[string]any{
+			"admin_state_up":  true,
+			"default_pool_id": poolID,
+			"listener_id":     id,
+			"loadbalancer_id": lb.id,
+			"name":            spec.name,
+			"project_id":      p.id,
+			"protocol":        spec.protocol,
+			"protocol_port":   spec.port,
+		})
+	}
+
+	pools := make([]any, 0, len(lb.poolIDs))
+	for index, id := range lb.poolIDs {
+		pools = append(pools, map[string]any{
+			"admin_state_up":  true,
+			"lb_algorithm":    "ROUND_ROBIN",
+			"loadbalancer_id": lb.id,
+			"name":            fmt.Sprintf("pool-%d", index),
+			"pool_id":         id,
+			"project_id":      p.id,
+			"protocol":        "HTTP",
+		})
+	}
+
+	payload["listeners"] = listeners
+	payload["pools"] = pools
+	return payload
 }

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -1,6 +1,8 @@
 package simulator
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -128,6 +130,160 @@ func TestRenderedPayloadsCarryTheRecordedMembers(t *testing.T) {
 			t.Errorf("%s payload members = %v, want %v (rendered and not recorded: %v; recorded and not rendered: %v)",
 				transition.EventType, got, want, missingFrom(want, got), missingFrom(got, want))
 		}
+	}
+}
+
+func TestRenderWritesANullPublisherForAnEmptyPublisherID(t *testing.T) {
+	// The publisher is read as text and not through a decoder: a JSON null and
+	// an empty JSON string both arrive as the empty Go string, so the bytes on
+	// the wire are the only place the two are told apart.
+	message := func(t *testing.T, transition Transition) string {
+		t.Helper()
+
+		var envelope map[string]string
+		if err := json.Unmarshal(render(t, transition), &envelope); err != nil {
+			t.Fatalf("unmarshalling the rendered envelope: %v", err)
+		}
+		return envelope["oslo.message"]
+	}
+
+	t.Run("octavia publishes without one", func(t *testing.T) {
+		got := message(t, Transition{
+			EventType: "octavia.loadbalancer.create.end",
+			Payload:   map[string]any{"loadbalancer_id": "5e6f7081-92a3-4b4c-8d5e-6f708192a3b4"},
+		})
+
+		const want = `"publisher_id":null`
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered notification = %s, want it to carry %s", got, want)
+		}
+	})
+
+	t.Run("every other service names its instance", func(t *testing.T) {
+		got := message(t, Transition{
+			EventType:   "compute.instance.create.end",
+			PublisherID: "compute.compute-01",
+			Payload:     map[string]any{"instance_id": "8f7e6d5c-4b3a-4291-8071-6f5e4d3c2b1a"},
+		})
+
+		const want = `"publisher_id":"compute.compute-01"`
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered notification = %s, want it to carry %s", got, want)
+		}
+	})
+}
+
+// TestFloatingIPCreateReportsWhatTheAddressPointsAt covers the one branch of a
+// floating IP payload: an address a tenant allocates points at nothing and is
+// down, while the address of a load balancer's VIP port is associated the
+// moment it exists. Both sides carry the same members, so their values are the
+// only place the two are told apart.
+func TestFloatingIPCreateReportsWhatTheAddressPointsAt(t *testing.T) {
+	p := &project{id: "4f6b8d0a2c1e3f5a7b9c0d2e4f6a8b0c"}
+	tests := []struct {
+		name string
+		fip  *floatingIP
+		want map[string]any
+	}{
+		{
+			name: "an address a tenant allocates points at nothing",
+			fip:  &floatingIP{id: "1a2b3c4d-5e6f-4071-8293-a4b5c6d7e8f9", address: "203.0.113.7"},
+			want: map[string]any{
+				"status":           "DOWN",
+				"port_id":          nil,
+				"router_id":        nil,
+				"fixed_ip_address": nil,
+			},
+		},
+		{
+			name: "the address of a VIP port is associated at once",
+			fip: &floatingIP{
+				id:           "2b3c4d5e-6f70-4182-93a4-b5c6d7e8f9a0",
+				address:      "203.0.113.8",
+				portID:       "3c4d5e6f-7081-4293-a4b5-c6d7e8f9a0b1",
+				fixedAddress: "10.250.1.10",
+				routerID:     "4d5e6f70-8192-43a4-b5c6-d7e8f9a0b1c2",
+			},
+			want: map[string]any{
+				"status":           "ACTIVE",
+				"port_id":          "3c4d5e6f-7081-4293-a4b5-c6d7e8f9a0b1",
+				"router_id":        "4d5e6f70-8192-43a4-b5c6-d7e8f9a0b1c2",
+				"fixed_ip_address": "10.250.1.10",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			notification := parse(t, render(t, Transition{
+				EventType: "floatingip.create.end",
+				Payload:   floatingIPCreatePayload(p, test.fip, "5e6f7081-92a3-44b5-c6d7-e8f9a0b1c2d3"),
+			}))
+
+			address, ok := notification.Payload["floatingip"].(map[string]any)
+			if !ok {
+				t.Fatalf("the payload carries %v under floatingip, want the address neutron nests there",
+					notification.Payload["floatingip"])
+			}
+			for member, want := range test.want {
+				if got := address[member]; got != want {
+					t.Errorf("floatingip.%s = %v, want %v: an address that is associated reports its "+
+						"port, the address behind it, and its router, and one that is not reports none "+
+						"of the three", member, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadBalancerPayloadDescribesEveryListener covers a balancer that carries
+// more listeners than the catalog names. The catalog is read from the front
+// again rather than past its end, because a shoot that publishes another port
+// is a change in gardener.go and the renderer is where it would otherwise end
+// the run.
+func TestLoadBalancerPayloadDescribesEveryListener(t *testing.T) {
+	lb := &loadBalancer{
+		id:        "6f708192-a3b4-45c6-d7e8-f9a0b1c2d3e4",
+		name:      "kube_service_shoot--alpha--api-prod_ingress_nginx-ingress-controller",
+		vipPortID: "708192a3-b4c5-46d7-e8f9-a0b1c2d3e4f5",
+		poolIDs:   []string{"8192a3b4-c5d6-47e8-f9a0-b1c2d3e4f506"},
+	}
+	for index := range len(listenerSpecs) + 1 {
+		lb.listenerIDs = append(lb.listenerIDs, fmt.Sprintf("92a3b4c5-d6e7-48f9-a0b1-c2d3e4f5061%d", index))
+	}
+
+	payload := loadBalancerPayload(&project{id: "5a7c9e1b3d5f7091a2b4c6d8e0f2a4b6"}, &shoot{}, lb, true)
+
+	listeners, _ := payload["listeners"].([]any)
+	if len(listeners) != len(lb.listenerIDs) {
+		t.Fatalf("the update of a balancer with %d listeners describes %d of them, want all of them: "+
+			"the mapping books the count the array carries", len(lb.listenerIDs), len(listeners))
+	}
+}
+
+// TestLoadBalancerPayloadWithoutAPool covers a balancer that carries a listener
+// and no pool, the way a headless or UDP-only service publishes one. The
+// listener points at nothing rather than at a pool the balancer never had, and
+// the renderer does not end the run over it.
+func TestLoadBalancerPayloadWithoutAPool(t *testing.T) {
+	lb := &loadBalancer{
+		id:          "6f708192-a3b4-45c6-d7e8-f9a0b1c2d3e4",
+		name:        "kube_service_shoot--alpha--api-prod_default_api",
+		vipPortID:   "708192a3-b4c5-46d7-e8f9-a0b1c2d3e4f5",
+		listenerIDs: []string{"92a3b4c5-d6e7-48f9-a0b1-c2d3e4f50610"},
+	}
+
+	payload := loadBalancerPayload(&project{id: "5a7c9e1b3d5f7091a2b4c6d8e0f2a4b6"}, &shoot{}, lb, true)
+
+	listeners, _ := payload["listeners"].([]any)
+	if len(listeners) != 1 {
+		t.Fatalf("the update of a balancer with one listener describes %d of them, want one: "+
+			"the mapping books the count the array carries", len(listeners))
+	}
+	listener, _ := listeners[0].(map[string]any)
+	if got := listener["default_pool_id"]; got != nil {
+		t.Errorf("listener.default_pool_id = %v, want nil: a balancer with no pool has no pool "+
+			"to point its listener at", got)
 	}
 }
 

--- a/internal/providers/openstack/simulator/stream.go
+++ b/internal/providers/openstack/simulator/stream.go
@@ -17,7 +17,7 @@ import (
 // would publish a month no collector receives.
 type Line struct {
 	// Exchange is the service exchange the notification belongs on, one of nova,
-	// cinder, neutron, and glance.
+	// cinder, neutron, glance, and octavia.
 	Exchange string `json:"exchange"`
 	// RoutingKey is the topic the notification was published under.
 	RoutingKey string `json:"routing_key"`

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -35,6 +35,11 @@ type Transition struct {
 	// notification. It is false only for the image.create that precedes an
 	// upload: that one carries no size yet, and the mapping skips it on purpose.
 	Billable bool
+	// Workload names which of the three workloads emitted the transition, one of
+	// the workload constants. Nothing on the wire carries it: it is what a test
+	// and the later reconciliation oracle tell the workloads of one month apart
+	// by, since the tenants of a month are otherwise ids alone.
+	Workload string
 	// MessageID is the oslo message id, which the Reporting API deduplicates on.
 	// It is drawn after the month is sorted, so the ids run in the order the
 	// notifications are published.
@@ -82,6 +87,15 @@ const routingKey = "notifications.info"
 // notification has no size to bill, and the upload that follows is what the
 // image is booked from.
 const imageCreateType = "image.create"
+
+// The workloads a month is made of. The classic tenants are the ones a person
+// works in, a Gardener project's shoots are driven by their machine controller,
+// and the CI tenant is driven by its pipelines.
+const (
+	workloadClassic  = "classic"
+	workloadGardener = "gardener"
+	workloadCI       = "ci"
+)
 
 // exchangeFor names the exchange a type is published on. The four are the
 // service exchanges of nova, cinder, neutron, and glance. A type outside them
@@ -223,9 +237,13 @@ func (r idReader) nextHexID() string {
 // they populated, and the transitions so far.
 type generator struct {
 	shape *rand.Rand
-	from  time.Time
-	to    time.Time
-	cloud string
+	// identifiers is the month's identifier stream, kept past the fixed draws
+	// because the resources a month churns are named when they are created: how
+	// many workers or runners a month makes follows from its calendar.
+	identifiers idReader
+	from        time.Time
+	to          time.Time
+	cloud       string
 
 	// networkID is the external network the month's addresses come from. There
 	// is one per month, the way a deployment has one.
@@ -236,7 +254,14 @@ type generator struct {
 	addresses []int
 	assigned  int
 
-	projects []*project
+	projects         []*project
+	gardenerProjects []*gardenerProject
+	ciTenant         *project
+
+	// workload is the one emit tags its transitions with. run sets it before
+	// each block of the month, so a transition carries the workload that was
+	// running when it was generated.
+	workload string
 	schedule Schedule
 }
 
@@ -245,7 +270,7 @@ type generator struct {
 // finished before the first transition is generated, which is what keeps the
 // number of identifiers a function of the shape alone.
 func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cloud string) *generator {
-	g := &generator{shape: shape, from: from, to: to, cloud: cloud}
+	g := &generator{shape: shape, identifiers: identifiers, from: from, to: to, cloud: cloud}
 
 	g.networkID = identifiers.nextUUID()
 	g.addresses = identifiers.src.Perm(addressPoolSize)
@@ -291,6 +316,7 @@ func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cl
 // and addresses follow the instances they belong to, and the tear-down comes
 // last.
 func (g *generator) run() {
+	g.workload = workloadClassic
 	for index, p := range g.projects {
 		g.images(p)
 		g.instances(p)
@@ -312,6 +338,7 @@ func (g *generator) emit(at time.Time, eventType, publisherID, resourceID string
 		EventType:   eventType,
 		Exchange:    exchangeFor(eventType),
 		Billable:    eventType != imageCreateType,
+		Workload:    g.workload,
 		PublisherID: publisherID,
 		ProjectID:   requester.id,
 		UserID:      requester.userID,

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -29,7 +29,9 @@ type Transition struct {
 	// "compute.instance.create.end".
 	EventType string
 	// Exchange is the notification exchange the type belongs on. A deployment
-	// gives each service its own, and the collector binds its queue to all four.
+	// gives each service its own. The collector's default binds nova, neutron,
+	// cinder, and glance, and a deployment running octavia lists the fifth
+	// itself.
 	Exchange string
 	// Billable reports whether the collector's mapping records an event for this
 	// notification. It is false only for the image.create that precedes an
@@ -97,11 +99,11 @@ const (
 	workloadCI       = "ci"
 )
 
-// exchangeFor names the exchange a type is published on. The four are the
-// service exchanges of nova, cinder, neutron, and glance. A type outside them
-// is one this package does not generate, and it is reported as the empty
-// exchange rather than guessed at, because a wrong exchange is a notification
-// no bound queue receives.
+// exchangeFor names the exchange a type is published on. The five are the
+// service exchanges of nova, cinder, neutron, glance, and octavia. A type
+// outside them is one this package does not generate, and it is reported as the
+// empty exchange rather than guessed at, because a wrong exchange is a
+// notification no bound queue receives.
 func exchangeFor(eventType string) string {
 	switch {
 	case strings.HasPrefix(eventType, "compute."):
@@ -112,6 +114,8 @@ func exchangeFor(eventType string) string {
 		return "neutron"
 	case strings.HasPrefix(eventType, "image."):
 		return "glance"
+	case strings.HasPrefix(eventType, "octavia."):
+		return "octavia"
 	default:
 		return ""
 	}
@@ -159,10 +163,14 @@ const shapeStream = 1
 // while the same triple republishes the very notifications ingestion has
 // already deduplicated.
 //
-// Splitting them is what makes both properties hold at once. Identifiers are
-// drawn in a fixed order before the first transition is generated, so how many
-// of them a month costs depends on the shape and never on the salt, and a month
-// keeps its shape when the cloud changes.
+// Splitting them is what makes both properties hold at once, and the rule that
+// keeps them apart runs in both directions: an identifier comes from the
+// identifier stream and never from the shape stream, and what happens, when,
+// and therefore how many identifiers a month draws comes from the shape stream
+// and the period's calendar and never from the value of an identifier. The same
+// seed, period, and cloud draw the same identifiers in the same order, and
+// another cloud or another month renames everything while the shape stays the
+// shape stream's.
 func Generate(seed uint64, from, to time.Time, cloud string) (Schedule, error) {
 	// A caller that reached here without going through period.Parse is caught
 	// before it produces a month that no billing period covers.
@@ -265,10 +273,18 @@ type generator struct {
 	schedule Schedule
 }
 
-// newGenerator draws every identifier of the month and returns the generator
-// that walks the world they name. The order of the draws is fixed here and
-// finished before the first transition is generated, which is what keeps the
-// number of identifiers a function of the shape alone.
+// newGenerator draws the identifiers of the world a month starts from and
+// returns the generator that walks it. The fixed resources are the ones that
+// exist before the first transition: the tenants, their users and images, the
+// classic tenants' servers, volumes and addresses, and the network, subnet,
+// router, and security group of a shoot. They are drawn here, in this order.
+//
+// What a month churns is drawn from the same stream at the moment the generator
+// creates the resource: the workers of a shoot and their root volumes, the
+// workers a rolling update puts in their place, the claims, the load balancers
+// with their VIP ports, listeners, pools, and addresses, and the CI runners.
+// How many of them a month makes follows from its calendar, so drawing them
+// here would mean counting the month's days twice.
 func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cloud string) *generator {
 	g := &generator{shape: shape, identifiers: identifiers, from: from, to: to, cloud: cloud}
 
@@ -308,13 +324,38 @@ func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cl
 			name: fmt.Sprintf("handover-%02d", index+1),
 		}
 	}
+
+	shoots := 0
+	for _, gp := range newGardenerProjects() {
+		gp.tenant = &project{id: identifiers.nextHexID()}
+		gp.tenant.userID = identifiers.nextHexID()
+		gp.tenant.images = []*image{{id: identifiers.nextUUID(), name: gardenerImageName}}
+		for _, s := range gp.shoots {
+			s.owner = gp
+			// The technical id is what Gardener names a shoot's OpenStack
+			// resources after, and every name of the shoot is built from it.
+			s.technicalID = "shoot--" + gp.name + "--" + s.name
+			s.keypairName = s.technicalID + "-ssh-publickey"
+			shoots++
+			s.index = shoots
+			s.awake = true
+			s.networkID = identifiers.nextUUID()
+			s.subnetID = identifiers.nextUUID()
+			s.routerID = identifiers.nextUUID()
+			s.securityGroupID = identifiers.nextUUID()
+		}
+		g.gardenerProjects = append(g.gardenerProjects, gp)
+	}
 	return g
 }
 
-// run generates every project's month. The phases are ordered the way a tenant
+// run generates the month of every workload, one block after another, and tags
+// what each block emits with the workload it came from.
+//
+// The classic tenants come first. Their phases are ordered the way a tenant
 // works: the images come first because an instance boots from one, the volumes
 // and addresses follow the instances they belong to, and the tear-down comes
-// last.
+// last. The Gardener projects follow, each shoot walking its own days.
 func (g *generator) run() {
 	g.workload = workloadClassic
 	for index, p := range g.projects {
@@ -324,6 +365,11 @@ func (g *generator) run() {
 		g.floatingIPs(p)
 		g.deleteFirstInstance(p)
 		g.spareVolume(p, g.projects[(index+1)%len(g.projects)])
+	}
+
+	g.workload = workloadGardener
+	for _, gp := range g.gardenerProjects {
+		g.gardener(gp)
 	}
 }
 

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -346,6 +346,10 @@ func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cl
 		}
 		g.gardenerProjects = append(g.gardenerProjects, gp)
 	}
+
+	g.ciTenant = &project{id: identifiers.nextHexID()}
+	g.ciTenant.userID = identifiers.nextHexID()
+	g.ciTenant.images = []*image{{id: identifiers.nextUUID(), name: ciImageName}}
 	return g
 }
 
@@ -355,7 +359,9 @@ func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cl
 // The classic tenants come first. Their phases are ordered the way a tenant
 // works: the images come first because an instance boots from one, the volumes
 // and addresses follow the instances they belong to, and the tear-down comes
-// last. The Gardener projects follow, each shoot walking its own days.
+// last. The Gardener projects follow, each shoot walking its own days, and the
+// CI tenant comes last, bursting its runners through the working days of the
+// month.
 func (g *generator) run() {
 	g.workload = workloadClassic
 	for index, p := range g.projects {
@@ -371,6 +377,9 @@ func (g *generator) run() {
 	for _, gp := range g.gardenerProjects {
 		g.gardener(gp)
 	}
+
+	g.workload = workloadCI
+	g.ci()
 }
 
 // emit records one transition. The project is the one the request ran in, which

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -255,7 +255,7 @@ func TestGenerateSaltsIdentifiersWithPeriodAndCloud(t *testing.T) {
 		}
 
 		// A month that moved its machine-driven workloads still holds them.
-		for _, workload := range []string{workloadGardener} {
+		for _, workload := range []string{workloadGardener, workloadCI} {
 			for name, schedule := range map[string]Schedule{"July": july, "May": may} {
 				if len(ofWorkload(schedule, workload)) == 0 {
 					t.Errorf("%s holds no %s transition, want every workload in every month",
@@ -754,4 +754,56 @@ func TestLoadBalancersAreBookedFromTheirUpdate(t *testing.T) {
 				lb.name, grown["pools"], attached["pools"])
 		}
 	})
+}
+
+// TestCIRunnersBurstInWorkingHours covers when the CI tenant's runners exist
+// and how long each of them lives. A runner holds one job, so a month of them
+// is churn the other two workloads do not produce: hundreds of servers that are
+// created and closed inside the period rather than carried over it.
+func TestCIRunnersBurstInWorkingHours(t *testing.T) {
+	schedule := ofWorkload(generateMonth(t, 1, july2026, testCloud), workloadCI)
+
+	created := make(map[string]time.Time)
+	deleted := make(map[string]time.Time)
+	perDay := make(map[time.Time]int)
+	for _, transition := range schedule {
+		switch transition.EventType {
+		case "compute.instance.create.end":
+			created[transition.ResourceID] = transition.At
+			perDay[at(transition.At, 0, 0)]++
+			if !workingDay(transition.At) || transition.At.Hour() < 7 || transition.At.Hour() >= 19 {
+				t.Errorf("the runner %s comes up on a %s at %s, want a Monday to Friday between "+
+					"07:00 and 19:00 UTC: a CI runner runs while the pipelines that ask for it run",
+					transition.ResourceID, transition.At.Weekday(), transition.At.Format(time.RFC3339))
+			}
+		case "compute.instance.delete.end":
+			deleted[transition.ResourceID] = transition.At
+		}
+	}
+	if len(created) == 0 {
+		t.Fatalf("the month holds no CI runner, want the bursts of every working day of July")
+	}
+
+	for id, createdAt := range created {
+		deletedAt, ok := deleted[id]
+		if !ok {
+			t.Errorf("the runner %s comes up at %s and reports no delete, want one: a runner "+
+				"nothing deletes is billed as a server that outlives its job",
+				id, createdAt.Format(time.RFC3339))
+			continue
+		}
+		if life := deletedAt.Sub(createdAt); life < 3*time.Minute || life >= 40*time.Minute {
+			t.Errorf("the runner %s lives %s, want [3m, 40m): a runner is destroyed when its job "+
+				"ends, and a longer life is a fleet the month bills by the hour", id, life)
+		}
+	}
+
+	// Four to eight bursts of two to five runners each.
+	for _, d := range workingDays(july2026, july2026.AddDate(0, 1, 0)) {
+		if runners := perDay[d]; runners < 8 || runners > 40 {
+			t.Errorf("%s brings %d runners, want 8 to 40: a day outside the band is a month whose "+
+				"bursts drifted off the working days they belong on",
+				d.Format("2006-01-02"), runners)
+		}
+	}
 }

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -761,49 +761,53 @@ func TestLoadBalancersAreBookedFromTheirUpdate(t *testing.T) {
 // is churn the other two workloads do not produce: hundreds of servers that are
 // created and closed inside the period rather than carried over it.
 func TestCIRunnersBurstInWorkingHours(t *testing.T) {
-	schedule := ofWorkload(generateMonth(t, 1, july2026, testCloud), workloadCI)
+	for seed := uint64(1); seed <= 5; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			schedule := ofWorkload(generateMonth(t, seed, july2026, testCloud), workloadCI)
 
-	created := make(map[string]time.Time)
-	deleted := make(map[string]time.Time)
-	perDay := make(map[time.Time]int)
-	for _, transition := range schedule {
-		switch transition.EventType {
-		case "compute.instance.create.end":
-			created[transition.ResourceID] = transition.At
-			perDay[at(transition.At, 0, 0)]++
-			if !workingDay(transition.At) || transition.At.Hour() < 7 || transition.At.Hour() >= 19 {
-				t.Errorf("the runner %s comes up on a %s at %s, want a Monday to Friday between "+
-					"07:00 and 19:00 UTC: a CI runner runs while the pipelines that ask for it run",
-					transition.ResourceID, transition.At.Weekday(), transition.At.Format(time.RFC3339))
+			created := make(map[string]time.Time)
+			deleted := make(map[string]time.Time)
+			perDay := make(map[time.Time]int)
+			for _, transition := range schedule {
+				switch transition.EventType {
+				case "compute.instance.create.end":
+					created[transition.ResourceID] = transition.At
+					perDay[at(transition.At, 0, 0)]++
+					if !workingDay(transition.At) || transition.At.Hour() < 7 || transition.At.Hour() >= 19 {
+						t.Errorf("the runner %s comes up on a %s at %s, want a Monday to Friday between "+
+							"07:00 and 19:00 UTC: a CI runner runs while the pipelines that ask for it run",
+							transition.ResourceID, transition.At.Weekday(), transition.At.Format(time.RFC3339))
+					}
+				case "compute.instance.delete.end":
+					deleted[transition.ResourceID] = transition.At
+				}
 			}
-		case "compute.instance.delete.end":
-			deleted[transition.ResourceID] = transition.At
-		}
-	}
-	if len(created) == 0 {
-		t.Fatalf("the month holds no CI runner, want the bursts of every working day of July")
-	}
+			if len(created) == 0 {
+				t.Fatalf("the month holds no CI runner, want the bursts of every working day of July")
+			}
 
-	for id, createdAt := range created {
-		deletedAt, ok := deleted[id]
-		if !ok {
-			t.Errorf("the runner %s comes up at %s and reports no delete, want one: a runner "+
-				"nothing deletes is billed as a server that outlives its job",
-				id, createdAt.Format(time.RFC3339))
-			continue
-		}
-		if life := deletedAt.Sub(createdAt); life < 3*time.Minute || life >= 40*time.Minute {
-			t.Errorf("the runner %s lives %s, want [3m, 40m): a runner is destroyed when its job "+
-				"ends, and a longer life is a fleet the month bills by the hour", id, life)
-		}
-	}
+			for id, createdAt := range created {
+				deletedAt, ok := deleted[id]
+				if !ok {
+					t.Errorf("the runner %s comes up at %s and reports no delete, want one: a runner "+
+						"nothing deletes is billed as a server that outlives its job",
+						id, createdAt.Format(time.RFC3339))
+					continue
+				}
+				if life := deletedAt.Sub(createdAt); life < 3*time.Minute || life >= 40*time.Minute {
+					t.Errorf("the runner %s lives %s, want [3m, 40m): a runner is destroyed when its job "+
+						"ends, and a longer life is a fleet the month bills by the hour", id, life)
+				}
+			}
 
-	// Four to eight bursts of two to five runners each.
-	for _, d := range workingDays(july2026, july2026.AddDate(0, 1, 0)) {
-		if runners := perDay[d]; runners < 8 || runners > 40 {
-			t.Errorf("%s brings %d runners, want 8 to 40: a day outside the band is a month whose "+
-				"bursts drifted off the working days they belong on",
-				d.Format("2006-01-02"), runners)
-		}
+			// Four to eight bursts of two to five runners each.
+			for _, d := range workingDays(july2026, july2026.AddDate(0, 1, 0)) {
+				if runners := perDay[d]; runners < 8 || runners > 40 {
+					t.Errorf("%s brings %d runners, want 8 to 40: a day outside the band is a month whose "+
+						"bursts drifted off the working days they belong on",
+						d.Format("2006-01-02"), runners)
+				}
+			}
+		})
 	}
 }

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -2,10 +2,15 @@ package simulator
 
 import (
 	"bytes"
+	"fmt"
+	"math/rand/v2"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
 )
 
 // The months the workload tests generate. July and May are both 31 days long,
@@ -20,13 +25,12 @@ var (
 // testCloud is the cloud the generated months are salted with.
 const testCloud = "os-test"
 
-// collectorTopic and collectorExchanges are what the collector binds its queue
-// to out of the box: the defaults of TALLY_OSC_TOPICS and TALLY_OSC_EXCHANGES
-// in internal/providers/openstack/config.go. A simulator that addressed
-// anything else would publish a month no collector receives.
+// collectorTopic is the topic the collector binds its queue with out of the
+// box: the default of TALLY_OSC_TOPICS in
+// internal/providers/openstack/config.go. A simulator that published under
+// another one would produce a month no collector receives. The exchanges it
+// publishes on are ServiceExchanges.
 const collectorTopic = "notifications.info"
-
-var collectorExchanges = []string{"nova", "cinder", "neutron", "glance"}
 
 // generateMonth generates one month or fails the test. Every test takes its
 // schedule through it, so a generation error is reported once and in one form.
@@ -55,6 +59,128 @@ func requireDisjoint(t *testing.T, field string, first, second Schedule, of func
 			return
 		}
 	}
+}
+
+// ofWorkload returns the transitions one workload emitted, in schedule order.
+// The workloads of a month are told apart by nothing else: their tenants are
+// ids, and their notifications are the ones every other tenant sends.
+func ofWorkload(schedule Schedule, workload string) Schedule {
+	of := schedule[:0:0]
+	for _, transition := range schedule {
+		if transition.Workload == workload {
+			of = append(of, transition)
+		}
+	}
+	return of
+}
+
+// buildMonth generates July 2026 over testCloud the way Generate does and
+// returns the generator that built it, so a test reads the world behind the
+// schedule as well as the schedule. The message ids are not drawn, which is the
+// one thing Generate does that these tests do not read.
+func buildMonth(t *testing.T, seed uint64) *generator {
+	t.Helper()
+
+	shape := rand.New(rand.NewPCG(seed, shapeStream))
+	identifiers := idReader{src: rand.New(rand.NewPCG(seed, identifierSalt(testCloud, july2026)))}
+
+	g := newGenerator(shape, identifiers, july2026, july2026.AddDate(0, 1, 0), testCloud)
+	g.run()
+	slices.SortStableFunc(g.schedule, func(a, b Transition) int { return a.At.Compare(b.At) })
+	return g
+}
+
+// shootNamed returns the shoot of that name, whichever project holds it.
+func shootNamed(t *testing.T, g *generator, name string) *shoot {
+	t.Helper()
+
+	for _, gp := range g.gardenerProjects {
+		for _, s := range gp.shoots {
+			if s.name == name {
+				return s
+			}
+		}
+	}
+	t.Fatalf("the month holds no shoot named %q, want the three the workload creates", name)
+	return nil
+}
+
+// transitionsOf returns the transitions of one shoot, in schedule order. A
+// transition names no shoot, so every type is matched by what carries the
+// shoot's name: the display_name of a server or a volume, the name of a load
+// balancer, and, for an address, the balancer that holds it.
+func transitionsOf(schedule Schedule, s *shoot) []Transition {
+	var of []Transition
+	for _, transition := range ofWorkload(schedule, workloadGardener) {
+		switch {
+		case strings.HasPrefix(transition.EventType, "compute."),
+			strings.HasPrefix(transition.EventType, "volume."):
+			if name, _ := transition.Payload["display_name"].(string); !strings.HasPrefix(name, s.technicalID+"-") {
+				continue
+			}
+		case strings.HasPrefix(transition.EventType, "octavia."):
+			if name, _ := transition.Payload["name"].(string); !strings.HasPrefix(name, "kube_service_"+s.technicalID+"_") {
+				continue
+			}
+		case strings.HasPrefix(transition.EventType, "floatingip."):
+			if !slices.ContainsFunc(s.loadBalancers, func(lb *loadBalancer) bool {
+				return lb.fip.id == transition.ResourceID
+			}) {
+				continue
+			}
+		default:
+			continue
+		}
+		of = append(of, transition)
+	}
+	return of
+}
+
+// idsIn lists the resource ids of the transitions of one type inside [lo, hi),
+// in schedule order.
+func idsIn(transitions []Transition, eventType string, lo, hi time.Time) []string {
+	var ids []string
+	for _, transition := range transitions {
+		if transition.EventType != eventType || transition.At.Before(lo) || !transition.At.Before(hi) {
+			continue
+		}
+		ids = append(ids, transition.ResourceID)
+	}
+	return ids
+}
+
+// instantOf returns when one resource reported an event type, and the zero
+// instant when it never did.
+func instantOf(transitions []Transition, eventType, resourceID string) time.Time {
+	for _, transition := range transitions {
+		if transition.EventType == eventType && transition.ResourceID == resourceID {
+			return transition.At
+		}
+	}
+	return time.Time{}
+}
+
+// window returns the first and the last instant of the transitions match picks,
+// and false when it picks none.
+func window(transitions []Transition, match func(Transition) bool) (first, last time.Time, ok bool) {
+	for _, transition := range transitions {
+		if !match(transition) {
+			continue
+		}
+		if !ok {
+			first, ok = transition.At, true
+		}
+		last = transition.At
+	}
+	return first, last, ok
+}
+
+// isClaimDelete reports whether the transition releases a persistent volume
+// claim rather than the root volume of a worker, which carries its worker's
+// name.
+func isClaimDelete(transition Transition) bool {
+	name, _ := transition.Payload["display_name"].(string)
+	return transition.EventType == "volume.delete.end" && strings.Contains(name, "-dynamic-pvc-")
 }
 
 func TestGenerateIsDeterministic(t *testing.T) {
@@ -102,22 +228,39 @@ func TestGenerateSaltsIdentifiersWithPeriodAndCloud(t *testing.T) {
 	})
 
 	t.Run("another month of the same length keeps every offset", func(t *testing.T) {
+		// The offsets are compared over the classic tenants alone. The profile the
+		// machine-driven workloads are drawn on follows the real calendar of the
+		// period, so a shoot and a pipeline move their activity onto the working
+		// days of the month they run in, while a classic tenant, which is anchored
+		// on the month start alone, keeps every offset it has (author decision of
+		// 2026-08-29).
 		july := generateMonth(t, 7, july2026, testCloud)
 		may := generateMonth(t, 7, may2026, testCloud)
 
-		if len(july) != len(may) {
-			t.Fatalf("two 31 day months produced %d and %d transitions, want the same shape",
-				len(july), len(may))
+		classicJuly, classicMay := ofWorkload(july, workloadClassic), ofWorkload(may, workloadClassic)
+		if len(classicJuly) != len(classicMay) {
+			t.Fatalf("two 31 day months produced %d and %d classic transitions, want the same shape",
+				len(classicJuly), len(classicMay))
 		}
-		for i := range july {
-			if july[i].EventType != may[i].EventType {
+		for i := range classicJuly {
+			if classicJuly[i].EventType != classicMay[i].EventType {
 				t.Errorf("transition %d is %s in July and %s in May, want the same shape",
-					i, july[i].EventType, may[i].EventType)
+					i, classicJuly[i].EventType, classicMay[i].EventType)
 			}
-			inJuly, inMay := july[i].At.Sub(july2026), may[i].At.Sub(may2026)
+			inJuly, inMay := classicJuly[i].At.Sub(july2026), classicMay[i].At.Sub(may2026)
 			if inJuly != inMay {
 				t.Errorf("transition %d sits %s into July and %s into May, want the same offset",
 					i, inJuly, inMay)
+			}
+		}
+
+		// A month that moved its machine-driven workloads still holds them.
+		for _, workload := range []string{workloadGardener} {
+			for name, schedule := range map[string]Schedule{"July": july, "May": may} {
+				if len(ofWorkload(schedule, workload)) == 0 {
+					t.Errorf("%s holds no %s transition, want every workload in every month",
+						name, workload)
+				}
 			}
 		}
 		requireDisjoint(t, "message id", july, may, func(tr Transition) string { return tr.MessageID })
@@ -154,9 +297,9 @@ func TestGenerateStaysInsideThePeriod(t *testing.T) {
 			t.Errorf("transition %d is at %s after %s, want the schedule sorted",
 				i, transition.At, schedule[i-1].At)
 		}
-		if !slices.Contains(collectorExchanges, transition.Exchange) {
-			t.Errorf("%s is published on %q, want one of the exchanges the collector binds: %v",
-				transition.EventType, transition.Exchange, collectorExchanges)
+		if !slices.Contains(ServiceExchanges, transition.Exchange) {
+			t.Errorf("%s is published on %q, want one of the exchanges the simulator declares: %v",
+				transition.EventType, transition.Exchange, ServiceExchanges)
 		}
 		if previous, ok := last[transition.ResourceID]; ok && transition.At.Sub(previous) < time.Second {
 			t.Errorf("resource %s reports %s at %s, %s after its previous transition, want at least a second",
@@ -213,4 +356,402 @@ func TestGenerateRefusesANonMonth(t *testing.T) {
 			}
 		})
 	}
+}
+
+// sizeOf maps one transition the way the collector does and returns the size
+// the booked event carries, together with the notification it was read from.
+func sizeOf(t *testing.T, transition Transition) (map[string]any, openstack.Notification) {
+	t.Helper()
+
+	notification := parse(t, render(t, transition))
+	mapped, ok := openstack.MapNotification(notification, testCloud)
+	if !ok {
+		t.Fatalf("MapNotification(%s) mapped = false, want the collector to book it", transition.EventType)
+	}
+	return mapped.Payload.Size, notification
+}
+
+// TestShootsFollowTheirLives holds each of the three shoots against the life it
+// stands for: one that runs the whole month and rolls its workers once, one
+// that hibernates every night, and one that is created and torn down inside the
+// month. A shoot that scaled up without scaling back, woke up without
+// hibernating, or reported a resource after its tear-down would put usage into
+// the month that no cluster ever had.
+func TestShootsFollowTheirLives(t *testing.T) {
+	for seed := uint64(1); seed <= 5; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			g := buildMonth(t, seed)
+
+			t.Run("api-prod keeps its pool and replaces every worker of it", func(t *testing.T) {
+				s := shootNamed(t, g, "api-prod")
+				transitions := transitionsOf(g.schedule, s)
+
+				if len(s.workers) != s.baseWorkers {
+					t.Errorf("api-prod ends the month with %d workers, want the %d of its pool: "+
+						"what the autoscaler adds in the morning it gives back the same evening",
+						len(s.workers), s.baseWorkers)
+				}
+
+				created := make(map[string]int)
+				creates, deletes := 0, 0
+				for _, transition := range transitions {
+					switch transition.EventType {
+					case "compute.instance.create.end":
+						creates++
+						created[transition.ResourceID]++
+					case "compute.instance.delete.end":
+						deletes++
+					}
+				}
+				if creates-deletes != s.baseWorkers {
+					t.Errorf("api-prod creates %d workers and deletes %d, want %d more created than "+
+						"deleted: the pool the month ends with is the one it started with",
+						creates, deletes, s.baseWorkers)
+				}
+				if deletes < s.baseWorkers {
+					t.Errorf("api-prod deletes %d workers, want at least the %d of its pool: the "+
+						"rolling update replaces every one of them", deletes, s.baseWorkers)
+				}
+				for id, count := range created {
+					if count > 1 {
+						t.Errorf("the instance %s is created %d times, want every worker to carry an id "+
+							"no earlier worker had: a resource that comes back reopens a closed record",
+							id, count)
+					}
+				}
+
+				// A worker that boots from an image names the one its tenant
+				// uploaded, which is the mirror of the empty image_ref_url api-dev's
+				// workers carry.
+				want := fmt.Sprintf("http://glance.%s.example:9292/images/%s",
+					testCloud, s.owner.tenant.images[0].id)
+				for _, transition := range transitions {
+					if transition.EventType != "compute.instance.create.end" {
+						continue
+					}
+					if url, _ := transition.Payload["image_ref_url"].(string); url != want {
+						t.Errorf("the worker %s boots from %q, want %q: a shoot's workers run the image "+
+							"its tenant uploaded", transition.ResourceID, url, want)
+						break
+					}
+				}
+			})
+
+			t.Run("api-dev boots its pool every working morning", func(t *testing.T) {
+				s := shootNamed(t, g, "api-dev")
+				transitions := transitionsOf(g.schedule, s)
+				// The working days after the first, which is the day the shoot is
+				// created on rather than woken up on.
+				wakeUps := workingDays(july2026.AddDate(0, 0, 1), july2026.AddDate(0, 1, 0))
+
+				var previous []string
+				for _, d := range wakeUps {
+					ids := idsIn(transitions, "compute.instance.create.end", at(d, 7, 0), at(d, 7, 1))
+					if len(ids) != s.baseWorkers {
+						t.Errorf("api-dev boots %d workers at 07:00 on %s, want the %d of its pool: a "+
+							"woken shoot comes back with the pool it hibernated with",
+							len(ids), d.Format(time.DateOnly), s.baseWorkers)
+					}
+					for _, id := range ids {
+						if slices.Contains(previous, id) {
+							t.Errorf("the instance %s comes back on %s, want a woken shoot to boot new "+
+								"machines: a destroyed server is billed to its end and never resumed",
+								id, d.Format(time.DateOnly))
+						}
+					}
+					previous = ids
+				}
+
+				for _, d := range append([]time.Time{july2026}, wakeUps...) {
+					ids := idsIn(transitions, "compute.instance.delete.end", at(d, 19, 0), at(d, 19, 5))
+					if len(ids) != s.baseWorkers {
+						t.Errorf("api-dev destroys %d workers at 19:00 on %s, want the %d of its pool: "+
+							"hibernation takes every worker and keeps everything else",
+							len(ids), d.Format(time.DateOnly), s.baseWorkers)
+					}
+				}
+
+				for _, transition := range transitions {
+					if transition.EventType == "compute.instance.create.end" && !workingDay(transition.At) {
+						t.Errorf("api-dev boots a worker on %s, a %s, want it hibernated over the weekend",
+							transition.At, transition.At.Weekday())
+					}
+				}
+
+				// A worker that boots from a volume names no image: the image was
+				// written to the volume before the server existed.
+				for _, transition := range transitions {
+					if transition.EventType != "compute.instance.create.end" {
+						continue
+					}
+					if url, _ := transition.Payload["image_ref_url"].(string); url != "" {
+						t.Errorf("the worker %s names the image %q, want none: it boots off the volume "+
+							"the image was written to", transition.ResourceID, url)
+						break
+					}
+				}
+
+				// A root volume carries the name of the worker it boots, which is
+				// what pairs the two here.
+				workerCreated, workerDeleted := map[string]time.Time{}, map[string]time.Time{}
+				volumeCreated, volumeDeleted := map[string]time.Time{}, map[string]time.Time{}
+				for _, transition := range transitions {
+					name, _ := transition.Payload["display_name"].(string)
+					switch transition.EventType {
+					case "compute.instance.create.end":
+						workerCreated[name] = transition.At
+					case "compute.instance.delete.end":
+						workerDeleted[name] = transition.At
+					case "volume.create.end":
+						volumeCreated[name] = transition.At
+					case "volume.delete.end":
+						volumeDeleted[name] = transition.At
+					}
+				}
+				for name, booted := range workerCreated {
+					provisioned, ok := volumeCreated[name]
+					if !ok {
+						t.Errorf("the worker %s has no root volume, want one: it runs on a flavor "+
+							"without a root disk and boots from a volume", name)
+						continue
+					}
+					if !provisioned.Before(booted) {
+						t.Errorf("the root volume of %s is created at %s and the worker at %s, want the "+
+							"volume first: the image is written to it before the server boots off it",
+							name, provisioned, booted)
+					}
+					released, ok := volumeDeleted[name]
+					if !ok {
+						t.Errorf("the root volume of %s is never deleted, want it to go with its worker: "+
+							"a volume nothing releases is billed past the server that carried it", name)
+						continue
+					}
+					if destroyed := workerDeleted[name]; !released.After(destroyed) {
+						t.Errorf("the root volume of %s is deleted at %s and the worker at %s, want the "+
+							"volume after it", name, released, destroyed)
+					}
+				}
+
+				for _, transition := range transitions {
+					if transition.EventType == "volume.delete.end" && transition.ResourceID == s.claims[0].id {
+						t.Errorf("the first claim of api-dev is released at %s, want it to outlive the "+
+							"month: it carries the state that survives every workload", transition.At)
+					}
+				}
+			})
+
+			t.Run("batch is torn down in the order it was built", func(t *testing.T) {
+				s := shootNamed(t, g, "batch")
+				transitions := transitionsOf(g.schedule, s)
+
+				from, to := july2026.Add(2*day), july2026.Add(8*day)
+				if s.createdAt.Before(from) || !s.createdAt.Before(to) {
+					t.Errorf("batch is created at %s, want it inside [%s, %s): a transient shoot lives "+
+						"a stretch of the month and not all of it", s.createdAt, from, to)
+				}
+				last := transitions[len(transitions)-1]
+				from, to = july2026.Add(18*day), july2026.Add(27*day)
+				if last.At.Before(from) || !last.At.Before(to) {
+					t.Errorf("batch reports its last transition at %s, want it inside [%s, %s)",
+						last.At, from, to)
+				}
+				if !isClaimDelete(last) {
+					name, _ := last.Payload["display_name"].(string)
+					t.Errorf("batch ends on %s of %q, want the release of a claim: the tear-down is the "+
+						"last thing the shoot does and its claims go last of all",
+						last.EventType, name)
+				}
+
+				// The tear-down day, which is the only day of the shoot the deletes
+				// below can come from: a shoot is torn down inside working hours, so
+				// its last day brings nothing else.
+				torn := transitions[:0:0]
+				for _, transition := range transitions {
+					if !transition.At.Before(at(s.deletedAt, 0, 0)) {
+						torn = append(torn, transition)
+					}
+				}
+
+				for _, lb := range s.loadBalancers {
+					address := instantOf(torn, "floatingip.delete.end", lb.fip.id)
+					balancer := instantOf(torn, "octavia.loadbalancer.delete.end", lb.id)
+					if address.IsZero() || balancer.IsZero() {
+						t.Fatalf("the tear-down releases the address of %s at %v and deletes the "+
+							"balancer at %v, want both", lb.name, address, balancer)
+					}
+					if !address.Before(balancer) {
+						t.Errorf("the address of %s is released at %s and its balancer deleted at %s, "+
+							"want the address first: an address of a gone balancer is one nothing "+
+							"releases", lb.name, address, balancer)
+					}
+				}
+
+				_, balancers, hasBalancers := window(torn, func(transition Transition) bool {
+					return transition.EventType == "octavia.loadbalancer.delete.end"
+				})
+				workersFrom, workersTo, hasWorkers := window(torn, func(transition Transition) bool {
+					return transition.EventType == "compute.instance.delete.end"
+				})
+				claims, _, hasClaims := window(torn, isClaimDelete)
+				if !hasBalancers || !hasWorkers || !hasClaims {
+					t.Fatalf("the tear-down of batch deletes balancers = %v, workers = %v, claims = %v, "+
+						"want all three", hasBalancers, hasWorkers, hasClaims)
+				}
+				if !balancers.Before(workersFrom) {
+					t.Errorf("the last balancer of batch goes at %s and its first worker at %s, want the "+
+						"balancers first: they route to the workers", balancers, workersFrom)
+				}
+				if !workersTo.Before(claims) {
+					t.Errorf("the last worker of batch goes at %s and its first claim at %s, want the "+
+						"workers first: a claim is released once nothing mounts it", workersTo, claims)
+				}
+			})
+
+			t.Run("a claim that runs out of room doubles and grows at most twice", func(t *testing.T) {
+				// A resize is the one step that changes what a claim is billed at
+				// after it exists, and the cap is what keeps a month from doubling
+				// one volume into a size no cluster carries.
+				sizes := make(map[string]int)
+				grown := make(map[string]int)
+				for _, transition := range ofWorkload(g.schedule, workloadGardener) {
+					size, _ := transition.Payload["size"].(int)
+					switch transition.EventType {
+					case "volume.create.end":
+						sizes[transition.ResourceID] = size
+					case "volume.resize.end":
+						grown[transition.ResourceID]++
+						if want := 2 * sizes[transition.ResourceID]; size != want {
+							t.Errorf("the claim %s grows to %d GB from %d GB, want %d: a claim that runs "+
+								"out of room doubles", transition.ResourceID, size,
+								sizes[transition.ResourceID], want)
+						}
+						sizes[transition.ResourceID] = size
+					}
+				}
+
+				if len(grown) == 0 {
+					t.Fatalf("no claim of the month grows, want the working days to expand one: a month " +
+						"without a resize never prices a size change")
+				}
+				for id, count := range grown {
+					if count > 2 {
+						t.Errorf("the claim %s grows %d times, want at most twice: a claim doubled once "+
+							"more than that is a volume of a size no cluster carries", id, count)
+					}
+				}
+			})
+		})
+	}
+}
+
+// TestLoadBalancersAreBookedFromTheirUpdate covers the notification order a
+// balancer's size depends on. Octavia sends the create before the service's
+// ports are attached, so it carries no listener and no pool, and the update
+// that follows carries both: a month booked from the create alone would bill
+// every balancer of it as empty.
+func TestLoadBalancersAreBookedFromTheirUpdate(t *testing.T) {
+	g := buildMonth(t, 1)
+
+	want := []string{
+		"octavia.loadbalancer.create.end",
+		"floatingip.create.end",
+		"octavia.loadbalancer.update.end",
+	}
+	balancers := 0
+	for _, gp := range g.gardenerProjects {
+		for _, s := range gp.shoots {
+			transitions := transitionsOf(g.schedule, s)
+			for _, lb := range s.loadBalancers {
+				balancers++
+
+				var of []Transition
+				for _, transition := range transitions {
+					if transition.ResourceID == lb.id || transition.ResourceID == lb.fip.id {
+						of = append(of, transition)
+					}
+				}
+				if len(of) < len(want) {
+					t.Fatalf("the balancer %s reports %d transitions, want at least its create, its "+
+						"address, and its update", lb.name, len(of))
+				}
+				for i, eventType := range want {
+					if of[i].EventType != eventType {
+						t.Errorf("the balancer %s reports %s as its transition %d, want %s: octavia "+
+							"creates the balancer, neutron gives it its address, and the update carries "+
+							"what the service attached", lb.name, of[i].EventType, i, eventType)
+					}
+				}
+
+				size, _ := sizeOf(t, of[0])
+				for _, member := range []string{"listeners", "pools"} {
+					if got := fmt.Sprint(size[member]); got != "0" {
+						t.Errorf("the create of %s books %s = %s, want 0: it is sent before the "+
+							"service's ports are attached", lb.name, member, got)
+					}
+				}
+
+				size, notification := sizeOf(t, of[2])
+				for _, member := range []string{"listeners", "pools"} {
+					elements, _ := notification.Payload[member].([]any)
+					if len(elements) == 0 {
+						t.Errorf("the update of %s carries no %s, want the ones the service attached",
+							lb.name, member)
+					}
+					if got, count := fmt.Sprint(size[member]), strconv.Itoa(len(elements)); got != count {
+						t.Errorf("the update of %s books %s = %s, want %s, the number its payload "+
+							"carries", lb.name, member, got, count)
+					}
+				}
+			}
+		}
+	}
+	if balancers == 0 {
+		t.Fatalf("the month holds no load balancer, want one per service of type LoadBalancer")
+	}
+
+	deletes := 0
+	for _, transition := range g.schedule {
+		if transition.EventType == "octavia.loadbalancer.delete.end" {
+			deletes++
+		}
+	}
+	if deletes == 0 {
+		t.Errorf("the month renders no octavia.loadbalancer.delete.end, want the torn-down shoot to " +
+			"close its balancers: one nothing deletes is billed past the cluster it served")
+	}
+
+	// The listener day publishes another port on the ingress balancer of
+	// api-prod. Octavia notifies on the balancer alone, so the new count arrives
+	// on a second update rather than on a notification of the listener itself,
+	// and that update is the one place a booked balancer grows inside the month.
+	t.Run("a listener added later is booked on a second update", func(t *testing.T) {
+		s := shootNamed(t, g, "api-prod")
+		lb := s.loadBalancers[0]
+
+		var updates []Transition
+		for _, transition := range transitionsOf(g.schedule, s) {
+			if transition.EventType == "octavia.loadbalancer.update.end" && transition.ResourceID == lb.id {
+				updates = append(updates, transition)
+			}
+		}
+		if len(updates) != 2 {
+			t.Fatalf("the balancer %s reports %d updates, want 2: the one its service attaches its "+
+				"ports on and the one the listener day adds a port on", lb.name, len(updates))
+		}
+
+		attached, _ := sizeOf(t, updates[0])
+		grown, _ := sizeOf(t, updates[1])
+		before, _ := attached["listeners"].(int)
+		after, _ := grown["listeners"].(int)
+		if after != before+1 {
+			t.Errorf("the balancer %s books %d listeners on its second update and %d on its first, "+
+				"want one more: a service that publishes another port adds a listener to the balancer "+
+				"it already has", lb.name, after, before)
+		}
+		if grown["pools"] != attached["pools"] {
+			t.Errorf("the balancer %s books %v pools on its second update and %v on its first, want "+
+				"them unchanged: the new listener shares the pool behind it",
+				lb.name, grown["pools"], attached["pools"])
+		}
+	})
 }

--- a/internal/providers/openstack/simulator/world.go
+++ b/internal/providers/openstack/simulator/world.go
@@ -48,6 +48,12 @@ var flavors = []flavor{
 // ephemeral disk into every generated month.
 var largeFlavor = flavors[2]
 
+// xlargeFlavor is the flavor a production shoot's workers run on. It is named
+// beside largeFlavor so that the catalog is read by position in one place: a
+// workload that picked its flavor by index would change what it runs on when an
+// entry is inserted before it.
+var xlargeFlavor = flavors[3]
+
 // bootVolumeFlavor is the flavor a server that boots from a volume runs on. A
 // server reports the root disk of its flavor whether it boots from one or not,
 // so a flavor without root disk is what keeps the root volume from being billed

--- a/internal/providers/openstack/simulator/world.go
+++ b/internal/providers/openstack/simulator/world.go
@@ -48,6 +48,20 @@ var flavors = []flavor{
 // ephemeral disk into every generated month.
 var largeFlavor = flavors[2]
 
+// bootVolumeFlavor is the flavor a server that boots from a volume runs on. A
+// server reports the root disk of its flavor whether it boots from one or not,
+// so a flavor without root disk is what keeps the root volume from being billed
+// twice, once as disk and once as volume. It sits outside flavors so that the
+// draws over the catalog keep the shape they have.
+var bootVolumeFlavor = flavor{
+	name: "c1.large", vcpus: 4, memoryMB: 8192, rootGB: 0, ephemeralGB: 0,
+	typeID: 9, flavorID: "e2d4b6a8-0c1e-4f3a-95b7-6d8f0a2c4e61",
+}
+
+// runnerFlavors are the flavors a CI runner is drawn from. A runner holds one
+// job and is gone again, so it runs on the two small flavors of the catalog.
+var runnerFlavors = []flavor{flavors[0], flavors[1]}
+
 // volumeTypes are the cinder types a simulated volume carries. ssd and hdd
 // carry a type_modifier in pricing/2026-03.yaml; standard carries none there
 // and is rated at the implicit modifier 1. Drawing from all three is what makes
@@ -56,6 +70,19 @@ var volumeTypes = []string{"ssd", "hdd", "standard"}
 
 // volumeSizesGB are the sizes a volume is created with, in gibibytes.
 var volumeSizesGB = []int{50, 100, 200}
+
+// claimSizesGB are the sizes a persistent volume claim is created with, in
+// gibibytes. A claim holds the data of one workload and starts smaller than a
+// volume a tenant creates by hand.
+var claimSizesGB = []int{10, 20, 50}
+
+// The root volume of a worker that boots from one. Its size comes from the
+// shoot rather than from the flavor, and a Kubernetes worker keeps its root
+// filesystem on the fast type.
+const (
+	rootVolumeSizeGB = 50
+	rootVolumeType   = "ssd"
+)
 
 // quarterGiB is the step image sizes are drawn on. Glance reports bytes and the
 // mapping divides them into gibibytes, so a size that is a whole number of
@@ -87,6 +114,14 @@ const (
 var (
 	imageNames    = []string{"debian-13-golden", "ubuntu-24.04"}
 	instanceNames = []string{"web", "db", "batch", "cache"}
+)
+
+// The images the two machine-driven workloads boot from. A shoot's workers run
+// the distribution Gardener ships, and a CI runner runs the one its jobs are
+// built on.
+const (
+	gardenerImageName = "gardenlinux-1592.4"
+	ciImageName       = "ubuntu-24.04-ci"
 )
 
 // project is one tenant of the simulated cloud together with everything it
@@ -127,6 +162,9 @@ type instance struct {
 	deletedAt time.Time
 	volumes   []*volume
 	fip       *floatingIP
+	// bootVolume is the volume the server boots from, and nil on a server that
+	// boots from an image.
+	bootVolume *volume
 }
 
 // volume is one cinder volume. attached is what the world knows and cinder
@@ -140,6 +178,10 @@ type volume struct {
 	volumeType string
 	attached   bool
 	createdAt  time.Time
+	// resizes is how often the volume has grown. A claim grows at most twice,
+	// and the count does not follow from the size: 10 grown twice and 20 grown
+	// once are both 40.
+	resizes int
 }
 
 // floatingIP is one neutron address. It has no timestamps of its own, because
@@ -147,4 +189,62 @@ type volume struct {
 type floatingIP struct {
 	id      string
 	address string
+	// The port the address is associated with, the address behind that port, and
+	// the router that carries the traffic. All three are empty on an address
+	// that is associated with nothing, which every classic tenant's address is.
+	portID       string
+	fixedAddress string
+	routerID     string
+}
+
+// gardenerProject is one Gardener project: the shoots it holds and the
+// OpenStack tenant they run on. Gardener bills the tenant, and the project is
+// the name an operator knows the shoots under.
+type gardenerProject struct {
+	name   string
+	tenant *project
+	shoots []*shoot
+}
+
+// shoot is one Kubernetes cluster Gardener runs on the tenant. Its workers are
+// nova servers, its persistent volume claims are cinder volumes, and each of
+// its services of type LoadBalancer is an octavia load balancer with a floating
+// address.
+type shoot struct {
+	name, technicalID string
+	owner             *gardenerProject
+	// index counts the shoots of all projects from 1. It is the third octet of
+	// the shoot's VIP addresses, which keeps two shoots off each other's range.
+	index          int
+	flavor         flavor
+	bootFromVolume bool
+	hibernates     bool
+	// transient marks the shoot that is created and deleted inside the month.
+	transient   bool
+	baseWorkers int
+
+	networkID, subnetID, routerID, securityGroupID, keypairName string
+
+	// createdAt is when the shoot comes up. deletedAt is the zero instant on a
+	// shoot that outlives the month.
+	createdAt, deletedAt time.Time
+	// The midnights of the days the shoot's one-off steps fall on. Each is the
+	// zero instant when the shoot has no such step.
+	rollingUpdateDay, secondBalancerDay, listenerDay time.Time
+
+	awake bool
+	// workers are the servers alive now, and added are the ones the autoscaler
+	// added today.
+	workers, added []*instance
+	claims         []*volume
+	loadBalancers  []*loadBalancer
+}
+
+// loadBalancer is one octavia load balancer. The id slices hold every listener
+// and every pool the balancer has, so their lengths are the counts an update
+// reports.
+type loadBalancer struct {
+	id, name, vipPortID, vipAddress string
+	listenerIDs, poolIDs            []string
+	fip                             *floatingIP
 }


### PR DESCRIPTION
Closes #85

Gives the simulated month its workloads. The three classic tenants of #63 stay exactly as they are; beside them a month now holds two Gardener projects with three shoots on two OpenStack tenants and one CI tenant that boots runners in bursts, all drawn on the real calendar of the simulated period. The `octavia` exchange the shoots' load balancers publish on is added and listed for the collector of the compose stack. Nothing in the collector, the Reporting API or the engine changes.

## The commits, in order

**`34414cf` Add the working-week profile the simulated workloads draw on** — new `profile.go` with `hourWeight`, `drawInstant`, `drawWorkingInstant` and `workingDays`. The new workloads happen when people work, so their instants are drawn on the calendar of the period rather than spread evenly over the month: July 2026 opens on a Wednesday and holds the 23 working days the calendar has. Every instant is a whole second and every draw comes from the shape generator, so the profile decides what happens and when, never which identifiers a month is built from.

**`0a6db0c` Extend the world and render load balancers and boot volumes** — `world.go` gains the Gardener projects, their shoots, a shoot's load balancers and the CI tenant, plus the flavors, sizes and images those workloads draw from; `render.go` gains the octavia payloads and the fields the new resources need. Three rendering decisions follow the recorded samples: octavia carries a null publisher, so an empty publisher id is written as `null` rather than `""`; listeners and pools are reported on the update alone, so a balancer's size is booked from the update and the create carries 0/0; a server booted from a volume names no image and runs on a rootless flavor, so its root volume is billed once as a volume. Associated addresses name their port, fixed address and router and are `ACTIVE`; every classic tenant's address keeps its three nulls and `DOWN`. This commit alone leaves the new types unused — the phases that use them land in the two commits after it.

**`3f9f9b2` Tag transitions with their workload and hold the id reader** — `Transition` gains a `Workload` member (the tag #87's oracle will tell the workloads apart by; it travels beside the notification, never on the wire) and `newGenerator` keeps the identifier reader it used to drop after the fixed draws, because the resources a shoot or a pipeline churns are named as they are created. The classic month is unchanged byte for byte.

**`02d6d2f` Simulate two Gardener projects with three shoots on octavia** — new `gardener.go`. Workers are nova servers, claims are cinder volumes, and every `LoadBalancer` service is an octavia balancer with a floating address on its VIP port. `api-prod` runs the whole month and rolls its workers once, `api-dev` hibernates every night and boots from volumes, `batch` is created and torn down inside the month in the order its resources depend on each other. Billable side only — the network, subnet, router, security group, keypair and port identifiers are drawn so the payloads can name them, and their notifications are #86.

**`bebef6a` Simulate a CI tenant that boots runners in working-hour bursts** — new `ci.go`. One runner per job, destroyed when the job ends, so a month closes hundreds of servers inside the period instead of carrying them into the next one. Bursts fall on the month's real Mondays to Fridays because a pipeline is started by somebody pushing. The CI image is the ninth image of a month and therefore the ninth `image.create` the collector skips, which is the count the CLI test and the collector integration test move by.

**`2f8c7b3` List octavia for the compose collector** — a topic exchange copies a message only to the queues bound to it, so the stack's collector at its default of four exchanges dropped every octavia notification silently. `deploy/compose/compose.yaml` lists the fifth exchange and `compose_test.go` holds that list against the exchanges the simulator declares, so an exchange added there and forgotten here fails before the stack is started.

**`aae2dfb` Keep every CI burst inside the working hours** — a burst's first runner was drawn from the whole working window and its followers come seconds apart, so a burst drawn late enough put its last runners at or after 19:00; four of the first 200 seeds hit it. The first runner is now drawn against a window shortened by the longest burst a day can produce. Runner count, gaps and the rest of the tenant are unchanged, and `TestCIRunnersBurstInWorkingHours` walks seeds 1 to 5 rather than seed 1 alone.

**`125c800` Document the shoots, the CI tenant, the profile and octavia** — `docs/openstack-simulator.md` described a cloud of three tenants rendering 18 types on four exchanges and told the reader no seed produces a load balancer. It now describes the three workloads and their lives, the working-week profile and the calendar decision, the three octavia rows of the type table and the exchange list the compose collector needs. The counts of seed 1 over `2026-07` are measured: 1821 notifications, 1812 of them billable, nine unsized `image.create`.

**`dabfb3e` Describe the drift guard's filter as it stands** — the comment above the `exchangeFor` filter in `mapping_test.go` claimed octavia's types were recorded but rendered by nobody. The shoots render them and `exchangeFor` names the exchange, so the claim is false. Comment only; the filter still drops a recorded type that publishes on no exchange, for the next service the collector records before the workload renders it.

## Divergences from the issue

- **`aae2dfb` is a correction, not a new requirement.** The issue asks that every CI create fall Monday to Friday in `[07:00, 19:00)`; the first implementation satisfied that for seed 1 but not for four of the first 200 seeds. The reserved tail of the working window is how the property is made to hold for every seed, and the test was widened to seeds 1–5 accordingly.
- **`dabfb3e` touches a comment the issue does not mention.** It was left stale by `02d6d2f` rendering the octavia types the comment said nobody rendered.
- **`0a6db0c` does not compile clean under the linter on its own** — the world and payload types it adds are used first by `02d6d2f` and `bebef6a`. This is deliberate commit shaping; `golangci-lint` and `go vet` are clean at branch HEAD.
- Everything the issue lists as a non-goal stays out: the non-billable noise (#86), the oracle (#87), the fault switches (#88), the registry relations (#89), and the classic tenants' uniform draws.

The diff touches only `internal/providers/openstack/simulator/`, `cmd/tally-openstack-simulator/`, `deploy/compose/` and `docs/openstack-simulator.md`, as the issue requires.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) f9eb7a6 with Claude:claude-opus-5_
