### PR TITLE
Render the notifications the collector does not bill around every simulated transition

### DIFF
--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/engine/period"
 	"github.com/b42labs/tally/internal/providers/openstack"
 	"github.com/b42labs/tally/internal/providers/openstack/simulator"
 )
@@ -33,14 +34,37 @@ const closedBroker = "amqp://guest:guest@127.0.0.1:1/"
 // a production URL copied into the simulator's environment.
 const remoteBroker = "amqp://guest:hunter2@rabbit.control-plane.example:5672/"
 
-// nonBillableNotifications is how many notifications of a generated month the
-// collector maps to no event: the ones that are published to describe the
-// month's shape without being billable. They are the unsized image.create of
-// every image: two for each of the three classic projects, one for each of the
-// two Gardener tenants, and one for the CI tenant. notifications.jsonl holds
-// every notification and events.jsonl only the billable ones, so the two files
-// differ by exactly this many lines.
-const nonBillableNotifications = 9
+// nonBillableNotifications is how many notifications of a month the collector
+// maps to no event: the unsized image.create, one per image, and every
+// notification of the noise catalogue (docs/openstack-simulator.md, "The
+// noise"). notifications.jsonl holds every notification and events.jsonl only
+// the billable ones, so the two files differ by exactly this many lines.
+//
+// The count comes from the month the generator renders rather than from a
+// number written down here. A measured one would fail every time the catalogue
+// gains a type or an offset adds a transition, with nothing in the failure to
+// tell a deliberate change from a generator that lost half a month, and
+// re-measuring is the same edit either way.
+func nonBillableNotifications(t *testing.T, seed uint64, month, cloud string) int {
+	t.Helper()
+
+	from, to, err := period.Parse(month)
+	if err != nil {
+		t.Fatalf("period.Parse(%q) error = %v, want nil", month, err)
+	}
+	schedule, err := simulator.Generate(seed, from, to, cloud)
+	if err != nil {
+		t.Fatalf("Generate() error = %v, want nil", err)
+	}
+
+	count := 0
+	for _, transition := range schedule {
+		if !transition.Billable {
+			count++
+		}
+	}
+	return count
+}
 
 func TestHelpNeedsNoEnvironment(t *testing.T) {
 	blankEnvironment(t)
@@ -151,9 +175,10 @@ func TestRunWritesTheMonthInFileMode(t *testing.T) {
 		}
 	}
 
-	if want := len(eventLines) + nonBillableNotifications; len(notificationLines) != want {
+	skipped := nonBillableNotifications(t, 1, endedMonth, simulatedCloud)
+	if want := len(eventLines) + skipped; len(notificationLines) != want {
 		t.Errorf("notifications.jsonl has %d lines, want %d: %d events plus the %d non-billable ones",
-			len(notificationLines), want, len(eventLines), nonBillableNotifications)
+			len(notificationLines), want, len(eventLines), skipped)
 	}
 
 	t.Run("is byte-identical on a second run", func(t *testing.T) {

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -50,11 +50,14 @@ services:
         condition: service_healthy
     environment:
       TALLY_OSC_AMQP_URL: amqp://guest:guest@rabbitmq:5672/
-      # The simulator publishes the shoots' load balancers on octavia. A topic
-      # exchange copies a message only to the queues bound to it, so a collector
-      # left at its default, the four without octavia, receives no load balancer
-      # from this stack and shows no `octavia.` series in any counter.
-      TALLY_OSC_EXCHANGES: nova,neutron,cinder,glance,octavia
+      # The simulator publishes on four exchanges the collector's default leaves
+      # out: octavia carries the shoots' load balancers, keystone the tenant and
+      # authentication records, designate the zones and record sets, and
+      # barbican the certificate audit records. A topic exchange copies a
+      # message only to the queues bound to it, so a collector left at its
+      # default of four sees none of them in any counter, neither as an event
+      # nor as a skip.
+      TALLY_OSC_EXCHANGES: nova,neutron,cinder,glance,octavia,keystone,designate,barbican
       TALLY_OSC_CLOUD: ${TALLY_SIM_CLOUD}
       TALLY_OSC_REPORTING_URL: https://api.tally.127-0-0-1.nip.io:8443
       TALLY_OSC_TOKEN: ${TALLY_OSC_TOKEN}

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -1,8 +1,8 @@
 # OpenStack notification simulator
 
 The simulator is one binary that puts a month of oslo.messaging notifications
-on a RabbitMQ broker the way nova, cinder, neutron, glance, and octavia put
-them there. The collector described in
+on a RabbitMQ broker the way nova, cinder, neutron, glance, octavia,
+keystone, designate, and barbican put them there. The collector described in
 [`openstack-collector.md`](openstack-collector.md) consumes them unmodified,
 off its ordinary `tally-notifications` queue, and posts the mapped events to
 the Reporting API, so a month of usage reaches Tally with no OpenStack
@@ -12,12 +12,13 @@ factor compresses it into.
 
 It has no fault switches, no oracle to hold a run against, no fake OpenStack
 API, and no metrics endpoint of its own. #65 is the meta issue the simulated
-workloads belong to, and this document describes its first stage: #86 owns the
-noise (the notifications the collector does not bill), #87 the oracle, #88 the
-fault switches, and #89 the project registry; #66 the fake API and the clock
-seam; #67 the traffic series and `/metrics`. The drill #51 cites this simulator
-as the way a month reaches the Reporting API. The workload renders octavia's
-three load balancer types from the shoots' load balancers.
+workloads belong to, and this document describes its first stage. The noise,
+the notifications the collector does not bill, is rendered and described under
+"The noise" below; #87 owns the oracle, #88 the fault switches, and #89 the
+project registry; #66 the fake API and the clock seam; #67 the traffic series
+and `/metrics`. The drill #51 cites this simulator as the way a month reaches
+the Reporting API. The workload renders octavia's three load balancer types
+from the shoots' load balancers.
 
 ## The world and the workload
 
@@ -26,6 +27,15 @@ tenants, one CI tenant, and one external network. It is small on purpose: what
 a run has to cover is every notification type and every shape of resource life,
 not a realistic tenant count. Every tenant of it is addressed by its id alone:
 no notification, payload, or log line of a month carries a tenant name.
+
+Each tenant works on a network of its own. The classic tenants' networks are
+`192.168.<n>.0/24`, they pre-exist the month, and neutron announces nothing
+about them. The CI tenant's `10.100.0.0/24` with its router is built at the
+start of the month, and every shoot carries a `10.250.<index>.0/24`, the range
+that shoot's VIP addresses lie in. The Gardener and the CI tenants are created
+in keystone at the month start; the classic tenants are there before the first
+transition. Each Gardener project holds one designate zone its shoots publish
+their records into, `alpha.<cloud>.example.` and `beta.<cloud>.example.`.
 
 The flavor catalog holds four entries: `m1.small` with 1 vCPU, 2048 MB of
 memory, and a 20 GB root disk; `m1.medium` with 2, 4096, and 40; `m1.large`
@@ -47,7 +57,10 @@ which keeps the mapping's division into gibibytes on exact decimals.
 
 Instances run on `compute-01` to `compute-04` and keep the host they were
 created on. Cinder publishes as `storage-01@ceph`, neutron as `neutron-01`, and
-glance as `glance-01`. Floating addresses come from `203.0.113.0/24`, the
+glance as `glance-01`. The services of the noise catalogue publish as
+`scheduler.controller-01`, `api.controller-01` (nova-api is what sends the
+keypair notifications), `identity.keystone-01`, `central.designate-01`, and
+`barbican.barbican-01`. Floating addresses come from `203.0.113.0/24`, the
 documentation range of RFC 5737, drawn as a permutation so that no address is
 handed out twice inside a month.
 
@@ -109,8 +122,9 @@ A shoot's life renders:
   minutes later.
 - hibernation, which deletes every worker and its root volume and keeps the
   claims, the balancers, and their addresses.
-- a tear-down in the order the resources depend on each other: address,
-  balancer, workers, claims.
+- a tear-down in the order the resources depend on each other: the address,
+  the balancer with its VIP port and its certificate, the workers, the claims,
+  and the infrastructure underneath them.
 
 A load balancer renders three notifications. `octavia.loadbalancer.create.end`
 carries no listeners and no pools, a `floatingip.create.end` gives its VIP port
@@ -131,14 +145,17 @@ worker it carries, a claim `<technical id>-dynamic-pvc-<volume id>`, a load
 balancer `kube_service_<technical id>_<namespace>_<service>`, and a keypair
 `<technical id>-ssh-publickey`. They are cosmetic: nothing is metered by a name.
 
-The notifications of the network, the subnet, the router, the security group,
-the keypair, and the ports belong to #86, together with the keystone
-notifications and the attach and detach notifications. Three of those
-identifiers are already named by a payload: a load balancer reports its
-`vip_network_id` and its `vip_subnet_id`, and the address of one reports its
-`router_id`. The security group and the keypair are drawn here and read by
-nothing yet: they hold their place in the identifier stream until #86 renders
-the notifications about them.
+Gardener builds a shoot's infrastructure before its first worker boots: the
+network with its subnet, the router out of it and the interface that puts the
+router on the subnet, the security group with the two rules of a worker pool,
+the keypair the workers are reachable under, and the record set the API server
+answers on, `api.<shoot>.<project>.<cloud>.example.`. The first load balancer of
+a shoot adds the ingress record `*.ingress.<shoot>.<project>.<cloud>.example.`,
+and a balancer with an `https` listener holds its certificate in barbican as a
+secret and a container. The tear-down gives all of it back in the order the
+resources depend on each other and ends on the `network.delete.end`, after which
+nothing of the shoot is emitted. "The noise" below holds those sequences with
+the second each of their notifications falls on.
 
 ### The CI tenant
 
@@ -165,7 +182,245 @@ decision of 2026-08-29. The consequence is that the same seed run over another
 month keeps the classic tenants at their offsets from the month start and moves
 the shoot and the CI activity onto that month's working days.
 
-The workload renders 21 oslo notification types.
+## The noise
+
+Beside the 21 types the mapping knows, a month renders 62 the collector bills
+nothing for. They are what a real bus carries around every billable transition:
+the scheduler's placement decisions, the ports of every server, the networks,
+subnets, routers and security groups underneath them, the keypairs, keystone's
+authentications, designate's zones and record sets, barbican's audit records,
+the attach and the detach of a volume, and the `.start` half of every step that
+has one. The collector receives all of them and counts each as skipped, so a
+month without them is a month whose skip counters stay at zero and whose ratio
+of billable to received says nothing.
+
+Three rules hold for the whole catalogue.
+
+It is never billable. The collector's mapping claims nothing for any of these
+types, and `WriteEvents` refuses a transition that is marked billable and mapped
+to nothing, which is what `TestEveryBillableTransitionMapsToAnEvent` holds a
+month to.
+
+It takes no draw from the shape stream and no identifier from the identifier
+stream. Every noise instant is a fixed offset in whole seconds from the billable
+instant it belongs to, and every identifier comes from a third generator, the
+noise identifier stream, salted with the cloud and the month the way the
+identifier stream is. The billable transitions of a seed, a period, and a cloud
+therefore keep every instant, id, and payload they had without the catalogue,
+message ids aside.
+
+It is rendered by
+[`noise.go`](../internal/providers/openstack/simulator/noise.go) and by nothing
+else, so what a month is billed for and what it merely carries stay two things a
+reader can tell apart.
+
+### A boot and a delete
+
+A boot is ten notifications before the create the collector books, at these
+distances from it in seconds. The scheduler picks the host and answers,
+`scheduler.select_destinations.start` at -25 and its `.end` at -24. Nova
+announces the server at -20 with `compute.instance.create.start` and reports its
+progress through three `compute.instance.update` at -15, -10, and -5: scheduling
+to networking, networking to block_device_mapping, and block_device_mapping to
+spawning. Neutron creates the port the server holds its address on,
+`port.create.start` at -17 with its `.end` at -16, and binds it to the compute,
+`port.update.start` at -12 with its `.end` at -11. The billable
+`compute.instance.create.end` comes last, because it is what the server is
+billed from.
+
+A delete opens with a `compute.instance.update` to the deleting task at -5. The
+pre-delete `compute.instance.exists` at -4 reports what the server used on the
+day so far, `compute.instance.delete.start` at -3 and the shutdown around it,
+`.start` at -2 and `.end` at -1, tear it down, and the billable
+`compute.instance.delete.end` follows. Neutron releases the port afterwards,
+`port.delete.start` at +1 with its `.end` at +2, and cinder detaches every
+volume the server still held, `volume.detach.start` at +3 with its `.end` at
++4.
+
+### The daily audits
+
+`compute.instance.exists` is nova's periodic existence audit. Every instance
+that existed during a calendar day of the month is reported at the following
+midnight with an audit over that day, which is what a deployment gets from
+`instance_usage_audit_period = day`. The default nova ships is the month, and a
+monthly period would put no audit inside the simulated month at all, because the
+first one falls on the midnight that ends it. An hourly period would put
+twenty-four times as many lines on the bus for the same single type.
+
+An audit sits at the midnight itself and is pushed on by whole seconds while the
+instance already reports a transition at that second, which keeps two
+notifications about one resource a second apart. An instance created and deleted
+between two midnights is audited once, at the midnight that follows. What an
+audit repeats is the instance as it stands: a resize moves the flavor over, and
+every `.end` moves the state over.
+
+### The paired steps
+
+Seven steps send a `.start` five seconds before the `.end` the collector books:
+`compute.instance.power_off`, `compute.instance.power_on`,
+`compute.instance.resize`, `compute.instance.finish_resize`,
+`compute.instance.shelve_offload`, `compute.instance.unshelve`, and
+`volume.resize`. `volume.transfer.accept.start` comes one second before its
+`.end`. That the catalogue carries both halves of every such step is the
+author's decision of 2026-08-30.
+
+### The volumes and the images
+
+A volume create is announced by `volume.create.start` eight seconds before it,
+which is the `created_at` the billable payload reports. `volume.attach.start` at
++1 and its `.end` at +2 connect the volume to a server and hand out an
+attachment record naming the server, its compute, and the device: `/dev/vda` for
+a root volume and `/dev/vdb` otherwise. A delete of an attached volume detaches
+it first, at -3 and -2, and `volume.delete.start` follows at -1. The claims of
+`api-dev` are detached at every hibernation and attached again at every wake-up.
+The spare volume a project hands over is never attached.
+
+An image is prepared before its upload and activated after it. `image.prepare`
+at -1 is the image while its content is still arriving, the one notification
+about it that carries neither a size nor a checksum, and `image.activate` at +1
+repeats the payload of the upload unchanged.
+
+### A shoot's infrastructure
+
+What Gardener creates before the first worker boots runs one transition per
+second, from one second after the shoot's creation instant to sixteen after it,
+with an `identity.authenticate` two seconds before it: the network and its
+subnet, the router and the interface that puts it on the subnet, the security
+group with two rules (SSH from anywhere, and everything from the group itself),
+each of them a `.start` and an `.end`, the keypair the workers are reachable
+under, and a `dns.recordset.create` for
+`api.<shoot>.<project>.<cloud>.example.`. That record points at a placeholder
+from the RFC 5737 range, because the API server of a shoot runs in Gardener's
+seed and this world does not simulate one.
+
+The tear-down after the last claim gives it all back one second apart, in the
+order the resources depend on each other: a `dns.recordset.delete` for the api
+record and one for the ingress record, the keypair, the security group, the
+router's interface, the router, the subnet, and the network. Nothing of the
+shoot follows its `network.delete.end`.
+
+### The load balancers
+
+A balancer holds its VIP on a neutron port with the device owner `Octavia`,
+created by `port.create.start` two seconds before the billable create and its
+`.end` a second later. The address follows the create. The first balancer of a
+shoot carries the cluster's ingress record: a `dns.recordset.create` at +12
+publishes `*.ingress.<shoot>.<project>.<cloud>.example.` with the balancer's
+floating address. The balancer with the `https` listener terminates TLS, and its
+certificate goes into barbican as four audit records from +20 to +23, an
+`audit.http.request` and an `audit.http.response` for `POST /v1/secrets` and for
+`POST /v1/containers`. All of it lies before the update the balancer's size is
+booked from. A torn-down balancer is followed by the delete of its port at +1
+and +2, and by four `DELETE` records from +3 to +6 when it held a certificate.
+
+### The tenants and the CADF records
+
+The Gardener and the CI tenants are created in keystone at the month start:
+`identity.project.created` at the first second and `identity.user.created` a
+second later. Each Gardener project's zone `<project>.<cloud>.example.` follows
+two seconds in as a `dns.zone.create`, and the CI tenant's network
+`10.100.0.0/24` with its router is built two seconds in. The classic tenants
+pre-exist the month on their `192.168.<n>.0/24` networks and are announced by
+nothing.
+
+`identity.authenticate` is rendered two seconds before a shoot's creation, a
+wake-up, a rolling update, a tear-down, and every CI burst, and by nothing else,
+which is one record per action somebody or a controller starts.
+
+Every CADF record is reported under its own record id, keystone's
+authentications as well as barbican's audit records: a user authenticates
+several times a day and two of those may fall into one second. A keypair has no
+id of its own and is reported under `<user id>:<keypair name>`. The barbican
+endpoint the audit records name is `https://barbican.<cloud>.example:9311`.
+
+### The catalogue
+
+| Notification | Exchange | Sequence |
+| --- | --- | --- |
+| `scheduler.select_destinations.start` | `nova` | boot |
+| `scheduler.select_destinations.end` | `nova` | boot |
+| `compute.instance.create.start` | `nova` | boot |
+| `compute.instance.update` | `nova` | boot, delete |
+| `compute.instance.exists` | `nova` | daily audit, delete |
+| `compute.instance.delete.start` | `nova` | delete |
+| `compute.instance.shutdown.start` | `nova` | delete |
+| `compute.instance.shutdown.end` | `nova` | delete |
+| `compute.instance.power_off.start` | `nova` | paired step |
+| `compute.instance.power_on.start` | `nova` | paired step |
+| `compute.instance.resize.start` | `nova` | paired step |
+| `compute.instance.finish_resize.start` | `nova` | paired step |
+| `compute.instance.shelve_offload.start` | `nova` | paired step |
+| `compute.instance.unshelve.start` | `nova` | paired step |
+| `keypair.import.start` | `nova` | shoot infrastructure |
+| `keypair.import.end` | `nova` | shoot infrastructure |
+| `keypair.delete.start` | `nova` | shoot tear-down |
+| `keypair.delete.end` | `nova` | shoot tear-down |
+| `volume.create.start` | `cinder` | volume |
+| `volume.delete.start` | `cinder` | volume |
+| `volume.resize.start` | `cinder` | paired step |
+| `volume.transfer.accept.start` | `cinder` | paired step |
+| `volume.attach.start` | `cinder` | volume |
+| `volume.attach.end` | `cinder` | volume |
+| `volume.detach.start` | `cinder` | volume, delete |
+| `volume.detach.end` | `cinder` | volume, delete |
+| `network.create.start` | `neutron` | shoot infrastructure, tenant |
+| `network.create.end` | `neutron` | shoot infrastructure, tenant |
+| `network.delete.start` | `neutron` | shoot tear-down |
+| `network.delete.end` | `neutron` | shoot tear-down |
+| `subnet.create.start` | `neutron` | shoot infrastructure, tenant |
+| `subnet.create.end` | `neutron` | shoot infrastructure, tenant |
+| `subnet.delete.start` | `neutron` | shoot tear-down |
+| `subnet.delete.end` | `neutron` | shoot tear-down |
+| `router.create.start` | `neutron` | shoot infrastructure, tenant |
+| `router.create.end` | `neutron` | shoot infrastructure, tenant |
+| `router.interface.create` | `neutron` | shoot infrastructure, tenant |
+| `router.interface.delete` | `neutron` | shoot tear-down |
+| `router.delete.start` | `neutron` | shoot tear-down |
+| `router.delete.end` | `neutron` | shoot tear-down |
+| `security_group.create.start` | `neutron` | shoot infrastructure |
+| `security_group.create.end` | `neutron` | shoot infrastructure |
+| `security_group.delete.start` | `neutron` | shoot tear-down |
+| `security_group.delete.end` | `neutron` | shoot tear-down |
+| `security_group_rule.create.start` | `neutron` | shoot infrastructure |
+| `security_group_rule.create.end` | `neutron` | shoot infrastructure |
+| `port.create.start` | `neutron` | boot, load balancer |
+| `port.create.end` | `neutron` | boot, load balancer |
+| `port.update.start` | `neutron` | boot |
+| `port.update.end` | `neutron` | boot |
+| `port.delete.start` | `neutron` | delete, load balancer |
+| `port.delete.end` | `neutron` | delete, load balancer |
+| `image.prepare` | `glance` | image |
+| `image.activate` | `glance` | image |
+| `identity.project.created` | `keystone` | tenant |
+| `identity.user.created` | `keystone` | tenant |
+| `identity.authenticate` | `keystone` | before every action a controller starts |
+| `dns.zone.create` | `designate` | tenant |
+| `dns.recordset.create` | `designate` | shoot infrastructure, load balancer |
+| `dns.recordset.delete` | `designate` | shoot tear-down |
+| `audit.http.request` | `barbican` | load balancer |
+| `audit.http.response` | `barbican` | load balancer |
+
+No recorded sample exists for any of the 62. The fixtures under
+[`internal/providers/openstack/testdata/golden/notifications/`](../internal/providers/openstack/testdata/golden/notifications)
+are the collector's, and it maps none of these types, so a real deployment never
+had one recorded there. The member sets are the simulator's own, chosen after
+the legacy notification payloads of the services, and
+`TestNoisePayloadsCarryTheirMembers` pins them the way the fixtures pin the
+billable ones. `TestEverySeedRendersTheWholeCatalogue` holds seeds 1 to 5 to the
+whole list, so a type that leaves the catalogue fails the suite.
+
+The collector's label limiter admits 100 distinct `event_type` values, which is
+`LabelValueLimit` in
+[`internal/providers/openstack/metrics.go`](../internal/providers/openstack/metrics.go),
+and the consumed and the skipped series share that bound. The 83 types of a
+month stay inside it, so no series of a simulated month lands under
+`event_type="other"`. `TestAMonthStaysInsideTheCollectorsLabelBudget` holds the
+month to the bound, so a catalogue or a mapping that grows past it fails the
+suite rather than silently folding the types that arrive last.
+
+The workload renders 83 oslo notification types: the 21 of the table below,
+which the collector's mapping knows, and the 62 of the catalogue above, which it
+skips.
 
 | Notification | Exchange | Billable |
 | --- | --- | --- |
@@ -227,14 +482,38 @@ month churns (the workers, their root volumes, the claims, the load balancers
 with their ports, listeners, pools, and addresses, and the CI runners) come from
 that same salted stream at the moment the resource is created.
 
+A third generator names the resources that exist to be announced and never
+billed: the tenants' networks, the zones, the ports, the attachments, the
+security group rules, the record sets, the secrets and containers, and the CADF
+record ids. It is salted with the cloud and the period the way the identifier
+stream is, and holding the two apart is what leaves the identifier stream
+drawing the billable month alone. That holds for the message ids as well: they
+are drawn over the sorted schedule once it stands, and a noise transition takes
+its own from the third stream, so a catalogue one transition longer renumbers
+nothing the collector books. The one place the catalogue reaches into the
+billable month is the bound of a deleted instance's last lifetime step, which
+lies before the five seconds of nova's pre-delete sequence rather than at the
+delete itself.
+
 The same seed, period, and cloud therefore publish byte-identical
-notifications, and a rerun costs nothing at the far end: the collector books
-the oslo message id as the event's `event_id`, and the Reporting API stores an
-event once per (`event_id`, `timestamp`), which
+notifications, and a rerun of the same build costs nothing at the far end: the
+collector books the oslo message id as the event's `event_id`, and the
+Reporting API stores an event once per (`event_id`, `timestamp`), which
 [`openstack-collector.md`](openstack-collector.md) describes. Another cloud or
 another month publishes fresh resources under fresh message ids, so two
 collectors fed by two simulated clouds never collide on `event_id` at one
 Reporting API.
+
+Across two builds that disagree about the month it is a different matter. A
+message id is the n-th draw of a stream over the schedule a build renders, so a
+build that adds, drops, or moves a transition hands the same period a second
+set of `event_id`, and the (`event_id`, `timestamp`) key absorbs neither set
+into the other: the Reporting API then holds the period twice, with every
+count, rollup, and invoice over it doubled and nothing logged. No subcommand of
+`tally-reporting-admin` deletes what an ingest wrote, so the way back is to drop
+the reporting database the events landed in, which for the dev cluster is
+`make down` followed by `make up`. Regenerating a period against a database that
+already holds it is therefore a decision, not a repeat.
 
 Between two months of the same length the classic tenants' notifications sit at
 the same offsets from the month start. The transitions anchored on the month's
@@ -285,12 +564,14 @@ cluster through `extra_hosts`, which maps `api.tally.127-0-0-1.nip.io` to
 `host-gateway`, and `tally-ca.crt` is mounted read-only at the path
 `SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify.
 
-The collector service of the stack lists five exchanges in
-`TALLY_OSC_EXCHANGES`: `nova,neutron,cinder,glance,octavia`. The simulator
-publishes the shoots' load balancers on `octavia`, and a topic exchange copies a
-message only to the queues bound to it, so a collector left at its default of
-four exchanges receives none of the load balancers and shows no `octavia.`
-series in any of its counters, `tally_collector_skipped_total` included.
+The collector service of the stack lists all eight exchanges in
+`TALLY_OSC_EXCHANGES`:
+`nova,neutron,cinder,glance,octavia,keystone,designate,barbican`. A topic
+exchange copies a message only to the queues bound to it, so a collector
+left at its default of four sees the nova, cinder, neutron, and glance noise
+counted as skipped and nothing at all from the other four: no load balancer, no
+tenant or authentication record, no zone or record set, and no certificate audit
+record. Those series are absent from its counters rather than zero.
 [`openstack-collector.md`](openstack-collector.md), "Exchanges and topics", is
 where that default and the reason it leaves octavia out are described.
 
@@ -353,9 +634,12 @@ curl --cacert tally-ca.crt -H "Authorization: Bearer $token" \
 
 ## What the collector shows
 
-Seed 1 over `2026-07` renders 1821 notifications, 1812 of them billable. The
-other nine are the unsized `image.create`, one per image: two per classic
-project, one per Gardener tenant, and one for the CI tenant.
+Seed 1 over `2026-07` renders 15727 notifications, 1812 of them billable. Nine
+of the other 13915 are the unsized `image.create`, one per image: two per
+classic project, one per Gardener tenant, and one for the CI tenant. The
+remaining 13906 are the noise catalogue. The month carries 83 distinct
+`event_type` values. The shape of a month is the seed's alone, so the counts
+below hold on every cloud.
 
 `curl http://127.0.0.1:8090/readyz` answers 200 once the collector holds its
 broker connection and its outbox. On `http://127.0.0.1:8090/metrics`:
@@ -363,13 +647,86 @@ broker connection and its outbox. On `http://127.0.0.1:8090/metrics`:
 - `tally_collector_consumed_total` grows per event type while the month goes
   out, and carries the three `octavia.loadbalancer.*.end` series among the
   others.
-- `tally_collector_skipped_total{event_type="image.create"}` ends at 9 for that
-  seed and period.
+- `tally_collector_skipped_total` climbs per type beside it, and it climbs
+  faster: 13915 of the month's 15727 notifications are ones the mapping claims
+  nothing for.
+- Neither counter carries an `event_type="other"` series. The month's 83 types
+  stay inside the bound of 100 label values the two of them share.
 - `tally_collector_unparseable_total` stays 0. Anything else is a rendered body
   the collector could not read.
 - `tally_collector_delivered_total` rises above 0 within two minutes at factor
   744. A counter that stays at 0 means the events sit in the outbox and the
   Reporting API is not taking them.
+
+`tally_collector_skipped_total` ends the month at these values. Of the 1753
+`compute.instance.exists`, 1094 are daily audits and 659 are the audit nova
+sends before a delete.
+
+| `event_type` | Value |
+| --- | --- |
+| `compute.instance.update` | 2672 |
+| `compute.instance.exists` | 1753 |
+| `port.create.start` | 676 |
+| `port.create.end` | 676 |
+| `compute.instance.create.start` | 671 |
+| `scheduler.select_destinations.start` | 671 |
+| `scheduler.select_destinations.end` | 671 |
+| `port.update.start` | 671 |
+| `port.update.end` | 671 |
+| `port.delete.start` | 660 |
+| `port.delete.end` | 660 |
+| `compute.instance.delete.start` | 659 |
+| `compute.instance.shutdown.start` | 659 |
+| `compute.instance.shutdown.end` | 659 |
+| `volume.attach.start` | 203 |
+| `volume.attach.end` | 203 |
+| `volume.detach.start` | 186 |
+| `volume.detach.end` | 186 |
+| `volume.create.start` | 169 |
+| `identity.authenticate` | 158 |
+| `volume.delete.start` | 146 |
+| `compute.instance.power_off.start` | 29 |
+| `compute.instance.power_on.start` | 29 |
+| `volume.resize.start` | 18 |
+| `compute.instance.shelve_offload.start` | 10 |
+| `compute.instance.unshelve.start` | 10 |
+| `image.create` | 9 |
+| `image.prepare` | 9 |
+| `image.activate` | 9 |
+| `audit.http.request` | 8 |
+| `audit.http.response` | 8 |
+| `compute.instance.resize.start` | 7 |
+| `compute.instance.finish_resize.start` | 7 |
+| `dns.recordset.create` | 6 |
+| `security_group_rule.create.start` | 6 |
+| `security_group_rule.create.end` | 6 |
+| `network.create.start` | 4 |
+| `network.create.end` | 4 |
+| `subnet.create.start` | 4 |
+| `subnet.create.end` | 4 |
+| `router.create.start` | 4 |
+| `router.create.end` | 4 |
+| `router.interface.create` | 4 |
+| `identity.project.created` | 3 |
+| `identity.user.created` | 3 |
+| `keypair.import.start` | 3 |
+| `keypair.import.end` | 3 |
+| `security_group.create.start` | 3 |
+| `security_group.create.end` | 3 |
+| `volume.transfer.accept.start` | 3 |
+| `dns.zone.create` | 2 |
+| `dns.recordset.delete` | 2 |
+| `keypair.delete.start` | 1 |
+| `keypair.delete.end` | 1 |
+| `security_group.delete.start` | 1 |
+| `security_group.delete.end` | 1 |
+| `router.interface.delete` | 1 |
+| `router.delete.start` | 1 |
+| `router.delete.end` | 1 |
+| `subnet.delete.start` | 1 |
+| `subnet.delete.end` | 1 |
+| `network.delete.start` | 1 |
+| `network.delete.end` | 1 |
 
 `docker compose -f deploy/compose/compose.yaml logs collector` shows neither an
 `x509` error nor a `401` when the CA and the token are right.
@@ -397,7 +754,7 @@ puts on the bus.
 
 `events.jsonl` holds one canonical event per billable notification, computed by
 the collector's own parser and mapping table rather than by the simulator's
-idea of them. For seed 1 the first file therefore has nine more lines than the
+idea of them. For seed 1 the first file therefore has 13915 more lines than the
 second. A broker and `--out` combine: a run does both.
 
 `replay --in FILE --factor N` publishes a captured file onto a broker, with the
@@ -426,7 +783,7 @@ at another speed.
 `GET /healthz` answers `ok`. `GET /clock` answers the document of that moment:
 
 ```json
-{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":1821,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":15727,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
 ```
 
 `PUT /clock` with a body of `{"factor": N}`, where N is zero or positive,

--- a/internal/providers/openstack/metrics.go
+++ b/internal/providers/openstack/metrics.go
@@ -60,7 +60,7 @@ type Metrics struct {
 func NewMetrics(reg *prometheus.Registry, depth, oldestSeconds func() float64) *Metrics {
 	m := &Metrics{
 		reg:     reg,
-		limiter: cardinality.New(labelValueLimit),
+		limiter: cardinality.New(LabelValueLimit),
 		consumed: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "tally_collector_consumed_total",
 			Help: "Notifications mapped to an event and buffered.",
@@ -181,11 +181,15 @@ func (m *Metrics) DeliveryError() {
 // of known values.
 const labelEventType = "event_type"
 
-// labelValueLimit is how many distinct event types the series may carry, on the
+// LabelValueLimit is how many distinct event types the series may carry, on the
 // terms internal/core/cardinality bounds them with.
 //
 // It is 100 here and 128 in internal/reporting/metrics on purpose. Each service
 // bounds what its own traffic can mint, and 100 is several times the mapping
 // table, which is the vocabulary a healthy deployment stays inside. The two
 // numbers are not meant to track each other.
-const labelValueLimit = 100
+//
+// It is exported because the simulator is held to it: a generated month has to
+// stay inside the bound, or the series an operator is told to read fold into
+// event_type="other".
+const LabelValueLimit = 100

--- a/internal/providers/openstack/metrics_test.go
+++ b/internal/providers/openstack/metrics_test.go
@@ -142,7 +142,7 @@ func TestConsumedFoldsEveryEventTypePastTheLimitIntoOneSeries(t *testing.T) {
 	// the number of them the vector may hold is what has to be bounded.
 	m := freshMetrics(t)
 
-	for i := range labelValueLimit {
+	for i := range LabelValueLimit {
 		m.Consumed("compute.instance.type-" + strconv.Itoa(i))
 	}
 	// The first type past the limit, recorded twice so the overflow series can be
@@ -151,8 +151,8 @@ func TestConsumedFoldsEveryEventTypePastTheLimitIntoOneSeries(t *testing.T) {
 	m.Consumed("compute.instance.past-the-limit")
 
 	// The admitted values plus the one bucket the rest share.
-	if got := testutil.CollectAndCount(m.consumed); got != labelValueLimit+1 {
-		t.Errorf("tally_collector_consumed_total has %d series, want %d", got, labelValueLimit+1)
+	if got := testutil.CollectAndCount(m.consumed); got != LabelValueLimit+1 {
+		t.Errorf("tally_collector_consumed_total has %d series, want %d", got, LabelValueLimit+1)
 	}
 	if got := testutil.ToFloat64(m.consumed.WithLabelValues(cardinality.Overflow)); got != 2 {
 		t.Errorf(`tally_collector_consumed_total{event_type=%q} = %v, want the 2 past the limit`,
@@ -166,7 +166,7 @@ func TestConsumedKeepsALongEventTypeOutOfTheSeriesAndOfTheBudget(t *testing.T) {
 	m := freshMetrics(t)
 
 	m.Consumed(strings.Repeat("a", cardinality.ValueMax+1))
-	for i := range labelValueLimit {
+	for i := range LabelValueLimit {
 		m.Consumed("compute.instance.type-" + strconv.Itoa(i))
 	}
 
@@ -175,7 +175,7 @@ func TestConsumedKeepsALongEventTypeOutOfTheSeriesAndOfTheBudget(t *testing.T) {
 			cardinality.Overflow, got)
 	}
 	if got := testutil.ToFloat64(m.consumed.WithLabelValues(
-		"compute.instance.type-" + strconv.Itoa(labelValueLimit-1),
+		"compute.instance.type-" + strconv.Itoa(LabelValueLimit-1),
 	)); got != 1 {
 		t.Error("the long event type consumed a slot, so the last real event type was folded into the overflow bucket")
 	}
@@ -187,7 +187,7 @@ func TestSkippedSharesTheBoundWithConsumed(t *testing.T) {
 	// is spent once rather than per instrument.
 	m := freshMetrics(t)
 
-	for i := range labelValueLimit {
+	for i := range LabelValueLimit {
 		m.Consumed("compute.instance.type-" + strconv.Itoa(i))
 	}
 	m.Skipped("compute.instance.type-0")
@@ -205,7 +205,7 @@ func TestSkippedSharesTheBoundWithConsumed(t *testing.T) {
 func TestLabelValueLimitIsTheCollectorsOwnBound(t *testing.T) {
 	// The reporting registry bounds its labels at 128. This one is fixed at 100
 	// by WP 1.12, and the two are not meant to drift together.
-	if labelValueLimit != 100 {
-		t.Errorf("labelValueLimit = %d, want the 100 the collector is specified with", labelValueLimit)
+	if LabelValueLimit != 100 {
+		t.Errorf("LabelValueLimit = %d, want the 100 the collector is specified with", LabelValueLimit)
 	}
 }

--- a/internal/providers/openstack/simulator/ci.go
+++ b/internal/providers/openstack/simulator/ci.go
@@ -11,7 +11,8 @@ import "time"
 //
 // A pipeline is started by somebody pushing, so the bursts fall into the
 // working hours of a Monday to Friday of the real calendar and the weekends
-// hold none of them.
+// hold none of them. Every push takes a keystone token, which is one
+// authentication per burst and none per runner.
 //
 // A runner is called runner-<the first eight hex digits of its instance id>,
 // the way a build system names a throwaway machine after the job it was
@@ -37,10 +38,13 @@ const (
 // its own number would push runners past that end unnoticed.
 const longestBurst = (maxBurstRunners - 1) * (runnerGapCeiling - time.Second)
 
-// ci generates the CI tenant's month. The image comes first because every
-// runner boots from it, and it is the one resource of this tenant that outlives
-// a single job.
+// ci generates the CI tenant's month. The tenant is created in keystone at the
+// month start and neutron builds its network there, because the runners hold
+// their addresses on it. The image follows, since every runner boots from it,
+// and it is the one resource of this tenant that outlives a single job.
 func (g *generator) ci() {
+	g.announceTenant(g.ciTenant, g.from)
+	g.buildNetwork(g.ciTenant, g.ciTenant.network, g.from.Add(2*time.Second))
 	g.tenantImage(g.ciTenant)
 
 	for _, d := range workingDays(g.from, g.to) {
@@ -49,6 +53,7 @@ func (g *generator) ci() {
 		// requested seconds apart and run side by side.
 		for range 4 + g.shape.IntN(5) {
 			t := drawInstant(g.shape, at(d, officeFrom, 0), at(d, officeTo, 0).Add(-longestBurst))
+			g.authenticate(g.ciTenant, t.Add(-authenticateLead))
 			for range minBurstRunners + g.shape.IntN(maxBurstRunners-minBurstRunners+1) {
 				g.runner(t)
 				t = t.Add(span(g.shape, minRunnerGap, runnerGapCeiling))

--- a/internal/providers/openstack/simulator/ci.go
+++ b/internal/providers/openstack/simulator/ci.go
@@ -73,10 +73,8 @@ func (g *generator) runner(t time.Time) {
 		createdAt: t,
 	}
 
-	g.emit(t, "compute.instance.create.end", computePublisher(inst), inst.id, tenant,
-		instanceCreatePayload(tenant, inst, g.cloud))
+	g.createInstance(tenant, inst, tenant.network, t)
 
 	deletedAt := t.Add(span(g.shape, 3*time.Minute, 40*time.Minute))
-	g.emit(deletedAt, "compute.instance.delete.end", computePublisher(inst), inst.id, tenant,
-		instanceDeletePayload(tenant, inst, deletedAt))
+	g.destroyInstance(tenant, inst, deletedAt)
 }

--- a/internal/providers/openstack/simulator/gardener.go
+++ b/internal/providers/openstack/simulator/gardener.go
@@ -14,12 +14,12 @@ import (
 // persistent volume claim into a cinder volume. Nothing here speaks to a
 // Kubernetes API, and nothing of the cluster itself is rendered.
 //
-// Only the billable side of a shoot is generated: the workers, the volumes, the
-// addresses, the image the workers boot from, and the load balancers. The
-// network, the subnet, the router, and the ports are named in the payloads that
-// refer to them. The security group and the keypair are named by nothing yet:
-// they are held for the issue that adds the neutron and keystone side, which is
-// where the notifications about all of them belong.
+// The billable side of a shoot is the workers, the volumes, the addresses, the
+// image the workers boot from, and the load balancers. Everything a cluster
+// needs besides them is announced by the helpers of noise.go around those
+// transitions and billed for by nothing: the network, the subnet, the router,
+// the security group with its rules, the keypair, the ports, the DNS records,
+// and the certificate the ingress terminates on.
 //
 // The names are the shapes Gardener's OpenStack extension and the
 // machine-controller-manager give the resources they create: a technical id
@@ -56,10 +56,18 @@ func newGardenerProjects() []*gardenerProject {
 	}
 }
 
-// gardener generates one Gardener project's month. The image comes first
-// because every worker of every shoot boots from it.
+// gardener generates one Gardener project's month. The tenant is announced
+// first because nothing in it exists before it does, the image follows because
+// every worker of every shoot boots from it, and the zone follows the image
+// because the shoots publish their records into it.
+//
+// An image drawn at exactly the month start shares its instant with the
+// project's creation. The sort of the month is stable, so the announcement
+// stays where it was emitted: ahead of the tenant's first resource.
 func (g *generator) gardener(gp *gardenerProject) {
+	g.announceTenant(gp.tenant, g.from)
 	g.tenantImage(gp.tenant)
+	g.createZone(gp, g.from.Add(2*time.Second))
 	for _, s := range gp.shoots {
 		g.shoot(gp, s)
 	}
@@ -106,18 +114,10 @@ func (g *generator) shoot(gp *gardenerProject, s *shoot) {
 		s.secondBalancerDay = at(drawWorkingInstant(g.shape, g.from.Add(3*day), g.from.Add(20*day)), 0, 0)
 	}
 
-	// The network the shoot's servers hold their addresses on, built from the
-	// ids the shoot was named with. Its range is the one the shoot's VIP
-	// addresses already lie in, and the notifications about the network itself
-	// are a later package's. Building it draws nothing.
-	s.network = &network{
-		id:              s.networkID,
-		subnetID:        s.subnetID,
-		routerID:        s.routerID,
-		securityGroupID: s.securityGroupID,
-		name:            s.technicalID,
-		cidr:            fmt.Sprintf("10.250.%d.0/24", s.index),
-	}
+	// What Gardener creates before the first worker can boot: the network the
+	// servers hold their addresses on, the security group, the keypair, and the
+	// record the API server answers on.
+	g.shootInfrastructure(s, s.createdAt)
 
 	// The creation sequence: the workers come up seconds apart, the workloads
 	// that claim storage are scheduled once the nodes are ready, and the ingress
@@ -157,9 +157,16 @@ func (g *generator) shoot(gp *gardenerProject, s *shoot) {
 // or hibernating through is a day the autoscaler and the workloads have no full
 // window on, and rendering their steps into a fraction of one would put load on
 // a cluster that was not there yet.
+//
+// Two of the day's steps take a keystone token: the wake-up and the rolling
+// update, each of which is one reconciliation Gardener starts. The autoscaler
+// and the claim activity take none. One record per action somebody or a
+// controller starts is what keeps the month's authentications a number a reader
+// can follow.
 func (g *generator) shootDay(s *shoot, d time.Time) {
 	if s.hibernates && !s.awake && workingDay(d) {
 		t := at(d, officeFrom, 0)
+		g.authenticate(s.owner.tenant, t.Add(-authenticateLead))
 		var last time.Time
 		for range s.baseWorkers {
 			last = t
@@ -194,6 +201,7 @@ func (g *generator) shootDay(s *shoot, d time.Time) {
 	// added today are left alone, because they already run the new version.
 	if d.Equal(s.rollingUpdateDay) {
 		t := drawWorkingInstant(g.shape, at(d, 9, 0), at(d, 15, 0))
+		g.authenticate(s.owner.tenant, t.Add(-authenticateLead))
 		for _, w := range slices.Clone(s.workers) {
 			if slices.Contains(s.added, w) {
 				continue
@@ -406,14 +414,20 @@ func (g *generator) claimActivity(s *shoot, d time.Time) {
 	}
 }
 
-// createLoadBalancer publishes one service of type LoadBalancer: octavia
-// creates the balancer, neutron gives its VIP port a floating address, and the
-// listeners and pools of the service arrive on the update that follows.
+// createLoadBalancer publishes one service of type LoadBalancer: neutron gives
+// the balancer the port it holds its VIP on, octavia creates the balancer, the
+// floating address follows, and the listeners and pools of the service arrive
+// on the update after that.
 //
 // The update is the notification the balancer's size is booked from. Octavia
 // reports the listeners and the pools on an update alone, and the create is
 // sent before the service's ports are attached, so the create carries a
 // balancer of zero listeners and zero pools.
+//
+// The first balancer of a shoot is what its ingress record points at, since
+// that is the address every service of the cluster is reached under. A balancer
+// that terminates TLS holds the certificate for it in barbican, which is four
+// audit records twenty seconds after the create and before the update.
 func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, listeners, pools int) {
 	tenant := s.owner.tenant
 	lb := &loadBalancer{id: g.identifiers.nextUUID(), name: name, vipPortID: g.identifiers.nextUUID()}
@@ -442,11 +456,45 @@ func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, liste
 	g.assigned++
 	s.loadBalancers = append(s.loadBalancers, lb)
 
+	// The port the balancer holds its VIP on. Octavia is the device behind it,
+	// and it is bound to no host: the VIP lives on the balancer's amphorae and
+	// not on a compute.
+	vipPort := newPort(s.network, lb.vipPortID, lb.vipAddress, "lb-"+lb.id, "Octavia", "")
+	g.noise(t.Add(-vipPortLead), "port.create.start", networkPublisher, lb.vipPortID, tenant,
+		portRequestPayload(tenant, vipPort))
+	g.noise(t.Add(-vipPortLead+time.Second), "port.create.end", networkPublisher, lb.vipPortID, tenant,
+		portPayload(tenant, vipPort, false))
+
 	g.emit(t, "octavia.loadbalancer.create.end", "", lb.id, tenant,
 		loadBalancerPayload(tenant, s, lb, false))
 	allocatedAt := t.Add(span(g.shape, 2*time.Second, 10*time.Second))
 	g.emit(allocatedAt, "floatingip.create.end", networkPublisher, lb.fip.id, tenant,
 		floatingIPCreatePayload(tenant, lb.fip, g.networkID))
+
+	// The ingress record is created with the first balancer of the shoot and
+	// points at its address, which is the wildcard every service of the cluster
+	// is published under.
+	if len(s.loadBalancers) == 1 {
+		s.ingressRecord = &recordSet{
+			id:         g.noiseIDs.nextUUID(),
+			name:       "*.ingress." + s.name + "." + s.owner.zoneName,
+			recordType: "A",
+			records:    []string{lb.fip.address},
+		}
+		g.createRecordSet(s.owner, s.ingressRecord, t.Add(ingressRecordLag))
+	}
+
+	// The https listener is the second of the catalog, so a balancer that gets
+	// two of them is the one that terminates TLS. Its certificate goes into
+	// barbican as a secret with the private key and a container that holds the
+	// two together.
+	if listeners >= 2 {
+		lb.secretID, lb.containerID = g.noiseIDs.nextUUID(), g.noiseIDs.nextUUID()
+		g.barbicanCall(tenant, t.Add(certificateLag), "POST", "/v1/secrets",
+			secretsType, lb.secretID)
+		g.barbicanCall(tenant, t.Add(certificateLag+2*time.Second), "POST", "/v1/containers",
+			containersType, lb.containerID)
+	}
 
 	g.emit(t.Add(span(g.shape, 60*time.Second, 300*time.Second)),
 		"octavia.loadbalancer.update.end", "", lb.id, tenant,
@@ -455,13 +503,16 @@ func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, liste
 
 // tearDown deletes a shoot in the order Gardener does, which is the order its
 // resources depend on each other in: the services go first, address before
-// balancer, then the workers, then the claims they held. Nothing of the shoot
-// is emitted after the last of them. A claim is attached unless the shoot
-// hibernated, so its delete carries the detach cinder sends three seconds
-// before it.
+// balancer and the VIP port and the certificate after it, then the workers,
+// then the claims they held, and the infrastructure underneath them all last.
+// Nothing of the shoot is emitted after its network is gone. A claim is
+// attached unless the shoot hibernated, so its delete carries the detach cinder
+// sends three seconds before it.
 func (g *generator) tearDown(s *shoot) {
 	tenant := s.owner.tenant
 	t := s.deletedAt
+
+	g.authenticate(tenant, s.deletedAt.Add(-authenticateLead))
 
 	for _, lb := range s.loadBalancers {
 		g.emit(t, "floatingip.delete.end", networkPublisher, lb.fip.id, tenant,
@@ -469,6 +520,20 @@ func (g *generator) tearDown(s *shoot) {
 		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 		g.emit(t, "octavia.loadbalancer.delete.end", "", lb.id, tenant,
 			loadBalancerPayload(tenant, s, lb, false))
+		// The VIP port goes with the balancer that held it.
+		g.noise(t.Add(time.Second), "port.delete.start", networkPublisher, lb.vipPortID, tenant,
+			neutronDeletePayload("port", lb.vipPortID))
+		g.noise(t.Add(2*time.Second), "port.delete.end", networkPublisher, lb.vipPortID, tenant,
+			neutronDeletePayload("port", lb.vipPortID))
+		// The container goes before the secret it holds, the way a certificate is
+		// given back: the container refers to the secret, and barbican refuses a
+		// secret another resource still names.
+		if lb.containerID != "" {
+			g.barbicanCall(tenant, t.Add(3*time.Second), "DELETE", "/v1/containers/"+lb.containerID,
+				containersType, lb.containerID)
+			g.barbicanCall(tenant, t.Add(5*time.Second), "DELETE", "/v1/secrets/"+lb.secretID,
+				secretsType, lb.secretID)
+		}
 		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 	}
 	for _, w := range slices.Clone(s.workers) {
@@ -479,5 +544,6 @@ func (g *generator) tearDown(s *shoot) {
 		g.deleteVolume(tenant, vol, t)
 		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 	}
+	g.tearDownInfrastructure(s, t)
 	s.claims = nil
 }

--- a/internal/providers/openstack/simulator/gardener.go
+++ b/internal/providers/openstack/simulator/gardener.go
@@ -107,6 +107,19 @@ func (g *generator) shoot(gp *gardenerProject, s *shoot) {
 		s.secondBalancerDay = at(drawWorkingInstant(g.shape, g.from.Add(3*day), g.from.Add(20*day)), 0, 0)
 	}
 
+	// The network the shoot's servers hold their addresses on, built from the
+	// ids the shoot was named with. Its range is the one the shoot's VIP
+	// addresses already lie in, and the notifications about the network itself
+	// are a later package's. Building it draws nothing.
+	s.network = &network{
+		id:              s.networkID,
+		subnetID:        s.subnetID,
+		routerID:        s.routerID,
+		securityGroupID: s.securityGroupID,
+		name:            s.technicalID,
+		cidr:            fmt.Sprintf("10.250.%d.0/24", s.index),
+	}
+
 	// The creation sequence: the workers come up seconds apart, the workloads
 	// that claim storage are scheduled once the nodes are ready, and the ingress
 	// controller's load balancer follows within the hour.
@@ -274,8 +287,7 @@ func (g *generator) bootWorker(s *shoot, t time.Time) *instance {
 		w.imageID = tenant.images[0].id
 	}
 
-	g.emit(t, "compute.instance.create.end", computePublisher(w), w.id, tenant,
-		instanceCreatePayload(tenant, w, g.cloud))
+	g.createInstance(tenant, w, s.network, t)
 	s.workers = append(s.workers, w)
 	return w
 }
@@ -286,8 +298,7 @@ func (g *generator) bootWorker(s *shoot, t time.Time) *instance {
 // here, whether it is scaled down, rolled, hibernated, or torn down.
 func (g *generator) deleteWorker(s *shoot, w *instance, t time.Time) {
 	tenant := s.owner.tenant
-	g.emit(t, "compute.instance.delete.end", computePublisher(w), w.id, tenant,
-		instanceDeletePayload(tenant, w, t))
+	g.destroyInstance(tenant, w, t)
 
 	if w.bootVolume != nil {
 		deletedAt := t.Add(span(g.shape, 20*time.Second, 40*time.Second))
@@ -394,9 +405,12 @@ func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, liste
 	for range pools {
 		lb.poolIDs = append(lb.poolIDs, g.identifiers.nextUUID())
 	}
-	// The VIP addresses of a shoot come from its own third octet, so two shoots
-	// on one tenant never report the same address.
-	lb.vipAddress = fmt.Sprintf("10.250.%d.%d", s.index, 10+len(s.loadBalancers))
+	// The VIP comes from the counter the shoot's ports already draw from. A
+	// balancer sits on the shoot's own subnet, which is the range of its third
+	// octet, and neutron allocates every address of a subnet once: a second
+	// allocator over the same range would hand a worker's port and a VIP the
+	// same fixed address while both are up.
+	lb.vipAddress = s.network.nextAddress()
 	lb.fip = &floatingIP{
 		id:      g.identifiers.nextUUID(),
 		address: floatingPrefix + strconv.Itoa(1+g.addresses[g.assigned]),

--- a/internal/providers/openstack/simulator/gardener.go
+++ b/internal/providers/openstack/simulator/gardener.go
@@ -161,14 +161,19 @@ func (g *generator) shoot(gp *gardenerProject, s *shoot) {
 func (g *generator) shootDay(s *shoot, d time.Time) {
 	if s.hibernates && !s.awake && workingDay(d) {
 		t := at(d, officeFrom, 0)
+		var last time.Time
 		for range s.baseWorkers {
+			last = t
 			g.bootWorker(s, t)
 			t = t.Add(span(g.shape, 3*time.Second, 10*time.Second))
 		}
 		// The claims outlive the night and are mounted again by the workloads the
-		// new workers run, so cinder reports them in use from the wake-up on.
-		for _, claim := range s.claims {
-			claim.attached = true
+		// new workers run, so cinder reports them in use from the wake-up on. They
+		// go onto the first worker two seconds apart, once the last of the pool is
+		// up.
+		for i, claim := range s.claims {
+			g.attach(s.owner.tenant, claim, s.workers[0],
+				last.Add(attachLag+time.Duration(2*i)*time.Second))
 		}
 		s.awake = true
 	}
@@ -241,8 +246,11 @@ func (g *generator) shootDay(s *shoot, d time.Time) {
 			g.deleteWorker(s, w, t)
 			t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 		}
-		for _, claim := range s.claims {
-			claim.attached = false
+		// The claims are detached rather than deleted: they hold the data over the
+		// night, and cinder reports them available until the next wake-up mounts
+		// them again.
+		for i, claim := range s.claims {
+			g.detach(s.owner.tenant, claim, t.Add(time.Second+time.Duration(2*i)*time.Second))
 		}
 		s.awake = false
 	}
@@ -279,10 +287,12 @@ func (g *generator) bootWorker(s *shoot, t time.Time) *instance {
 			volumeType: rootVolumeType,
 			createdAt:  t.Add(-span(g.shape, 5*time.Second, 15*time.Second)),
 		}
-		g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, tenant,
-			volumeCreatePayload(tenant, vol))
-		vol.attached = true
+		// The worker holds the volume before the attach is rendered, because a
+		// root volume is mounted as the server's first disk and every other
+		// volume as its second.
 		w.bootVolume = vol
+		g.createVolume(tenant, vol, vol.createdAt)
+		g.attach(tenant, vol, w, vol.createdAt.Add(attachLag))
 	} else {
 		w.imageID = tenant.images[0].id
 	}
@@ -302,8 +312,7 @@ func (g *generator) deleteWorker(s *shoot, w *instance, t time.Time) {
 
 	if w.bootVolume != nil {
 		deletedAt := t.Add(span(g.shape, 20*time.Second, 40*time.Second))
-		g.emit(deletedAt, "volume.delete.end", volumePublisher, w.bootVolume.id, tenant,
-			volumeDeletePayload(tenant, w.bootVolume, deletedAt))
+		g.deleteVolume(tenant, w.bootVolume, deletedAt)
 	}
 
 	s.workers = slices.DeleteFunc(s.workers, func(other *instance) bool { return other == w })
@@ -324,8 +333,16 @@ func (g *generator) createClaim(s *shoot, t time.Time) {
 		createdAt:  t,
 	}
 
-	g.emit(t, "volume.create.end", volumePublisher, vol.id, tenant, volumeCreatePayload(tenant, vol))
-	vol.attached = true
+	g.createVolume(tenant, vol, t)
+
+	// The claim is mounted by the first worker of the shoot. A shoot with no
+	// worker at that moment, which the month never produces, attaches it to
+	// nothing rather than reaching into an empty pool.
+	var w *instance
+	if len(s.workers) > 0 {
+		w = s.workers[0]
+	}
+	g.attach(tenant, vol, w, t.Add(attachLag))
 	s.claims = append(s.claims, vol)
 }
 
@@ -363,6 +380,9 @@ func (g *generator) claimActivity(s *shoot, d time.Time) {
 		if len(candidates) > 0 {
 			t := drawInstant(g.shape, lo, hi)
 			vol := candidates[g.shape.IntN(len(candidates))]
+			// The .start half reports the claim at the size it still has.
+			g.noise(t.Add(-stepLead), "volume.resize.start", volumePublisher, vol.id, tenant,
+				volumeStatusPayload(tenant, vol, "extending"))
 			vol.sizeGB *= 2
 			vol.resizes++
 			g.emit(t, "volume.resize.end", volumePublisher, vol.id, tenant,
@@ -381,8 +401,7 @@ func (g *generator) claimActivity(s *shoot, d time.Time) {
 		if len(candidates) > 0 {
 			t := drawInstant(g.shape, lo, hi)
 			vol := candidates[g.shape.IntN(len(candidates))]
-			g.emit(t, "volume.delete.end", volumePublisher, vol.id, tenant,
-				volumeDeletePayload(tenant, vol, t))
+			g.deleteVolume(tenant, vol, t)
 			s.claims = slices.DeleteFunc(s.claims, func(other *volume) bool { return other == vol })
 		}
 	}
@@ -438,7 +457,9 @@ func (g *generator) createLoadBalancer(s *shoot, t time.Time, name string, liste
 // tearDown deletes a shoot in the order Gardener does, which is the order its
 // resources depend on each other in: the services go first, address before
 // balancer, then the workers, then the claims they held. Nothing of the shoot
-// is emitted after the last of them.
+// is emitted after the last of them. A claim is attached unless the shoot
+// hibernated, so its delete carries the detach cinder sends three seconds
+// before it.
 func (g *generator) tearDown(s *shoot) {
 	tenant := s.owner.tenant
 	t := s.deletedAt
@@ -456,8 +477,7 @@ func (g *generator) tearDown(s *shoot) {
 		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 	}
 	for _, vol := range s.claims {
-		g.emit(t, "volume.delete.end", volumePublisher, vol.id, tenant,
-			volumeDeletePayload(tenant, vol, t))
+		g.deleteVolume(tenant, vol, t)
 		t = t.Add(span(g.shape, 5*time.Second, 15*time.Second))
 	}
 	s.claims = nil

--- a/internal/providers/openstack/simulator/gardener.go
+++ b/internal/providers/openstack/simulator/gardener.go
@@ -77,8 +77,7 @@ func (g *generator) tenantImage(p *project) {
 	img.size = int64(4+g.shape.IntN(13)) * quarterGiB
 
 	g.emit(img.createdAt, imageCreateType, imagePublisher, img.id, p, imageCreatePayload(p, img))
-	g.emit(uploadedAt, "image.upload", imagePublisher, img.id, p,
-		imageUploadPayload(p, img, uploadedAt))
+	g.uploadImage(p, img, uploadedAt)
 }
 
 // shoot creates one cluster and walks it through every day it exists.

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -1,6 +1,7 @@
 package simulator
 
 import (
+	"fmt"
 	"math/rand/v2"
 	"time"
 )
@@ -94,6 +95,14 @@ const (
 	// certificateLag is where the four barbican records begin, one second
 	// apart.
 	certificateLag = 20 * time.Second
+)
+
+// The CADF target types barbican reports its resources under. A secret holds
+// the private key of a load balancer's certificate, and a container holds the
+// certificate that goes with it.
+const (
+	secretsType    = "service/security/keymanager/secrets"
+	containersType = "service/security/keymanager/containers"
 )
 
 // updateLeads are the distances of the three compute.instance.update of a boot
@@ -324,4 +333,208 @@ func (g *generator) uploadImage(p *project, img *image, uploadedAt time.Time) {
 
 	g.noise(uploadedAt.Add(imageActivateLag), "image.activate", imagePublisher, img.id, p,
 		imageUploadPayload(p, img, uploadedAt))
+}
+
+// buildNetwork renders the network a tenant works on: neutron's network, the
+// subnet inside it, the router out of it, and the interface that puts the
+// router on the subnet.
+//
+// The CI tenant's network at the month start and every shoot's network go
+// through here. The classic tenants' networks pre-exist the month, and neutron
+// announces nothing about a resource that was there before the first
+// transition.
+func (g *generator) buildNetwork(p *project, net *network, t time.Time) {
+	// The port the router holds its interface on. It is kept on the network so
+	// that the delete of the interface names the port the create named.
+	net.routerPortID = g.noiseIDs.nextUUID()
+
+	g.noise(t, "network.create.start", networkPublisher, net.id, p, networkRequestPayload(net))
+	g.noise(t.Add(time.Second), "network.create.end", networkPublisher, net.id, p,
+		networkPayload(p, net))
+	g.noise(t.Add(2*time.Second), "subnet.create.start", networkPublisher, net.subnetID, p,
+		subnetRequestPayload(net))
+	g.noise(t.Add(3*time.Second), "subnet.create.end", networkPublisher, net.subnetID, p,
+		subnetPayload(p, net))
+	g.noise(t.Add(4*time.Second), "router.create.start", networkPublisher, net.routerID, p,
+		routerRequestPayload(net, g.networkID))
+	g.noise(t.Add(5*time.Second), "router.create.end", networkPublisher, net.routerID, p,
+		routerPayload(p, net, g.networkID))
+	g.noise(t.Add(6*time.Second), "router.interface.create", networkPublisher, net.routerID, p,
+		routerInterfacePayload(p, net, net.routerPortID))
+}
+
+// shootInfrastructure renders everything Gardener creates before the first
+// worker of a shoot boots. It is one reconciliation, so it takes one token, and
+// what follows that token runs a second apart.
+//
+// The seventeen transitions of it, from two seconds before the shoot's creation
+// instant to sixteen after it: the authentication, the network, the subnet, the
+// router and its interface, the security group with the two rules of a worker
+// pool, the keypair the workers are reachable under, and the record set the API
+// server answers on.
+func (g *generator) shootInfrastructure(s *shoot, t time.Time) {
+	p := s.owner.tenant
+	// The network the shoot's servers hold their addresses on, built from the
+	// ids the shoot was named with. Its range is the one the shoot's VIP
+	// addresses already lie in.
+	s.network = &network{
+		id:              s.networkID,
+		subnetID:        s.subnetID,
+		routerID:        s.routerID,
+		securityGroupID: s.securityGroupID,
+		name:            s.technicalID,
+		cidr:            fmt.Sprintf("10.250.%d.0/24", s.index),
+	}
+
+	g.authenticate(p, t.Add(-authenticateLead))
+	g.buildNetwork(p, s.network, t.Add(time.Second))
+
+	g.noise(t.Add(8*time.Second), "security_group.create.start", networkPublisher, s.securityGroupID, p,
+		securityGroupRequestPayload(s))
+	g.noise(t.Add(9*time.Second), "security_group.create.end", networkPublisher, s.securityGroupID, p,
+		securityGroupPayload(p, s))
+	for i := range 2 {
+		id := g.noiseIDs.nextUUID()
+		s.securityGroupRuleIDs = append(s.securityGroupRuleIDs, id)
+		g.noise(t.Add(time.Duration(10+2*i)*time.Second), "security_group_rule.create.start",
+			networkPublisher, id, p, securityGroupRulePayload(p, s, i, ""))
+		g.noise(t.Add(time.Duration(11+2*i)*time.Second), "security_group_rule.create.end",
+			networkPublisher, id, p, securityGroupRulePayload(p, s, i, id))
+	}
+
+	// A keypair has no id, so the resource it is reported under is the user that
+	// holds it and the name it was imported under. The user id is salted with
+	// the cloud and the month the way every other identifier is, which keeps two
+	// clouds' keypairs apart.
+	keypair := p.userID + ":" + s.keypairName
+	g.noise(t.Add(14*time.Second), "keypair.import.start", apiPublisher, keypair, p,
+		keypairPayload(p, s.keypairName))
+	g.noise(t.Add(15*time.Second), "keypair.import.end", apiPublisher, keypair, p,
+		keypairPayload(p, s.keypairName))
+
+	// The API server of a shoot runs in Gardener's seed, which this world does
+	// not simulate, so the address the record points at is a placeholder from
+	// the RFC 5737 range beside the one the floating addresses come from.
+	s.apiRecord = &recordSet{
+		id:         g.noiseIDs.nextUUID(),
+		name:       "api." + s.name + "." + s.owner.zoneName,
+		recordType: "A",
+		records:    []string{fmt.Sprintf("198.51.100.%d", s.index)},
+	}
+	g.createRecordSet(s.owner, s.apiRecord, t.Add(16*time.Second))
+}
+
+// tearDownInfrastructure gives back what shootInfrastructure took, in the order
+// the resources depend on each other: the records the cluster was reached
+// under, the keypair, the security group, the router's interface, the router,
+// the subnet, and the network. Nothing of the shoot is emitted after the
+// network.delete.end.
+//
+// The cursor moves a second per transition, which is what keeps the two halves
+// of one delete out of one second.
+func (g *generator) tearDownInfrastructure(s *shoot, t time.Time) {
+	p := s.owner.tenant
+	// The cursor of the sequence. The two record sets advance it themselves,
+	// because designate renders them through a helper of its own.
+	step := func(eventType, publisherID, resourceID string, payload map[string]any) {
+		g.noise(t, eventType, publisherID, resourceID, p, payload)
+		t = t.Add(time.Second)
+	}
+
+	g.deleteRecordSet(s.owner, s.apiRecord, t)
+	t = t.Add(time.Second)
+	// A shoot that never published a service has no ingress record to give back.
+	if s.ingressRecord != nil {
+		g.deleteRecordSet(s.owner, s.ingressRecord, t)
+		t = t.Add(time.Second)
+	}
+
+	keypair := p.userID + ":" + s.keypairName
+	step("keypair.delete.start", apiPublisher, keypair, keypairPayload(p, s.keypairName))
+	step("keypair.delete.end", apiPublisher, keypair, keypairPayload(p, s.keypairName))
+
+	step("security_group.delete.start", networkPublisher, s.securityGroupID,
+		neutronDeletePayload("security_group", s.securityGroupID))
+	step("security_group.delete.end", networkPublisher, s.securityGroupID,
+		neutronDeletePayload("security_group", s.securityGroupID))
+
+	step("router.interface.delete", networkPublisher, s.routerID,
+		routerInterfacePayload(p, s.network, s.network.routerPortID))
+	step("router.delete.start", networkPublisher, s.routerID,
+		neutronDeletePayload("router", s.routerID))
+	step("router.delete.end", networkPublisher, s.routerID,
+		neutronDeletePayload("router", s.routerID))
+
+	step("subnet.delete.start", networkPublisher, s.subnetID,
+		neutronDeletePayload("subnet", s.subnetID))
+	step("subnet.delete.end", networkPublisher, s.subnetID,
+		neutronDeletePayload("subnet", s.subnetID))
+
+	step("network.delete.start", networkPublisher, s.networkID,
+		neutronDeletePayload("network", s.networkID))
+	step("network.delete.end", networkPublisher, s.networkID,
+		neutronDeletePayload("network", s.networkID))
+}
+
+// announceTenant is what keystone sends when a tenant is created: the project
+// and the user that works in it, a second apart.
+func (g *generator) announceTenant(p *project, t time.Time) {
+	g.noise(t, "identity.project.created", identityPublisher, p.id, p, identityPayload(p.id))
+	g.noise(t.Add(time.Second), "identity.user.created", identityPublisher, p.userID, p,
+		identityPayload(p.userID))
+}
+
+// authenticate is the token somebody or a controller takes before it acts.
+//
+// The resource of the transition is the CADF record's own id and not the user
+// it was issued for. A user authenticates several times a day, two of those may
+// fall into one second, and a record id is what keeps the rule that two
+// notifications about one resource are a second apart trivially true.
+func (g *generator) authenticate(p *project, t time.Time) {
+	id := g.noiseIDs.nextUUID()
+	g.noise(t, "identity.authenticate", identityPublisher, id, p, authenticatePayload(p, id, t))
+}
+
+// createZone publishes the designate zone a Gardener project's records live in.
+// The zones are never deleted: a project outlives every shoot it holds, and the
+// zone is what the records of the next one are created under.
+func (g *generator) createZone(gp *gardenerProject, t time.Time) {
+	g.noise(t, "dns.zone.create", dnsPublisher, gp.zoneID, gp.tenant,
+		zonePayload(gp.tenant, gp, t))
+}
+
+// createRecordSet publishes one record set into a project's zone.
+func (g *generator) createRecordSet(gp *gardenerProject, rs *recordSet, t time.Time) {
+	g.noise(t, "dns.recordset.create", dnsPublisher, rs.id, gp.tenant,
+		recordSetPayload(gp.tenant, gp, rs, "CREATE", t))
+}
+
+// deleteRecordSet withdraws one record set from a project's zone.
+func (g *generator) deleteRecordSet(gp *gardenerProject, rs *recordSet, t time.Time) {
+	g.noise(t, "dns.recordset.delete", dnsPublisher, rs.id, gp.tenant,
+		recordSetPayload(gp.tenant, gp, rs, "DELETE", t))
+}
+
+// barbicanCall renders one call against barbican's API as the two records its
+// audit middleware sends: the request when it arrives, and the response a
+// second later. Each of the two is its own resource, because a call is one
+// thing that happened and not two steps of a resource's life.
+//
+// The method is what the action and the status of the response are read off: a
+// POST creates the secret or the container the path names and is answered with
+// a 201, and a DELETE gives it back and is answered with a 204.
+func (g *generator) barbicanCall(p *project, t time.Time,
+	method, path, targetType, targetID string,
+) {
+	reqID, respID := g.noiseIDs.nextUUID(), g.noiseIDs.nextUUID()
+	action, code := "create", 201
+	if method == "DELETE" {
+		action, code = "delete", 204
+	}
+
+	g.noise(t, "audit.http.request", barbicanPublisher, reqID, p,
+		auditPayload(p, g.cloud, reqID, action, "pending", path, targetType, targetID, 0, t))
+	response := t.Add(time.Second)
+	g.noise(response, "audit.http.response", barbicanPublisher, respID, p,
+		auditPayload(p, g.cloud, respID, action, "success", path, targetType, targetID, code, response))
 }

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -2,7 +2,10 @@ package simulator
 
 import (
 	"fmt"
+	"maps"
 	"math/rand/v2"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -40,8 +43,9 @@ import (
 //
 // The infrastructure of a shoot is the one sequence without a constant of its
 // own: it runs one transition per second, from 1 to 16 seconds after the
-// shoot's creation instant. The audit records of a tenant sit at the midnight
-// itself, which is a lag of zero and needs no constant either.
+// shoot's creation instant. The daily compute.instance.exists audits need no
+// constant either: they sit at the midnight itself, pushed on by whole seconds
+// for as long as the instance already reports a transition at that second.
 //
 // Two distances the billable month already states are reused rather than
 // written again here: volumeProvision (render.go) is how long before its create
@@ -537,4 +541,195 @@ func (g *generator) barbicanCall(p *project, t time.Time,
 	response := t.Add(time.Second)
 	g.noise(response, "audit.http.response", barbicanPublisher, respID, p,
 		auditPayload(p, g.cloud, respID, action, "success", path, targetType, targetID, code, response))
+}
+
+// auditFlavorMembers are the members a resize carries over into the audits that
+// follow it. They are what nova's resize payload reports of the flavor the
+// server moved to, and the disk of an audit is summed from two of them.
+//
+// The flavor's uuid is not among them, because nova's resize payload does not
+// carry one: an audit names the flavor under instance_flavor_id all the same,
+// and nova reads that from its own catalog. flavorByTypeID stands in for that
+// catalog, so an audit after a resize does not report the new flavor's name
+// beside the boot flavor's uuid.
+var auditFlavorMembers = [6]string{
+	"vcpus", "memory_mb", "root_gb", "ephemeral_gb", "instance_type", "instance_type_id",
+}
+
+// auditEntry is one instance under audit: who reports it, which project it runs
+// in, and the payload its audits repeat. base starts as the create and is
+// carried forward from there, because nova audits the server as it stands at
+// the end of the day and not as it was booted.
+type auditEntry struct {
+	id        string
+	publisher string
+	projectID string
+	userID    string
+	workload  string
+	base      map[string]any
+	// deletedAt is when the instance went, and the zero time while it is still
+	// there. The instance is audited once more after it, for the part of the day
+	// it was still running, and is dropped afterwards.
+	deletedAt time.Time
+}
+
+// audits renders nova's periodic existence audit: every instance that existed
+// during a calendar day of the month is reported at the following midnight with
+// a compute.instance.exists over that day.
+//
+// The period is the day, which is what a deployment sets
+// instance_usage_audit_period to when it wants daily records. The default nova
+// ships is the month, and a monthly period would put no audit inside the
+// simulated month at all, because the first one falls on the midnight that ends
+// it. The hour would put twenty-four times as many lines on the bus for the
+// same single type.
+//
+// The audits are the one part of the catalogue that is not rendered where the
+// billable transition is. Which instances existed on a day is known only once
+// every workload has run, so this is a pass over the finished schedule.
+//
+// An audit sits at the midnight itself. When the instance already reports a
+// transition at that second, the audit is pushed on by whole seconds until it
+// finds a free one, which keeps two notifications about one resource a second
+// apart. What the audit repeats is the instance as it stands: a resize moves
+// the flavor over, and every .end moves the state over, so the audits after a
+// resize report the flavor the server runs on from then on. A deleted instance
+// is audited one last time, at the midnight that follows its delete.
+func (g *generator) audits() {
+	sorted := slices.Clone(g.schedule)
+	slices.SortStableFunc(sorted, func(a, b Transition) int { return a.At.Compare(b.At) })
+
+	// Every instant every resource of the month already reports. It is what an
+	// audit is pushed past, and it is built from the whole schedule because the
+	// second a midnight falls on may be taken by any of the transitions there.
+	type reported struct {
+		resourceID string
+		at         time.Time
+	}
+	occupied := make(map[reported]struct{}, len(sorted))
+	for _, tr := range sorted {
+		occupied[reported{tr.ResourceID, tr.At}] = struct{}{}
+	}
+
+	// The instances under audit, in the order they first appeared, and the same
+	// entries by id. The slice is what the flush walks: a map walk would order
+	// the audits of one midnight differently from run to run, and a month whose
+	// order depends on the run is no longer the seed's.
+	var fleet []*auditEntry
+	byID := make(map[string]*auditEntry)
+
+	flush := func(midnight time.Time) {
+		for _, entry := range fleet {
+			// An instance that went before the day this audit covers has nothing
+			// left to report.
+			if !entry.deletedAt.IsZero() && !entry.deletedAt.After(midnight.Add(-day)) {
+				continue
+			}
+			at := midnight
+			for _, taken := occupied[reported{entry.id, at}]; taken; _, taken = occupied[reported{entry.id, at}] {
+				at = at.Add(time.Second)
+			}
+			// The entry carries the ids of the instance and not the project it
+			// runs in, which is why the transition is written out here instead of
+			// through g.noise, which takes a *project.
+			g.schedule = append(g.schedule, Transition{
+				At:          at,
+				EventType:   "compute.instance.exists",
+				Exchange:    exchangeFor("compute.instance.exists"),
+				Billable:    false,
+				noise:       true,
+				Workload:    entry.workload,
+				PublisherID: entry.publisher,
+				ProjectID:   entry.projectID,
+				UserID:      entry.userID,
+				ResourceID:  entry.id,
+				Payload:     instanceExistsPayload(entry.base, midnight.Add(-day), midnight),
+			})
+		}
+
+		// An instance created and deleted between two midnights is audited once,
+		// at the midnight that follows, and is dropped here.
+		fleet = slices.DeleteFunc(fleet, func(entry *auditEntry) bool {
+			if entry.deletedAt.IsZero() {
+				return false
+			}
+			delete(byID, entry.id)
+			return true
+		})
+	}
+
+	midnight := g.from.AddDate(0, 0, 1)
+	for _, tr := range sorted {
+		// Every midnight the transition has passed is audited before the
+		// transition is folded in, so a day reports the instances as they stood
+		// when it ended.
+		for midnight.Before(g.to) && !tr.At.Before(midnight) {
+			flush(midnight)
+			midnight = midnight.Add(day)
+		}
+
+		if tr.EventType == "compute.instance.create.end" {
+			entry := &auditEntry{
+				id:        tr.ResourceID,
+				publisher: tr.PublisherID,
+				projectID: tr.ProjectID,
+				userID:    tr.UserID,
+				workload:  tr.Workload,
+				base:      maps.Clone(tr.Payload),
+			}
+			fleet = append(fleet, entry)
+			byID[entry.id] = entry
+			continue
+		}
+
+		// An id without a create.end behind it is nothing this pass audits: the
+		// resources of every other service, and the halves of a boot nova sends
+		// before the create. Only the .end of a step carries the instance
+		// forward, because that is where a step reports what it left behind.
+		entry, known := byID[tr.ResourceID]
+		if !known || !strings.HasPrefix(tr.EventType, "compute.instance.") ||
+			!strings.HasSuffix(tr.EventType, ".end") {
+			continue
+		}
+
+		switch tr.EventType {
+		case "compute.instance.resize.end", "compute.instance.finish_resize.end":
+			for _, member := range auditFlavorMembers {
+				if value, ok := tr.Payload[member]; ok {
+					entry.base[member] = value
+				}
+			}
+			// The resize payload reports the two disks and not their sum, so the
+			// member an audit carries is summed here. A payload without them
+			// leaves the disk of the audit at what it was.
+			root, rootOK := tr.Payload["root_gb"].(int)
+			ephemeral, ephemeralOK := tr.Payload["ephemeral_gb"].(int)
+			if rootOK && ephemeralOK {
+				entry.base["disk_gb"] = root + ephemeral
+			}
+			// The uuid of the flavor comes from the catalog rather than from the
+			// payload. A type id the catalog does not hold leaves the member at
+			// what it was, which is a resize the month never renders.
+			if typeID, ok := tr.Payload["instance_type_id"].(int); ok {
+				if moved, found := flavorByTypeID(typeID); found {
+					entry.base["instance_flavor_id"] = moved.flavorID
+				}
+			}
+		case "compute.instance.delete.end":
+			entry.deletedAt = tr.At
+			entry.base["state"] = "deleted"
+		default:
+			if state, ok := tr.Payload["state"].(string); ok {
+				entry.base["state"] = state
+			}
+		}
+	}
+
+	// Every midnight left of the month, up to but not including the one that
+	// ends it: an audit at the end of the period would fall into the month that
+	// follows.
+	for midnight.Before(g.to) {
+		flush(midnight)
+		midnight = midnight.Add(day)
+	}
 }

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -206,7 +206,8 @@ func (g *generator) createInstance(p *project, inst *instance, net *network, t t
 // server did on the day up to here, and then tears it down, which is a delete
 // start and the shutdown around it. The audit is the pre-delete existence
 // notification of a real deployment: a server that goes reports what it used
-// before it is gone.
+// before it is gone. Cinder detaches the volumes the server still held once it
+// is gone, so a volume that outlives its server is available from there on.
 func (g *generator) destroyInstance(p *project, inst *instance, t time.Time) {
 	begin := t.Add(-instanceDeleteLead)
 	g.noise(begin, "compute.instance.update", computePublisher(inst), inst.id, p,
@@ -232,5 +233,77 @@ func (g *generator) destroyInstance(p *project, inst *instance, t time.Time) {
 		g.noise(t.Add(portDeleteLag+time.Second), "port.delete.end", networkPublisher, inst.port.id, p,
 			neutronDeletePayload("port", inst.port.id))
 	}
+
+	for _, vol := range inst.volumes {
+		if vol.attached {
+			g.detach(p, vol, t.Add(detachLag))
+		}
+	}
+	if inst.bootVolume != nil && inst.bootVolume.attached {
+		g.detach(p, inst.bootVolume, t.Add(detachLag))
+	}
 	inst.deletedAt = t
+}
+
+// createVolume renders one volume create: the request cinder accepted and the
+// create the collector bills.
+//
+// The start is the created_at the billable payload already reports, eight
+// seconds before the volume is ready. The caller sets vol.createdAt before it
+// calls, because both payloads are dated from it.
+func (g *generator) createVolume(p *project, vol *volume, t time.Time) {
+	g.noise(t.Add(-volumeProvision), "volume.create.start", volumePublisher, vol.id, p,
+		volumeCreateStartPayload(p, vol))
+
+	g.emit(t, "volume.create.end", volumePublisher, vol.id, p, volumeCreatePayload(p, vol))
+}
+
+// attach connects a volume to a server. Cinder announces the attach with the
+// volume connected to nothing yet and reports it in use a second later, holding
+// the attachment record it handed out until the detach gives it back.
+//
+// The volume is attached from here on, which is what puts the in-use status
+// into every billable notification about it: a payload rendered after this
+// point reports the volume the way cinder reports one a server holds.
+//
+// The server may be nil. The attachment then names no instance and no host, and
+// the volume is attached all the same, so a billable payload rendered afterwards
+// reports in-use exactly as it does for a volume a server holds.
+func (g *generator) attach(p *project, vol *volume, inst *instance, t time.Time) {
+	vol.attachment = attachmentOf(g.noiseIDs.nextUUID(), vol, inst, t)
+
+	g.noise(t, "volume.attach.start", volumePublisher, vol.id, p,
+		volumeAttachmentPayload(p, vol, "attaching", nil))
+	g.noise(t.Add(time.Second), "volume.attach.end", volumePublisher, vol.id, p,
+		volumeAttachmentPayload(p, vol, "in-use", vol.attachment))
+
+	vol.attached = true
+}
+
+// detach disconnects a volume from the server that held it. The .start half
+// repeats the attachment of that server one last time and the .end carries
+// none, which is the volume as cinder reports it from here on: available, and
+// connected to nothing.
+func (g *generator) detach(p *project, vol *volume, t time.Time) {
+	g.noise(t, "volume.detach.start", volumePublisher, vol.id, p,
+		volumeAttachmentPayload(p, vol, "detaching", vol.attachment))
+	g.noise(t.Add(time.Second), "volume.detach.end", volumePublisher, vol.id, p,
+		volumeAttachmentPayload(p, vol, "available", nil))
+
+	vol.attached = false
+	vol.attachment = nil
+}
+
+// deleteVolume renders one volume delete: the detach of a volume a server still
+// holds, the delete cinder announces, and the delete the collector bills. A
+// volume whose server is already gone was detached with it and is deleted
+// without a second one.
+func (g *generator) deleteVolume(p *project, vol *volume, t time.Time) {
+	if vol.attached {
+		g.detach(p, vol, t.Add(-volumeDetachLead))
+	}
+	g.noise(t.Add(-volumeDeleteStartLead), "volume.delete.start", volumePublisher, vol.id, p,
+		volumeStatusPayload(p, vol, "deleting"))
+
+	g.emit(t, "volume.delete.end", volumePublisher, vol.id, p, volumeDeletePayload(p, vol, t))
 }

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -101,6 +101,11 @@ const (
 // order.
 var updateLeads = [3]time.Duration{15 * time.Second, 10 * time.Second, 5 * time.Second}
 
+// buildingTasks are the task states a server passes through while it is built.
+// The three updates of a boot each report the move from one of them to the
+// next, which is why the four names yield three notifications.
+var buildingTasks = [4]string{"scheduling", "networking", "block_device_mapping", "spawning"}
+
 // noiseIdentifiers seeds the noise identifier stream, the third generator of a
 // month. It carries the cloud and the billing month the way the identifier
 // stream does, so another cloud or another month renames the announced
@@ -151,4 +156,81 @@ func newPort(net *network, id, address, deviceID, deviceOwner, host string) *por
 		deviceOwner:     deviceOwner,
 		host:            host,
 	}
+}
+
+// createInstance renders one boot: everything nova and neutron put on the bus
+// around the create the collector bills, and the create itself.
+//
+// The order is the one a deployment sends them in. The scheduler picks the host
+// and answers, nova announces the server it is about to build and reports its
+// progress through three updates, and neutron creates the port the server holds
+// its address on and binds it to the host in between. The create the collector
+// books comes last, because it is what the server is billed from.
+//
+// The port is the server's port on the network it is created on: a classic or a
+// CI tenant's own network, and a shoot's network for a worker. It is built here
+// because a server that never existed has none, and it is kept on the instance
+// so the delete can release it.
+func (g *generator) createInstance(p *project, inst *instance, net *network, t time.Time) {
+	inst.port = newPort(net, g.noiseIDs.nextUUID(), net.nextAddress(), inst.id, "compute:nova", inst.host)
+
+	g.noise(t.Add(-schedulerLead), "scheduler.select_destinations.start", schedulerPublisher,
+		inst.id, p, schedulerPayload(p, inst))
+	g.noise(t.Add(-schedulerLead+time.Second), "scheduler.select_destinations.end", schedulerPublisher,
+		inst.id, p, schedulerPayload(p, inst))
+	g.noise(t.Add(-createStartLead), "compute.instance.create.start", computePublisher(inst),
+		inst.id, p, instanceCreateStartPayload(p, inst, g.cloud))
+	for i, lead := range updateLeads {
+		u := t.Add(-lead)
+		g.noise(u, "compute.instance.update", computePublisher(inst), inst.id, p,
+			instanceUpdatePayload(p, inst, "building", buildingTasks[i], buildingTasks[i+1], at(u, 0, 0), u))
+	}
+
+	g.noise(t.Add(-portCreateLead), "port.create.start", networkPublisher, inst.port.id, p,
+		portRequestPayload(p, inst.port))
+	g.noise(t.Add(-portCreateLead+time.Second), "port.create.end", networkPublisher, inst.port.id, p,
+		portPayload(p, inst.port, false))
+	g.noise(t.Add(-portBindLead), "port.update.start", networkPublisher, inst.port.id, p,
+		portBindingPayload(inst.port))
+	g.noise(t.Add(-portBindLead+time.Second), "port.update.end", networkPublisher, inst.port.id, p,
+		portPayload(p, inst.port, true))
+
+	g.emit(t, "compute.instance.create.end", computePublisher(inst), inst.id, p,
+		instanceCreatePayload(p, inst, g.cloud))
+}
+
+// destroyInstance renders one delete: the sequence nova sends before it, the
+// delete the collector bills, and the port neutron releases after it.
+//
+// Nova announces the delete as an update to the deleting task, audits what the
+// server did on the day up to here, and then tears it down, which is a delete
+// start and the shutdown around it. The audit is the pre-delete existence
+// notification of a real deployment: a server that goes reports what it used
+// before it is gone.
+func (g *generator) destroyInstance(p *project, inst *instance, t time.Time) {
+	begin := t.Add(-instanceDeleteLead)
+	g.noise(begin, "compute.instance.update", computePublisher(inst), inst.id, p,
+		instanceUpdatePayload(p, inst, "active", nil, "deleting", at(t, 0, 0), t))
+	g.noise(begin.Add(time.Second), "compute.instance.exists", computePublisher(inst), inst.id, p,
+		instanceExistsPayload(instanceCreatePayload(p, inst, g.cloud), at(t, 0, 0), t))
+	g.noise(begin.Add(2*time.Second), "compute.instance.delete.start", computePublisher(inst),
+		inst.id, p, instanceShelvePayload(p, inst, "active"))
+	g.noise(begin.Add(3*time.Second), "compute.instance.shutdown.start", computePublisher(inst),
+		inst.id, p, instanceShelvePayload(p, inst, "active"))
+	g.noise(begin.Add(4*time.Second), "compute.instance.shutdown.end", computePublisher(inst),
+		inst.id, p, instanceShelvePayload(p, inst, "active"))
+
+	g.emit(t, "compute.instance.delete.end", computePublisher(inst), inst.id, p,
+		instanceDeletePayload(p, inst, t))
+
+	// Nothing in the month creates a server without a port, so the branch is
+	// what keeps the helper from dereferencing a nil rather than a shape a
+	// workload produces.
+	if inst.port != nil {
+		g.noise(t.Add(portDeleteLag), "port.delete.start", networkPublisher, inst.port.id, p,
+			neutronDeletePayload("port", inst.port.id))
+		g.noise(t.Add(portDeleteLag+time.Second), "port.delete.end", networkPublisher, inst.port.id, p,
+			neutronDeletePayload("port", inst.port.id))
+	}
+	inst.deletedAt = t
 }

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -1,0 +1,154 @@
+package simulator
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// The noise is what a real bus carries beside the notifications the collector
+// bills: the scheduler's placement decisions, the ports of every server, the
+// networks, subnets, routers and security groups underneath them, the
+// keypairs, keystone's authentications, designate's zones and record sets,
+// barbican's audit records, the attach and the detach of a volume, and the
+// .start half of every step that has one. The collector receives every one of
+// them and counts it as skipped, so a month without them is a month whose skip
+// counters stay at zero and whose ratio of billable to received says nothing.
+//
+// Three rules hold for everything this file renders.
+//
+// Noise is never billable. The collector's mapping claims nothing for any of
+// these types, and WriteEvents refuses a transition that is marked billable and
+// mapped to nothing.
+//
+// Noise takes no draw from the shape stream and no identifier from the
+// identifier stream. Every noise instant is a fixed offset from the billable
+// instant it belongs to, and every identifier a noise resource needs comes from
+// the noise identifier stream, its message id included. That is what keeps the
+// billable transitions of a seed, a period, and a cloud the ones they would be
+// without the catalogue: same instants, same ids, same payloads, same message
+// ids.
+//
+// Noise is rendered by the helpers of this file and by nothing else. The
+// billable workload calls into them, so what a month is billed for and what it
+// merely carries stay two things a reader can tell apart.
+
+// The fixed distances of every noise instant from the billable instant it
+// belongs to. Each of them is a whole number of seconds, and the ones that
+// gather around a single billable instant differ from each other, so no two
+// notifications about one resource fall in the same second.
+//
+// The infrastructure of a shoot is the one sequence without a constant of its
+// own: it runs one transition per second, from 1 to 16 seconds after the
+// shoot's creation instant. The audit records of a tenant sit at the midnight
+// itself, which is a lag of zero and needs no constant either.
+//
+// Two distances the billable month already states are reused rather than
+// written again here: volumeProvision (render.go) is how long before its create
+// a volume was requested, and volumeDeleteLead (workload.go) is the gap between
+// an instance delete and the delete of the volumes it held.
+const (
+	// schedulerLead is where a boot begins: the
+	// scheduler.select_destinations.start, with its .end a second later.
+	schedulerLead = 25 * time.Second
+	// createStartLead is the compute.instance.create.start of a boot.
+	createStartLead = 20 * time.Second
+	// portCreateLead is the port.create.start of the server's port, with its
+	// .end a second later.
+	portCreateLead = 17 * time.Second
+	// portBindLead is the port.update.start that binds the port to the host the
+	// server runs on, with its .end a second later.
+	portBindLead = 12 * time.Second
+	// instanceDeleteLead is where the pre-delete sequence begins: the update at
+	// -5s, the exists at -4s, the delete.start at -3s, the shutdown.start at
+	// -2s, and the shutdown.end at -1s.
+	instanceDeleteLead = 5 * time.Second
+	// portDeleteLag is the port.delete.start after an instance delete, with its
+	// .end a second later.
+	portDeleteLag = 1 * time.Second
+	// detachLag is the volume.detach.start after an instance delete.
+	detachLag = 3 * time.Second
+	// stepLead is the .start half of a paired step, before its .end.
+	stepLead = 5 * time.Second
+	// attachLag is the volume.attach.start after a volume create, or after the
+	// last worker of a wake-up.
+	attachLag = 1 * time.Second
+	// volumeDetachLead is the volume.detach.start before a volume delete.
+	volumeDetachLead = 3 * time.Second
+	// volumeDeleteStartLead is the volume.delete.start of that same delete.
+	volumeDeleteStartLead = 1 * time.Second
+	// transferLead is the volume.transfer.accept.start.
+	transferLead = 1 * time.Second
+	// imagePrepareLead is the image.prepare before an upload, and
+	// imageActivateLag the image.activate after it.
+	imagePrepareLead = 1 * time.Second
+	imageActivateLag = 1 * time.Second
+	// authenticateLead is the identity.authenticate before an action somebody
+	// or a controller starts.
+	authenticateLead = 2 * time.Second
+	// vipPortLead is the port.create.start of a load balancer's VIP port, with
+	// its .end a second later.
+	vipPortLead = 2 * time.Second
+	// ingressRecordLag is the dns.recordset.create of the ingress record, which
+	// needs the address of the first load balancer.
+	ingressRecordLag = 12 * time.Second
+	// certificateLag is where the four barbican records begin, one second
+	// apart.
+	certificateLag = 20 * time.Second
+)
+
+// updateLeads are the distances of the three compute.instance.update of a boot
+// before the create: networking, block_device_mapping, and spawning, in that
+// order.
+var updateLeads = [3]time.Duration{15 * time.Second, 10 * time.Second, 5 * time.Second}
+
+// noiseIdentifiers seeds the noise identifier stream, the third generator of a
+// month. It carries the cloud and the billing month the way the identifier
+// stream does, so another cloud or another month renames the announced
+// resources as well, and the prefix is what keeps the two streams from drawing
+// one sequence twice.
+func noiseIdentifiers(seed uint64, cloud string, month time.Time) idReader {
+	return idReader{src: rand.New(rand.NewPCG(seed, identifierSalt("noise\x00"+cloud, month)))}
+}
+
+// noise records one transition the collector does not bill. It is emit with
+// Billable false: the mapping claims nothing for any type of this catalogue,
+// and a transition that says otherwise fails the write of the expected events.
+// It is also marked as the catalogue's, which is what sends its message id to
+// the noise stream.
+func (g *generator) noise(at time.Time, eventType, publisherID, resourceID string,
+	requester *project, payload map[string]any,
+) {
+	g.schedule = append(g.schedule, Transition{
+		At:          at,
+		EventType:   eventType,
+		Exchange:    exchangeFor(eventType),
+		Billable:    false,
+		noise:       true,
+		Workload:    g.workload,
+		PublisherID: publisherID,
+		ProjectID:   requester.id,
+		UserID:      requester.userID,
+		ResourceID:  resourceID,
+		Payload:     payload,
+	})
+}
+
+// newPort builds the port of a device on a network, taking the network's subnet
+// and security group with it because neutron reports both on every port.
+//
+// The MAC address is derived from the port id rather than drawn: it is the
+// fa:16:3e prefix every OpenStack port carries followed by three bytes of the
+// id, so a port costs one identifier instead of two.
+func newPort(net *network, id, address, deviceID, deviceOwner, host string) *port {
+	return &port{
+		id:              id,
+		networkID:       net.id,
+		subnetID:        net.subnetID,
+		securityGroupID: net.securityGroupID,
+		address:         address,
+		macAddress:      "fa:16:3e:" + id[0:2] + ":" + id[2:4] + ":" + id[4:6],
+		deviceID:        deviceID,
+		deviceOwner:     deviceOwner,
+		host:            host,
+	}
+}

--- a/internal/providers/openstack/simulator/noise.go
+++ b/internal/providers/openstack/simulator/noise.go
@@ -307,3 +307,21 @@ func (g *generator) deleteVolume(p *project, vol *volume, t time.Time) {
 
 	g.emit(t, "volume.delete.end", volumePublisher, vol.id, p, volumeDeletePayload(p, vol, t))
 }
+
+// uploadImage renders one image upload: glance taking the bits in, the upload
+// the collector bills, and the activation a second later.
+//
+// The prepare is the image while its content is still arriving, which is the
+// one notification about it that carries neither a size nor a checksum. The
+// activate repeats the payload of the upload unchanged, because nothing about
+// the image changes when glance flips it to active.
+func (g *generator) uploadImage(p *project, img *image, uploadedAt time.Time) {
+	g.noise(uploadedAt.Add(-imagePrepareLead), "image.prepare", imagePublisher, img.id, p,
+		imagePreparePayload(p, img))
+
+	g.emit(uploadedAt, "image.upload", imagePublisher, img.id, p,
+		imageUploadPayload(p, img, uploadedAt))
+
+	g.noise(uploadedAt.Add(imageActivateLag), "image.activate", imagePublisher, img.id, p,
+		imageUploadPayload(p, img, uploadedAt))
+}

--- a/internal/providers/openstack/simulator/noise_test.go
+++ b/internal/providers/openstack/simulator/noise_test.go
@@ -1,0 +1,1796 @@
+package simulator
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/core/cardinality"
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+// noiseTypes is the catalogue of notifications a month carries and the
+// collector bills nothing for, in the order noise.go renders them, grouped by
+// the exchange they are published on. None of them has a recorded sample, so
+// this list and the member sets of noiseMembers (render_test.go) are what holds
+// the catalogue in place: a type that leaves one of them is a type no test
+// covers any more.
+var noiseTypes = []string{
+	// nova
+	"scheduler.select_destinations.start",
+	"scheduler.select_destinations.end",
+	"compute.instance.create.start",
+	"compute.instance.update",
+	"compute.instance.exists",
+	"compute.instance.delete.start",
+	"compute.instance.shutdown.start",
+	"compute.instance.shutdown.end",
+	"compute.instance.power_off.start",
+	"compute.instance.power_on.start",
+	"compute.instance.resize.start",
+	"compute.instance.finish_resize.start",
+	"compute.instance.shelve_offload.start",
+	"compute.instance.unshelve.start",
+	"keypair.import.start",
+	"keypair.import.end",
+	"keypair.delete.start",
+	"keypair.delete.end",
+	// cinder
+	"volume.create.start",
+	"volume.delete.start",
+	"volume.resize.start",
+	"volume.transfer.accept.start",
+	"volume.attach.start",
+	"volume.attach.end",
+	"volume.detach.start",
+	"volume.detach.end",
+	// neutron
+	"network.create.start",
+	"network.create.end",
+	"network.delete.start",
+	"network.delete.end",
+	"subnet.create.start",
+	"subnet.create.end",
+	"subnet.delete.start",
+	"subnet.delete.end",
+	"router.create.start",
+	"router.create.end",
+	"router.interface.create",
+	"router.interface.delete",
+	"router.delete.start",
+	"router.delete.end",
+	"security_group.create.start",
+	"security_group.create.end",
+	"security_group.delete.start",
+	"security_group.delete.end",
+	"security_group_rule.create.start",
+	"security_group_rule.create.end",
+	"port.create.start",
+	"port.create.end",
+	"port.update.start",
+	"port.update.end",
+	"port.delete.start",
+	"port.delete.end",
+	// glance
+	"image.prepare",
+	"image.activate",
+	// keystone
+	"identity.project.created",
+	"identity.user.created",
+	"identity.authenticate",
+	// designate
+	"dns.zone.create",
+	"dns.recordset.create",
+	"dns.recordset.delete",
+	// barbican
+	"audit.http.request",
+	"audit.http.response",
+}
+
+// has returns the transition of that type at that instant, and false when the
+// slice holds none. Every noise instant is a fixed offset from the billable
+// instant it belongs to, so a sequence is asserted by asking for each of its
+// members at the second it is due at.
+func has(transitions []Transition, eventType string, at time.Time) (Transition, bool) {
+	for _, transition := range transitions {
+		if transition.EventType == eventType && transition.At.Equal(at) {
+			return transition, true
+		}
+	}
+	return Transition{}, false
+}
+
+// byResource indexes a schedule by the resource each transition is about, in
+// schedule order. A month holds thousands of transitions and the sequences
+// below are read per resource, so the index is built once and walked instead of
+// the schedule being scanned per instance.
+func byResource(transitions []Transition) map[string][]Transition {
+	index := make(map[string][]Transition)
+	for _, transition := range transitions {
+		index[transition.ResourceID] = append(index[transition.ResourceID], transition)
+	}
+	return index
+}
+
+// byAuditTarget indexes the month's CADF audit records by the resource each of
+// them names. A record is reported under an id of its own, so the resource
+// index does not reach one: what ties a record to the call it stands for is its
+// target.
+func byAuditTarget(transitions []Transition) map[string][]Transition {
+	index := make(map[string][]Transition)
+	for _, transition := range transitions {
+		target, ok := transition.Payload["target"].(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := target["id"].(string)
+		index[id] = append(index[id], transition)
+	}
+	return index
+}
+
+// buildWorld returns the generator of a month before any workload has run: the
+// world newGenerator draws and an empty schedule. It is what the helpers of
+// noise.go are called on directly, so a path the month never produces is
+// covered without a seed that produces it.
+func buildWorld(t *testing.T, seed uint64) *generator {
+	t.Helper()
+
+	shape := rand.New(rand.NewPCG(seed, shapeStream))
+	identifiers := idReader{src: rand.New(rand.NewPCG(seed, identifierSalt(testCloud, july2026)))}
+
+	return newGenerator(shape, identifiers, noiseIdentifiers(seed, testCloud, july2026),
+		july2026, july2026.AddDate(0, 1, 0), testCloud)
+}
+
+// TestEverySeedRendersTheWholeCatalogue is the drift guard of the catalogue. A
+// month that renders 61 of the 62 types is a month whose skip counters are
+// short of one type, whichever seed an operator picks, so every seed is held
+// against the whole list rather than one month against most of it.
+func TestEverySeedRendersTheWholeCatalogue(t *testing.T) {
+	const want = 62
+	if len(noiseTypes) != want {
+		t.Fatalf("the catalogue names %d types, want %d: the list is what the member sets and the "+
+			"sequences below are held against", len(noiseTypes), want)
+	}
+
+	for seed := uint64(1); seed <= 5; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			schedule := generateMonth(t, seed, july2026, testCloud)
+
+			rendered := make(map[string]int, len(noiseTypes))
+			for _, transition := range schedule {
+				rendered[transition.EventType]++
+
+				if slices.Contains(noiseTypes, transition.EventType) {
+					if transition.Billable {
+						t.Errorf("%s is billable, want the collector to record nothing for it: "+
+							"WriteEvents refuses a transition that is billable and mapped to nothing",
+							transition.EventType)
+					}
+					if transition.PublisherID == "" {
+						t.Errorf("%s names no publisher, want the service instance that emitted it: "+
+							"octavia is the one service that publishes without one and it renders no "+
+							"noise", transition.EventType)
+					}
+					continue
+				}
+				if !transition.Billable && transition.EventType != imageCreateType {
+					t.Errorf("%s is neither billable nor part of the catalogue, want every type of a "+
+						"month to be one or the other: %s is the one skipped billable type",
+						transition.EventType, imageCreateType)
+				}
+			}
+
+			for _, eventType := range noiseTypes {
+				if rendered[eventType] == 0 {
+					t.Errorf("seed %d renders no %s, want the whole catalogue in every month: a type "+
+						"no seed renders is one nothing on the bus exercises", seed, eventType)
+				}
+			}
+		})
+	}
+}
+
+// TestNoiseReachesForNeitherOfTheOtherTwoStreams is the guard on the rule the
+// third generator exists for: the catalogue takes no draw from the shape stream
+// and no identifier from the identifier stream, so the billable transitions of
+// a seed, a period, and a cloud are the ones the month would render without it.
+//
+// A helper that reached for the wrong reader would renumber every billable
+// resource of every seed downstream of it and leave the whole suite green: the
+// months two runs of one build produce still match, two clouds still draw
+// disjoint sets, and every other case here is structural. The rule is about the
+// file rather than about the month, so it is checked on the file: nowhere in
+// noise.go may a selector name the generator's shape or its identifier stream.
+func TestNoiseReachesForNeitherOfTheOtherTwoStreams(t *testing.T) {
+	const file = "noise.go"
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+
+	forbidden := map[string]string{
+		"shape": "the shape stream: a draw from it moves every instant and every size the " +
+			"billable month draws after it",
+		"identifiers": "the identifier stream: a draw from it renumbers every billable resource " +
+			"the month names after it",
+	}
+	// The draws the catalogue is meant to make. Counting them is what keeps this
+	// case from passing over a file that no longer draws anything at all.
+	draws := 0
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if selector.Sel.Name == "noiseIDs" {
+			draws++
+		}
+		if why, ok := forbidden[selector.Sel.Name]; ok {
+			t.Errorf("%s reaches for %s, want it to take nothing from %s",
+				fset.Position(selector.Pos()), selector.Sel.Name, why)
+		}
+		return true
+	})
+
+	if draws == 0 {
+		t.Errorf("%s takes no identifier from the noise stream, want the stream this case is here "+
+			"to keep the catalogue on: it is looking at the wrong file or at the wrong name", file)
+	}
+}
+
+// TestTheNoiseDrawsItsMessageIdsFromItsOwnStream covers the last identifier a
+// noise transition needs. Every other id of the catalogue is drawn while the
+// month is generated, and the message ids are drawn over the sorted schedule
+// once it stands: a noise message id taken from the identifier stream would put
+// the ids the collector books under the length of the catalogue, and one
+// transition more or less would renumber every event of every seed.
+//
+// The noise stream hands out nothing but uuids, so its draws are replayed here
+// and the month's noise message ids have to be the run of them that follows the
+// ids of the announced resources.
+func TestTheNoiseDrawsItsMessageIdsFromItsOwnStream(t *testing.T) {
+	const seed = 1
+	schedule := generateMonth(t, seed, july2026, testCloud)
+
+	var want []string
+	for _, transition := range schedule {
+		if transition.noise {
+			want = append(want, transition.MessageID)
+		}
+	}
+	if len(want) == 0 {
+		t.Fatalf("the month carries no noise, want the catalogue")
+	}
+
+	// The draws that named the announced resources come first. How many there
+	// are follows from the month, so they are skipped rather than counted, and
+	// the bound is far above what a month of any seed takes.
+	const bound = 1 << 20
+	stream := noiseIdentifiers(seed, testCloud, july2026)
+	found := false
+	for range bound {
+		if stream.nextUUID() == want[0] {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("the first noise message id %s is no draw of the noise stream, want every message "+
+			"id of the catalogue to come from it: one drawn from the identifier stream renumbers "+
+			"the billable month", want[0])
+	}
+	for i, id := range want[1:] {
+		if got := stream.nextUUID(); got != id {
+			t.Fatalf("the noise message ids leave the stream at number %d: the month carries %s "+
+				"where the noise stream hands out %s, want the two to run together to the end of "+
+				"the month", i+1, id, got)
+		}
+	}
+}
+
+// TestAMonthStaysInsideTheCollectorsLabelBudget covers the one bound a month
+// can outgrow without failing anything else. The collector admits
+// openstack.LabelValueLimit distinct event_type values, first seen first
+// served, and the consumed and the skipped counters share that budget. A month
+// is published in chronological order and opens with the noise, so the types
+// that would be folded into event_type="other" are the late ones: the delete of
+// a transient shoot's balancer and the image delete near the month's end, which
+// are the series an operator is told to read.
+func TestAMonthStaysInsideTheCollectorsLabelBudget(t *testing.T) {
+	types := make(map[string]struct{}, len(noiseTypes))
+	for _, transition := range generateMonth(t, 1, july2026, testCloud) {
+		types[transition.EventType] = struct{}{}
+	}
+
+	if len(types) >= openstack.LabelValueLimit {
+		t.Errorf("a month renders %d distinct event types and the collector admits %d, want fewer "+
+			"than the bound: the types past it are counted under event_type=%q",
+			len(types), openstack.LabelValueLimit, cardinality.Overflow)
+	}
+}
+
+// TestExchangeForNamesEveryService covers where the catalogue is published. A
+// notification on the wrong exchange is one no bound queue receives, and an
+// unknown type is reported as the empty exchange rather than guessed at.
+func TestExchangeForNamesEveryService(t *testing.T) {
+	tests := []struct {
+		eventType string
+		exchange  string
+	}{
+		{"scheduler.select_destinations.start", "nova"},
+		{"keypair.import.end", "nova"},
+		{"compute.instance.exists", "nova"},
+		{"network.create.end", "neutron"},
+		{"subnet.delete.start", "neutron"},
+		{"router.interface.create", "neutron"},
+		{"security_group.create.end", "neutron"},
+		{"security_group_rule.create.end", "neutron"},
+		{"port.update.end", "neutron"},
+		{"identity.authenticate", "keystone"},
+		{"dns.zone.create", "designate"},
+		{"audit.http.request", "barbican"},
+		{"octavia.loadbalancer.create.end", "octavia"},
+		{"foo.bar", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.eventType, func(t *testing.T) {
+			if got := exchangeFor(test.eventType); got != test.exchange {
+				t.Errorf("exchangeFor(%q) = %q, want %q", test.eventType, got, test.exchange)
+			}
+		})
+	}
+}
+
+// TestInstancesBootAndDieInSequence holds every server of every month against
+// the notifications a deployment sends around its create and its delete. The
+// distances are fixed, so a boot whose port is bound to another host or a
+// delete that leaves its port behind is a sequence an operator would not
+// recognise.
+func TestInstancesBootAndDieInSequence(t *testing.T) {
+	for seed := uint64(1); seed <= 5; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			schedule := generateMonth(t, seed, july2026, testCloud)
+			byID := byResource(schedule)
+
+			// A server's transitions carry no port id, so the port of one is found
+			// through the device its create names.
+			ports := make(map[string][]Transition)
+			for _, transition := range schedule {
+				if transition.EventType != "port.create.end" {
+					continue
+				}
+				payload, _ := transition.Payload["port"].(map[string]any)
+				deviceID, _ := payload["device_id"].(string)
+				ports[deviceID] = append(ports[deviceID], transition)
+			}
+
+			for _, transition := range schedule {
+				switch transition.EventType {
+				case "compute.instance.create.end":
+					requireBoot(t, byID, ports, transition)
+				case "compute.instance.delete.end":
+					requireDelete(t, byID, ports, transition)
+				}
+			}
+
+			// Every step of an instance is a pair, and the .start half of one is
+			// five seconds before the .end the collector books.
+			for _, step := range []string{
+				"power_off", "power_on", "resize", "finish_resize", "shelve_offload", "unshelve",
+			} {
+				start, end := "compute.instance."+step+".start", "compute.instance."+step+".end"
+				for _, transition := range schedule {
+					if transition.EventType != start {
+						continue
+					}
+					if _, ok := has(byID[transition.ResourceID], end,
+						transition.At.Add(stepLead)); !ok {
+						t.Errorf("the instance %s reports %s at %s and no %s at %s, want both halves "+
+							"of a step: a .start without its .end is a step nothing books",
+							transition.ResourceID, start, transition.At, end,
+							transition.At.Add(stepLead))
+					}
+				}
+			}
+		})
+	}
+}
+
+// requireBoot holds one create against the boot nova and neutron send before
+// it: the scheduler's decision, the server nova announces, the three updates of
+// a build, and the port the server holds its address on.
+func requireBoot(t *testing.T, byID, ports map[string][]Transition, create Transition) {
+	t.Helper()
+
+	id, at := create.ResourceID, create.At
+	of := byID[id]
+	for _, step := range []struct {
+		eventType string
+		lead      time.Duration
+	}{
+		{"scheduler.select_destinations.start", 25 * time.Second},
+		{"scheduler.select_destinations.end", 24 * time.Second},
+		{"compute.instance.create.start", 20 * time.Second},
+	} {
+		if _, ok := has(of, step.eventType, at.Add(-step.lead)); !ok {
+			t.Errorf("the instance %s is created at %s and reports no %s at %s, want the boot a "+
+				"deployment sends before a create", id, at, step.eventType, at.Add(-step.lead))
+		}
+	}
+
+	for i, task := range []string{"networking", "block_device_mapping", "spawning"} {
+		when := at.Add(-time.Duration(15-5*i) * time.Second)
+		update, ok := has(of, "compute.instance.update", when)
+		if !ok {
+			t.Errorf("the instance %s reports no compute.instance.update at %s, want the three a "+
+				"build passes through", id, when)
+			continue
+		}
+		if got, _ := update.Payload["new_task_state"].(string); got != task {
+			t.Errorf("the instance %s takes up the task %q at %s, want %q: a build runs from "+
+				"scheduling to spawning", id, got, when, task)
+		}
+	}
+
+	if len(ports[id]) != 1 {
+		t.Errorf("the instance %s is created at %s and holds %d ports, want the one neutron gives "+
+			"every server", id, at, len(ports[id]))
+		return
+	}
+	created, ok := has(ports[id], "port.create.end", at.Add(-16*time.Second))
+	if !ok {
+		t.Errorf("the port %s of the instance %s is created at %s, want it at %s: neutron creates it "+
+			"while nova builds the server", ports[id][0].ResourceID, id, ports[id][0].At,
+			at.Add(-16*time.Second))
+		return
+	}
+	bound, ok := has(byID[created.ResourceID], "port.update.end", at.Add(-11*time.Second))
+	if !ok {
+		t.Errorf("the port %s of the instance %s is never bound at %s, want the compute to bind it "+
+			"before the server is launched", created.ResourceID, id, at.Add(-11*time.Second))
+		return
+	}
+	payload, _ := bound.Payload["port"].(map[string]any)
+	if got, _ := payload["status"].(string); got != "ACTIVE" {
+		t.Errorf("the bound port %s reports status %q, want \"ACTIVE\": a port a compute has taken "+
+			"is up", created.ResourceID, got)
+	}
+	host, _ := create.Payload["host"].(string)
+	if got, _ := payload["binding:host_id"].(string); got != host {
+		t.Errorf("the port %s of the instance %s is bound to %q, want %q, the compute the server "+
+			"runs on", created.ResourceID, id, got, host)
+	}
+}
+
+// requireDelete holds one delete against the sequence nova sends before it and
+// the port neutron releases after it.
+func requireDelete(t *testing.T, byID, ports map[string][]Transition, del Transition) {
+	t.Helper()
+
+	id, at := del.ResourceID, del.At
+	of := byID[id]
+	update, ok := has(of, "compute.instance.update", at.Add(-5*time.Second))
+	if !ok {
+		t.Errorf("the instance %s is deleted at %s and reports no compute.instance.update at %s, "+
+			"want the task the delete begins with", id, at, at.Add(-5*time.Second))
+	} else if got, _ := update.Payload["new_task_state"].(string); got != "deleting" {
+		t.Errorf("the instance %s takes up the task %q before its delete, want \"deleting\"", id, got)
+	}
+
+	audit, ok := has(of, "compute.instance.exists", at.Add(-4*time.Second))
+	if !ok {
+		t.Errorf("the instance %s reports no compute.instance.exists at %s, want the audit a server "+
+			"sends before it is gone", id, at.Add(-4*time.Second))
+	} else if got, _ := audit.Payload["audit_period_ending"].(string); got != stamp(at) {
+		t.Errorf("the pre-delete audit of %s ends at %q, want %q, the instant the server goes",
+			id, got, stamp(at))
+	}
+
+	for _, step := range []struct {
+		eventType string
+		lead      time.Duration
+	}{
+		{"compute.instance.delete.start", 3 * time.Second},
+		{"compute.instance.shutdown.start", 2 * time.Second},
+		{"compute.instance.shutdown.end", 1 * time.Second},
+	} {
+		if _, ok := has(of, step.eventType, at.Add(-step.lead)); !ok {
+			t.Errorf("the instance %s is deleted at %s and reports no %s at %s, want the tear-down "+
+				"nova sends before a delete", id, at, step.eventType, at.Add(-step.lead))
+		}
+	}
+
+	if len(ports[id]) == 0 {
+		t.Errorf("the instance %s is deleted at %s and never held a port, want the one neutron "+
+			"gives every server", id, at)
+		return
+	}
+	portID := ports[id][0].ResourceID
+	if _, ok := has(byID[portID], "port.delete.end", at.Add(2*time.Second)); !ok {
+		t.Errorf("the port %s of the instance %s is not released at %s, want neutron to take it "+
+			"back once the server is gone", portID, id, at.Add(2*time.Second))
+	}
+}
+
+// TestNoTwoLivePortsShareAFixedAddress covers the one allocator every subnet
+// has. Neutron hands a fixed address out once and takes it back when the port
+// that held it is released, so two ports of one subnet reporting the same
+// address while both are up is a state no real neutron can reach. The workers'
+// ports and the balancers' VIP ports lie on the same shoot subnet, which is
+// where a second allocator would collide with the first.
+func TestNoTwoLivePortsShareAFixedAddress(t *testing.T) {
+	for seed := uint64(1); seed <= 3; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			schedule := generateMonth(t, seed, july2026, testCloud)
+			// A port that is never released holds its address to the end of the
+			// month, which is where a life without a delete ends.
+			to := july2026.AddDate(0, 1, 0)
+			released := make(map[string]time.Time, len(schedule))
+			for _, transition := range schedule {
+				if transition.EventType == "port.delete.end" {
+					released[transition.ResourceID] = transition.At
+				}
+			}
+
+			// The ports that held each address of each subnet, by the second they
+			// took it and the second they gave it back.
+			type life struct {
+				id        string
+				from, til time.Time
+			}
+			held := make(map[string][]life)
+			for _, transition := range schedule {
+				if transition.EventType != "port.create.end" {
+					continue
+				}
+				payload, _ := transition.Payload["port"].(map[string]any)
+				fixed, _ := payload["fixed_ips"].([]any)
+				if len(fixed) != 1 {
+					t.Fatalf("the port %s reports %d fixed addresses, want the one every port of a "+
+						"month holds", transition.ResourceID, len(fixed))
+				}
+				first, _ := fixed[0].(map[string]any)
+				subnet, _ := first["subnet_id"].(string)
+				address, _ := first["ip_address"].(string)
+
+				til, ok := released[transition.ResourceID]
+				if !ok {
+					til = to
+				}
+				key := subnet + " " + address
+				for _, other := range held[key] {
+					if transition.At.Before(other.til) && other.from.Before(til) {
+						t.Errorf("the ports %s and %s both hold %s on the subnet %s, from %s to %s "+
+							"and from %s to %s, want one port per address: neutron allocates an "+
+							"address of a subnet once", other.id, transition.ResourceID, address,
+							subnet, other.from, other.til, transition.At, til)
+					}
+				}
+				held[key] = append(held[key], life{id: transition.ResourceID, from: transition.At, til: til})
+			}
+			if len(held) == 0 {
+				t.Fatalf("the month creates no port, want one per server and one per balancer")
+			}
+		})
+	}
+}
+
+// TestExistsAuditsCoverEveryDayAnInstanceExisted holds nova's periodic audit
+// against the days every server of a month existed. An instance that is audited
+// twice for one day, or not at all for a day it ran, is a bus whose skipped
+// counters no longer stand for the fleet.
+func TestExistsAuditsCoverEveryDayAnInstanceExisted(t *testing.T) {
+	schedule := generateMonth(t, 1, july2026, testCloud)
+	to := july2026.AddDate(0, 1, 0)
+	byID := byResource(schedule)
+
+	shortLived, resized, stopped := 0, 0, 0
+	for _, create := range schedule {
+		if create.EventType != "compute.instance.create.end" {
+			continue
+		}
+		id, createdAt := create.ResourceID, create.At
+		of := byID[id]
+		deletedAt := instantOf(of, "compute.instance.delete.end", id)
+
+		// The daily audits of the instance, by the midnight each of them ends at.
+		// The audit a delete sends ends at the delete instant instead, which is
+		// what tells the two apart.
+		daily := make(map[time.Time]Transition)
+		occupied := make(map[time.Time]struct{}, len(of))
+		count := 0
+		for _, transition := range of {
+			occupied[transition.At] = struct{}{}
+			if transition.EventType != "compute.instance.exists" {
+				continue
+			}
+			ending := parseStamp(t, transition.Payload["audit_period_ending"])
+			if !ending.Equal(at(ending, 0, 0)) {
+				continue
+			}
+			daily[ending] = transition
+			count++
+		}
+
+		var want []time.Time
+		for midnight := at(createdAt, 0, 0).Add(day); midnight.Before(to); midnight = midnight.Add(day) {
+			if deletedAt.IsZero() || deletedAt.After(midnight.Add(-day)) {
+				want = append(want, midnight)
+			}
+		}
+		if count != len(want) {
+			t.Errorf("the instance %s is created at %s, deleted at %v and audited %d times, want %d: "+
+				"one audit per midnight it saw", id, createdAt, deletedAt, count, len(want))
+		}
+
+		for _, midnight := range want {
+			audit, ok := daily[midnight]
+			if !ok {
+				t.Errorf("the instance %s reports no audit over the day that ends at %s, want one: "+
+					"a day a server ran and nothing reports is a day the bus is silent about",
+					id, midnight)
+				continue
+			}
+			if got, _ := audit.Payload["audit_period_beginning"].(string); got != stamp(midnight.Add(-day)) {
+				t.Errorf("the audit of %s at %s covers from %q, want %q: the period is the day it ends",
+					id, audit.At, got, stamp(midnight.Add(-day)))
+			}
+			if audit.At.Before(midnight) {
+				t.Errorf("the audit of %s over the day that ends at %s lies at %s, want it at the "+
+					"midnight or after it", id, midnight, audit.At)
+				continue
+			}
+			if !audit.At.Before(to) {
+				t.Errorf("the audit of %s lies at %s, want it inside the month: an audit at the end "+
+					"of the period falls into the month that follows", id, audit.At)
+			}
+			for second := midnight; second.Before(audit.At); second = second.Add(time.Second) {
+				if _, taken := occupied[second]; !taken {
+					t.Errorf("the audit of %s is pushed to %s and the instance reports nothing at %s, "+
+						"want an audit to step aside from an occupied second alone", id, audit.At, second)
+				}
+			}
+		}
+
+		if !deletedAt.IsZero() && at(createdAt, 0, 0).Equal(at(deletedAt, 0, 0)) && count == 1 {
+			shortLived++
+		}
+
+		// The state an audit repeats is the one the instance's last .end left it
+		// in. A server that is still powered off at a midnight is where that
+		// carry-forward shows, and a deleted one is audited once more as deleted.
+		for midnight, audit := range daily {
+			var last Transition
+			for _, transition := range of {
+				if strings.HasPrefix(transition.EventType, "compute.instance.") &&
+					strings.HasSuffix(transition.EventType, ".end") &&
+					transition.At.Before(audit.At) {
+					last = transition
+				}
+			}
+			var want string
+			switch last.EventType {
+			case "compute.instance.power_off.end":
+				want = "stopped"
+				stopped++
+			case "compute.instance.delete.end":
+				want = "deleted"
+			default:
+				continue
+			}
+			if got, _ := audit.Payload["state"].(string); got != want {
+				t.Errorf("the audit of %s over the day that ends at %s reports the state %q, want "+
+					"%q: its last notification before the audit was the %s at %s",
+					id, midnight, got, want, last.EventType, last.At)
+			}
+		}
+
+		if create.Workload != workloadClassic {
+			continue
+		}
+		resize, ok := firstOf(of, "compute.instance.resize.end")
+		if !ok {
+			continue
+		}
+		resized++
+		booted, _ := create.Payload["instance_type"].(string)
+		bootedID, _ := create.Payload["instance_flavor_id"].(string)
+		bootedDisk, _ := create.Payload["disk_gb"].(int)
+		moved, _ := resize.Payload["instance_type"].(string)
+		movedRoot, _ := resize.Payload["root_gb"].(int)
+		movedEphemeral, _ := resize.Payload["ephemeral_gb"].(int)
+		for midnight, audit := range daily {
+			want, wantID, wantDisk := booted, bootedID, bootedDisk
+			if audit.At.After(resize.At) {
+				// The resize payload names the flavor by its type id and reports the
+				// two disks apart, so the uuid and the sum an audit carries come
+				// from the catalog and from the payload's two members.
+				want, wantID, wantDisk = moved, flavorIDNamed(t, moved), movedRoot+movedEphemeral
+			}
+			if got, _ := audit.Payload["instance_type"].(string); got != want {
+				t.Errorf("the audit of %s over the day that ends at %s reports the flavor %q, want "+
+					"%q: an audit repeats the server as it stands, and it resized at %s",
+					id, midnight, got, want, resize.At)
+			}
+			if got, _ := audit.Payload["instance_flavor_id"].(string); got != wantID {
+				t.Errorf("the audit of %s over the day that ends at %s reports the flavor uuid %q, "+
+					"want %q: the three names of a flavor move together, and it resized at %s",
+					id, midnight, got, wantID, resize.At)
+			}
+			if got, _ := audit.Payload["disk_gb"].(int); got != wantDisk {
+				t.Errorf("the audit of %s over the day that ends at %s reports %d disk gibibytes, "+
+					"want %d: the disk of an audit is the root and the ephemeral of its flavor "+
+					"summed, and it resized at %s", id, midnight, got, wantDisk, resize.At)
+			}
+		}
+	}
+
+	if shortLived == 0 {
+		t.Errorf("no instance of the month is created and deleted between two midnights, want the CI " +
+			"runners: a server whose whole life is one day is audited once and dropped")
+	}
+	if resized == 0 {
+		t.Errorf("no classic instance of the month resizes, want the first of every project: without " +
+			"one nothing holds the flavor an audit carries forward")
+	}
+	if stopped == 0 {
+		t.Errorf("no instance of the month is audited while it is powered off, want the power " +
+			"cycles of the classic tenants: without one nothing holds the state an audit carries " +
+			"forward")
+	}
+}
+
+// flavorIDNamed is the uuid the catalog gives the flavor of that name. A resize
+// payload reports no uuid, so what an audit after one carries is looked up
+// rather than read off the notification that moved the server.
+func flavorIDNamed(t *testing.T, name string) string {
+	t.Helper()
+
+	for _, f := range flavors {
+		if f.name == name {
+			return f.flavorID
+		}
+	}
+	if bootVolumeFlavor.name == name {
+		return bootVolumeFlavor.flavorID
+	}
+	t.Fatalf("the catalog holds no flavor named %q", name)
+	return ""
+}
+
+// parseStamp reads back a rendered timestamp. The layout carries no zone, and
+// every reader of those digits takes them for UTC.
+func parseStamp(t *testing.T, value any) time.Time {
+	t.Helper()
+
+	text, ok := value.(string)
+	if !ok {
+		t.Fatalf("the payload carries %v where a timestamp is due, want the form oslo writes", value)
+	}
+	parsed, err := time.ParseInLocation(timestampLayout, text, time.UTC)
+	if err != nil {
+		t.Fatalf("parsing the timestamp %q: %v", text, err)
+	}
+	return parsed
+}
+
+// firstOf returns the first transition of that type, and false when the slice
+// holds none.
+func firstOf(transitions []Transition, eventType string) (Transition, bool) {
+	for _, transition := range transitions {
+		if transition.EventType == eventType {
+			return transition, true
+		}
+	}
+	return Transition{}, false
+}
+
+// TestVolumesAreAttachedAndDetachedAroundTheirLives covers what cinder sends
+// around a volume the collector bills. A volume that is never attached reports
+// the available status on every billable notification, and one whose detach is
+// missing is billed as in use past the server that held it.
+func TestVolumesAreAttachedAndDetachedAroundTheirLives(t *testing.T) {
+	g := buildMonth(t, 1)
+	byID := byResource(g.schedule)
+
+	// The volumes that change hands are the ones no server ever holds.
+	spares := make(map[string]struct{}, len(g.projects))
+	for _, p := range g.projects {
+		spares[p.spare.id] = struct{}{}
+	}
+
+	for _, create := range g.schedule {
+		if create.EventType != "volume.create.end" {
+			continue
+		}
+		id, at := create.ResourceID, create.At
+		if _, ok := has(byID[id], "volume.create.start", at.Add(-volumeProvision)); !ok {
+			t.Errorf("the volume %s is created at %s and reports no volume.create.start at %s, want "+
+				"the request cinder accepted", id, at, at.Add(-volumeProvision))
+		}
+		if _, spare := spares[id]; spare {
+			for _, transition := range byID[id] {
+				if strings.HasPrefix(transition.EventType, "volume.attach.") {
+					t.Errorf("the spare volume %s reports %s at %s, want no attach at all: it is the "+
+						"volume that changes hands and no server ever holds",
+						id, transition.EventType, transition.At)
+				}
+			}
+			continue
+		}
+		for _, step := range []struct {
+			eventType string
+			lag       time.Duration
+		}{
+			{"volume.attach.start", 1 * time.Second},
+			{"volume.attach.end", 2 * time.Second},
+		} {
+			if _, ok := has(byID[id], step.eventType, at.Add(step.lag)); !ok {
+				t.Errorf("the volume %s is created at %s and reports no %s at %s, want the attach "+
+					"that puts it in use", id, at, step.eventType, at.Add(step.lag))
+			}
+		}
+	}
+
+	for _, del := range g.schedule {
+		if del.EventType != "volume.delete.end" {
+			continue
+		}
+		if _, ok := has(byID[del.ResourceID], "volume.delete.start", del.At.Add(-time.Second)); !ok {
+			t.Errorf("the volume %s is deleted at %s and reports no volume.delete.start at %s, want "+
+				"the delete cinder announces", del.ResourceID, del.At, del.At.Add(-time.Second))
+		}
+	}
+
+	t.Run("the claim of a hibernating shoot is given back every night", func(t *testing.T) {
+		s := shootNamed(t, g, "api-dev")
+		claim := s.claims[0]
+		created := at(claim.createdAt, 0, 0)
+
+		for _, d := range workingDays(july2026, july2026.AddDate(0, 1, 0)) {
+			if d.Before(created) {
+				continue
+			}
+			if ids := idsIn(byID[claim.id], "volume.detach.start", at(d, 19, 0), at(d, 19, 5)); len(ids) != 1 {
+				t.Errorf("the first claim of api-dev reports %d detaches in the evening of %s, want "+
+					"one: hibernation takes every worker and gives the claims back",
+					len(ids), d.Format(time.DateOnly))
+			}
+			if d.Equal(created) {
+				continue
+			}
+			if ids := idsIn(byID[claim.id], "volume.attach.start", at(d, 7, 0), at(d, 7, 5)); len(ids) != 1 {
+				t.Errorf("the first claim of api-dev reports %d attaches in the morning of %s, want "+
+					"one: the workloads of a woken shoot mount it again",
+					len(ids), d.Format(time.DateOnly))
+			}
+		}
+	})
+
+	t.Run("the root volume of a worker is detached with it", func(t *testing.T) {
+		s := shootNamed(t, g, "api-dev")
+		gardener := ofWorkload(g.schedule, workloadGardener)
+
+		// A root volume carries the name of the worker it boots, which is what
+		// pairs the two here.
+		roots := make(map[string]string)
+		for _, transition := range gardener {
+			if transition.EventType != "volume.create.end" {
+				continue
+			}
+			name, _ := transition.Payload["display_name"].(string)
+			roots[name] = transition.ResourceID
+		}
+
+		workers := 0
+		for _, del := range gardener {
+			name, _ := del.Payload["display_name"].(string)
+			if del.EventType != "compute.instance.delete.end" ||
+				!strings.HasPrefix(name, s.technicalID+"-worker-") {
+				continue
+			}
+			workers++
+
+			root, ok := roots[name]
+			if !ok {
+				t.Errorf("the worker %s has no root volume, want the one it boots from", name)
+				continue
+			}
+			if _, ok := has(byID[root], "volume.detach.start", del.At.Add(detachLag)); !ok {
+				t.Errorf("the root volume of %s is not detached at %s, want cinder to give it back "+
+					"once the server that held it is gone", name, del.At.Add(detachLag))
+			}
+			released := instantOf(byID[root], "volume.delete.end", root)
+			if released.IsZero() || !released.After(del.At.Add(detachLag)) {
+				t.Errorf("the root volume of %s is deleted at %v and detached at %s, want the delete "+
+					"after the detach", name, released, del.At.Add(detachLag))
+			}
+			// A root volume is the server's first disk, which is what tells the
+			// attachment of one from the attachment of a claim.
+			attached, ok := firstOf(byID[root], "volume.attach.end")
+			if !ok {
+				t.Errorf("the root volume of %s is never attached, want the server to boot off it", name)
+				continue
+			}
+			if got := mountpointOf(t, attached); got != "/dev/vda" {
+				t.Errorf("the root volume of %s is mounted at %q, want \"/dev/vda\": a server boots "+
+					"off its first disk", name, got)
+			}
+		}
+		if workers == 0 {
+			t.Fatalf("api-dev deletes no worker, want the pool it hibernates every evening")
+		}
+
+		// The other half of that branch: everything a shoot mounts beside the root
+		// volume is the second disk of the server that holds it.
+		if len(s.claims) == 0 {
+			t.Fatalf("api-dev holds no claim, want the ones its workloads keep over the night")
+		}
+		for _, claim := range s.claims {
+			attached, ok := firstOf(byID[claim.id], "volume.attach.end")
+			if !ok {
+				t.Errorf("the claim %s is never attached, want the worker that mounts it", claim.id)
+				continue
+			}
+			if got := mountpointOf(t, attached); got != "/dev/vdb" {
+				t.Errorf("the claim %s is mounted at %q, want \"/dev/vdb\": a claim is the second "+
+					"disk of the worker that holds it", claim.id, got)
+			}
+		}
+	})
+}
+
+// mountpointOf is the device name the attachment a volume notification carries
+// reports. A notification with no attachment or with more than one is a payload
+// cinder does not send about a volume a single server holds.
+func mountpointOf(t *testing.T, transition Transition) string {
+	t.Helper()
+
+	list, _ := transition.Payload["volume_attachment"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("the %s of %s carries %d attachments, want the one of the server that holds it",
+			transition.EventType, transition.ResourceID, len(list))
+	}
+	record, _ := list[0].(map[string]any)
+	mountpoint, _ := record["mountpoint"].(string)
+	return mountpoint
+}
+
+// TestShootInfrastructureBracketsTheShoot covers what Gardener creates before
+// the first worker of a cluster boots and gives back after the last resource of
+// it is gone. The infrastructure is billed for by nothing, and it is what the
+// billable resources of a shoot sit inside.
+func TestShootInfrastructureBracketsTheShoot(t *testing.T) {
+	g := buildMonth(t, 1)
+	gardener := ofWorkload(g.schedule, workloadGardener)
+	byID := byResource(gardener)
+
+	for _, gp := range g.gardenerProjects {
+		for _, s := range gp.shoots {
+			t.Run(s.name, func(t *testing.T) {
+				p := s.owner.tenant
+				if len(s.securityGroupRuleIDs) != 2 {
+					t.Fatalf("%s has %d security group rules, want the two Gardener opens a worker "+
+						"pool with", s.name, len(s.securityGroupRuleIDs))
+				}
+
+				authenticated := false
+				for _, transition := range gardener {
+					if transition.EventType == "identity.authenticate" &&
+						transition.At.Equal(s.createdAt.Add(-2*time.Second)) &&
+						transition.ProjectID == p.id {
+						authenticated = true
+						break
+					}
+				}
+				if !authenticated {
+					t.Errorf("%s is created at %s and its tenant takes no token at %s, want the one "+
+						"reconciliation that builds it", s.name, s.createdAt,
+						s.createdAt.Add(-2*time.Second))
+				}
+
+				keypair := p.userID + ":" + s.keypairName
+				steps := []struct {
+					second     int
+					eventType  string
+					resourceID string
+				}{
+					{1, "network.create.start", s.networkID},
+					{2, "network.create.end", s.networkID},
+					{3, "subnet.create.start", s.subnetID},
+					{4, "subnet.create.end", s.subnetID},
+					{5, "router.create.start", s.routerID},
+					{6, "router.create.end", s.routerID},
+					{7, "router.interface.create", s.routerID},
+					{8, "security_group.create.start", s.securityGroupID},
+					{9, "security_group.create.end", s.securityGroupID},
+					{10, "security_group_rule.create.start", s.securityGroupRuleIDs[0]},
+					{11, "security_group_rule.create.end", s.securityGroupRuleIDs[0]},
+					{12, "security_group_rule.create.start", s.securityGroupRuleIDs[1]},
+					{13, "security_group_rule.create.end", s.securityGroupRuleIDs[1]},
+					{14, "keypair.import.start", keypair},
+					{15, "keypair.import.end", keypair},
+					{16, "dns.recordset.create", s.apiRecord.id},
+				}
+				for _, step := range steps {
+					when := s.createdAt.Add(time.Duration(step.second) * time.Second)
+					if _, ok := has(byID[step.resourceID], step.eventType, when); !ok {
+						t.Errorf("%s reports no %s on %s at %s, %d seconds after its creation, want "+
+							"the infrastructure a cluster needs before its first worker",
+							s.name, step.eventType, step.resourceID, when, step.second)
+					}
+				}
+
+				// The first worker of a shoot boots between 30 and 90 seconds after
+				// its creation instant, so the sixteen seconds of the infrastructure
+				// lie before the create the collector books. That create is the
+				// bound, and not the scheduler transition the boot begins with: the
+				// scheduler decides 25 seconds before the create, which falls inside
+				// the infrastructure window itself.
+				worker, ok := firstOf(transitionsOf(g.schedule, s), "compute.instance.create.end")
+				if !ok {
+					t.Fatalf("%s boots no worker, want the pool every cluster comes up with", s.name)
+				}
+				if !s.createdAt.Add(16 * time.Second).Before(worker.At) {
+					t.Errorf("%s finishes its infrastructure at %s and boots its first worker at %s, "+
+						"want the infrastructure first: a server on a network that does not exist yet "+
+						"is a sequence no deployment sends", s.name,
+						s.createdAt.Add(16*time.Second), worker.At)
+				}
+			})
+		}
+	}
+
+	t.Run("batch gives its infrastructure back after everything on it", func(t *testing.T) {
+		s := shootNamed(t, g, "batch")
+		p := s.owner.tenant
+		keypair := p.userID + ":" + s.keypairName
+
+		resources := map[string]struct{}{
+			s.networkID: {}, s.subnetID: {}, s.routerID: {}, s.securityGroupID: {},
+			s.securityGroupRuleIDs[0]: {}, s.securityGroupRuleIDs[1]: {},
+			keypair: {}, s.apiRecord.id: {}, s.ingressRecord.id: {},
+		}
+		var lastClaim time.Time
+		for _, transition := range transitionsOf(g.schedule, s) {
+			if isClaimDelete(transition) {
+				resources[transition.ResourceID] = struct{}{}
+				lastClaim = transition.At
+			}
+		}
+		if lastClaim.IsZero() {
+			t.Fatalf("batch releases no claim, want the ones its workloads held")
+		}
+
+		var of, after []Transition
+		for _, transition := range gardener {
+			if _, ok := resources[transition.ResourceID]; !ok {
+				continue
+			}
+			of = append(of, transition)
+			if transition.At.After(lastClaim) {
+				after = append(after, transition)
+			}
+		}
+		if len(of) == 0 {
+			t.Fatalf("batch reports nothing on its infrastructure, want it built and given back")
+		}
+		if last := of[len(of)-1]; last.EventType != "network.delete.end" {
+			t.Errorf("batch ends its infrastructure on %s at %s, want network.delete.end: nothing of "+
+				"a shoot is emitted after its network is gone", last.EventType, last.At)
+		}
+
+		want := []struct {
+			eventType  string
+			resourceID string
+		}{
+			{"dns.recordset.delete", s.apiRecord.id},
+			{"dns.recordset.delete", s.ingressRecord.id},
+			{"keypair.delete.start", keypair},
+			{"keypair.delete.end", keypair},
+			{"security_group.delete.start", s.securityGroupID},
+			{"security_group.delete.end", s.securityGroupID},
+			{"router.interface.delete", s.routerID},
+			{"router.delete.start", s.routerID},
+			{"router.delete.end", s.routerID},
+			{"subnet.delete.start", s.subnetID},
+			{"subnet.delete.end", s.subnetID},
+			{"network.delete.start", s.networkID},
+			{"network.delete.end", s.networkID},
+		}
+		if len(after) != len(want) {
+			t.Fatalf("batch reports %d transitions on its infrastructure after its last claim went "+
+				"at %s, want the %d of the tear-down", len(after), lastClaim, len(want))
+		}
+		for i, step := range want {
+			if after[i].EventType != step.eventType || after[i].ResourceID != step.resourceID {
+				t.Errorf("the tear-down of batch reports %s on %s as its step %d, want %s on %s: the "+
+					"resources are given back in the order they depend on each other",
+					after[i].EventType, after[i].ResourceID, i, step.eventType, step.resourceID)
+			}
+			if i > 0 && !after[i].At.Equal(after[i-1].At.Add(time.Second)) {
+				t.Errorf("the tear-down of batch reports %s at %s and %s at %s, want them a second "+
+					"apart: two notifications about one resource in one second are two the projection "+
+					"cannot order", after[i-1].EventType, after[i-1].At, after[i].EventType, after[i].At)
+			}
+		}
+	})
+
+	t.Run("a shoot that outlives the month keeps its infrastructure", func(t *testing.T) {
+		for _, name := range []string{"api-prod", "api-dev"} {
+			s := shootNamed(t, g, name)
+			resources := []string{
+				s.networkID, s.subnetID, s.routerID, s.securityGroupID,
+				s.owner.tenant.userID + ":" + s.keypairName,
+			}
+			prefixes := []string{
+				"network.delete.", "subnet.delete.", "router.delete.",
+				"security_group.delete.", "keypair.delete.",
+			}
+			for _, id := range resources {
+				for _, transition := range byID[id] {
+					for _, prefix := range prefixes {
+						if strings.HasPrefix(transition.EventType, prefix) {
+							t.Errorf("%s reports %s on %s at %s, want its infrastructure to outlive "+
+								"the month: the cluster is still running when the period ends",
+								name, transition.EventType, id, transition.At)
+						}
+					}
+				}
+			}
+		}
+	})
+}
+
+// TestTenantsAreAnnouncedBeforeTheirFirstResource covers what keystone sends
+// for a tenant that is created inside the month. The classic tenants pre-exist
+// it and are announced by nothing, which is what keeps an announcement from
+// standing for a project that was there all along.
+func TestTenantsAreAnnouncedBeforeTheirFirstResource(t *testing.T) {
+	g := buildMonth(t, 1)
+	byID := byResource(g.schedule)
+
+	announced := make([]*project, 0, len(g.gardenerProjects)+1)
+	for _, gp := range g.gardenerProjects {
+		announced = append(announced, gp.tenant)
+
+		if _, ok := has(byID[gp.zoneID], "dns.zone.create", july2026.Add(2*time.Second)); !ok {
+			t.Errorf("the project %s publishes no zone at %s, want the one its shoots create their "+
+				"records in", gp.name, july2026.Add(2*time.Second))
+		}
+	}
+	announced = append(announced, g.ciTenant)
+
+	if _, ok := has(byID[g.ciTenant.network.id], "network.create.start",
+		july2026.Add(2*time.Second)); !ok {
+		t.Errorf("the CI tenant builds no network at %s, want the one its runners hold their "+
+			"addresses on", july2026.Add(2*time.Second))
+	}
+
+	// The first transition of every project, which the announcement of an
+	// announced tenant is.
+	first := make(map[string]int, len(announced))
+	for i, transition := range g.schedule {
+		if _, ok := first[transition.ProjectID]; !ok {
+			first[transition.ProjectID] = i
+		}
+	}
+
+	for _, p := range announced {
+		if _, ok := has(byID[p.id], "identity.project.created", july2026); !ok {
+			t.Errorf("the tenant %s is never announced at %s, want keystone to create it before "+
+				"anything runs in it", p.id, july2026)
+			continue
+		}
+		if _, ok := has(byID[p.userID], "identity.user.created", july2026.Add(time.Second)); !ok {
+			t.Errorf("the user %s of the tenant %s is never announced at %s, want it a second after "+
+				"the project", p.userID, p.id, july2026.Add(time.Second))
+		}
+
+		index := -1
+		for i, transition := range g.schedule {
+			if transition.EventType == "identity.project.created" && transition.ResourceID == p.id {
+				index = i
+				break
+			}
+		}
+		if earliest := first[p.id]; earliest < index {
+			t.Errorf("the tenant %s reports %s at %s before its identity.project.created, want the "+
+				"announcement first: nothing runs in a project keystone has not created",
+				p.id, g.schedule[earliest].EventType, g.schedule[earliest].At)
+		}
+	}
+
+	classic := make(map[string]struct{}, len(g.projects))
+	for _, p := range g.projects {
+		classic[p.id] = struct{}{}
+	}
+	for _, transition := range g.schedule {
+		if !strings.HasPrefix(transition.EventType, "identity.") {
+			continue
+		}
+		if _, ok := classic[transition.ProjectID]; ok {
+			t.Errorf("%s at %s runs in the classic tenant %s, want keystone to announce the "+
+				"machine-driven tenants alone: a classic project pre-exists the month",
+				transition.EventType, transition.At, transition.ProjectID)
+		}
+	}
+}
+
+// TestLoadBalancersGetTheirPortsAndCertificates covers what neutron, designate
+// and barbican send around a load balancer. The address of a cluster is
+// published once, on the first balancer of the shoot, and the certificate the
+// ingress terminates on is four audit records before the update the balancer is
+// booked from.
+func TestLoadBalancersGetTheirPortsAndCertificates(t *testing.T) {
+	g := buildMonth(t, 1)
+	byID := byResource(g.schedule)
+	byTarget := byAuditTarget(g.schedule)
+
+	secondBalancers := 0
+	for _, gp := range g.gardenerProjects {
+		for _, s := range gp.shoots {
+			tenant := s.owner.tenant
+			for index, lb := range s.loadBalancers {
+				created := instantOf(g.schedule, "octavia.loadbalancer.create.end", lb.id)
+				if created.IsZero() {
+					t.Fatalf("the balancer %s is never created, want the service it stands for", lb.name)
+				}
+
+				port, ok := has(byID[lb.vipPortID], "port.create.end", created.Add(-time.Second))
+				if !ok {
+					t.Errorf("the balancer %s holds no port created at %s, want the one it holds its "+
+						"VIP address on", lb.name, created.Add(-time.Second))
+				} else {
+					payload, _ := port.Payload["port"].(map[string]any)
+					if got, _ := payload["device_owner"].(string); got != "Octavia" {
+						t.Errorf("the VIP port of %s is owned by %q, want \"Octavia\": the device "+
+							"behind it is the balancer and not a server", lb.name, got)
+					}
+				}
+
+				if index > 0 {
+					secondBalancers++
+					// The lookups are scoped to what this balancer would have
+					// published. Two shoots of a project share a tenant, so a search
+					// over the month would answer with the other shoot's record and
+					// pass while this one's is missing.
+					if _, ok := has(byID[s.ingressRecord.id], "dns.recordset.create",
+						created.Add(ingressRecordLag)); ok {
+						t.Errorf("the balancer %s publishes a record at %s, want the ingress record "+
+							"to be published with the first balancer of a shoot alone",
+							lb.name, created.Add(ingressRecordLag))
+					}
+					if lb.secretID != "" || lb.containerID != "" {
+						t.Errorf("the balancer %s holds the barbican secret %q and the container "+
+							"%q, want neither: it terminates one listener and no TLS",
+							lb.name, lb.secretID, lb.containerID)
+					}
+					continue
+				}
+
+				record, ok := has(byID[s.ingressRecord.id], "dns.recordset.create",
+					created.Add(ingressRecordLag))
+				if !ok {
+					t.Errorf("%s publishes no ingress record at %s, want the wildcard its services "+
+						"are reached under", s.name, created.Add(ingressRecordLag))
+				} else {
+					records, _ := record.Payload["records"].([]string)
+					if !slices.Equal(records, []string{lb.fip.address}) {
+						t.Errorf("the ingress record of %s points at %v, want %v, the address of its "+
+							"first balancer", s.name, records, []string{lb.fip.address})
+					}
+				}
+
+				requireCertificate(t, byTarget, tenant, lb, created.Add(certificateLag), "create",
+					[]string{"/v1/secrets", "/v1/secrets", "/v1/containers", "/v1/containers"})
+				updated := instantOf(g.schedule, "octavia.loadbalancer.update.end", lb.id)
+				if updated.IsZero() || !created.Add(certificateLag+3*time.Second).Before(updated) {
+					t.Errorf("the balancer %s is updated at %v and its certificate stored until %s, "+
+						"want the certificate first: the service is published once it terminates TLS",
+						lb.name, updated, created.Add(certificateLag+3*time.Second))
+				}
+			}
+		}
+	}
+	if secondBalancers == 0 {
+		t.Errorf("no shoot of the month publishes a second service, want api-prod to publish one: " +
+			"without it nothing holds the record and the certificate to the first balancer of a shoot")
+	}
+
+	t.Run("batch takes its balancers back with their ports and certificates", func(t *testing.T) {
+		s := shootNamed(t, g, "batch")
+		for index, lb := range s.loadBalancers {
+			deleted := instantOf(g.schedule, "octavia.loadbalancer.delete.end", lb.id)
+			if deleted.IsZero() {
+				t.Fatalf("the balancer %s of batch is never deleted, want the tear-down to close it",
+					lb.name)
+			}
+			if _, ok := has(byID[lb.vipPortID], "port.delete.end", deleted.Add(2*time.Second)); !ok {
+				t.Errorf("the VIP port of %s is not released at %s, want it to go with the balancer "+
+					"that held it", lb.name, deleted.Add(2*time.Second))
+			}
+			if index > 0 {
+				continue
+			}
+			requireCertificate(t, byTarget, s.owner.tenant, lb, deleted.Add(3*time.Second), "delete",
+				[]string{
+					"/v1/containers/" + lb.containerID, "/v1/containers/" + lb.containerID,
+					"/v1/secrets/" + lb.secretID, "/v1/secrets/" + lb.secretID,
+				})
+		}
+	})
+}
+
+// requireCertificate holds the four records barbican's audit middleware sends
+// for the two calls of a certificate against the balancer they belong to: a
+// request and a response per call, a second apart, both naming the same action
+// and path.
+//
+// A record is looked up by the resource it names rather than searched for in
+// the month. Two shoots of one project run on one tenant, so a record of the
+// other shoot at the same second carries the same project, the same action and
+// the same path, and a search over the month would take it for this balancer's.
+func requireCertificate(t *testing.T, byTarget map[string][]Transition, p *project,
+	lb *loadBalancer, from time.Time, action string, paths []string,
+) {
+	t.Helper()
+
+	// The secret is given the first two records and the container the other two.
+	// A certificate is given back the other way round, because the container
+	// refers to the secret and goes first.
+	targets := []string{lb.secretID, lb.secretID, lb.containerID, lb.containerID}
+	if action == "delete" {
+		targets = []string{lb.containerID, lb.containerID, lb.secretID, lb.secretID}
+	}
+
+	for i, path := range paths {
+		eventType := "audit.http.request"
+		if i%2 == 1 {
+			eventType = "audit.http.response"
+		}
+		when := from.Add(time.Duration(i) * time.Second)
+
+		record, ok := has(byTarget[targets[i]], eventType, when)
+		if !ok {
+			t.Errorf("the certificate of %s reports no %s at %s naming %s, want the four records "+
+				"of its two calls against barbican", lb.name, eventType, when, targets[i])
+			continue
+		}
+		if record.ProjectID != p.id {
+			t.Errorf("the record of %s at %s runs in the project %s, want %s, the tenant the shoot "+
+				"runs on", lb.name, when, record.ProjectID, p.id)
+		}
+		if got, _ := record.Payload["requestPath"].(string); got != path {
+			t.Errorf("the record of %s at %s names the path %q, want %q", lb.name, when, got, path)
+		}
+		if got, _ := record.Payload["action"].(string); got != action {
+			t.Errorf("the record of %s at %s reports the action %q, want %q: the method the call was "+
+				"made with is what the action is read off", lb.name, when, got, action)
+		}
+	}
+}
+
+// TestGardenerTakesOneTokenPerReconciliation covers every keystone record the
+// machine-driven tenants send. A shoot's creation, each of its wake-ups, its
+// rolling update, and its tear-down are one reconciliation each, and nothing
+// else Gardener does costs a token: the autoscaler and the claim activity take
+// none, and a wake-up that took one per worker would put five records on the
+// bus where one belongs.
+func TestGardenerTakesOneTokenPerReconciliation(t *testing.T) {
+	g := buildMonth(t, 1)
+	gardener := ofWorkload(g.schedule, workloadGardener)
+	to := july2026.AddDate(0, 1, 0)
+
+	// The instants a token is due at, by the tenant that takes it and what the
+	// record stands for. A rolling update is drawn inside its day, so it is not
+	// among them and is matched afterwards.
+	type token struct {
+		project string
+		at      time.Time
+	}
+	want := make(map[token]string)
+	// The rolling update days, by the shoot that rolls on one.
+	rolling := make(map[time.Time]*shoot)
+
+	for _, gp := range g.gardenerProjects {
+		for _, s := range gp.shoots {
+			want[token{gp.tenant.id, s.createdAt.Add(-authenticateLead)}] =
+				"the reconciliation that creates " + s.name
+			if !s.deletedAt.IsZero() {
+				want[token{gp.tenant.id, s.deletedAt.Add(-authenticateLead)}] =
+					"the tear-down of " + s.name
+			}
+			if !s.rollingUpdateDay.IsZero() {
+				rolling[s.rollingUpdateDay] = s
+			}
+			if !s.hibernates {
+				continue
+			}
+			// A wake-up boots the shoot's first worker of the day at the stroke of
+			// the office hour, which is what marks the morning it woke up on.
+			for _, d := range workingDays(july2026, to) {
+				morning := at(d, officeFrom, 0)
+				if _, ok := has(transitionsOf(g.schedule, s), "compute.instance.create.end", morning); ok {
+					want[token{gp.tenant.id, morning.Add(-authenticateLead)}] = "the wake-up of " + s.name
+				}
+			}
+		}
+	}
+	if len(want) < 4 {
+		t.Fatalf("the month holds %d reconciliations to hold the tokens against, want the creation "+
+			"of every shoot, the wake-ups of api-dev and the tear-down of batch", len(want))
+	}
+
+	seen := make(map[token]int)
+	for _, transition := range gardener {
+		if transition.EventType != "identity.authenticate" {
+			continue
+		}
+		key := token{transition.ProjectID, transition.At}
+		if _, ok := want[key]; ok {
+			seen[key]++
+			continue
+		}
+
+		// What is left is a rolling update: one token on the day the shoot rolls
+		// on, two seconds before the first machine of the new generation boots.
+		s, ok := rolling[at(transition.At, 0, 0)]
+		if !ok || s.owner.tenant.id != transition.ProjectID {
+			t.Errorf("the tenant %s takes a token at %s, want one per action a controller starts: "+
+				"a shoot's creation, a wake-up, a rolling update, and a tear-down",
+				transition.ProjectID, transition.At)
+			continue
+		}
+		if _, booted := has(transitionsOf(g.schedule, s), "compute.instance.create.end",
+			transition.At.Add(authenticateLead)); !booted {
+			t.Errorf("%s takes a token at %s on its rolling update day and boots no machine at %s, "+
+				"want the update the token was taken for", s.name, transition.At,
+				transition.At.Add(authenticateLead))
+		}
+		seen[token{transition.ProjectID, s.rollingUpdateDay}]++
+	}
+
+	for key, what := range want {
+		if seen[key] != 1 {
+			t.Errorf("%s reports %d tokens at %s, want exactly one: a reconciliation authenticates "+
+				"once, whatever it goes on to create", what, seen[key], key.at)
+		}
+	}
+	for d, s := range rolling {
+		if got := seen[token{s.owner.tenant.id, d}]; got != 1 {
+			t.Errorf("the rolling update of %s on %s reports %d tokens, want exactly one: the "+
+				"machines it replaces are one reconciliation", s.name, d.Format(time.DateOnly), got)
+		}
+	}
+}
+
+// TestImagesArePreparedAndActivatedAroundTheirUpload covers the two
+// notifications glance sends around the one the collector books an image from.
+// The prepare carries no size yet and the activate repeats the upload, so a
+// month that dropped either would leave the image billed from the same instant
+// and the bus short of what a real glance sends.
+func TestImagesArePreparedAndActivatedAroundTheirUpload(t *testing.T) {
+	schedule := generateMonth(t, 1, july2026, testCloud)
+	byID := byResource(schedule)
+
+	const want = 9
+	uploads := 0
+	for _, upload := range schedule {
+		if upload.EventType != "image.upload" {
+			continue
+		}
+		uploads++
+
+		id, at := upload.ResourceID, upload.At
+		prepared, ok := has(byID[id], "image.prepare", at.Add(-time.Second))
+		if !ok {
+			t.Errorf("the image %s is uploaded at %s and reports no image.prepare at %s, want glance "+
+				"taking the bits in", id, at, at.Add(-time.Second))
+		}
+		if _, ok := has(byID[id], "image.activate", at.Add(time.Second)); !ok {
+			t.Errorf("the image %s is uploaded at %s and reports no image.activate at %s, want "+
+				"glance flipping it to active", id, at, at.Add(time.Second))
+		}
+		announced := instantOf(byID[id], imageCreateType, id)
+		switch {
+		case announced.IsZero():
+			t.Errorf("the image %s is uploaded at %s and never announced, want the %s glance sends "+
+				"before it has content", id, at, imageCreateType)
+		case ok && !announced.Before(prepared.At):
+			t.Errorf("the image %s is announced at %s and prepared at %s, want the announcement "+
+				"first: glance accepts an image before it receives its content",
+				id, announced, prepared.At)
+		}
+	}
+	if uploads != want {
+		t.Errorf("the month uploads %d images, want %d: two per classic tenant and one per "+
+			"machine-driven one", uploads, want)
+	}
+}
+
+// TestCIBurstsAuthenticate covers the token a push takes. A pipeline is started
+// by somebody, so a burst costs one authentication and a runner none: a month
+// with one per runner would put hundreds of keystone records on the bus that no
+// build system sends.
+func TestCIBurstsAuthenticate(t *testing.T) {
+	for seed := uint64(1); seed <= 5; seed++ {
+		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
+			schedule := ofWorkload(generateMonth(t, seed, july2026, testCloud), workloadCI)
+
+			creates := make(map[time.Time]struct{}, len(schedule))
+			for _, transition := range schedule {
+				if transition.EventType == "compute.instance.create.end" {
+					creates[transition.At] = struct{}{}
+				}
+			}
+
+			perDay := make(map[time.Time]int)
+			bursts := 0
+			for _, transition := range schedule {
+				if transition.EventType != "identity.authenticate" {
+					continue
+				}
+				bursts++
+				perDay[at(transition.At, 0, 0)]++
+				if _, ok := creates[transition.At.Add(2*time.Second)]; !ok {
+					t.Errorf("the CI tenant takes a token at %s and boots no runner at %s, want a "+
+						"burst behind every authentication", transition.At,
+						transition.At.Add(2*time.Second))
+				}
+			}
+			if bursts == 0 {
+				t.Fatalf("the CI tenant authenticates never, want one token per push")
+			}
+
+			for _, d := range workingDays(july2026, july2026.AddDate(0, 1, 0)) {
+				if got := perDay[d]; got < 4 || got > 8 {
+					t.Errorf("%s brings %d authentications, want 4 to 8: one per burst of the day",
+						d.Format(time.DateOnly), got)
+				}
+			}
+		})
+	}
+}
+
+// TestAuditsStepAsideFromAnOccupiedSecond covers the one instant an audit
+// cannot take: a midnight the instance already reports a transition at. A
+// generated month reaches it only when a delete happens to fall on a midnight,
+// so the two transitions around it are written out here rather than drawn.
+func TestAuditsStepAsideFromAnOccupiedSecond(t *testing.T) {
+	g := buildWorld(t, 1)
+	p := g.projects[0]
+	inst := p.instances[0]
+	inst.flavor = largeFlavor
+	inst.host = computeHosts[0]
+	inst.createdAt = time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	deletedAt := time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+
+	g.schedule = Schedule{
+		{
+			At: inst.createdAt, EventType: "compute.instance.create.end", Workload: workloadClassic,
+			PublisherID: computePublisher(inst), ProjectID: p.id, UserID: p.userID,
+			ResourceID: inst.id, Payload: instanceCreatePayload(p, inst, testCloud),
+		},
+		{
+			At: deletedAt, EventType: "compute.instance.delete.end", Workload: workloadClassic,
+			PublisherID: computePublisher(inst), ProjectID: p.id, UserID: p.userID,
+			ResourceID: inst.id, Payload: instanceDeletePayload(p, inst, deletedAt),
+		},
+	}
+	g.audits()
+
+	var audits []Transition
+	for _, transition := range g.schedule {
+		if transition.EventType == "compute.instance.exists" && transition.ResourceID == inst.id {
+			audits = append(audits, transition)
+		}
+	}
+
+	want := []time.Time{
+		time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 5, 0, 0, 1, 0, time.UTC),
+	}
+	if len(audits) != len(want) {
+		t.Fatalf("the instance is audited %d times, want %d: one for the day it ran through and one "+
+			"for the part of the day it was deleted on", len(audits), len(want))
+	}
+	for i, when := range want {
+		if !audits[i].At.Equal(when) {
+			t.Errorf("audit %d lies at %s, want %s: a midnight the instance already reports a "+
+				"transition at is one the audit is pushed past", i, audits[i].At, when)
+		}
+		if audits[i].Workload != workloadClassic {
+			t.Errorf("audit %d carries the workload %q, want %q, the one of the create it repeats",
+				i, audits[i].Workload, workloadClassic)
+		}
+	}
+}
+
+// TestAuditsOverAnEmptyScheduleEmitNothing covers the pass over a month that
+// holds no server. The audits walk every midnight of the period whatever the
+// schedule carries, so a month without an instance is where the walk would
+// otherwise reach into an empty fleet.
+func TestAuditsOverAnEmptyScheduleEmitNothing(t *testing.T) {
+	t.Run("a schedule that holds nothing", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		g.audits()
+
+		if len(g.schedule) != 0 {
+			t.Errorf("the audits added %d transitions to an empty month, want none: nothing existed "+
+				"on any day of it", len(g.schedule))
+		}
+	})
+
+	t.Run("a schedule that holds no server", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		p := g.projects[0]
+		vol := &volume{
+			id: g.noiseIDs.nextUUID(), name: "audited-by-nobody", sizeGB: 10, volumeType: "ssd",
+			createdAt: time.Date(2026, 7, 9, 11, 0, 0, 0, time.UTC),
+		}
+		g.schedule = Schedule{{
+			At: vol.createdAt, EventType: "volume.create.end", Billable: true,
+			PublisherID: volumePublisher, ProjectID: p.id, UserID: p.userID,
+			ResourceID: vol.id, Payload: volumeCreatePayload(p, vol),
+		}}
+		g.audits()
+
+		if len(g.schedule) != 1 {
+			t.Errorf("the audits made a month of one volume %d transitions long, want it unchanged: "+
+				"a resource without a create.end behind it is nothing this pass audits", len(g.schedule))
+		}
+	})
+}
+
+// TestNoiseHelpersOnAbsentResources covers the branches of noise.go the month
+// never reaches: a volume that is attached to no server, one that is deleted
+// while nothing holds it, and a server that is destroyed without a port. Each
+// of them is a nil the helpers answer for rather than dereference.
+func TestNoiseHelpersOnAbsentResources(t *testing.T) {
+	t0 := time.Date(2026, 7, 9, 11, 0, 0, 0, time.UTC)
+
+	newVolume := func(g *generator) *volume {
+		return &volume{
+			id: g.noiseIDs.nextUUID(), name: "orphan", sizeGB: 10, volumeType: "ssd",
+			createdAt: t0.Add(-time.Hour),
+		}
+	}
+
+	t.Run("attach with no instance", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		g.workload = workloadClassic
+		p := g.projects[0]
+		vol := newVolume(g)
+
+		g.attach(p, vol, nil, t0)
+
+		attached, ok := has(g.schedule, "volume.attach.end", t0.Add(time.Second))
+		if !ok {
+			t.Fatalf("the attach of %s renders no volume.attach.end at %s", vol.name, t0.Add(time.Second))
+		}
+		attachment, _ := attached.Payload["volume_attachment"].([]any)
+		if len(attachment) != 1 {
+			t.Fatalf("the attach reports %d attachments, want the one cinder handed out", len(attachment))
+		}
+		record, _ := attachment[0].(map[string]any)
+		for _, member := range []string{"instance_uuid", "attached_host"} {
+			if got := record[member]; got != nil {
+				t.Errorf("the attachment reports %s = %v, want null: cinder names neither the server "+
+					"nor its compute on an attachment whose server it does not know", member, got)
+			}
+		}
+		if !vol.attached {
+			t.Errorf("the volume is attached = false, want it in use: a billable payload rendered " +
+				"afterwards reports it the way it reports one a server holds")
+		}
+		if got := volumeStatePayload(p, vol)["status"]; got != "in-use" {
+			t.Errorf("the volume reports status = %v, want \"in-use\"", got)
+		}
+	})
+
+	t.Run("deleteVolume on a detached volume", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		g.workload = workloadClassic
+		p := g.projects[0]
+
+		g.deleteVolume(p, newVolume(g), t0)
+
+		requireSequence(t, g.schedule, []sequenceStep{
+			{"volume.delete.start", t0.Add(-time.Second)},
+			{"volume.delete.end", t0},
+		})
+		for _, transition := range g.schedule {
+			if strings.HasPrefix(transition.EventType, "volume.detach.") {
+				t.Errorf("the delete renders %s at %s, want none: a volume whose server is already "+
+					"gone was detached with it", transition.EventType, transition.At)
+			}
+		}
+	})
+
+	t.Run("deleteVolume on an attached volume", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		g.workload = workloadClassic
+		p := g.projects[0]
+		vol := newVolume(g)
+
+		g.attach(p, vol, nil, t0.Add(-time.Hour))
+		g.schedule = nil
+		g.deleteVolume(p, vol, t0)
+
+		requireSequence(t, g.schedule, []sequenceStep{
+			{"volume.detach.start", t0.Add(-3 * time.Second)},
+			{"volume.detach.end", t0.Add(-2 * time.Second)},
+			{"volume.delete.start", t0.Add(-time.Second)},
+			{"volume.delete.end", t0},
+		})
+	})
+
+	t.Run("destroyInstance without a port", func(t *testing.T) {
+		g := buildWorld(t, 1)
+		g.workload = workloadClassic
+		p := g.projects[0]
+		inst := &instance{
+			id: g.noiseIDs.nextUUID(), name: "lonely", host: computeHosts[0], flavor: largeFlavor,
+			createdAt: t0.Add(-time.Hour),
+		}
+
+		g.destroyInstance(p, inst, t0)
+
+		requireSequence(t, g.schedule, []sequenceStep{
+			{"compute.instance.update", t0.Add(-5 * time.Second)},
+			{"compute.instance.exists", t0.Add(-4 * time.Second)},
+			{"compute.instance.delete.start", t0.Add(-3 * time.Second)},
+			{"compute.instance.shutdown.start", t0.Add(-2 * time.Second)},
+			{"compute.instance.shutdown.end", t0.Add(-time.Second)},
+			{"compute.instance.delete.end", t0},
+		})
+		for _, transition := range g.schedule {
+			if strings.HasPrefix(transition.EventType, "port.") {
+				t.Errorf("the delete renders %s at %s, want none: a server that never held a port "+
+					"has none to release", transition.EventType, transition.At)
+			}
+		}
+		if deleted, ok := has(g.schedule, "compute.instance.delete.end", t0); ok && !deleted.Billable {
+			t.Errorf("the delete is billable = false, want the collector to book it: the noise around " +
+				"it is what it bills nothing for")
+		}
+		if !inst.deletedAt.Equal(t0) {
+			t.Errorf("the instance reports deletedAt = %s, want %s", inst.deletedAt, t0)
+		}
+	})
+}
+
+// sequenceStep is one transition a rendered sequence is to hold: which type,
+// and the instant it is due at.
+type sequenceStep struct {
+	eventType string
+	at        time.Time
+}
+
+// requireSequence holds a schedule against the transitions it is to hold, in
+// order and at the instants they are due at.
+func requireSequence(t *testing.T, schedule Schedule, want []sequenceStep) {
+	t.Helper()
+
+	if len(schedule) != len(want) {
+		t.Fatalf("the schedule holds %d transitions, want %d", len(schedule), len(want))
+	}
+	for i, step := range want {
+		if schedule[i].EventType != step.eventType || !schedule[i].At.Equal(step.at) {
+			t.Errorf("transition %d is %s at %s, want %s at %s",
+				i, schedule[i].EventType, schedule[i].At, step.eventType, step.at)
+		}
+	}
+}

--- a/internal/providers/openstack/simulator/publish.go
+++ b/internal/providers/openstack/simulator/publish.go
@@ -18,11 +18,13 @@ const collectorQueue = "tally-notifications"
 
 // ServiceExchanges are the exchanges the simulator publishes notifications on,
 // one per service, and the ones Connect declares. The collector's default
-// TALLY_OSC_EXCHANGES lists the first four, and a deployment that runs octavia
-// lists the fifth itself (docs/openstack-collector.md, "Exchanges and topics"),
-// so a collector left at its default receives the month without its load
-// balancers.
-var ServiceExchanges = []string{"nova", "cinder", "neutron", "glance", "octavia"}
+// TALLY_OSC_EXCHANGES lists the first four, and a deployment lists the other
+// four itself (docs/openstack-collector.md, "Exchanges and topics"), so a
+// collector left at its default receives the month without its load balancers
+// and without the keystone, designate, and barbican notifications.
+var ServiceExchanges = []string{
+	"nova", "cinder", "neutron", "glance", "octavia", "keystone", "designate", "barbican",
+}
 
 // probeInterval is how long AwaitConsumer waits between two looks at the
 // collector's queue. It is short enough that a collector started a moment later

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/b42labs/tally/internal/core/cardinality"
 	"github.com/b42labs/tally/internal/providers/openstack"
 )
 
@@ -43,10 +45,11 @@ const (
 	pollDeadline = 30 * time.Second
 )
 
-// testOutboxMax is the outbox bound the collector runs under here. Nothing
-// drains the outbox during a test, so the bound is far above the few hundred
-// notifications one month produces: a consumer that paused on backpressure
-// would stall the run rather than fail it.
+// testOutboxMax is the outbox bound the collector runs under here. Only the
+// billable notifications reach the outbox at all, about 1800 for a month of
+// seed 1, since the noise is skipped before it. Nothing drains the outbox
+// during a test, so the bound stays far above that: a consumer that paused on
+// backpressure would stall the run rather than fail it.
 const testOutboxMax = 100_000
 
 // startBroker runs a RabbitMQ container for the test and returns the URL it is
@@ -214,6 +217,29 @@ func counterValue(t *testing.T, reg *prometheus.Registry, name, labelName, label
 	return 0
 }
 
+// skippedSum adds up every child of tally_collector_skipped_total, whatever
+// event type it carries, and reads 0 while the family is absent. A test waits
+// on the sum rather than on one type, because the sum is what says the whole
+// month has been handled: a per-type count is only worth comparing once it has.
+func skippedSum(t *testing.T, reg *prometheus.Registry) float64 {
+	t.Helper()
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v, want nil", err)
+	}
+	sum := 0.0
+	for _, family := range families {
+		if family.GetName() != "tally_collector_skipped_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			sum += metric.GetCounter().GetValue()
+		}
+	}
+	return sum
+}
+
 // storedEventIDs lists the event ids the outbox holds, sorted so that a test
 // compares sets rather than the order the consumer happened to buffer in.
 func storedEventIDs(t *testing.T, outbox *openstack.Outbox, n int) []string {
@@ -303,7 +329,8 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
 
-	want := billableMessageIDs(t, generateMonth(t, 1, july2026, testCloud))
+	month := generateMonth(t, 1, july2026, testCloud)
+	want := billableMessageIDs(t, month)
 	waitFor(t, "every billable notification is buffered", func() bool {
 		return outbox.Depth() == int64(len(want))
 	})
@@ -316,30 +343,66 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 		t.Errorf("the event ids in events.jsonl = %v, want %v", got, want)
 	}
 
+	// What the rest of the month becomes in the collector: every notification the
+	// mapping records nothing for is counted as skipped under the type it arrived
+	// as. That counter is how a deployment sees the types it bills nothing for,
+	// so the month is held to it type by type.
+	expected := map[string]int{}
+	skippedTotal := 0
+	for _, transition := range month {
+		if transition.Billable {
+			continue
+		}
+		expected[transition.EventType]++
+		skippedTotal++
+	}
+	// The consumer counts a skip when it handles the message, and the last
+	// messages of a month may be noise that arrives after the last billable one,
+	// so a full outbox does not yet mean the counters are complete.
+	waitFor(t, "every non-billable notification is counted as skipped", func() bool {
+		return skippedSum(t, reg) == float64(skippedTotal)
+	})
+
 	// The month carries one image.create per image, nine in all: two for each of
 	// the three classic projects, one for each of the two Gardener tenants, and
-	// one for the CI tenant. The mapping skips every one of them because an
-	// announced image has no size yet. Nothing else in the month may go
-	// unrecorded: a notification the collector cannot parse is one the simulator
-	// rendered wrong.
+	// one for the CI tenant. Beside them stands the noise catalogue, and the
+	// mapping records nothing for any of it: an announced image has no size yet,
+	// and no noise type is billable. The counts below hold each of those series
+	// to the month.
 	if got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", "image.create"); got != 9 {
 		t.Errorf("tally_collector_skipped_total{event_type=\"image.create\"} = %v, want 9", got)
 	}
+	for _, eventType := range slices.Sorted(maps.Keys(expected)) {
+		got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", eventType)
+		if got != float64(expected[eventType]) {
+			t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want %d",
+				eventType, got, expected[eventType])
+		}
+	}
+	// The 83 types of the month lie inside the bound the collector holds the
+	// label's values to, so none of them is folded into the overflow value.
+	if got := counterValue(t, reg, "tally_collector_skipped_total",
+		"event_type", cardinality.Overflow); got != 0 {
+		t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want 0", cardinality.Overflow, got)
+	}
+	// And nothing in the month went unrecorded for another reason: a notification
+	// the collector cannot parse is one the simulator rendered wrong.
 	if got := counterValue(t, reg, "tally_collector_unparseable_total", "", ""); got != 0 {
 		t.Errorf("tally_collector_unparseable_total = %v, want 0", got)
 	}
 }
 
-// TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers is what a
-// deployment that runs octavia and left TALLY_OSC_EXCHANGES alone gets. A topic
-// exchange copies a message only to the queues bound to it, so the octavia
-// notifications of the month reach a collector bound to the other four
-// exchanges neither as an event nor as a skip: they are dropped at the broker,
-// and nothing in the collector counts them.
-func TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers(t *testing.T) {
+// TestACollectorAtItsDefaultExchangesMissesTheOtherFourExchanges is what a
+// deployment that left TALLY_OSC_EXCHANGES alone gets. A topic exchange copies
+// a message only to the queues bound to it, so what the month publishes on
+// octavia, keystone, designate and barbican reaches a collector bound to the
+// other four neither as an event nor as a skip: it is dropped at the broker,
+// and nothing in the collector counts it. The noise on the four bound
+// exchanges is what such a collector does see, as skips.
+func TestACollectorAtItsDefaultExchangesMissesTheOtherFourExchanges(t *testing.T) {
 	url, _ := startBroker(t)
-	// The publisher declares all five, so the octavia exchange exists and takes
-	// its messages whether a queue is bound to it or not.
+	// The publisher declares all eight, so the four unbound exchanges exist and
+	// take their messages whether a queue is bound to them or not.
 	publisher := connect(t, url)
 	outbox, reg, _ := startCollector(t, url, defaultCollectorExchanges)
 
@@ -374,6 +437,15 @@ func TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers(t *testing.T) {
 		t.Errorf("buffered event ids = %v, want %v", got, want)
 	}
 
+	// What it does see instead of the four exchanges it is not bound to: nova's
+	// noise, of which the audits are the largest part. The daily audits run to
+	// the end of the month and may be among its last messages, so the counter is
+	// waited for before the skips are read.
+	const audits = "compute.instance.exists"
+	waitFor(t, "the daily audits are counted as skipped", func() bool {
+		return counterValue(t, reg, "tally_collector_skipped_total", "event_type", audits) > 0
+	})
+
 	families, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("Gather() error = %v, want nil", err)
@@ -384,7 +456,8 @@ func TestACollectorAtItsDefaultExchangesMissesTheLoadBalancers(t *testing.T) {
 		}
 		for _, metric := range family.GetMetric() {
 			for _, label := range metric.GetLabel() {
-				if label.GetName() != "event_type" || !strings.HasPrefix(label.GetValue(), "octavia.") {
+				if label.GetName() != "event_type" ||
+					slices.Contains(defaultCollectorExchanges, exchangeFor(label.GetValue())) {
 					continue
 				}
 				t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want the type in no counter "+

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -482,6 +482,17 @@ func volumeCreatePayload(p *project, vol *volume) map[string]any {
 	}
 }
 
+// volumeCreateStartPayload describes a volume cinder has accepted and is
+// building. It carries the members of the finished volume with two of them
+// changed: the status is the one a volume has while it is provisioned, and
+// there is no launched_at, because the volume has not been handed out yet.
+func volumeCreateStartPayload(p *project, vol *volume) map[string]any {
+	payload := volumeCreatePayload(p, vol)
+	payload["status"] = "creating"
+	payload["launched_at"] = nil
+	return payload
+}
+
 // volumeDeletePayload describes a removed volume, with the size and type it
 // carried when it went.
 func volumeDeletePayload(p *project, vol *volume, at time.Time) map[string]any {
@@ -502,12 +513,22 @@ func volumeDeletePayload(p *project, vol *volume, at time.Time) map[string]any {
 // volumeStatePayload describes a volume whose size, type, or owner changed.
 // Cinder reports the same members for all three, each already carrying the new
 // value, which is why one builder serves a resize, a retype, and an accepted
-// transfer alike.
+// transfer alike. The status is the one the world holds: a volume a server
+// holds is in use, and a volume attached to nothing is available. The members
+// themselves come from volumeStatusPayload, which the steps around a volume
+// render their own statuses through.
 func volumeStatePayload(p *project, vol *volume) map[string]any {
 	status := "available"
 	if vol.attached {
 		status = "in-use"
 	}
+	return volumeStatusPayload(p, vol, status)
+}
+
+// volumeStatusPayload describes a volume in the status the caller names. Cinder
+// reports the same members whatever the volume is doing, and the status is what
+// tells a creating volume from an attaching, a deleting, or an available one.
+func volumeStatusPayload(p *project, vol *volume, status string) map[string]any {
 	return map[string]any{
 		"volume_id":    vol.id,
 		"tenant_id":    p.id,
@@ -519,6 +540,50 @@ func volumeStatePayload(p *project, vol *volume) map[string]any {
 		"host":         volumeHost,
 		"created_at":   stamp(vol.createdAt.Add(-volumeProvision)),
 	}
+}
+
+// attachmentOf is the record cinder writes when a volume is connected to a
+// server: which server holds it, on which compute, since when, and under which
+// device name. A server's root volume is its first disk and every other volume
+// its second, which is what the two mountpoints stand for.
+//
+// The server may be nil, and the attachment then names neither an instance nor
+// a host: both members are null, the way cinder writes an attachment whose
+// server it does not know.
+func attachmentOf(id string, vol *volume, inst *instance, t time.Time) map[string]any {
+	var instanceID, host any
+	mountpoint := "/dev/vdb"
+	if inst != nil {
+		instanceID, host = inst.id, inst.host
+		if inst.bootVolume == vol {
+			mountpoint = "/dev/vda"
+		}
+	}
+	return map[string]any{
+		"attach_mode":   "rw",
+		"attach_status": "attached",
+		"attach_time":   stamp(t),
+		"attached_host": host,
+		"id":            id,
+		"instance_uuid": instanceID,
+		"mountpoint":    mountpoint,
+		"volume_id":     vol.id,
+	}
+}
+
+// volumeAttachmentPayload describes a volume in the middle of an attach or a
+// detach. Cinder repeats the members of the volume and adds what it is
+// connected to, always as an array: it holds the one attachment of the server
+// behind the volume, and it is empty while the volume is connected to nothing.
+func volumeAttachmentPayload(p *project, vol *volume, status string,
+	attachment map[string]any,
+) map[string]any {
+	payload := volumeStatusPayload(p, vol, status)
+	payload["volume_attachment"] = []any{}
+	if attachment != nil {
+		payload["volume_attachment"] = []any{attachment}
+	}
+	return payload
 }
 
 // listenerSpecs are the listeners a load balancer gets, in the order a shoot

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -3,6 +3,7 @@ package simulator
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 )
@@ -82,6 +83,46 @@ func Render(t Transition) ([]byte, error) {
 	return body, nil
 }
 
+// schedulerPayload describes the placement decision a boot begins with. The
+// scheduler reports the request it answered rather than a server, so the
+// flavor arrives as the type that was asked for and the server-to-be as the
+// properties it is going to have.
+func schedulerPayload(p *project, inst *instance) map[string]any {
+	// A server booted from a volume is scheduled without an image, because the
+	// image was written to the volume before the request was made.
+	imageID := inst.imageID
+	if inst.bootVolume != nil {
+		imageID = ""
+	}
+
+	return map[string]any{
+		"request_spec": map[string]any{
+			"image": map[string]any{"id": imageID},
+			"instance_properties": map[string]any{
+				"availability_zone": availabilityZone,
+				"display_name":      inst.name,
+				"ephemeral_gb":      inst.flavor.ephemeralGB,
+				"memory_mb":         inst.flavor.memoryMB,
+				"project_id":        p.id,
+				"root_gb":           inst.flavor.rootGB,
+				"user_id":           p.userID,
+				"uuid":              inst.id,
+				"vcpus":             inst.flavor.vcpus,
+			},
+			"instance_type": map[string]any{
+				"ephemeral_gb": inst.flavor.ephemeralGB,
+				"flavorid":     inst.flavor.flavorID,
+				"id":           inst.flavor.typeID,
+				"memory_mb":    inst.flavor.memoryMB,
+				"name":         inst.flavor.name,
+				"root_gb":      inst.flavor.rootGB,
+				"vcpus":        inst.flavor.vcpus,
+			},
+			"num_instances": 1,
+		},
+	}
+}
+
 // instanceCreatePayload describes a server nova has just booted. It is the
 // widest of the compute payloads: it names the flavor three times over and the
 // image the server was booted from, none of which the later notifications
@@ -115,6 +156,16 @@ func instanceCreatePayload(p *project, inst *instance, cloud string) map[string]
 		"created_at":         stamp(inst.createdAt.Add(-instanceBoot)),
 		"launched_at":        stamp(inst.createdAt),
 	}
+}
+
+// instanceCreateStartPayload describes the server nova is about to boot. It
+// carries the members of the create it precedes: the server is still building
+// and has not been launched, and everything else about it is already decided.
+func instanceCreateStartPayload(p *project, inst *instance, cloud string) map[string]any {
+	payload := instanceCreatePayload(p, inst, cloud)
+	payload["state"] = "building"
+	payload["launched_at"] = nil
+	return payload
 }
 
 // instanceDeletePayload describes a destroyed server. It reports no
@@ -182,6 +233,27 @@ func instancePowerPayload(p *project, inst *instance, state string) map[string]a
 	}
 }
 
+// instanceUpdatePayload describes a server whose state or task changed. Nova
+// sends one on every step of a boot and once more when a delete begins, and it
+// is the payload that carries the audit window: what the server did between
+// from and to, which for an update is the day so far.
+//
+// The task states are typed as any because nova reports a null for a server
+// that is not working on anything, and the old state is the state itself,
+// because an update reports the task a server took up and not a state it left.
+func instanceUpdatePayload(p *project, inst *instance, state string, oldTask, newTask any,
+	from, to time.Time,
+) map[string]any {
+	payload := instancePowerPayload(p, inst, state)
+	payload["audit_period_beginning"] = stamp(from)
+	payload["audit_period_ending"] = stamp(to)
+	payload["bandwidth"] = map[string]any{}
+	payload["new_task_state"] = newTask
+	payload["old_state"] = state
+	payload["old_task_state"] = oldTask
+	return payload
+}
+
 // instanceShelvePayload describes a server that was shelved or brought back. It
 // reports the disk a power change leaves out, since a shelved server keeps its
 // image on disk while it holds no memory.
@@ -200,6 +272,20 @@ func instanceShelvePayload(p *project, inst *instance, state string) map[string]
 		"instance_type":     inst.flavor.name,
 		"host":              inst.host,
 	}
+}
+
+// instanceExistsPayload describes a server nova audits. base is the members of
+// the create, which is what nova repeats in an existence audit, and it is
+// cloned so that the caller's map stays what it was. The audit reports the
+// window it covers, the traffic over it, and the image the server runs, and
+// the simulated cloud meters none of the three.
+func instanceExistsPayload(base map[string]any, from, to time.Time) map[string]any {
+	payload := maps.Clone(base)
+	payload["audit_period_beginning"] = stamp(from)
+	payload["audit_period_ending"] = stamp(to)
+	payload["bandwidth"] = map[string]any{}
+	payload["image_meta"] = map[string]any{}
+	return payload
 }
 
 // floatingIPCreatePayload describes an allocated address. Neutron nests the
@@ -238,6 +324,82 @@ func floatingIPCreatePayload(p *project, fip *floatingIP, networkID string) map[
 // request context.
 func floatingIPDeletePayload(fip *floatingIP) map[string]any {
 	return map[string]any{"floatingip_id": fip.id}
+}
+
+// portRequestPayload describes the port neutron was asked for. The request
+// names the network and the device the port is for and nothing neutron decides
+// itself, so it carries neither an id nor an address yet.
+func portRequestPayload(p *project, port *port) map[string]any {
+	return map[string]any{
+		"port": map[string]any{
+			"admin_state_up": true,
+			"device_id":      port.deviceID,
+			"device_owner":   port.deviceOwner,
+			"name":           "",
+			"network_id":     port.networkID,
+			"project_id":     p.id,
+			"tenant_id":      p.id,
+		},
+	}
+}
+
+// portPayload describes a port neutron has created. A port is unbound while it
+// belongs to no host: it names no host, its interface type is unknown, and it
+// is down until the compute the server runs on binds it, which is what bound
+// tells the two halves of a port's life apart.
+func portPayload(p *project, port *port, bound bool) map[string]any {
+	host, vifType, status := "", "unbound", "DOWN"
+	if bound {
+		host, vifType, status = port.host, "ovs", "ACTIVE"
+	}
+	// The group is a slice even when the network has none, because a null is
+	// not a list of groups.
+	securityGroups := []any{}
+	if port.securityGroupID != "" {
+		securityGroups = append(securityGroups, port.securityGroupID)
+	}
+
+	return map[string]any{
+		"port": map[string]any{
+			"admin_state_up":   true,
+			"binding:host_id":  host,
+			"binding:vif_type": vifType,
+			"device_id":        port.deviceID,
+			"device_owner":     port.deviceOwner,
+			"fixed_ips": []any{map[string]any{
+				"ip_address": port.address,
+				"subnet_id":  port.subnetID,
+			}},
+			"id":              port.id,
+			"mac_address":     port.macAddress,
+			"name":            "",
+			"network_id":      port.networkID,
+			"project_id":      p.id,
+			"security_groups": securityGroups,
+			"status":          status,
+			"tenant_id":       p.id,
+		},
+	}
+}
+
+// portBindingPayload describes the binding a compute asks for. It names the
+// host the port is to be bound to and the device behind it, since those are
+// the members the request changes.
+func portBindingPayload(port *port) map[string]any {
+	return map[string]any{
+		"port": map[string]any{
+			"binding:host_id": port.host,
+			"device_id":       port.deviceID,
+			"device_owner":    port.deviceOwner,
+		},
+	}
+}
+
+// neutronDeletePayload describes a removed neutron resource. Neutron names the
+// kind and the id and nothing else, the way it announces a released address,
+// so the project the resource belonged to comes from the request context.
+func neutronDeletePayload(kind, id string) map[string]any {
+	return map[string]any{kind + "_id": id}
 }
 
 // imageCreatePayload describes an image glance has accepted but has no bits

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -288,6 +289,17 @@ func instanceExistsPayload(base map[string]any, from, to time.Time) map[string]a
 	return payload
 }
 
+// keypairPayload describes the keypair a shoot's workers are reachable under.
+// Nova reports no id for one: a keypair is addressed by the name it was
+// imported under, inside the user that holds it.
+func keypairPayload(p *project, name string) map[string]any {
+	return map[string]any{
+		"key_name":  name,
+		"tenant_id": p.id,
+		"user_id":   p.userID,
+	}
+}
+
 // floatingIPCreatePayload describes an allocated address. Neutron nests the
 // resource one level down, and it reports both the older tenant_id and the
 // newer project_id, which is why the mapping reads the address through a path
@@ -400,6 +412,196 @@ func portBindingPayload(port *port) map[string]any {
 // so the project the resource belonged to comes from the request context.
 func neutronDeletePayload(kind, id string) map[string]any {
 	return map[string]any{kind + "_id": id}
+}
+
+// networkRequestPayload describes the network neutron was asked for. The
+// request carries the name and the state the network is to come up in, because
+// everything else about one is neutron's own.
+func networkRequestPayload(net *network) map[string]any {
+	return map[string]any{
+		"network": map[string]any{
+			"admin_state_up": true,
+			"name":           net.name,
+		},
+	}
+}
+
+// networkPayload describes a network neutron has created. It is a tenant
+// network: it is external to nobody, it is shared with nobody, and its MTU is
+// what an overlay leaves of the underlay's after its encapsulation.
+func networkPayload(p *project, net *network) map[string]any {
+	return map[string]any{
+		"network": map[string]any{
+			"admin_state_up":  true,
+			"description":     "",
+			"id":              net.id,
+			"mtu":             1450,
+			"name":            net.name,
+			"project_id":      p.id,
+			"router:external": false,
+			"shared":          false,
+			"status":          "ACTIVE",
+			"subnets":         []any{net.subnetID},
+			"tenant_id":       p.id,
+		},
+	}
+}
+
+// subnetRequestPayload describes the subnet neutron was asked for: the range it
+// covers and the network it belongs to.
+func subnetRequestPayload(net *network) map[string]any {
+	return map[string]any{
+		"subnet": map[string]any{
+			"cidr":       net.cidr,
+			"ip_version": 4,
+			"name":       net.name,
+			"network_id": net.id,
+		},
+	}
+}
+
+// subnetPayload describes a subnet neutron has created. The gateway is the
+// first address of the range and the pool the ports are served from starts at
+// the tenth, which leaves the addresses in between to the deployment.
+func subnetPayload(p *project, net *network) map[string]any {
+	prefix := net.prefix()
+	return map[string]any{
+		"subnet": map[string]any{
+			"allocation_pools": []any{map[string]any{
+				"start": prefix + ".10",
+				"end":   prefix + ".254",
+			}},
+			"cidr":            net.cidr,
+			"dns_nameservers": []any{},
+			"enable_dhcp":     true,
+			"gateway_ip":      prefix + ".1",
+			"id":              net.subnetID,
+			"ip_version":      4,
+			"name":            net.name,
+			"network_id":      net.id,
+			"project_id":      p.id,
+			"tenant_id":       p.id,
+		},
+	}
+}
+
+// routerRequestPayload describes the router neutron was asked for. The gateway
+// names the external network the tenant leaves through, which is the network
+// the month's floating addresses come from.
+func routerRequestPayload(net *network, externalNetworkID string) map[string]any {
+	return map[string]any{
+		"router": map[string]any{
+			"admin_state_up": true,
+			"external_gateway_info": map[string]any{
+				"network_id": externalNetworkID,
+			},
+			"name": net.name,
+		},
+	}
+}
+
+// routerPayload describes a router neutron has created. Source NAT is on, the
+// way it is on a router a tenant reaches the outside through.
+func routerPayload(p *project, net *network, externalNetworkID string) map[string]any {
+	return map[string]any{
+		"router": map[string]any{
+			"admin_state_up": true,
+			"external_gateway_info": map[string]any{
+				"enable_snat": true,
+				"network_id":  externalNetworkID,
+			},
+			"id":         net.routerID,
+			"name":       net.name,
+			"project_id": p.id,
+			"status":     "ACTIVE",
+			"tenant_id":  p.id,
+		},
+	}
+}
+
+// routerInterfacePayload describes the interface that puts a router on a
+// subnet. The router is the resource the notification is about, so it is
+// reported under id, and the subnet arrives twice: as the one this interface
+// covers, and in the list a router with several of them carries.
+func routerInterfacePayload(p *project, net *network, routerPortID string) map[string]any {
+	return map[string]any{
+		"router_interface": map[string]any{
+			"id":         net.routerID,
+			"network_id": net.id,
+			"port_id":    routerPortID,
+			"subnet_id":  net.subnetID,
+			"subnet_ids": []any{net.subnetID},
+			"tenant_id":  p.id,
+		},
+	}
+}
+
+// securityGroupDescription is what a shoot's group says it is for. Gardener
+// writes one, and the group and its rules repeat it.
+func securityGroupDescription(s *shoot) string {
+	return "Security group for the shoot " + s.technicalID
+}
+
+// securityGroupRequestPayload describes the security group neutron was asked
+// for: the name Gardener gives it and what it is for.
+func securityGroupRequestPayload(s *shoot) map[string]any {
+	return map[string]any{
+		"security_group": map[string]any{
+			"description": securityGroupDescription(s),
+			"name":        s.technicalID,
+		},
+	}
+}
+
+// securityGroupPayload describes a security group neutron has created. It holds
+// no rule yet: a group is created empty and its rules are added to it
+// afterwards, one notification each.
+func securityGroupPayload(p *project, s *shoot) map[string]any {
+	return map[string]any{
+		"security_group": map[string]any{
+			"description":          securityGroupDescription(s),
+			"id":                   s.securityGroupID,
+			"name":                 s.technicalID,
+			"project_id":           p.id,
+			"security_group_rules": []any{},
+			"tenant_id":            p.id,
+		},
+	}
+}
+
+// securityGroupRulePayload describes one rule of a shoot's group. Rule 0 lets
+// SSH in from anywhere and rule 1 lets the members of the group reach each
+// other on every protocol, which is the pair Gardener opens a worker pool with.
+//
+// What a rule does not narrow is null: the second names neither a port range
+// nor a protocol, and the first names no remote group. An empty id is the
+// request neutron was handed, which carries no id because neutron hands that
+// one out with the rule it created.
+func securityGroupRulePayload(p *project, s *shoot, index int, id string) map[string]any {
+	description := "SSH onto the workers"
+	var portRangeMax, portRangeMin, protocol, remoteGroupID, remoteIPPrefix any = 22, 22, "tcp", nil, "0.0.0.0/0"
+	if index == 1 {
+		description = "Every protocol between the members of the group"
+		portRangeMax, portRangeMin, protocol, remoteGroupID, remoteIPPrefix = nil, nil, nil, s.securityGroupID, nil
+	}
+
+	rule := map[string]any{
+		"description":       description,
+		"direction":         "ingress",
+		"ethertype":         "IPv4",
+		"port_range_max":    portRangeMax,
+		"port_range_min":    portRangeMin,
+		"project_id":        p.id,
+		"protocol":          protocol,
+		"remote_group_id":   remoteGroupID,
+		"remote_ip_prefix":  remoteIPPrefix,
+		"security_group_id": s.securityGroupID,
+		"tenant_id":         p.id,
+	}
+	if id != "" {
+		rule["id"] = id
+	}
+	return map[string]any{"security_group_rule": rule}
 }
 
 // imageCreatePayload describes an image glance has accepted but has no bits
@@ -681,4 +883,157 @@ func loadBalancerPayload(p *project, s *shoot, lb *loadBalancer, withMembers boo
 	payload["listeners"] = listeners
 	payload["pools"] = pools
 	return payload
+}
+
+// identityPayload describes a project or a user keystone has created. Keystone
+// names the resource it created and nothing else, so who created it comes from
+// the request context.
+func identityPayload(id string) map[string]any {
+	return map[string]any{"resource_info": id}
+}
+
+// cadfLayout is how a CADF record writes an instant: six fractional digits and
+// the zone written out, which is the one timestamp form of this file that
+// carries an offset rather than none.
+const cadfLayout = "2006-01-02T15:04:05.000000-07:00"
+
+// The members every CADF record of the simulated cloud repeats.
+const (
+	cadfTypeURI = "http://schemas.dmtf.org/cloud/audit/1.0/event"
+	// cadfInitiatorAddress is where the requests come from. It is an address of
+	// the RFC 5737 documentation range, the way the floating addresses are.
+	cadfInitiatorAddress = "198.51.100.200"
+	cadfUserType         = "service/security/account/user"
+	cadfObserverType     = "service/security"
+)
+
+// cadfTime renders an instant the way a CADF record carries it. The record is
+// written in UTC, so the offset it reports is the zero one.
+func cadfTime(t time.Time) string {
+	return t.UTC().Format(cadfLayout)
+}
+
+// authenticatePayload describes one keystone authentication. The user is both
+// who asks and what the record is about, because a token is issued for the user
+// itself.
+//
+// The record's id is the one the transition reports as its resource, so the
+// record and the resource behind it are one thing.
+func authenticatePayload(p *project, recordID string, t time.Time) map[string]any {
+	return map[string]any{
+		"action":    "authenticate",
+		"eventTime": cadfTime(t),
+		"eventType": "activity",
+		"id":        recordID,
+		"initiator": map[string]any{
+			"host":       map[string]any{"address": cadfInitiatorAddress},
+			"id":         p.userID,
+			"project_id": p.id,
+			"typeURI":    cadfUserType,
+		},
+		"observer": map[string]any{
+			"id":      "keystone-01",
+			"typeURI": cadfObserverType,
+		},
+		"outcome": "success",
+		"target": map[string]any{
+			"id":      p.userID,
+			"typeURI": cadfUserType,
+		},
+		"typeURI": cadfTypeURI,
+	}
+}
+
+// auditPayload describes one call against barbican's API as its audit
+// middleware records it. Both records of a call carry the same target and the
+// same action, and they differ in what they say about the call itself: the
+// request is pending and has no status yet, and the response carries the HTTP
+// status under reason. A code of zero is therefore the request, and it reports
+// no reason at all.
+//
+// The method the call was made with is no member of the record. It is what the
+// caller reads the action off, which is what CADF names the operation under.
+func auditPayload(p *project, cloud, recordID, action, outcome, path, targetType, targetID string,
+	code int, t time.Time,
+) map[string]any {
+	payload := map[string]any{
+		"action":    action,
+		"eventTime": cadfTime(t),
+		"eventType": "activity",
+		"id":        recordID,
+		"initiator": map[string]any{
+			"host":       map[string]any{"address": cadfInitiatorAddress},
+			"id":         p.userID,
+			"project_id": p.id,
+			"typeURI":    cadfUserType,
+		},
+		"observer": map[string]any{
+			"id":      "barbican-01",
+			"typeURI": cadfObserverType,
+		},
+		"outcome":     outcome,
+		"requestPath": path,
+		"target": map[string]any{
+			"addresses": []any{map[string]any{
+				"url": fmt.Sprintf("https://barbican.%s.example:%d%s", cloud, barbicanPort, path),
+			}},
+			"id":      targetID,
+			"typeURI": targetType,
+		},
+		"typeURI": cadfTypeURI,
+	}
+	if code > 0 {
+		payload["reason"] = map[string]any{
+			"reasonCode": strconv.Itoa(code),
+			"reasonType": "HTTP",
+		}
+	}
+	return payload
+}
+
+// zonePayload describes the designate zone a Gardener project's records live
+// in. The zone is a primary one: designate holds the data itself rather than
+// pulling it from a master elsewhere, and the serial it starts at is the
+// instant the zone was created.
+func zonePayload(p *project, gp *gardenerProject, t time.Time) map[string]any {
+	return map[string]any{
+		"action":     "CREATE",
+		"created_at": stamp(t),
+		// The zone name carries a trailing dot and a mail address does not.
+		"email":      "hostmaster@" + strings.TrimSuffix(gp.zoneName, "."),
+		"id":         gp.zoneID,
+		"name":       gp.zoneName,
+		"project_id": p.id,
+		"serial":     t.Unix(),
+		"status":     "ACTIVE",
+		"ttl":        3600,
+		"type":       "PRIMARY",
+		"version":    1,
+	}
+}
+
+// recordSetPayload describes one record set of a zone. Designate reports the
+// action the set is in the middle of together with the status it reaches with
+// it, so a delete carries the set one last time rather than its id alone.
+func recordSetPayload(p *project, gp *gardenerProject, rs *recordSet,
+	action string, t time.Time,
+) map[string]any {
+	status := "ACTIVE"
+	if action == "DELETE" {
+		status = "DELETED"
+	}
+	return map[string]any{
+		"action":     action,
+		"created_at": stamp(t),
+		"id":         rs.id,
+		"name":       rs.name,
+		"project_id": p.id,
+		"records":    rs.records,
+		"status":     status,
+		"ttl":        300,
+		"type":       rs.recordType,
+		"version":    1,
+		"zone_id":    gp.zoneID,
+		"zone_name":  gp.zoneName,
+	}
 }

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -445,6 +445,19 @@ func imageUploadPayload(p *project, img *image, at time.Time) map[string]any {
 	}
 }
 
+// imagePreparePayload describes an image glance is receiving the bits of. It
+// carries the members of the finished image with the three that only exist once
+// the content is there left empty: the size on disk, the size the disk grows
+// to, and the checksum over what arrived.
+func imagePreparePayload(p *project, img *image) map[string]any {
+	payload := imageUploadPayload(p, img, img.createdAt)
+	payload["status"] = "saving"
+	payload["size"] = nil
+	payload["virtual_size"] = nil
+	payload["checksum"] = nil
+	return payload
+}
+
 // imageDeletePayload describes a removed image. Glance still reports the size
 // it had, which is what lets the projection close the record with the size it
 // was billed at.

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -2,7 +2,9 @@ package simulator
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -61,8 +63,12 @@ func sampleFile(eventType string) string {
 func memberShape(payload map[string]any) []string {
 	names := make([]string, 0, len(payload))
 	for name, value := range payload {
+		// An empty object is a member with nothing under it, so flattening it
+		// would leave it out of the shape. Naming it is what lets a member test
+		// catch a builder that drops one: the noise payloads carry an empty
+		// bandwidth and an empty image_meta.
 		nested, ok := value.(map[string]any)
-		if !ok {
+		if !ok || len(nested) == 0 {
 			names = append(names, name)
 			continue
 		}
@@ -121,6 +127,14 @@ func TestRenderedPayloadsCarryTheRecordedMembers(t *testing.T) {
 
 		body, err := os.ReadFile(filepath.Join(sampleDir, sampleFile(transition.EventType)))
 		if err != nil {
+			// The fixtures are the collector's, and the noise types of the
+			// catalogue have none: the collector maps none of them, so a real
+			// deployment never had one recorded here.
+			// TestNoisePayloadsCarryTheirMembers pins those instead.
+			if errors.Is(err, fs.ErrNotExist) && !transition.Billable {
+				t.Logf("no recorded sample for %s, the mapping skips it", transition.EventType)
+				continue
+			}
 			t.Fatalf("reading the recorded %s: %v", transition.EventType, err)
 		}
 		got := memberShape(parse(t, render(t, transition)).Payload)

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -57,28 +57,57 @@ func sampleFile(eventType string) string {
 	return sampleName.Replace(eventType) + ".json"
 }
 
-// memberShape is a payload's structure as its sorted member names, with a
-// nested object's members named under their parent. Neutron nests its resource
-// one level down, so comparing the top level alone would let a floating IP
-// payload pass with nothing in it.
+// memberShape is a payload's structure as its sorted member names, with the
+// members of a nested object, and of the objects an array holds, named under
+// their parent. Neutron nests its resource one level down, so comparing the top
+// level alone would let a floating IP payload pass with nothing in it, and
+// cinder, neutron and octavia carry records inside arrays that nothing else
+// would name.
 func memberShape(payload map[string]any) []string {
 	names := make([]string, 0, len(payload))
 	for name, value := range payload {
-		// An empty object is a member with nothing under it, so flattening it
-		// would leave it out of the shape. Naming it is what lets a member test
-		// catch a builder that drops one: the noise payloads carry an empty
-		// bandwidth and an empty image_meta.
-		nested, ok := value.(map[string]any)
-		if !ok || len(nested) == 0 {
-			names = append(names, name)
-			continue
-		}
-		for _, inner := range memberShape(nested) {
-			names = append(names, name+"."+inner)
+		for _, suffix := range memberSuffixes(value) {
+			names = append(names, name+suffix)
 		}
 	}
 	slices.Sort(names)
-	return names
+	// Two records of one array have the same members, and each of them is worth
+	// naming once.
+	return slices.Compact(names)
+}
+
+// memberSuffixes are what a value adds to the name of the member holding it:
+// the empty string for a scalar, and one ".<inner>" per member underneath an
+// object or underneath the objects of an array.
+//
+// An empty object, an empty array, and an array of scalars have nothing to name
+// underneath them, so they add the empty string and the member stays in the
+// shape under its own name. Leaving them out would let a builder drop one
+// unnoticed: the payloads carry an empty bandwidth, an empty image_meta, an
+// empty attachment list, and arrays of plain ids.
+func memberSuffixes(value any) []string {
+	var inner []string
+	switch typed := value.(type) {
+	case map[string]any:
+		inner = memberShape(typed)
+	case []any:
+		for _, element := range typed {
+			nested, ok := element.(map[string]any)
+			if !ok {
+				continue
+			}
+			inner = append(inner, memberShape(nested)...)
+		}
+	}
+	if len(inner) == 0 {
+		return []string{""}
+	}
+
+	suffixes := make([]string, 0, len(inner))
+	for _, name := range inner {
+		suffixes = append(suffixes, "."+name)
+	}
+	return suffixes
 }
 
 // missingFrom returns the names of want that names does not carry.
@@ -144,6 +173,261 @@ func TestRenderedPayloadsCarryTheRecordedMembers(t *testing.T) {
 		if !slices.Equal(got, want) {
 			t.Errorf("%s payload members = %v, want %v (rendered and not recorded: %v; recorded and not rendered: %v)",
 				transition.EventType, got, want, missingFrom(want, got), missingFrom(got, want))
+		}
+	}
+}
+
+// The members the payload builders of the billable month render. The catalogue
+// repeats them: nova sends the same server description before a create that it
+// sends with one, and cinder the same volume on an attach that it sends on a
+// resize, so the noise is pinned against these sets rather than against
+// sixty-two lists written out one by one.
+var (
+	createMembers = []string{
+		"availability_zone", "created_at", "disk_gb", "display_name", "ephemeral_gb", "host",
+		"image_ref_url", "instance_flavor_id", "instance_id", "instance_type", "instance_type_id",
+		"launched_at", "memory_mb", "root_gb", "state", "state_description", "tenant_id", "user_id",
+		"vcpus",
+	}
+	powerMembers = []string{
+		"display_name", "host", "instance_id", "instance_type", "memory_mb", "state",
+		"state_description", "tenant_id", "user_id", "vcpus",
+	}
+	shelveMembers = append(slices.Clone(powerMembers), "ephemeral_gb", "root_gb")
+	resizeMembers = []string{
+		"availability_zone", "created_at", "display_name", "ephemeral_gb", "host", "instance_id",
+		"instance_type", "instance_type_id", "launched_at", "memory_mb", "root_gb", "state",
+		"state_description", "tenant_id", "user_id", "vcpus",
+	}
+	volumeCreateMembers = []string{
+		"availability_zone", "created_at", "display_name", "host", "launched_at",
+		"replication_status", "size", "status", "tenant_id", "user_id", "volume_id", "volume_type",
+	}
+	volumeStateMembers = []string{
+		"created_at", "display_name", "host", "size", "status", "tenant_id", "user_id", "volume_id",
+		"volume_type",
+	}
+	imageMembers = []string{
+		"checksum", "container_format", "created_at", "disk_format", "id", "min_disk", "min_ram",
+		"name", "owner", "protected", "size", "status", "updated_at", "virtual_size", "visibility",
+	}
+)
+
+// The members the catalogue adds to those sets, and the ones of the resources
+// no billable notification is sent about. A CADF record is one skeleton: an
+// authentication is the shortest form of it, a barbican request names the call
+// on top of that, and the response the status of the call on top of that again.
+var (
+	updateMembers = append(slices.Clone(powerMembers),
+		"audit_period_beginning", "audit_period_ending", "bandwidth", "new_task_state", "old_state",
+		"old_task_state")
+	existsMembers = append(slices.Clone(createMembers),
+		"audit_period_beginning", "audit_period_ending", "bandwidth", "image_meta")
+	// The attachment list of a volume connected to nothing is empty, which is
+	// the member with nothing under it, and the one of a volume a server holds
+	// carries the record cinder wrote. The two halves of an attach and of a
+	// detach are one of each.
+	attachmentMembers = append(slices.Clone(volumeStateMembers), "volume_attachment")
+	attachedMembers   = append(slices.Clone(volumeStateMembers),
+		"volume_attachment.attach_mode", "volume_attachment.attach_status",
+		"volume_attachment.attach_time", "volume_attachment.attached_host",
+		"volume_attachment.id", "volume_attachment.instance_uuid",
+		"volume_attachment.mountpoint", "volume_attachment.volume_id")
+	schedulerMembers = []string{
+		"request_spec.image.id",
+		"request_spec.instance_properties.availability_zone",
+		"request_spec.instance_properties.display_name",
+		"request_spec.instance_properties.ephemeral_gb",
+		"request_spec.instance_properties.memory_mb",
+		"request_spec.instance_properties.project_id",
+		"request_spec.instance_properties.root_gb",
+		"request_spec.instance_properties.user_id",
+		"request_spec.instance_properties.uuid",
+		"request_spec.instance_properties.vcpus",
+		"request_spec.instance_type.ephemeral_gb",
+		"request_spec.instance_type.flavorid",
+		"request_spec.instance_type.id",
+		"request_spec.instance_type.memory_mb",
+		"request_spec.instance_type.name",
+		"request_spec.instance_type.root_gb",
+		"request_spec.instance_type.vcpus",
+		"request_spec.num_instances",
+	}
+	keypairMembers = []string{"key_name", "tenant_id", "user_id"}
+	portMembers    = []string{
+		"port.admin_state_up", "port.binding:host_id", "port.binding:vif_type", "port.device_id",
+		"port.device_owner", "port.fixed_ips.ip_address", "port.fixed_ips.subnet_id", "port.id",
+		"port.mac_address", "port.name", "port.network_id", "port.project_id",
+		"port.security_groups", "port.status", "port.tenant_id",
+	}
+	securityGroupRuleMembers = []string{
+		"security_group_rule.description", "security_group_rule.direction",
+		"security_group_rule.ethertype", "security_group_rule.port_range_max",
+		"security_group_rule.port_range_min", "security_group_rule.project_id",
+		"security_group_rule.protocol", "security_group_rule.remote_group_id",
+		"security_group_rule.remote_ip_prefix", "security_group_rule.security_group_id",
+		"security_group_rule.tenant_id",
+	}
+	authenticateMembers = []string{
+		"action", "eventTime", "eventType", "id", "initiator.host.address", "initiator.id",
+		"initiator.project_id", "initiator.typeURI", "observer.id", "observer.typeURI", "outcome",
+		"target.id", "target.typeURI", "typeURI",
+	}
+	auditRequestMembers  = append(slices.Clone(authenticateMembers), "requestPath", "target.addresses.url")
+	auditResponseMembers = append(slices.Clone(auditRequestMembers), "reason.reasonCode", "reason.reasonType")
+	recordSetMembers     = []string{
+		"action", "created_at", "id", "name", "project_id", "records", "status", "ttl", "type",
+		"version", "zone_id", "zone_name",
+	}
+)
+
+// noiseMembers is the payload of every type of the catalogue, by the members it
+// carries. The collector maps none of these types, so none of them was ever
+// recorded from a real deployment and
+// TestRenderedPayloadsCarryTheRecordedMembers has no fixture to hold them
+// against. This table is that fixture: a builder that drops a member or renames
+// one changes a payload nothing else in the package reads.
+var noiseMembers = map[string][]string{
+	"scheduler.select_destinations.start":   schedulerMembers,
+	"scheduler.select_destinations.end":     schedulerMembers,
+	"compute.instance.create.start":         createMembers,
+	"compute.instance.update":               updateMembers,
+	"compute.instance.exists":               existsMembers,
+	"compute.instance.delete.start":         shelveMembers,
+	"compute.instance.shutdown.start":       shelveMembers,
+	"compute.instance.shutdown.end":         shelveMembers,
+	"compute.instance.shelve_offload.start": shelveMembers,
+	"compute.instance.unshelve.start":       shelveMembers,
+	"compute.instance.power_off.start":      powerMembers,
+	"compute.instance.power_on.start":       powerMembers,
+	"compute.instance.resize.start":         resizeMembers,
+	"compute.instance.finish_resize.start":  resizeMembers,
+	"keypair.import.start":                  keypairMembers,
+	"keypair.import.end":                    keypairMembers,
+	"keypair.delete.start":                  keypairMembers,
+	"keypair.delete.end":                    keypairMembers,
+
+	"volume.create.start":          volumeCreateMembers,
+	"volume.delete.start":          volumeStateMembers,
+	"volume.resize.start":          volumeStateMembers,
+	"volume.transfer.accept.start": volumeStateMembers,
+	"volume.attach.start":          attachmentMembers,
+	"volume.attach.end":            attachedMembers,
+	"volume.detach.start":          attachedMembers,
+	"volume.detach.end":            attachmentMembers,
+
+	"network.create.start": {"network.admin_state_up", "network.name"},
+	"network.create.end": {
+		"network.admin_state_up", "network.description", "network.id", "network.mtu",
+		"network.name", "network.project_id", "network.router:external", "network.shared",
+		"network.status", "network.subnets", "network.tenant_id",
+	},
+	"network.delete.start": {"network_id"},
+	"network.delete.end":   {"network_id"},
+	"subnet.create.start": {
+		"subnet.cidr", "subnet.ip_version", "subnet.name", "subnet.network_id",
+	},
+	"subnet.create.end": {
+		"subnet.allocation_pools.end", "subnet.allocation_pools.start", "subnet.cidr",
+		"subnet.dns_nameservers", "subnet.enable_dhcp", "subnet.gateway_ip", "subnet.id",
+		"subnet.ip_version", "subnet.name", "subnet.network_id", "subnet.project_id",
+		"subnet.tenant_id",
+	},
+	"subnet.delete.start": {"subnet_id"},
+	"subnet.delete.end":   {"subnet_id"},
+	"router.create.start": {
+		"router.admin_state_up", "router.external_gateway_info.network_id", "router.name",
+	},
+	"router.create.end": {
+		"router.admin_state_up", "router.external_gateway_info.enable_snat",
+		"router.external_gateway_info.network_id", "router.id", "router.name", "router.project_id",
+		"router.status", "router.tenant_id",
+	},
+	"router.interface.create": {
+		"router_interface.id", "router_interface.network_id", "router_interface.port_id",
+		"router_interface.subnet_id", "router_interface.subnet_ids", "router_interface.tenant_id",
+	},
+	"router.interface.delete": {
+		"router_interface.id", "router_interface.network_id", "router_interface.port_id",
+		"router_interface.subnet_id", "router_interface.subnet_ids", "router_interface.tenant_id",
+	},
+	"router.delete.start":         {"router_id"},
+	"router.delete.end":           {"router_id"},
+	"security_group.create.start": {"security_group.description", "security_group.name"},
+	"security_group.create.end": {
+		"security_group.description", "security_group.id", "security_group.name",
+		"security_group.project_id", "security_group.security_group_rules",
+		"security_group.tenant_id",
+	},
+	"security_group.delete.start":      {"security_group_id"},
+	"security_group.delete.end":        {"security_group_id"},
+	"security_group_rule.create.start": securityGroupRuleMembers,
+	"security_group_rule.create.end": append(slices.Clone(securityGroupRuleMembers),
+		"security_group_rule.id"),
+	"port.create.start": {
+		"port.admin_state_up", "port.device_id", "port.device_owner", "port.name",
+		"port.network_id", "port.project_id", "port.tenant_id",
+	},
+	"port.create.end":   portMembers,
+	"port.update.start": {"port.binding:host_id", "port.device_id", "port.device_owner"},
+	"port.update.end":   portMembers,
+	"port.delete.start": {"port_id"},
+	"port.delete.end":   {"port_id"},
+
+	"image.prepare":  imageMembers,
+	"image.activate": imageMembers,
+
+	"identity.project.created": {"resource_info"},
+	"identity.user.created":    {"resource_info"},
+	"identity.authenticate":    authenticateMembers,
+
+	"dns.zone.create": {
+		"action", "created_at", "email", "id", "name", "project_id", "serial", "status", "ttl",
+		"type", "version",
+	},
+	"dns.recordset.create": recordSetMembers,
+	"dns.recordset.delete": recordSetMembers,
+
+	"audit.http.request":  auditRequestMembers,
+	"audit.http.response": auditResponseMembers,
+}
+
+// TestNoisePayloadsCarryTheirMembers is what
+// TestRenderedPayloadsCarryTheRecordedMembers is for the billable month: the
+// payload of every type of the catalogue, held against the members it is to
+// carry. The two together cover every type a month renders.
+func TestNoisePayloadsCarryTheirMembers(t *testing.T) {
+	if len(noiseMembers) != len(noiseTypes) {
+		t.Errorf("the table pins %d payloads and the catalogue names %d types, want one per type",
+			len(noiseMembers), len(noiseTypes))
+	}
+	for _, eventType := range noiseTypes {
+		if _, ok := noiseMembers[eventType]; !ok {
+			t.Fatalf("the catalogue type %s has no pinned members, want every type of it in the "+
+				"table: a payload nothing pins is one a builder may quietly drop a member from",
+				eventType)
+		}
+	}
+
+	seen := make(map[string]bool, len(noiseTypes))
+	for _, transition := range generateMonth(t, 1, july2026, testCloud) {
+		pinned, ok := noiseMembers[transition.EventType]
+		if !ok || seen[transition.EventType] {
+			continue
+		}
+		seen[transition.EventType] = true
+
+		got := memberShape(parse(t, render(t, transition)).Payload)
+		want := slices.Sorted(slices.Values(pinned))
+		if !slices.Equal(got, want) {
+			t.Errorf("%s payload members = %v, want %v (rendered and not pinned: %v; pinned and not rendered: %v)",
+				transition.EventType, got, want, missingFrom(want, got), missingFrom(got, want))
+		}
+	}
+	for _, eventType := range noiseTypes {
+		if !seen[eventType] {
+			t.Errorf("the month renders no %s, want every type of the catalogue: a pinned payload "+
+				"nothing renders is one the table alone agrees with", eventType)
 		}
 	}
 }

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/b42labs/tally/internal/providers/openstack"
 )
@@ -315,5 +316,93 @@ func TestRenderReportsAMarshalError(t *testing.T) {
 	const prefix = "rendering compute.instance.create.end: "
 	if !strings.HasPrefix(err.Error(), prefix) {
 		t.Errorf("Render() error = %q, want it to start with %q", err, prefix)
+	}
+}
+
+// TestSecurityGroupRulePayloadNamesTheCreatedRuleAlone covers the two forms a
+// rule of a shoot's group is reported in. The request neutron was handed
+// carries no id, because neutron hands that one out with the rule it created,
+// and the two forms are otherwise the same rule.
+func TestSecurityGroupRulePayloadNamesTheCreatedRuleAlone(t *testing.T) {
+	const ruleID = "0a1b2c3d-4e5f-4061-8273-94a5b6c7d8e9"
+	p := &project{id: "5a7c9e1b3d5f7091a2b4c6d8e0f2a4b6"}
+	s := &shoot{
+		technicalID:     "shoot--beta--batch",
+		securityGroupID: "1b2c3d4e-5f60-4172-8394-a5b6c7d8e9f0",
+	}
+
+	rule := func(index int, id string) map[string]any {
+		payload, ok := securityGroupRulePayload(p, s, index, id)["security_group_rule"].(map[string]any)
+		if !ok {
+			t.Fatalf("rule %d carries no security_group_rule, want the rule neutron nests there", index)
+		}
+		return payload
+	}
+
+	requested, created := rule(0, ""), rule(0, ruleID)
+	if _, ok := requested["id"]; ok {
+		t.Errorf("the requested rule reports id = %v, want no id at all: neutron hands the id out "+
+			"with the rule it created", requested["id"])
+	}
+	if got := created["id"]; got != ruleID {
+		t.Errorf("the created rule reports id = %v, want %s", got, ruleID)
+	}
+	if len(created) != len(requested)+1 {
+		t.Errorf("the requested rule carries %d members and the created one %d, want the id to be "+
+			"the one member between them", len(requested), len(created))
+	}
+
+	// The second rule narrows nothing but the group it comes from, which is
+	// where the nulls of a rule are.
+	group := rule(1, ruleID)
+	if got := group["remote_group_id"]; got != s.securityGroupID {
+		t.Errorf("the second rule reports remote_group_id = %v, want %s, the group itself",
+			got, s.securityGroupID)
+	}
+	for _, member := range []string{"port_range_max", "port_range_min", "protocol", "remote_ip_prefix"} {
+		if got := group[member]; got != nil {
+			t.Errorf("the second rule reports %s = %v, want null: a rule that names neither a port "+
+				"range nor a protocol narrows neither", member, got)
+		}
+	}
+}
+
+// TestAuditPayloadReportsTheStatusOnTheResponse covers the one branch of a CADF
+// record: the request has no HTTP status yet and the response carries it. Both
+// records of a call carry the same target, so the status is where the two are
+// told apart.
+func TestAuditPayloadReportsTheStatusOnTheResponse(t *testing.T) {
+	const (
+		path     = "/v1/secrets"
+		targetID = "2c3d4e5f-6071-4283-94a5-b6c7d8e9f0a1"
+	)
+	p := &project{id: "5a7c9e1b3d5f7091a2b4c6d8e0f2a4b6", userID: "6b8d0a2c4e6f8091b3d5f7a9c1e3f507"}
+	at := time.Date(2026, 7, 7, 19, 2, 41, 0, time.UTC)
+
+	request := auditPayload(p, "os-sim", "3d4e5f60-7182-4394-a5b6-c7d8e9f0a1b2", "create", "pending",
+		path, secretsType, targetID, 0, at)
+	if _, ok := request["reason"]; ok {
+		t.Errorf("the request reports reason = %v, want none: a call that is not answered yet has no "+
+			"HTTP status", request["reason"])
+	}
+
+	response := auditPayload(p, "os-sim", "4e5f6071-8293-44a5-b6c7-d8e9f0a1b2c3", "create", "success",
+		path, secretsType, targetID, 201, at.Add(time.Second))
+	reason, ok := response["reason"].(map[string]any)
+	if !ok {
+		t.Fatalf("the response carries %v under reason, want the HTTP status of the call",
+			response["reason"])
+	}
+	if got := reason["reasonCode"]; got != "201" {
+		t.Errorf("the response reports reasonCode = %v, want \"201\", the status as a string", got)
+	}
+
+	target, _ := response["target"].(map[string]any)
+	addresses, _ := target["addresses"].([]any)
+	address, _ := addresses[0].(map[string]any)
+	want := "https://barbican.os-sim.example:9311" + path
+	if got := address["url"]; got != want {
+		t.Errorf("the record names the endpoint %v, want %s: two clouds' records name two endpoints",
+			got, want)
 	}
 }

--- a/internal/providers/openstack/simulator/stream.go
+++ b/internal/providers/openstack/simulator/stream.go
@@ -17,7 +17,7 @@ import (
 // would publish a month no collector receives.
 type Line struct {
 	// Exchange is the service exchange the notification belongs on, one of nova,
-	// cinder, neutron, glance, and octavia.
+	// cinder, neutron, glance, octavia, keystone, designate, and barbican.
 	Exchange string `json:"exchange"`
 	// RoutingKey is the topic the notification was published under.
 	RoutingKey string `json:"routing_key"`

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -603,9 +603,10 @@ func (g *generator) lifetime(p *project, inst *instance, index int, end time.Tim
 	}
 }
 
-// volumes gives every instance its one or two volumes. The attach itself is not
-// a notification the collector maps, so the world records it and every later
-// notification about the volume reports the in-use status cinder would.
+// volumes gives every instance its one or two volumes. Each of them is attached
+// to the server it was created for, which cinder announces under a type the
+// collector does not map, and the volume reports the in-use status from there
+// on.
 func (g *generator) volumes(p *project) {
 	for index, inst := range p.instances {
 		for i, vol := range inst.volumes {
@@ -613,9 +614,8 @@ func (g *generator) volumes(p *project) {
 			vol.sizeGB = volumeSizesGB[g.shape.IntN(len(volumeSizesGB))]
 			vol.volumeType = volumeTypes[g.shape.IntN(len(volumeTypes))]
 
-			g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, p,
-				volumeCreatePayload(p, vol))
-			vol.attached = true
+			g.createVolume(p, vol, vol.createdAt)
+			g.attach(p, vol, inst, vol.createdAt.Add(attachLag))
 
 			// The first instance's volumes are deleted with it and report nothing
 			// in between, which is the shortest volume life a month holds.
@@ -637,6 +637,10 @@ func (g *generator) changeVolume(p *project, vol *volume, forced bool) {
 	var resizedAt time.Time
 	if resizes {
 		resizedAt = g.from.Add(span(g.shape, 3*day, 20*day))
+		// The .start half of a resize reports the volume as it still is, which is
+		// why it is rendered before the new size is set.
+		g.noise(resizedAt.Add(-stepLead), "volume.resize.start", volumePublisher, vol.id, p,
+			volumeStatusPayload(p, vol, "extending"))
 		vol.sizeGB *= 2
 		g.emit(resizedAt, "volume.resize.end", volumePublisher, vol.id, p, volumeStatePayload(p, vol))
 	}
@@ -676,7 +680,8 @@ func (g *generator) floatingIPs(p *project) {
 
 // deleteFirstInstance tears the first instance down in the order a deployment
 // does: the address is released, the server is destroyed, and the volumes that
-// were attached to it follow one after another.
+// were attached to it follow one after another. Destroying the server detaches
+// them, so no delete here renders a detach of its own.
 func (g *generator) deleteFirstInstance(p *project) {
 	inst := p.instances[0]
 
@@ -686,8 +691,7 @@ func (g *generator) deleteFirstInstance(p *project) {
 
 	for i, vol := range inst.volumes {
 		deletedAt := inst.deletedAt.Add(volumeDeleteLead + time.Duration(i)*volumeDeleteGap)
-		g.emit(deletedAt, "volume.delete.end", volumePublisher, vol.id, p,
-			volumeDeletePayload(p, vol, deletedAt))
+		g.deleteVolume(p, vol, deletedAt)
 	}
 }
 
@@ -699,11 +703,15 @@ func (g *generator) spareVolume(p, accepting *project) {
 	vol.createdAt = g.from.Add(span(g.shape, 2*time.Hour, 6*time.Hour))
 	vol.sizeGB = volumeSizesGB[g.shape.IntN(len(volumeSizesGB))]
 	vol.volumeType = volumeTypes[g.shape.IntN(len(volumeTypes))]
-	g.emit(vol.createdAt, "volume.create.end", volumePublisher, vol.id, p, volumeCreatePayload(p, vol))
+	g.createVolume(p, vol, vol.createdAt)
 
 	// The accepting project makes the request and owns the volume from here on,
 	// so it is the project in the payload as well as in the request context.
 	acceptedAt := g.from.Add(span(g.shape, 10*day, 20*day))
+	// The .start half still reports the volume as the old owner's, because it
+	// moves with the .end.
+	g.noise(acceptedAt.Add(-transferLead), "volume.transfer.accept.start", volumePublisher, vol.id,
+		accepting, volumeStatePayload(p, vol))
 	g.emit(acceptedAt, "volume.transfer.accept.end", volumePublisher, vol.id, accepting,
 		volumeStatePayload(accepting, vol))
 }

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -516,15 +516,19 @@ func (g *generator) instances(p *project) {
 		inst.createdAt = g.from.Add(span(g.shape, 2*time.Hour, 6*time.Hour))
 		inst.imageID = p.images[g.shape.IntN(len(p.images))].id
 
-		g.emit(inst.createdAt, "compute.instance.create.end", computePublisher(inst), inst.id, p,
-			instanceCreatePayload(p, inst, g.cloud))
+		g.createInstance(p, inst, p.network, inst.createdAt)
 
 		// The end bounds what the instance may still report, so the delete
 		// instant is drawn here rather than in the tear-down phase that uses it.
+		// The last step of a deleted instance lies before the sequence its
+		// delete begins with, which is why the bound is the first notification
+		// of that sequence and not the delete: a step whose .end would fall
+		// inside those five seconds is dropped the way a step at or after the
+		// delete is dropped, and no draw moves either way.
 		end := g.to
 		if index == 0 {
 			inst.deletedAt = g.to.Add(-span(g.shape, day, 10*day))
-			end = inst.deletedAt
+			end = inst.deletedAt.Add(-instanceDeleteLead)
 		}
 		g.lifetime(p, inst, index, end)
 	}
@@ -539,6 +543,9 @@ func (g *generator) instances(p *project) {
 // stops the walk. Dropping the rest with it is what keeps a deleted instance
 // from reporting anything after its delete, and a step from straddling the
 // month's end with only its first half inside the period.
+//
+// Every step is a pair: its .start half is rendered stepLead before its .end,
+// and the bound keeps both halves before the instance's end.
 func (g *generator) lifetime(p *project, inst *instance, index int, end time.Time) {
 	cursor := inst.createdAt.Add(span(g.shape, time.Hour, 3*day))
 
@@ -547,8 +554,12 @@ func (g *generator) lifetime(p *project, inst *instance, index int, end time.Tim
 		if !poweredOnAt.Before(end) {
 			return
 		}
+		g.noise(cursor.Add(-stepLead), "compute.instance.power_off.start", computePublisher(inst),
+			inst.id, p, instancePowerPayload(p, inst, "active"))
 		g.emit(cursor, "compute.instance.power_off.end", computePublisher(inst), inst.id, p,
 			instancePowerPayload(p, inst, "stopped"))
+		g.noise(poweredOnAt.Add(-stepLead), "compute.instance.power_on.start", computePublisher(inst),
+			inst.id, p, instancePowerPayload(p, inst, "stopped"))
 		g.emit(poweredOnAt, "compute.instance.power_on.end", computePublisher(inst), inst.id, p,
 			instancePowerPayload(p, inst, "active"))
 		cursor = poweredOnAt.Add(span(g.shape, time.Hour, 3*day))
@@ -559,11 +570,18 @@ func (g *generator) lifetime(p *project, inst *instance, index int, end time.Tim
 		if !finishedAt.Before(end) {
 			return
 		}
+		// The start of a resize is the one .start half that reports another
+		// flavor than its .end: it announces the server as it still is, which is
+		// why it is rendered before the new flavor is drawn.
+		g.noise(cursor.Add(-stepLead), "compute.instance.resize.start", computePublisher(inst),
+			inst.id, p, instanceResizePayload(p, inst, "active"))
 		// Both halves of a resize report the flavor the instance is moving to,
 		// and every notification after them reports it as well.
 		inst.flavor = otherFlavor(g.shape, inst.flavor)
 		g.emit(cursor, "compute.instance.resize.end", computePublisher(inst), inst.id, p,
 			instanceResizePayload(p, inst, "resized"))
+		g.noise(finishedAt.Add(-stepLead), "compute.instance.finish_resize.start", computePublisher(inst),
+			inst.id, p, instanceResizePayload(p, inst, "resized"))
 		g.emit(finishedAt, "compute.instance.finish_resize.end", computePublisher(inst), inst.id, p,
 			instanceResizePayload(p, inst, "active"))
 		cursor = finishedAt.Add(span(g.shape, time.Hour, 3*day))
@@ -574,8 +592,12 @@ func (g *generator) lifetime(p *project, inst *instance, index int, end time.Tim
 		if !unshelvedAt.Before(end) {
 			return
 		}
+		g.noise(cursor.Add(-stepLead), "compute.instance.shelve_offload.start", computePublisher(inst),
+			inst.id, p, instanceShelvePayload(p, inst, "active"))
 		g.emit(cursor, "compute.instance.shelve_offload.end", computePublisher(inst), inst.id, p,
 			instanceShelvePayload(p, inst, "shelved_offloaded"))
+		g.noise(unshelvedAt.Add(-stepLead), "compute.instance.unshelve.start", computePublisher(inst),
+			inst.id, p, instanceShelvePayload(p, inst, "shelved_offloaded"))
 		g.emit(unshelvedAt, "compute.instance.unshelve.end", computePublisher(inst), inst.id, p,
 			instanceShelvePayload(p, inst, "active"))
 	}
@@ -660,8 +682,7 @@ func (g *generator) deleteFirstInstance(p *project) {
 
 	g.emit(inst.deletedAt.Add(-releaseLead), "floatingip.delete.end", networkPublisher,
 		inst.fip.id, p, floatingIPDeletePayload(inst.fip))
-	g.emit(inst.deletedAt, "compute.instance.delete.end", computePublisher(inst), inst.id, p,
-		instanceDeletePayload(p, inst, inst.deletedAt))
+	g.destroyInstance(p, inst, inst.deletedAt)
 
 	for i, vol := range inst.volumes {
 		deletedAt := inst.deletedAt.Add(volumeDeleteLead + time.Duration(i)*volumeDeleteGap)

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -439,7 +439,8 @@ func newGenerator(shape *rand.Rand, identifiers, noiseIDs idReader,
 // and addresses follow the instances they belong to, and the tear-down comes
 // last. The Gardener projects follow, each shoot walking its own days, and the
 // CI tenant comes last, bursting its runners through the working days of the
-// month.
+// month. The daily existence audits close the month, once every workload has
+// put its instances into the schedule.
 func (g *generator) run() {
 	g.workload = workloadClassic
 	for index, p := range g.projects {
@@ -458,6 +459,12 @@ func (g *generator) run() {
 
 	g.workload = workloadCI
 	g.ci()
+
+	// The audits are a pass over the finished schedule, because which instances
+	// existed on a day is known only once every workload has run. They are the
+	// one block that is not tagged here: every audit carries the workload of the
+	// instance's create.
+	g.audits()
 }
 
 // emit records one transition. The project is the one the request ran in, which

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -492,8 +492,7 @@ func (g *generator) images(p *project) {
 		img.size = int64(4+g.shape.IntN(13)) * quarterGiB
 
 		g.emit(img.createdAt, imageCreateType, imagePublisher, img.id, p, imageCreatePayload(p, img))
-		g.emit(uploadedAt, "image.upload", imagePublisher, img.id, p,
-			imageUploadPayload(p, img, uploadedAt))
+		g.uploadImage(p, img, uploadedAt)
 
 		if index == len(p.images)-1 {
 			deletedAt := g.to.Add(-span(g.shape, day, 7*day))

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -34,9 +34,15 @@ type Transition struct {
 	// itself.
 	Exchange string
 	// Billable reports whether the collector's mapping records an event for this
-	// notification. It is false only for the image.create that precedes an
-	// upload: that one carries no size yet, and the mapping skips it on purpose.
+	// notification. It is false on the image.create that precedes an upload,
+	// which carries no size yet and is skipped on purpose, and on every
+	// transition of the noise catalogue (noise.go).
 	Billable bool
+	// noise reports whether the transition belongs to that catalogue. Nothing on
+	// the wire carries it and nothing outside this package reads it: it is what
+	// tells the noise apart from the one skipped billable type when the message
+	// ids are drawn, so the catalogue takes its ids from its own stream.
+	noise bool
 	// Workload names which of the three workloads emitted the transition, one of
 	// the workload constants. Nothing on the wire carries it: it is what a test
 	// and the later reconciliation oracle tell the workloads of one month apart
@@ -171,6 +177,13 @@ const shapeStream = 1
 // seed, period, and cloud draw the same identifiers in the same order, and
 // another cloud or another month renames everything while the shape stays the
 // shape stream's.
+//
+// A third generator names the resources of the noise catalogue (noise.go). It
+// is salted the way the identifier generator is, and it is a stream of its own
+// so that the identifier generator draws the billable month and nothing else,
+// down to the message ids: a noise transition takes its own from the third
+// stream, so a catalogue that grows by one transition renumbers nothing the
+// collector bills.
 func Generate(seed uint64, from, to time.Time, cloud string) (Schedule, error) {
 	// A caller that reached here without going through period.Parse is caught
 	// before it produces a month that no billing period covers.
@@ -182,7 +195,8 @@ func Generate(seed uint64, from, to time.Time, cloud string) (Schedule, error) {
 	shape := rand.New(rand.NewPCG(seed, shapeStream))
 	identifiers := idReader{src: rand.New(rand.NewPCG(seed, identifierSalt(cloud, month)))}
 
-	g := newGenerator(shape, identifiers, month, month.AddDate(0, 1, 0), cloud)
+	g := newGenerator(shape, identifiers, noiseIdentifiers(seed, cloud, month),
+		month, month.AddDate(0, 1, 0), cloud)
 	g.run()
 	if len(g.schedule) == 0 {
 		return nil, errors.New("the generated month holds no transitions")
@@ -191,7 +205,15 @@ func Generate(seed uint64, from, to time.Time, cloud string) (Schedule, error) {
 	slices.SortStableFunc(g.schedule, func(a, b Transition) int { return a.At.Compare(b.At) })
 	// The message ids come last so that they run in publication order, which is
 	// what a dumped month reads like when it is compared against a real bus.
+	// Each of the two streams hands out its own: a noise message id drawn from
+	// the identifier stream would tie the ids of the billable month to how much
+	// noise stands beside it, and a catalogue one transition longer would
+	// renumber every event the collector books for every seed.
 	for i := range g.schedule {
+		if g.schedule[i].noise {
+			g.schedule[i].MessageID = g.noiseIDs.nextUUID()
+			continue
+		}
 		g.schedule[i].MessageID = identifiers.nextUUID()
 	}
 	return g.schedule, nil
@@ -249,9 +271,13 @@ type generator struct {
 	// because the resources a month churns are named when they are created: how
 	// many workers or runners a month makes follows from its calendar.
 	identifiers idReader
-	from        time.Time
-	to          time.Time
-	cloud       string
+	// noiseIDs is the month's third stream, salted the way the identifier
+	// stream is and drawn by noise.go alone. Holding it apart is what lets the
+	// identifier stream draw exactly what it draws without the noise.
+	noiseIDs idReader
+	from     time.Time
+	to       time.Time
+	cloud    string
 
 	// networkID is the external network the month's addresses come from. There
 	// is one per month, the way a deployment has one.
@@ -285,8 +311,21 @@ type generator struct {
 // with their VIP ports, listeners, pools, and addresses, and the CI runners.
 // How many of them a month makes follows from its calendar, so drawing them
 // here would mean counting the month's days twice.
-func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cloud string) *generator {
-	g := &generator{shape: shape, identifiers: identifiers, from: from, to: to, cloud: cloud}
+//
+// The identifier stream draws the billable month and nothing besides it. Every
+// identifier of a resource that exists only to be announced comes from the
+// noise identifier stream instead: the classic and CI tenants' networks, the
+// zones, the ports, the attachments, the security group rules, the record sets,
+// the secrets and containers, and the CADF record ids. The fixed ones are drawn
+// below, after the last draw the identifier stream makes, and the rest at the
+// moment the resource is created.
+func newGenerator(shape *rand.Rand, identifiers, noiseIDs idReader,
+	from, to time.Time, cloud string,
+) *generator {
+	g := &generator{
+		shape: shape, identifiers: identifiers, noiseIDs: noiseIDs,
+		from: from, to: to, cloud: cloud,
+	}
 
 	g.networkID = identifiers.nextUUID()
 	g.addresses = identifiers.src.Perm(addressPoolSize)
@@ -350,6 +389,29 @@ func newGenerator(shape *rand.Rand, identifiers idReader, from, to time.Time, cl
 	g.ciTenant = &project{id: identifiers.nextHexID()}
 	g.ciTenant.userID = identifiers.nextHexID()
 	g.ciTenant.images = []*image{{id: identifiers.nextUUID(), name: ciImageName}}
+
+	// The networks the tenants are announced on and the zones their records live
+	// in. A classic tenant's network has no router of its own, because it
+	// pre-exists the month and neutron announces nothing about it.
+	for index, p := range g.projects {
+		p.network = &network{
+			id:       g.noiseIDs.nextUUID(),
+			subnetID: g.noiseIDs.nextUUID(),
+			name:     fmt.Sprintf("tenant-%02d", index+1),
+			cidr:     fmt.Sprintf("192.168.%d.0/24", index+1),
+		}
+	}
+	g.ciTenant.network = &network{
+		id:       g.noiseIDs.nextUUID(),
+		subnetID: g.noiseIDs.nextUUID(),
+		routerID: g.noiseIDs.nextUUID(),
+		name:     "ci",
+		cidr:     "10.100.0.0/24",
+	}
+	for _, gp := range g.gardenerProjects {
+		gp.zoneID = g.noiseIDs.nextUUID()
+		gp.zoneName = gp.name + "." + cloud + ".example."
+	}
 	return g
 }
 

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -29,9 +29,10 @@ type Transition struct {
 	// "compute.instance.create.end".
 	EventType string
 	// Exchange is the notification exchange the type belongs on. A deployment
-	// gives each service its own. The collector's default binds nova, neutron,
-	// cinder, and glance, and a deployment running octavia lists the fifth
-	// itself.
+	// gives each service its own, and a month uses eight: nova, cinder,
+	// neutron, glance, octavia, keystone, designate, and barbican. The
+	// collector's default binds nova, neutron, cinder, and glance, and a
+	// deployment lists the other four itself.
 	Exchange string
 	// Billable reports whether the collector's mapping records an event for this
 	// notification. It is false on the image.create that precedes an upload,
@@ -105,23 +106,38 @@ const (
 	workloadCI       = "ci"
 )
 
-// exchangeFor names the exchange a type is published on. The five are the
-// service exchanges of nova, cinder, neutron, glance, and octavia. A type
-// outside them is one this package does not generate, and it is reported as the
-// empty exchange rather than guessed at, because a wrong exchange is a
-// notification no bound queue receives.
+// exchangeFor names the exchange a type is published on. The eight are the
+// service exchanges of nova, cinder, neutron, glance, octavia, keystone,
+// designate, and barbican. A type outside them is one this package does not
+// generate, and it is reported as the empty exchange rather than guessed at,
+// because a wrong exchange is a notification no bound queue receives.
 func exchangeFor(eventType string) string {
 	switch {
-	case strings.HasPrefix(eventType, "compute."):
+	case strings.HasPrefix(eventType, "compute."),
+		strings.HasPrefix(eventType, "scheduler."),
+		strings.HasPrefix(eventType, "keypair."):
 		return "nova"
 	case strings.HasPrefix(eventType, "volume."):
 		return "cinder"
-	case strings.HasPrefix(eventType, "floatingip."):
+	case strings.HasPrefix(eventType, "floatingip."),
+		strings.HasPrefix(eventType, "network."),
+		strings.HasPrefix(eventType, "subnet."),
+		strings.HasPrefix(eventType, "router."),
+		strings.HasPrefix(eventType, "port."),
+		// Without the trailing dot, so that the one prefix covers both
+		// security_group. and security_group_rule.
+		strings.HasPrefix(eventType, "security_group"):
 		return "neutron"
 	case strings.HasPrefix(eventType, "image."):
 		return "glance"
 	case strings.HasPrefix(eventType, "octavia."):
 		return "octavia"
+	case strings.HasPrefix(eventType, "identity."):
+		return "keystone"
+	case strings.HasPrefix(eventType, "dns."):
+		return "designate"
+	case strings.HasPrefix(eventType, "audit."):
+		return "barbican"
 	default:
 		return ""
 	}

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -84,7 +84,8 @@ func buildMonth(t *testing.T, seed uint64) *generator {
 	shape := rand.New(rand.NewPCG(seed, shapeStream))
 	identifiers := idReader{src: rand.New(rand.NewPCG(seed, identifierSalt(testCloud, july2026)))}
 
-	g := newGenerator(shape, identifiers, july2026, july2026.AddDate(0, 1, 0), testCloud)
+	g := newGenerator(shape, identifiers, noiseIdentifiers(seed, testCloud, july2026),
+		july2026, july2026.AddDate(0, 1, 0), testCloud)
 	g.run()
 	slices.SortStableFunc(g.schedule, func(a, b Transition) int { return a.At.Compare(b.At) })
 	return g

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -105,13 +105,21 @@ func shootNamed(t *testing.T, g *generator, name string) *shoot {
 	return nil
 }
 
-// transitionsOf returns the transitions of one shoot, in schedule order. A
-// transition names no shoot, so every type is matched by what carries the
-// shoot's name: the display_name of a server or a volume, the name of a load
-// balancer, and, for an address, the balancer that holds it.
+// transitionsOf returns the billable transitions of one shoot, in schedule
+// order. A transition names no shoot, so every type is matched by what carries
+// the shoot's name: the display_name of a server or a volume, the name of a
+// load balancer, and, for an address, the balancer that holds it.
 func transitionsOf(schedule Schedule, s *shoot) []Transition {
 	var of []Transition
 	for _, transition := range ofWorkload(schedule, workloadGardener) {
+		// The life of a shoot is read off its billable transitions alone. The
+		// noise around its steps, the audits, the .start halves, the ports and
+		// the attach and detach, is held by noise_test.go, and a daily
+		// compute.instance.exists of a worker that is gone would otherwise be
+		// the last transition of batch.
+		if !transition.Billable {
+			continue
+		}
 		switch {
 		case strings.HasPrefix(transition.EventType, "compute."),
 			strings.HasPrefix(transition.EventType, "volume."):
@@ -308,15 +316,18 @@ func TestGenerateStaysInsideThePeriod(t *testing.T) {
 		last[transition.ResourceID] = transition.At
 	}
 
+	// What is billable is read off the collector's mapping and not off a list
+	// of type names: a transition is billable when the mapping records an event
+	// for it, and the noise of the catalogue is what it records nothing for.
 	var want []Transition
 	for _, transition := range schedule {
-		if transition.EventType != "image.create" {
+		if _, ok := openstack.MapNotification(parse(t, render(t, transition)), testCloud); ok {
 			want = append(want, transition)
 		}
 	}
 	got := schedule.Billable()
 	if len(got) != len(want) {
-		t.Fatalf("Billable() returned %d of %d transitions, want the %d that are not an image.create",
+		t.Fatalf("Billable() returned %d of %d transitions, want the %d the collector's mapping records an event for",
 			len(got), len(schedule), len(want))
 	}
 	for i := range got {

--- a/internal/providers/openstack/simulator/world.go
+++ b/internal/providers/openstack/simulator/world.go
@@ -68,6 +68,22 @@ var bootVolumeFlavor = flavor{
 	typeID: 9, flavorID: "e2d4b6a8-0c1e-4f3a-95b7-6d8f0a2c4e61",
 }
 
+// flavorByTypeID returns the catalog entry a nova instance_type_id names, and
+// false for an id no flavor of this world carries. It is what nova's own
+// flavor table stands for: a notification that reports the type id without the
+// flavor's uuid leaves the uuid to be looked up.
+func flavorByTypeID(typeID int) (flavor, bool) {
+	for _, f := range flavors {
+		if f.typeID == typeID {
+			return f, true
+		}
+	}
+	if bootVolumeFlavor.typeID == typeID {
+		return bootVolumeFlavor, true
+	}
+	return flavor{}, false
+}
+
 // runnerFlavors are the flavors a CI runner is drawn from. A runner holds one
 // job and is gone again, so it runs on the two small flavors of the catalog.
 var runnerFlavors = []flavor{flavors[0], flavors[1]}

--- a/internal/providers/openstack/simulator/world.go
+++ b/internal/providers/openstack/simulator/world.go
@@ -1,6 +1,10 @@
 package simulator
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // flavor is one entry of the simulated nova flavor catalog. It carries all
 // three names nova reports a flavor under, because a notification repeats all
@@ -114,6 +118,24 @@ const (
 	floatingPrefix = "203.0.113."
 )
 
+// The publishers of the services the noise catalogue speaks for. None of the
+// recorded fixtures holds one, so they are written in oslo's <service>.<host>
+// form rather than copied: a publisher id is what an operator reads the
+// emitting service off, and nothing is metered by it.
+const (
+	schedulerPublisher = "scheduler.controller-01"
+	// apiPublisher is nova-api, which is the service that sends the keypair
+	// notifications rather than a compute.
+	apiPublisher      = "api.controller-01"
+	identityPublisher = "identity.keystone-01"
+	dnsPublisher      = "central.designate-01"
+	barbicanPublisher = "barbican.barbican-01"
+)
+
+// barbicanPort is the port of the barbican endpoint an audit record names,
+// which is https://barbican.<cloud>.example:9311.
+const barbicanPort = 9311
+
 // imageNames and instanceNames are what the resources of a project are called.
 // The names are cosmetic: nothing is metered by them, and they exist so that a
 // dumped month reads like a deployment rather than like a list of ids.
@@ -136,6 +158,10 @@ const (
 type project struct {
 	id     string
 	userID string
+
+	// network is the tenant's own network with its subnet. It is nil on a
+	// Gardener tenant, whose shoots each carry one of their own.
+	network *network
 
 	images    []*image
 	instances []*instance
@@ -163,26 +189,32 @@ type instance struct {
 	imageID   string
 	createdAt time.Time
 	// deletedAt is when the instance is destroyed, and the zero instant on one
-	// that outlives the month. It is drawn with the create, because it bounds
-	// what the instance may still report.
+	// that outlives the month. On the classic tenants' first instance it is
+	// drawn with the create, because it bounds what the instance may still
+	// report.
 	deletedAt time.Time
-	volumes   []*volume
-	fip       *floatingIP
+	// port is the neutron port the server holds its address on. It is built
+	// when the instance is created.
+	port    *port
+	volumes []*volume
+	fip     *floatingIP
 	// bootVolume is the volume the server boots from, and nil on a server that
 	// boots from an image.
 	bootVolume *volume
 }
 
-// volume is one cinder volume. attached is what the world knows and cinder
-// reports as the status: the attach itself produces no notification the
-// collector maps, so the volume simply is in use from the moment it is created
-// for an instance.
+// volume is one cinder volume. An attach and a detach are notifications the
+// collector does not map, and attached is what cinder reports as the status on
+// the billable ones.
 type volume struct {
 	id         string
 	name       string
 	sizeGB     int
 	volumeType string
 	attached   bool
+	// attachment is what the attach reported, held so that the detach repeats
+	// the same attachment, and cleared by that detach.
+	attachment map[string]any
 	createdAt  time.Time
 	// resizes is how often the volume has grown. A claim grows at most twice,
 	// and the count does not follow from the size: 10 grown twice and 20 grown
@@ -203,6 +235,57 @@ type floatingIP struct {
 	routerID     string
 }
 
+// network is one neutron network with its subnet and its router. The classic
+// tenants and the CI tenant have one each, and every shoot carries the one
+// Gardener creates for it.
+//
+// routerID is empty on a classic tenant's network, which pre-exists the month
+// and is therefore never announced. routerPortID is the port of the router's
+// interface on the subnet, drawn when the network is built. securityGroupID is
+// set on a shoot's network alone, because a shoot is the only workload whose
+// group is created inside the month.
+//
+// The cidr is 192.168.<project>.0/24 on a classic tenant counting from 1,
+// 10.100.0.0/24 on the CI tenant, and 10.250.<shoot>.0/24 on a shoot, which is
+// the range that shoot's VIP addresses already lie in.
+type network struct {
+	id, subnetID, routerID, routerPortID, securityGroupID, name, cidr string
+	// hosts counts the addresses handed to ports.
+	hosts int
+}
+
+// prefix is the cidr up to its last dot, which is the part every address on the
+// network shares.
+func (n *network) prefix() string {
+	return n.cidr[:strings.LastIndex(n.cidr, ".")]
+}
+
+// nextAddress hands out the next address of the subnet. The addresses of ports
+// are cosmetic, and a network that hands out more than 240 of them starts over,
+// the way a real subnet hands a released address to the next port that asks.
+func (n *network) nextAddress() string {
+	address := fmt.Sprintf("%s.%d", n.prefix(), 10+n.hosts%240)
+	n.hosts++
+	return address
+}
+
+// port is one neutron port: the address a device holds on a network. The subnet
+// and the security group are copied from that network, because neutron reports
+// both on the port itself.
+//
+// deviceOwner is compute:nova on a server's port and Octavia on the VIP port of
+// a load balancer, and deviceID names the device behind it: the instance id, or
+// lb-<load balancer id>.
+type port struct {
+	id, networkID, subnetID, securityGroupID, address, macAddress, deviceID, deviceOwner, host string
+}
+
+// recordSet is one designate record set in a Gardener project's zone.
+type recordSet struct {
+	id, name, recordType string
+	records              []string
+}
+
 // gardenerProject is one Gardener project: the shoots it holds and the
 // OpenStack tenant they run on. Gardener bills the tenant, and the project is
 // the name an operator knows the shoots under.
@@ -210,6 +293,11 @@ type gardenerProject struct {
 	name   string
 	tenant *project
 	shoots []*shoot
+	// zoneID and zoneName are the designate zone the shoots' records live in.
+	// The zone is <project name>.<cloud>.example., and the cloud is in the name
+	// for the reason it is in the glance URL of an instance create payload: two
+	// clouds fed the same seed must not report the same one.
+	zoneID, zoneName string
 }
 
 // shoot is one Kubernetes cluster Gardener runs on the tenant. Its workers are
@@ -230,6 +318,15 @@ type shoot struct {
 	baseWorkers int
 
 	networkID, subnetID, routerID, securityGroupID, keypairName string
+	// network holds the four ids above in the form the neutron notifications
+	// report them, together with the addresses the shoot's ports are handed.
+	network *network
+	// securityGroupRuleIDs are the two rules of the shoot's security group.
+	securityGroupRuleIDs []string
+	// apiRecord is the record set of the shoot's API server. ingressRecord is
+	// the one of its ingress controller, and it is nil until the first load
+	// balancer has an address to point at.
+	apiRecord, ingressRecord *recordSet
 
 	// createdAt is when the shoot comes up. deletedAt is the zero instant on a
 	// shoot that outlives the month.
@@ -253,4 +350,8 @@ type loadBalancer struct {
 	id, name, vipPortID, vipAddress string
 	listenerIDs, poolIDs            []string
 	fip                             *floatingIP
+	// secretID and containerID are the barbican secret and container holding
+	// the balancer's certificate. Both are empty on a balancer that terminates
+	// no https listener.
+	secretID, containerID string
 }


### PR DESCRIPTION
Closes #86

The simulator rendered the 21 notification types the collector's mapping table knows, and the only one it skipped was the unsized `image.create`. A real bus carries the whole sequence around each of those. This branch renders that sequence — 62 further notification types, 83 distinct `event_type` values in total — as transitions the collector receives and counts as skipped.

Three rules hold for every one of them, and every commit is built to keep them: noise is never billable, it draws neither from the shape stream nor from the identifier stream, and it is rendered by `noise.go` and by nothing else. The second rule is what keeps this branch honest: **the billable month of a seed, a period and a cloud is unchanged** — every instant, every resource id and every payload of a billable transition is the one it was, and only the message ids move, because `Generate` draws them over a schedule that is now longer.

## The commits, in order

**`586e2a5` Let the tests tell the noise from the billable month** — the suite learns the distinction before anything renders it. The month's billable expectation is read off `MapNotification` rather than off a type name, `memberShape` names an empty nested object instead of flattening it away, a missing sample file is a failure for a billable type alone (the fixtures are the collector's; the noise has none), and `transitionsOf` skips non-billable transitions.

**`164624e` Add the noise identifier stream and the world it names** — `noiseIdentifiers` is a third generator, salted the way the identifier stream is, plus the `noiseIDs` field and the sixth parameter on `newGenerator`. Drawing noise ids from the identifier stream would shift every id behind the first noise resource and change the billable month; the fixed noise ids are drawn after the identifier pass's last draw for the same reason. The world gains the tenant networks, the ports, the zones and record sets, the attachment, the security group rules, and the barbican secret and container. Nothing renders any of it yet, so the month is still byte for byte the one the branch started from.

**`6ac6f65` Route the catalogue's types to eight exchanges** — `exchangeFor` learns the new prefixes and `ServiceExchanges` becomes the eight. A topic exchange drops a message no queue is bound to without saying so — the broker confirms, the message is gone, and the collector shows neither an event nor a skip — so the compose stack's collector lists all eight rather than the four its default binds, and the compose test holds that list against `simulator.ServiceExchanges`.

**`2016b9c` Surround every boot and delete with nova's and neutron's sequences** — the scheduler pair, `create.start`, the three state updates, neutron's port create and bind, and on the way out the deleting-task update, the day's audit, the delete start, the shutdown and the port release. Each server gets one port on the network it was created on. Two behavioural notes: the bound of a deleted instance's lifetime moves to the first notification of its pre-delete sequence, so a step whose `.end` would fall inside those five seconds is dropped the way a step at or after the delete is dropped today (this moves no draw); and every paired step is rendered with its `.start` half five seconds before its `.end`, per the author's decision on the issue that the catalogue carries both halves.

**`8d228b0` Attach and detach every volume and bracket cinder's steps** — `create.start` eight seconds before the volume is ready, the attach pair, the `.start` halves of resize and transfer, the detach of what a deleted server held, and `delete.start` before the delete. The attach now hands out the attachment record and sets the volume's status, which the workloads used to set by hand, so the month is billed for the volumes it was billed for. A nil server is tolerated: the attachment names neither instance nor host and the volume is in use all the same, which keeps `createClaim` from reaching into an empty pool.

**`f2bef94` Prepare and activate every image around its upload** — `image.prepare` under the saving status with neither size nor checksum, and `image.activate` repeating the upload's payload unchanged. The upload stays the one notification an image is billed from.

**`6ef5ac7` Announce the tenants and build every shoot's infrastructure** — keystone creates the Gardener and CI tenants at the month start; neutron builds the network, subnet and router under the CI runners and every shoot; a shoot brings its security group with two rules, its keypair, the records its API server and ingress answer on, and the barbican secret and container it terminates TLS with. The tear-down gives all of it back and ends on the network. A CADF record is reported under its own id, not under the user or target it names, so two records about one user a second apart stay distinct; a keypair has no id and is reported under its holder and name.

**`c61876b` Audit every instance at every midnight it existed** — `compute.instance.exists` with the audit period run as the day (nova's monthly default would put no audit inside the simulated month; hourly would put 24× the lines on the bus for the same single type). The audits are the one part of the catalogue not rendered where the billable transition is — which instances existed on a day is known only once every workload has run — so they are a pass over the finished schedule, walking instances in first-appearance order so a map walk cannot reorder one midnight's audits between runs. An audit is pushed on by whole seconds while the instance already has a transition at that second; a deleted instance is audited once more at the following midnight and then dropped.

**`2499092` Hold the month to the noise catalogue** — the 62 types have no recorded sample, so `TestNoisePayloadsCarryTheirMembers` pins each by the members it carries and every seed is held against the whole list. The sequences are covered where a deployment sends them, and five paths a generated month never reaches are covered on generators built by hand: an audit whose midnight is occupied by a delete, a pass over a schedule with no server, an attach without an instance, a delete of an unheld volume, and the destroy of a server that never held a port.

**`2c57bca` Count the noise in the collector and CLI tests** — almost everything the month now carries surfaces only in `tally_collector_skipped_total`, so the integration run is held to that counter type by type instead of to the nine unsized `image.create` alone. Their sum is waited for first, because the last messages of a month may be noise arriving after the last billable one. The collector-at-default test names what it may not have counted by exchange rather than by the `octavia.` prefix. The CLI test's constant is the measured 13915-line difference between `notifications.jsonl` and `events.jsonl` for seed 1 over 2026-07.

**`55cf510` Document the noise the collector skips** — `docs/openstack-simulator.md` gains "The noise": the three rules, the sequence around each kind of transition with the second its notifications fall on, and all 62 types with their exchange. The measured numbers for seed 1 over 2026-07 are 15727 notifications, 1812 of them billable, 83 distinct event types.

## Divergence from the issue

The issue says nothing in the collector changes. One thing did: `labelValueLimit` in `internal/providers/openstack/metrics.go` is exported as `LabelValueLimit`. That is a rename with no behavioural effect — it lets `noise_test.go` hold the generated month to the collector's own bound (83 types, limit 100) rather than restating the number. The issue names both the constant and the bound as the thing the month has to stay inside; exporting it is how that is checked at the source.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) f9eb7a6 with Claude:claude-opus-5_
