### PR TITLE
Add fault switches for pre-existing resources, duplicates, reordering, refused shapes and held-back notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMAGES := $(SERVICES) tally-openstack-collector tally-openstack-simulator
 SIM_IMAGES := tally-openstack-collector tally-openstack-simulator
 
 # The simulator stack, deploy/compose/compose.yaml: a broker, the collector, and
-# the simulator, run beside the dev cluster rather than in it. The four SIM_
+# the simulator, run beside the dev cluster rather than in it. The five SIM_
 # values below are what `simulator-up` writes into the .env file compose reads.
 # A factor of 744 puts a 31-day month on the bus in an hour.
 SIM_CLOUD ?= os-sim
@@ -50,6 +50,9 @@ SIM_FACTOR ?= 744
 # No default: the target refuses to run until a month is named, because any
 # month guessed here would be as wrong as another.
 SIM_PERIOD ?=
+# The fault switches to turn on, comma-separated: pre-existing, missing-create,
+# duplicates, reordering, refused-shapes, held-back. Empty is every switch off.
+SIM_FAULTS ?=
 COMPOSE := docker compose -f deploy/compose/compose.yaml
 
 # Every kubectl call names the cluster explicitly. Creating a kind cluster
@@ -174,7 +177,7 @@ simulator-up:
 	@echo '==> writing the dev CA to tally-ca.crt'
 	$(MAKE) -s ca > tally-ca.crt
 	@echo '==> issuing an ingest credential for $(SIM_CLOUD)'
-	@token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud '$(SIM_CLOUD)' --description 'openstack simulator')"; printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_OSC_TOKEN=%s\n' '$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' "$$token" > deploy/compose/.env
+	@token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud '$(SIM_CLOUD)' --description 'openstack simulator')"; printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_SIM_FAULTS=%s\nTALLY_OSC_TOKEN=%s\n' '$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' '$(SIM_FAULTS)' "$$token" > deploy/compose/.env
 	$(COMPOSE) up -d
 	@echo
 	@echo 'Simulator stack is up:'
@@ -185,6 +188,8 @@ simulator-up:
 	@echo
 	@echo "Finish the month at once with:"
 	@echo "  curl -X PUT -d '{\"factor\": 0}' http://127.0.0.1:8091/clock"
+	@echo "Release the held-back notifications of a run with SIM_FAULTS=held-back with:"
+	@echo "  curl -X POST http://127.0.0.1:8091/release"
 
 # Dropping the volumes empties the outbox and the broker's queue, so the next
 # `simulator-up` starts from nothing rather than delivering what the last run

--- a/cmd/tally-openstack-simulator/commands.go
+++ b/cmd/tally-openstack-simulator/commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -90,6 +91,9 @@ func newRunCmd() *cobra.Command {
 		"directory to write notifications.jsonl, events.jsonl and oracle.json to")
 	cmd.Flags().DurationVar(&opts.WaitForCollector, "wait-for-collector", defaultWaitForCollector,
 		"how long to wait for a consumer on the collector's queue before publishing; 0 disables the wait")
+	cmd.Flags().StringSliceVar(&opts.Faults, "faults", nil,
+		"fault switches to turn on, comma-separated: "+strings.Join(simulator.FaultNames, ", ")+
+			"; every switch is off by default")
 	cmd.Flags().BoolVar(&allowRemoteBroker, allowRemoteBrokerFlag, false, allowRemoteBrokerUsage)
 	_ = cmd.MarkFlagRequired("period")
 	return cmd

--- a/cmd/tally-openstack-simulator/commands.go
+++ b/cmd/tally-openstack-simulator/commands.go
@@ -88,7 +88,8 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().Float64Var(&opts.Factor, "factor", defaultFactor,
 		"virtual seconds per wall second; 0 publishes as fast as the broker confirms")
 	cmd.Flags().StringVar(&opts.Out, "out", "",
-		"directory to write notifications.jsonl, events.jsonl and oracle.json to")
+		"directory to write notifications.jsonl, events.jsonl and oracle.json to, "+
+			"and held-back.jsonl when a switch holds notifications back")
 	cmd.Flags().DurationVar(&opts.WaitForCollector, "wait-for-collector", defaultWaitForCollector,
 		"how long to wait for a consumer on the collector's queue before publishing; 0 disables the wait")
 	cmd.Flags().StringSliceVar(&opts.Faults, "faults", nil,

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -4,13 +4,15 @@
 // The run subcommand generates the month from --seed and --period and publishes
 // it onto the broker TALLY_SIM_AMQP_URL names, at --factor virtual seconds per
 // wall second. With --out it writes the month to notifications.jsonl,
-// events.jsonl and oracle.json instead, and with both it does both. The replay
-// subcommand publishes a notifications.jsonl an earlier run wrote, which puts
-// the same month on a bus again without the generator behind it. The compare
-// subcommand reads the oracle a run wrote, an engine export of the month and
-// the pricing model the run rated with, and lists every resource whose metered
-// intervals or quantities differ from the oracle; it exits 1 when anything
-// differs.
+// events.jsonl and oracle.json instead, and with both it does both. With
+// --faults it turns fault switches on, each of which changes what the bus
+// carries and never the month the oracle states; the run help names the six.
+// The replay subcommand publishes a notifications.jsonl an earlier run wrote,
+// which puts the same month on a bus again without the generator behind it. The
+// compare subcommand reads the oracle a run wrote, an engine export of the
+// month and the pricing model the run rated with, and lists every resource
+// whose metered intervals or quantities differ from the oracle; it exits 1 when
+// anything differs.
 //
 // The control endpoint on TALLY_SIM_HTTP_PORT changes the factor while a run
 // publishes, so a month that is going out too slowly is sped up without being

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -16,7 +16,8 @@
 //
 // The control endpoint on TALLY_SIM_HTTP_PORT changes the factor while a run
 // publishes, so a month that is going out too slowly is sped up without being
-// started over.
+// started over. POST /release on it publishes the notifications a run with the
+// held-back fault switch kept back.
 //
 // SIGINT and SIGTERM stop a run cleanly: what went out stays out, and the
 // process ends with exit status 0. Every other failure exits 1.

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -4,9 +4,10 @@
 // The run subcommand generates the month from --seed and --period and publishes
 // it onto the broker TALLY_SIM_AMQP_URL names, at --factor virtual seconds per
 // wall second. With --out it writes the month to notifications.jsonl,
-// events.jsonl and oracle.json instead, and with both it does both. With
-// --faults it turns fault switches on, each of which changes what the bus
-// carries and never the month the oracle states; the run help names the six.
+// events.jsonl and oracle.json instead, and to held-back.jsonl beside them when
+// a switch holds notifications back; with both it does both. With --faults it
+// turns fault switches on, each of which changes what the bus carries and never
+// the month the oracle states; the run help names the six.
 // The replay subcommand publishes a notifications.jsonl an earlier run wrote,
 // which puts the same month on a bus again without the generator behind it. The
 // compare subcommand reads the oracle a run wrote, an engine export of the

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -222,6 +223,95 @@ func TestRunWritesTheMonthInFileMode(t *testing.T) {
 			again, _ := readLines(t, filepath.Join(second, name))
 			if !bytes.Equal(first, again) {
 				t.Errorf("%s differs between two runs of the same seed, period, and cloud", name)
+			}
+		}
+	})
+}
+
+// TestRunWritesTheHeldBackFileInFileMode covers the fourth file a run writes:
+// the notifications the held-back switch keeps off the bus. They are missing
+// from notifications.jsonl, so the two files together are the month
+// events.jsonl and the noise account for.
+func TestRunWritesTheHeldBackFileInFileMode(t *testing.T) {
+	useCloud(t)
+
+	dir := t.TempDir()
+	if _, stderr, err := runCLI(t, "run", "--period", endedMonth, "--seed", "1",
+		"--faults", "held-back", "--out", dir); err != nil {
+		t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+	}
+
+	heldPath := filepath.Join(dir, "held-back.jsonl")
+	_, heldLines := readLines(t, heldPath)
+	// Through the reader a replay uses, so the file is one the simulator itself
+	// can put on a bus later.
+	held, err := simulator.ReadStream(heldPath)
+	if err != nil {
+		t.Fatalf("ReadStream(%s) error = %v, want nil", heldPath, err)
+	}
+	if len(held) != len(heldLines) {
+		t.Errorf("ReadStream read %d notifications of the %d lines of held-back.jsonl",
+			len(held), len(heldLines))
+	}
+
+	_, notificationLines := readLines(t, filepath.Join(dir, "notifications.jsonl"))
+	_, eventLines := readLines(t, filepath.Join(dir, "events.jsonl"))
+	// The switch leaves the schedule alone, so the non-billable notifications are
+	// the ones a month without it carries.
+	skipped := nonBillableNotifications(t, 1, endedMonth, simulatedCloud)
+	if got, want := len(notificationLines)+len(heldLines), len(eventLines)+skipped; got != want {
+		t.Errorf("notifications.jsonl and held-back.jsonl hold %d lines together, want %d: "+
+			"%d events plus the %d non-billable ones", got, want, len(eventLines), skipped)
+	}
+
+	t.Run("a second run without the switch takes the file away", func(t *testing.T) {
+		if _, stderr, err := runCLI(t,
+			"run", "--period", endedMonth, "--seed", "1", "--out", dir); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		if _, err := os.Stat(heldPath); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("Stat(%s) error = %v, want it to wrap fs.ErrNotExist: a directory reused "+
+				"across runs must not carry the held share of another month", heldPath, err)
+		}
+	})
+
+	t.Run("a rerun that fails partway takes every earlier file away too", func(t *testing.T) {
+		reused := t.TempDir()
+		stale := writeFile(t, reused, "held-back.jsonl", "{}\n")
+		staleOracle := writeFile(t, reused, "oracle.json", "{}\n")
+		// A directory in the way of one of the files is a run that ends partway
+		// through the output directory. Whatever ends it there, no file of the
+		// earlier month may stay behind: a drill would compare this month against
+		// that oracle, and a replay would put that held share on the bus. Each
+		// directory holds a file of its own so the run cannot take it away and
+		// carry on, and there are two of them because what an operator clears out
+		// after such a run is every path the run could not take away, not the
+		// first one it reached.
+		obstructions := []string{
+			filepath.Join(reused, "notifications.jsonl"),
+			filepath.Join(reused, "events.jsonl"),
+		}
+		for _, obstruction := range obstructions {
+			if err := os.Mkdir(obstruction, 0o755); err != nil {
+				t.Fatalf("making the directory that fails the run: %v", err)
+			}
+			writeFile(t, obstruction, "keep", "")
+		}
+
+		_, stderr, err := runCLI(t, "run", "--period", endedMonth, "--seed", "1", "--out", reused)
+		if err == nil {
+			t.Fatalf("run error = nil, want the failure over %v (stderr %q)", obstructions, stderr)
+		}
+		for _, obstruction := range obstructions {
+			if !strings.Contains(err.Error(), obstruction) {
+				t.Errorf("run error = %v, want it to name %s too: a path the run could not take "+
+					"away is a file of the earlier month still in the directory", err, obstruction)
+			}
+		}
+		for _, path := range []string{stale, staleOracle} {
+			if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+				t.Errorf("Stat(%s) error = %v, want it to wrap fs.ErrNotExist: a run that fails "+
+					"must not leave a file of another month behind", path, err)
 			}
 		}
 	})
@@ -617,6 +707,50 @@ func TestCompareMatchesAndDiffers(t *testing.T) {
 		}
 	})
 
+	t.Run("a resource a switch touched", func(t *testing.T) {
+		// A month of its own, because a switch names the resources it touched in
+		// the oracle, and the oracle of the plain month above names none.
+		faultyDir := t.TempDir()
+		if _, stderr, err := runCLI(t, "run", "--period", endedMonth, "--seed", "1",
+			"--faults", simulator.FaultMissingCreate, "--out", faultyDir); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		faultyPath := filepath.Join(faultyDir, "oracle.json")
+		faultyOracle, err := simulator.ReadOracle(faultyPath)
+		if err != nil {
+			t.Fatalf("ReadOracle() error = %v, want nil", err)
+		}
+
+		resourceType, id := firstTouchedResource(t, faultyOracle, simulator.FaultMissingCreate)
+		faultyRows := ratedOf(t, faultyOracle)
+		kept := make([][]string, 0, len(faultyRows))
+		for _, row := range faultyRows {
+			if row[columnResourceID] != id {
+				kept = append(kept, row)
+			}
+		}
+
+		stdout, _, err := runCLI(t, "compare",
+			"--oracle", faultyPath, "--export", writeRated(t, kept), "--pricing", model)
+		if err == nil {
+			t.Fatalf("compare error = nil, want the missing resource reported (stdout %q)", stdout)
+		}
+		if want := "1 resources differ from the oracle"; err.Error() != want {
+			t.Errorf("compare error = %q, want %q", err, want)
+		}
+		// The switch stands beside the difference it explains, and under the
+		// differences stand the switches the month ran with.
+		want := fmt.Sprintf("%s %s: missing from the export (touched by %s)",
+			resourceType, id, simulator.FaultMissingCreate)
+		if !strings.Contains(stdout, want+"\n") {
+			t.Errorf("stdout = %q, want a line %q", stdout, want)
+		}
+		want = "the month ran with the fault switches " + simulator.FaultMissingCreate
+		if !strings.Contains(stdout, want+"\n") {
+			t.Errorf("stdout = %q, want a line %q", stdout, want)
+		}
+	})
+
 	t.Run("an export directory holding no rated.csv", func(t *testing.T) {
 		_, stderr, err := runCLI(t, "compare",
 			"--oracle", oraclePath, "--export", t.TempDir(), "--pricing", model)
@@ -839,6 +973,24 @@ func firstResourceID(t *testing.T, oracle simulator.Oracle, resourceType string)
 	}
 	t.Fatalf("the oracle holds no %s, and the case needs one", resourceType)
 	return ""
+}
+
+// firstTouchedResource is the oracle's first resource of a priced type that the
+// switch touched, by type and id. A resource of an unpriced type carries no row
+// in an export, so dropping one would report no difference at all.
+func firstTouchedResource(t *testing.T, oracle simulator.Oracle, fault string) (resourceType, id string) {
+	t.Helper()
+
+	for _, resource := range oracle.Resources {
+		if _, priced := timeGauges[resource.ResourceType]; !priced {
+			continue
+		}
+		if slices.Contains(resource.Faults, fault) {
+			return resource.ResourceType, resource.ResourceID
+		}
+	}
+	t.Fatalf("the oracle names no resource of a priced type the %s switch touched", fault)
+	return "", ""
 }
 
 // lastLine is the last line of what a command printed, which is the verdict of

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -58,7 +58,7 @@ func nonBillableNotifications(t *testing.T, seed uint64, month, cloud string) in
 	if err != nil {
 		t.Fatalf("period.Parse(%q) error = %v, want nil", month, err)
 	}
-	generated, err := simulator.GenerateMonth(seed, from, to, cloud)
+	generated, err := simulator.GenerateMonth(seed, from, to, cloud, simulator.Faults{})
 	if err != nil {
 		t.Fatalf("GenerateMonth() error = %v, want nil", err)
 	}
@@ -231,6 +231,10 @@ func TestRunRefusesBadInput(t *testing.T) {
 	notADirectory := writeFile(t, t.TempDir(), "notifications.jsonl", "")
 	urlFile := writeFile(t, t.TempDir(), "amqp-url", closedBroker)
 	emptyURLFile := writeFile(t, t.TempDir(), "empty-amqp-url", "")
+	// The output directory of the case about an unknown fault switch. It is held
+	// outside the case so the body can read it back: a refused switch has to end
+	// the run before the month is written.
+	faultOut := t.TempDir()
 
 	for _, tc := range []struct {
 		name string
@@ -247,6 +251,9 @@ func TestRunRefusesBadInput(t *testing.T) {
 		// absent is a fragment the error must not carry, which is how the case
 		// about a secret checks that the secret stayed out of it.
 		absent string
+		// emptyDir is a directory the run must have written nothing into, which
+		// is how a case checks that it ended before it generated the month.
+		emptyDir string
 	}{
 		{
 			name: "a period that is not a month",
@@ -329,6 +336,21 @@ func TestRunRefusesBadInput(t *testing.T) {
 			args:     []string{"--period", endedMonth, "--out", filepath.Join(notADirectory, "sub")},
 			contains: fmt.Sprintf("creating %s:", filepath.Join(notADirectory, "sub")),
 		},
+		{
+			name: "a fault switch nobody named that way",
+			args: []string{"--period", endedMonth, "--faults", "bogus", "--out", faultOut},
+			want: `--faults: unknown fault switch "bogus"; the switches are ` +
+				`pre-existing, missing-create, duplicates, reordering, refused-shapes, held-back`,
+			emptyDir: faultOut,
+		},
+		{
+			name: "two fault switches that exclude each other",
+			args: []string{
+				"--period", endedMonth, "--faults", "pre-existing,missing-create",
+				"--out", t.TempDir(),
+			},
+			want: "--faults: pre-existing and missing-create exclude each other",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useCloud(t)
@@ -349,7 +371,37 @@ func TestRunRefusesBadInput(t *testing.T) {
 			if tc.absent != "" && strings.Contains(err.Error(), tc.absent) {
 				t.Errorf("run error = %q, want it to keep %q out", err, tc.absent)
 			}
+			if tc.emptyDir != "" {
+				entries, err := os.ReadDir(tc.emptyDir)
+				if err != nil {
+					t.Fatalf("reading %s: %v", tc.emptyDir, err)
+				}
+				if len(entries) > 0 {
+					t.Errorf("%s holds %d entries, want the run to have written nothing", tc.emptyDir, len(entries))
+				}
+			}
 		})
+	}
+}
+
+// TestRunHelpListsTheFaultSwitches holds the help of run to the six switches.
+// A switch --faults takes but the help does not name is one nobody reaches
+// without reading the source.
+func TestRunHelpListsTheFaultSwitches(t *testing.T) {
+	blankEnvironment(t)
+
+	stdout, stderr, err := runCLI(t, "run", "--help")
+	if err != nil {
+		t.Fatalf("run --help error = %v, want nil (stderr %q)", err, stderr)
+	}
+	if want := "--faults"; !strings.Contains(stdout, want) {
+		t.Fatalf("stdout = %q, want the flag %q in it", stdout, want)
+	}
+	for _, name := range simulator.FaultNames {
+		if !strings.Contains(stdout, name) {
+			t.Errorf("run --help does not name the fault switch %q, want all of %v listed",
+				name, simulator.FaultNames)
+		}
 	}
 }
 

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -15,7 +15,8 @@
 #
 # The values interpolated below come from deploy/compose/.env, which
 # `make simulator-up` writes and git ignores. It carries the cloud, the period,
-# the seed, the factor, and the ingest token issued for that cloud.
+# the seed, the factor, the fault switches, and the ingest token issued for that
+# cloud.
 #
 # A named volume of one of these images belongs under /home/nonroot; the
 # collector's outbox below says why.
@@ -98,14 +99,18 @@ services:
       # loopback inside the container is reachable from nothing. The port below
       # is what publishes it, on the host's 127.0.0.1 alone.
       TALLY_SIM_HTTP_ADDR: 0.0.0.0
+    # --faults is empty unless SIM_FAULTS names a switch. An empty value reaches
+    # the binary as --faults "", which is an empty list of switch names, and an
+    # empty list is the run with every switch off.
+    #
     # --allow-remote-broker is the confirmation the binary asks for before it
     # dials a broker that is not on its own machine. The broker here is the
     # container next door, and what it carries is thrown away with the stack; a
     # URL that named a control plane's broker would put a month of invented usage
     # into that deployment's billing data, which is why the flag has to be typed.
-    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--allow-remote-broker"]
+    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--faults", "${TALLY_SIM_FAULTS}", "--allow-remote-broker"]
     ports:
-      # the control endpoint: GET /clock, PUT /clock, GET /healthz
+      # the control endpoint: GET /clock, PUT /clock, POST /release, GET /healthz
       - "127.0.0.1:8091:8080"
 
 volumes:

--- a/deploy/compose/compose_test.go
+++ b/deploy/compose/compose_test.go
@@ -192,9 +192,11 @@ func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 	}
 	// The period is required by the binary, but the seed and the factor are not:
 	// dropping either leaves a month that is not the one asked for, published at
-	// a pace nobody chose. Without --allow-remote-broker the container refuses
-	// the broker beside it, which is a stack that starts and publishes nothing.
-	for _, flag := range []string{"--period", "--seed", "--factor", "--allow-remote-broker"} {
+	// a pace nobody chose. A dropped --faults leaves SIM_FAULTS with nowhere to
+	// arrive, so a stack asked for a fault switch publishes the month without it.
+	// Without --allow-remote-broker the container refuses the broker beside it,
+	// which is a stack that starts and publishes nothing.
+	for _, flag := range []string{"--period", "--seed", "--factor", "--faults", "--allow-remote-broker"} {
 		if !slices.Contains(svc.Command, flag) {
 			t.Errorf("command = %v, want %s among the arguments", svc.Command, flag)
 		}

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -10,15 +10,16 @@ deployment behind it. The month is rendered from a small simulated cloud and
 paced by a virtual clock, so a 31-day month goes out in the wall time the
 factor compresses it into.
 
-It has no fault switches, no fake OpenStack API, and no metrics endpoint of its
-own. #65 is the meta issue the simulated workloads belong to, and this document
-describes its first stage. The noise, the notifications the collector does not
-bill, is rendered and described under "The noise" below. The oracle of a month
-and the comparison against an engine export are described under "The oracle"
-below; #88 owns the fault switches and #89 the project registry; #66 the fake
-API and the clock seam; #67 the traffic series and `/metrics`. The drill #51
-cites this simulator as the way a month reaches the Reporting API. The workload
-renders octavia's three load balancer types from the shoots' load balancers.
+It has no fake OpenStack API and no metrics endpoint of its own. #65 is the meta
+issue the simulated workloads belong to, and this document describes its first
+stage. The noise, the notifications the collector does not bill, is rendered and
+described under "The noise" below. The oracle of a month and the comparison
+against an engine export are described under "The oracle" below, and the six
+fault switches under "The fault switches"; #89 owns the project registry; #66
+the fake API and the clock seam; #67 the traffic series and `/metrics`. The
+drill #51 cites this simulator as the way a month reaches the Reporting API. The
+workload renders octavia's three load balancer types from the shoots' load
+balancers.
 
 ## The world and the workload
 
@@ -495,6 +496,14 @@ billable month is the bound of a deleted instance's last lifetime step, which
 lies before the five seconds of nova's pre-delete sequence rather than at the
 delete itself.
 
+The fault switches draw from streams of their own, one per switch, seeded by the
+seed together with the switch's name. A fault stream carries neither the cloud
+nor the month: what it hands out is which resource or notification the switch
+reaches, and the message id of a refused twin, which no collector stores. None
+of them draws from the stream the month's shape comes from, so a run with every
+switch off consumes the three streams above the way a run without the switches
+consumes them.
+
 The same seed, period, and cloud therefore publish byte-identical
 notifications, and a rerun of the same build costs nothing at the far end: the
 collector books the oslo message id as the event's `event_id`, and the
@@ -515,6 +524,15 @@ the reporting database the events landed in, which for the dev cluster is
 `make down` followed by `make up`. Regenerating a period against a database that
 already holds it is therefore a decision, not a repeat.
 
+Two of the fault switches fall under that rule inside one build. `pre-existing`
+and `missing-create` move an instance's create across the period start, which
+reorders the sorted schedule the message ids are drawn over, so every id of the
+month is another one: such a run beside the plain month of the same seed,
+period, and cloud leaves the Reporting API holding the period twice. The other
+four keep every id, because none of them moves a transition in time or adds one
+to the schedule. Publish a month with one of the two under another `SIM_CLOUD`,
+or drop the reporting database before it.
+
 Between two months of the same length the classic tenants' notifications sit at
 the same offsets from the month start. The transitions anchored on the month's
 end (the second image's delete and the first instance's) move with its length.
@@ -531,13 +549,15 @@ make simulator-up SIM_PERIOD=2026-07
 ```
 
 `SIM_CLOUD` defaults to `os-sim`, `SIM_SEED` to 1, and `SIM_FACTOR` to 744. A
-factor of 744 puts a 31-day month on the bus in an hour.
+factor of 744 puts a 31-day month on the bus in an hour. `SIM_FAULTS` is empty,
+which is every fault switch off; it takes the switch names of "The fault
+switches" below, comma-separated, as in `SIM_FAULTS=held-back`.
 
 The target builds the collector and the simulator image, writes the dev CA to
 `tally-ca.crt`, issues an ingest credential for `SIM_CLOUD` with
 `tally-reporting-admin create-ingest-credential`, writes the cloud, the period,
-the seed, the factor, and that token into `deploy/compose/.env`, and starts the
-three containers of
+the seed, the factor, the fault switches as `TALLY_SIM_FAULTS`, and that token
+into `deploy/compose/.env`, and starts the three containers of
 [`../deploy/compose/compose.yaml`](../deploy/compose/compose.yaml): the broker,
 the collector image, and the simulator.
 
@@ -586,6 +606,12 @@ Finish the month at once instead of waiting the factor out:
 
 ```sh
 curl -X PUT -d '{"factor": 0}' http://127.0.0.1:8091/clock
+```
+
+Let the notifications a run with `SIM_FAULTS=held-back` keeps back out:
+
+```sh
+curl -X POST http://127.0.0.1:8091/release
 ```
 
 Build a backlog on the durable queue and drain it again:
@@ -639,7 +665,8 @@ of the other 13915 are the unsized `image.create`, one per image: two per
 classic project, one per Gardener tenant, and one for the CI tenant. The
 remaining 13906 are the noise catalogue. The month carries 83 distinct
 `event_type` values. The shape of a month is the seed's alone, so the counts
-below hold on every cloud.
+below hold on every cloud. They are those of a run with every fault switch off;
+what a month with a switch on carries stands under "The fault switches".
 
 `curl http://127.0.0.1:8090/readyz` answers 200 once the collector holds its
 broker connection and its outbox. On `http://127.0.0.1:8090/metrics`:
@@ -733,9 +760,10 @@ sends before a delete.
 
 ## File mode and replay
 
-`run --out DIR` writes three files, and it writes the whole month before it
-publishes anything, so a run interrupted halfway still leaves a complete month
-on disk. With no broker configured it writes the files and publishes nothing:
+`run --out DIR` writes three files, and a fourth when the held-back switch keeps
+part of the month off the bus. It writes the whole month before it publishes
+anything, so a run interrupted halfway still leaves a complete month on disk.
+With no broker configured it writes the files and publishes nothing:
 
 ```sh
 TALLY_SIM_CLOUD=os-sim tally-openstack-simulator run \
@@ -762,6 +790,14 @@ was meant to meter to: the intervals every billable resource was to be billed
 over and the events the collector has to record per project. "The oracle" below
 describes it.
 
+`held-back.jsonl` is the fourth, in the form of `notifications.jsonl` and
+holding what the held-back switch keeps back. Every run removes all four files
+an earlier one left in the directory before it writes the first of its own, so
+what a directory holds is one month and nothing of another, whether the run
+holds something back, holds nothing, or fails partway through the files. A path
+one of the removals cannot take away ends the run there, with the rest gone,
+and every path that stayed is named.
+
 `replay --in FILE --factor N` publishes a captured file onto a broker, with the
 virtual clock started at the first line's timestamp, so a month needs neither
 the generator nor the seed that produced it. The message ids are the recorded
@@ -772,6 +808,15 @@ what lets a file that is not perfectly sorted replay whole.
 `ReadStream` reads the file before the first message goes out and refuses an
 empty file, a line that is not JSON, and a body without a timestamp. A replay
 that would fail halfway through a month fails with nothing published.
+
+A held-back file is replayed the way any other stream file is:
+`replay --in DIR/held-back.jsonl --factor 0` puts it on the bus at once. The
+factor is what matters there. The replay clock starts at the first line's
+timestamp and the held instants are spread over the whole month, so a replay at
+744 would trickle the file out over an hour. A `pre-existing` month replays from
+its earliest pre-month create rather than from the month start, for the same
+reason: the clock starts at the first line, and the burst a run publishes ahead
+of the month is paced by the lead the switch drew.
 
 ## The oracle
 
@@ -846,10 +891,12 @@ closes it on a delete, keeps two consecutive facts of equal state, size, and
 project in one interval, and drops an interval of no length. Every interval is
 then clipped to the month: a start before the period start moves to it, an open
 end or one past the period end moves to the period end, and a resource whose
-intervals all fall outside the month is left out. Every instant a month emits
-today lies inside the month, so the clip only closes the open interval of a
-resource that outlives it. The general rule is written out because the
-pre-existing resources of #88 rely on it.
+intervals all fall outside the month is left out. A month with every fault
+switch off emits no instant outside the period, so the clip there only closes
+the open interval of a resource that outlives it. The other end of the rule is
+what the `pre-existing` and the `missing-create` switches rely on: the
+transitions they move behind the period start open an interval the clip pulls
+back to it.
 
 The counts are one entry per project and Tally event type, one count per
 billable notification the collector records. The event types are the mapping's:
@@ -978,23 +1025,243 @@ in both directions: a model that prices otherwise than the run rated with is not
 the model to read an export through, whichever of the two names the dimension. A
 `counter` is outside it, because a comparison reads none of them.
 
+## The fault switches
+
+`run --faults <name>[,<name>...]` turns fault switches on, and every one of the
+six is off by default. A switch changes what the bus carries and never what the
+simulated cloud did. The oracle is folded from the generator's own facts, so it
+states the same intervals whichever switches are on; its counts are the events
+the collector has to record, and a switch that keeps a notification off the bus
+for good is the one place they move. A run with a switch on is therefore held
+against the month the cloud lived, and a difference names the resource where the
+collector's picture of it parted from the oracle's.
+
+Every switch draws from a stream of its own, seeded by the seed together with
+the switch's name. None of them draws from the stream the month's shape comes
+from, so a run with every switch off renders byte for byte what the seed, the
+period, and the cloud render on their own, and which resources one switch
+touches does not move when another switch is on beside it. `missing-create`
+draws from the `pre-existing` stream: the two exclude each other, and one stream
+between them means both pick the same instances for one seed. A run that names
+both is refused with `pre-existing and missing-create exclude each other`, and
+one that names something else with `unknown fault switch`, which lists the six.
+
+`oracle.json` states the switches the run was started with under `faults`, and
+every resource carries a `faults` member of its own naming the switches that
+touched it. `compare` reads both: a difference on a touched resource carries
+` (touched by <names>)` behind it, and the line `the month ran with the fault
+switches <names>` stands above the verdict. The verdict and the exit status are
+the ones a month with no switch on prints, so a marked difference is still a
+difference and counts as one. The mark says which switch reached the resource
+and nothing about whether the difference is the one it was turned on for; that
+is what a drill's write-up decides. A difference no mark names is a finding
+about the engine.
+
+The two pre-existing switches work on the classic tenants' instances alone, with
+the volumes and the floating address of a picked instance. The shoots and the CI
+runners are left out of them by decision: their servers are created and deleted
+inside the month, and a classic instance is the one whose life a lead of up to
+30 days moves behind the period start without changing anything else about it.
+
+### pre-existing
+
+One in three of the twelve classic instances starts before the month, between 1
+and 30 days ahead of it, and its volumes and its floating address start with it.
+Every transition of such an instance is published, the ones before the period
+start included: the virtual clock starts at the month start, so they go out in a
+burst ahead of the month's own first notification. The engine holds the whole
+history of the resource and bills it from the month start, and the oracle clips
+its intervals to that same instant, which is the rule "The oracle" states.
+
+No notification is added or dropped, so the collector's counters are the ones a
+month with no switch on shows: 1812 consumed and 13915 skipped for seed 1 over
+`2026-07`, 60 of the consumed events carrying a timestamp before the month. The
+engine writes no warning about them, and the comparison reports no difference.
+What the switch shows is a resource whose life began before the period, billed
+over the part of it the period holds.
+
+Seed 1 over `2026-07` moves 5 instances, their 8 volumes, and their 5 floating
+addresses behind the month start, 18 resources the oracle marks `pre-existing`,
+and renders 176 transitions before the period start, 60 of them billable. The
+month holds the 15727 notifications and the 1812 billable events of the month
+with the switch off.
+
+### missing-create
+
+The switch picks the same instances `pre-existing` picks, with the same leads,
+and drops every transition before the period start from the schedule and from
+the stream. The bus carries a resource whose create it never saw, and the
+collector first hears of one of them through a notification from inside the
+month. The daily `compute.instance.exists` audits stay: the audit pass runs over
+the finished schedule before the drop, so an instance whose create was dropped
+is still reported by the audit of every day it exists on.
+
+The engine warns `history_starts_without_create` once per touched resource it
+sees, which is what a deployment collects when a collector was started
+mid-month. The oracle states every touched resource with its intervals clipped
+to the month start, the way it does with `pre-existing`, and its counts drop the
+events of the notifications the bus never carried. A resource the collector
+first sees mid-month is billed from that notification on, so the comparison
+reports it as a difference, marked ` (touched by missing-create)`. No correction
+closes that gap: the notifications were never delivered, so a later run over the
+same period reads the same history. A difference the mark does not name is a
+finding about the engine.
+
+Seed 1 over `2026-07` drops the 176 pre-month transitions of the same 18
+resources, 60 of them billable: 15551 notifications instead of 15727 and 1752
+billable events instead of 1812. The collector ends the month with 1752 consumed
+and 13799 skipped.
+
+### duplicates
+
+One in 20 of the billable transitions is published a second time, byte for byte
+and under the message id of the original, ten notifications later or behind the
+last one when the month ends before the distance is walked. The copy travels the
+route its original travels and the collector maps both, so
+`tally_collector_consumed_total` counts the repeat. The Reporting API stores one
+event per (`event_id`, `timestamp`) and counts the second under
+`tally_events_deduplicated_total`, which is the deduplication a rerun of a month
+relies on as well. The export and the comparison are those of the month with the
+switch off, and the engine writes no warning.
+
+Seed 1 over `2026-07` adds 86 copies on 85 resources: 15813 notifications
+instead of 15727, with `events.jsonl` and the oracle at the same 1812 events.
+
+### reordering
+
+One in 10 of the resources with at least two billable transitions has its first
+one published directly behind its second. The timestamps do not move: what
+changes is the order the collector consumes them in, the order a requeued
+delivery or a second consumer produces. The projection and the engine sort a
+resource's history by timestamp before they fold it, so the export is the export
+of the month with the switch off, the comparison reports no difference, and no
+counter of the collector moves.
+
+Seed 1 over `2026-07` swaps the first two billable notifications of 87
+resources, in a month of the same 15727 notifications and 1812 events.
+
+### refused-shapes
+
+Per billable transition the switch draws once in 400: one draw puts an oversized
+twin behind it, two a truncated one, and twenty a versioned one, which is drawn
+for nova alone because the versioned format is nova's. A twin follows its
+original directly, on the same exchange and under a fresh message id, and the
+collector refuses all three.
+
+The versioned twin is what a nova configured for versioned notifications would
+have sent: an `instance.*` type name and the payload under `nova_object.data`,
+the format [`openstack-collector.md`](openstack-collector.md) refuses under
+"Required OpenStack service settings". `ParseEnvelope` reads it and the mapping
+table claims nothing for the type, so it is counted as skipped under its
+versioned type name. The truncated twin is an envelope whose inner
+`oslo.message` is cut in half, which the collector's second decode fails on. The
+oversized twin carries a padding member that puts its body past the 1 MiB the
+collector reads a delivery with, so it is counted before anything is parsed.
+Both of them count as unparseable. `events.jsonl`, the oracle, and the
+comparison are those of the month with the switch off, because a twin is
+billable to nobody.
+
+The `notifications.jsonl` of such a month is written like any other and cannot
+be replayed. `ReadStream` bounds a line at 1 MiB, which the oversized twin is
+past, and it runs the collector's `ParseEnvelope` over every body, which the
+truncated twin fails. Either one ends the replay before the first message goes
+out.
+
+Seed 1 over `2026-07` adds 87 twins on 84 resources, 67 versioned, 15 truncated,
+and 5 oversized: 15814 notifications instead of 15727. The collector ends the
+month with `tally_collector_unparseable_total` at 20 and three `instance.*`
+series beside the month's 83 type names, which leaves it inside the bound of 100
+label values its two type-labelled counters share.
+
+### held-back
+
+One in 20 of the billable transitions is kept off the bus and written to
+`held-back.jsonl` instead. The run publishes the rest of the month and then
+holds: `/clock` reports the hold under `holding` and its size under `held`, and
+the notifications go out when `POST /release` arrives. A run stopped while it
+holds exits 0 with the held share never published. What the switch renders is a
+late arrival, the events that reach the Reporting API after the run that bills
+the period read it.
+
+The stack publishes the month with the switch on, and a file-mode run of the
+same seed, period, and cloud writes the oracle of it, the way "The oracle"
+describes:
+
+```sh
+make simulator-up SIM_PERIOD=2026-07 SIM_FAULTS=held-back
+TALLY_SIM_CLOUD=os-sim tally-openstack-simulator run \
+  --period 2026-07 --seed 1 --faults held-back --out /tmp/m
+```
+
+The stack holds once `http://127.0.0.1:8091/clock` reports `holding` true. The
+month as the collector recorded it is metered, closed, and held against the
+oracle:
+
+```sh
+tally-engine run --period 2026-07
+tally-engine finalize --period 2026-07 --run <run id>
+tally-engine export --run <run id> --format csv --out /tmp/export
+tally-openstack-simulator compare --oracle /tmp/m/oracle.json \
+  --export /tmp/export --pricing pricing/2026-03.yaml
+```
+
+That comparison lists the held resources as differences, each marked
+` (touched by held-back)`, because the run rated the month without their
+notifications. Then the held share goes out and the closed month is corrected:
+
+```sh
+curl -X POST http://127.0.0.1:8091/release
+tally-engine detect-late --period 2026-07
+tally-engine correct --period 2026-07
+tally-engine export --run <correction id> --format csv --out /tmp/corrected
+tally-openstack-simulator compare --oracle /tmp/m/oracle.json \
+  --export /tmp/corrected --pricing pricing/2026-03.yaml
+```
+
+`detect-late` names the events the reporting database received after the run
+that bills the period read it, which are the released ones. `correct` meters the
+month again from the full history and books the difference against the finalized
+run as deltas. The comparison of its export matches the oracle over every
+resource, and the line naming the switch stands above that verdict as it stands
+above the other.
+
+The collector's counters carry the hold: 1728 consumed while the month
+publishes, 1812 once the release is through, and 13915 skipped either way. Seed
+1 over `2026-07` holds 84 notifications back on 81 resources, so
+`notifications.jsonl` has 15643 lines, `held-back.jsonl` 84, and the month books
+the 1812 events of the month with the switch off.
+
 ## The control endpoint
 
 Both subcommands serve a control endpoint on `TALLY_SIM_HTTP_ADDR` and
-`TALLY_SIM_HTTP_PORT` while they publish and no longer: pacing is the only thing
-it changes, and there is nothing to pace before the first notification or after
-the last one. It carries no credential, so what keeps it out of reach is the
-address it binds: loopback, unless a deployment names another one. In the
-compose stack it binds `0.0.0.0` inside the container, where loopback would be
-reachable from nothing, and the container's port 8080 is published on the host's
-`127.0.0.1:8091`. Within that reach the worst a caller does is make the run go
-at another speed.
+`TALLY_SIM_HTTP_PORT` while they publish and no longer: what it decides is the
+pace of the month and, for a run with the held-back switch, when the held share
+goes out. Neither of the two is what the month contains, and there is nothing to
+decide before the first notification or after the last one. It carries no
+credential, so what keeps it out of reach is the address it binds: loopback,
+unless a deployment names another one. In the compose stack it binds `0.0.0.0`
+inside the container, where loopback would be reachable from nothing, and the
+container's port 8080 is published on the host's `127.0.0.1:8091`. Within that
+reach the worst a caller does is make the run go at another speed, or end its
+hold early.
 
 `GET /healthz` answers `ok`. `GET /clock` answers the document of that moment:
 
 ```json
-{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":15727,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+{"virtual_now":"2026-07-09T14:22:00Z","factor":744,"published":52,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
 ```
+
+`held` is how many notifications the held-back switch still keeps off the bus:
+0 for a run started without it, and 0 from the moment a release let them out.
+`total` counts the regular and the held lines together, so `published` reaches
+it only once everything is out.
+
+`holding` is whether the run waits for a release, and it is the one member a
+release may be sent on. It turns true when the last regular notification is on
+the bus and false again when a release lets the held share out. `published`
+equal to `total` minus `held` is the same month a moment earlier: the count is
+raised by the notification that was confirmed, and the run enters the hold
+after it, so a release sent on the count alone can still be refused.
 
 `PUT /clock` with a body of `{"factor": N}`, where N is zero or positive,
 rebases the clock on the virtual instant it has reached and answers the same
@@ -1002,7 +1269,34 @@ document. The month itself does not move: only what comes after the change runs
 at another speed. A body that is not JSON, one without the member, and one with
 a negative factor all answer 400 with
 `factor must be a JSON object with a number member "factor" that is zero or
-positive`. Any other method on either route answers 405. A run in file mode
+positive`. A factor change a page in a browser sent answers 403 with `the factor
+does not take a request a browser sent`.
+
+`POST /release` publishes the share a run with the held-back switch kept back.
+It answers 200 with the clock document as it stood the moment before the
+release, so the document reports the published count of a month one release
+short however fast the run publishes the rest; `held` in it is 0 and `holding`
+false, the two members the release changed. The three refusals answer 409 and
+name the run they arrived at:
+
+- `nothing is held back: the run was started without the held-back switch`
+- `the month is still publishing; release once /clock reports holding true`
+- `the held-back notifications were already released`
+
+A release a page in a browser sent answers 403 with `release does not take a
+request a browser sent`, the way a factor change does. A browser puts `Origin`
+on every request a page makes whose method is neither `GET` nor `HEAD`, the
+same-origin ones included, and `Sec-Fetch-Site` alongside it, whether the page
+submitted a form, called `fetch` without a body, or reached for `sendBeacon`;
+that is what keeps a page an operator happens to visit from ending a hold or
+changing the pace. A cross-origin `PUT` is stopped a step earlier, by the
+preflight the endpoint answers 405, but a page that resolved the endpoint's
+address itself sends one same-origin, where no preflight stands in the way. A
+release with a body of another media type than `application/json` answers 415
+with `release takes application/json or no body`. `curl -X POST` and a script
+send neither header nor a content type and are unaffected.
+
+Any other method on one of the three routes answers 405. A run in file mode
 serves nothing.
 
 ## Configuration
@@ -1034,12 +1328,16 @@ reason, and `--allow-remote-broker` is the confirmation that lets one through.
 The compose stack passes it, because its broker is the container next door.
 
 `run` takes `--period` (required, `YYYY-MM`), `--seed` (1), `--factor` (744),
-`--out` (empty), `--wait-for-collector` (two minutes), and
-`--allow-remote-broker` (off). `replay` takes `--in` (required), `--factor`
-(744), `--wait-for-collector` (two minutes), and `--allow-remote-broker` (off).
-`compare` takes `--oracle`, `--export`, and `--pricing`, all three required, and
-reads no variable of the table at all: it holds three files against each other
-and touches neither a broker nor the Reporting API.
+`--out` (empty), `--wait-for-collector` (two minutes), `--faults` (empty), and
+`--allow-remote-broker` (off). `--faults` takes the six switch names
+`pre-existing`, `missing-create`, `duplicates`, `reordering`, `refused-shapes`,
+and `held-back`, comma-separated; empty is every switch off, and "The fault
+switches" describes what each of them does. `replay` takes `--in` (required),
+`--factor` (744), `--wait-for-collector` (two minutes), and
+`--allow-remote-broker` (off). `compare` takes `--oracle`, `--export`, and
+`--pricing`, all three required, and reads no variable of the table at all: it
+holds three files against each other and touches neither a broker nor the
+Reporting API.
 
 `TALLY_METRICS_ENABLED` is not read: the simulator exports no metrics, and #67
 owns the endpoint that would serve them.

--- a/internal/providers/openstack/simulator/compare.go
+++ b/internal/providers/openstack/simulator/compare.go
@@ -97,6 +97,11 @@ type Difference struct {
 	ResourceID   string
 	Detail       string
 	More         int
+	// Faults holds the fault switches that touched the oracle's resource. A
+	// difference beside its switches is one the drill's write-up explains in a
+	// line, and one without them is a finding about the engine. A resource the
+	// export books that the oracle does not hold carries none.
+	Faults []string
 }
 
 // UnpricedType is a resource type the pricing model does not price and the
@@ -128,18 +133,28 @@ type Report struct {
 	// PricingVersion is the version of the model the comparison read, so that a
 	// report says which prices the unpriced types were unpriced by.
 	PricingVersion string
+	// Faults holds the fault switches the month ran with, as its oracle states
+	// them.
+	Faults []string
 }
 
 // Lines renders the report as the lines a command prints: the differences
 // first, then the types nothing was compared for, then the records of other
-// clouds, and last the verdict. Both slices are printed in the order the
-// comparison sorted them into.
+// clouds, then the switches the month ran with, and last the verdict. Both
+// slices are printed in the order the comparison sorted them into.
+//
+// A difference on a resource a switch touched names that switch. It stays a
+// difference and counts as one: whether it is the one the switch was turned on
+// for is what the drill's write-up decides.
 func (r Report) Lines() []string {
-	lines := make([]string, 0, len(r.Differences)+len(r.Unpriced)+2)
+	lines := make([]string, 0, len(r.Differences)+len(r.Unpriced)+3)
 	for _, difference := range r.Differences {
 		line := fmt.Sprintf("%s %s: %s", difference.ResourceType, difference.ResourceID, difference.Detail)
 		if difference.More > 0 {
 			line += fmt.Sprintf(" (and %d more)", difference.More)
+		}
+		if len(difference.Faults) > 0 {
+			line += fmt.Sprintf(" (touched by %s)", strings.Join(sortedFaultNames(difference.Faults), ", "))
 		}
 		lines = append(lines, line)
 	}
@@ -150,6 +165,10 @@ func (r Report) Lines() []string {
 	}
 	if r.Skipped > 0 {
 		lines = append(lines, fmt.Sprintf("skipped %d rated records of other clouds or platforms", r.Skipped))
+	}
+	if len(r.Faults) > 0 {
+		lines = append(lines, "the month ran with the fault switches "+
+			strings.Join(sortedFaultNames(r.Faults), ", "))
 	}
 	if len(r.Differences) == 0 {
 		return append(lines, fmt.Sprintf("the export matches the oracle over %d resources", r.Compared))
@@ -389,7 +408,7 @@ func (f found) note(key resourceKey, format string, args ...any) {
 // turn every resource of the month into a difference, and a report of that is
 // not a finding about the engine.
 func compare(oracle Oracle, rows []ratedRow, model pricing.Model) (Report, error) {
-	report := Report{PricingVersion: model.Version}
+	report := Report{PricingVersion: model.Version, Faults: oracle.Faults}
 
 	kept := make([]ratedRow, 0, len(rows))
 	for _, row := range rows {
@@ -462,11 +481,11 @@ func compare(oracle Oracle, rows []ratedRow, model pricing.Model) (Report, error
 
 	differences := make(found)
 	unpriced := make(map[string]int)
-	stated := make(map[resourceKey]bool, len(oracle.Resources))
+	faultsOf := make(map[resourceKey][]string, len(oracle.Resources))
 
 	for _, resource := range oracle.Resources {
 		key := resourceKey{resourceType: resource.ResourceType, resourceID: resource.ResourceID}
-		stated[key] = true
+		faultsOf[key] = resource.Faults
 
 		entry, ok := entries[resource.ResourceType]
 		if !ok {
@@ -492,7 +511,7 @@ func compare(oracle Oracle, rows []ratedRow, model pricing.Model) (Report, error
 	}
 
 	for key := range exported {
-		if stated[key] {
+		if _, ok := faultsOf[key]; ok {
 			continue
 		}
 		report.Compared++
@@ -505,6 +524,7 @@ func compare(oracle Oracle, rows []ratedRow, model pricing.Model) (Report, error
 			ResourceID:   key.resourceID,
 			Detail:       details[0],
 			More:         len(details) - 1,
+			Faults:       faultsOf[key],
 		})
 	}
 	slices.SortFunc(report.Differences, func(a, b Difference) int {

--- a/internal/providers/openstack/simulator/compare_test.go
+++ b/internal/providers/openstack/simulator/compare_test.go
@@ -454,7 +454,7 @@ func pricedResources(oracle Oracle, model pricing.Model) (priced int, unpriced m
 // billed the way it was meant to be.
 func TestCompareAcceptsWhatTheEngineRates(t *testing.T) {
 	to := july2026.AddDate(0, 1, 0)
-	month, err := GenerateMonth(1, july2026, to, testCloud)
+	month, err := GenerateMonth(1, july2026, to, testCloud, Faults{})
 	if err != nil {
 		t.Fatalf("GenerateMonth(1, %s, %q) error = %v, want nil", july2026.Format(time.RFC3339), testCloud, err)
 	}

--- a/internal/providers/openstack/simulator/compare_test.go
+++ b/internal/providers/openstack/simulator/compare_test.go
@@ -433,6 +433,27 @@ func reported(report Report) string {
 	return strings.Join(lines, "\n")
 }
 
+// sameDifference reports whether two differences say the same thing about one
+// resource. The switches are held by value, where a difference that names none
+// and one whose list is empty are the same finding.
+func sameDifference(a, b Difference) bool {
+	return a.ResourceType == b.ResourceType && a.ResourceID == b.ResourceID &&
+		a.Detail == b.Detail && a.More == b.More && slices.Equal(a.Faults, b.Faults)
+}
+
+// differenceOf is the report's difference about one resource, or a failed test.
+func differenceOf(t *testing.T, report Report, id string) Difference {
+	t.Helper()
+
+	for _, difference := range report.Differences {
+		if difference.ResourceID == id {
+			return difference
+		}
+	}
+	t.Fatalf("the report holds no difference about %s:\n%s", id, reported(report))
+	return Difference{}
+}
+
 // pricedResources counts the oracle's resources the model prices and the ones
 // it does not, per type.
 func pricedResources(oracle Oracle, model pricing.Model) (priced int, unpriced map[string]int) {
@@ -732,7 +753,7 @@ func TestCompareReportsEveryKindOfDifference(t *testing.T) {
 			if len(report.Differences) != 1 {
 				t.Fatalf("Compare() differences = %d, want one:\n%s", len(report.Differences), reported(report))
 			}
-			if report.Differences[0] != tc.want {
+			if !sameDifference(report.Differences[0], tc.want) {
 				t.Errorf("Compare() difference = %+v, want %+v", report.Differences[0], tc.want)
 			}
 
@@ -760,6 +781,131 @@ func TestCompareReportsEveryKindOfDifference(t *testing.T) {
 				tc.want.Detail, suffix)
 			if lines[0] != wantFirst {
 				t.Errorf("the first line = %q, want %q", lines[0], wantFirst)
+			}
+		})
+	}
+}
+
+// TestCompareCopiesTheFaultsOntoADifference holds the switches a report
+// carries: the ones the month ran with, and the ones that touched the resource
+// a difference is about. A difference beside its switches is one the drill's
+// write-up explains in a line, and one without them is a finding about the
+// engine.
+func TestCompareCopiesTheFaultsOntoADifference(t *testing.T) {
+	oracle := oracleOf(t)
+	// Stated by hand, because no switch touches a resource of a generated month
+	// yet. The order is the document's rather than FaultNames', which is what a
+	// report keeps and its lines sort.
+	oracle.Faults = []string{FaultHeldBack, FaultDuplicates}
+	touched := pickResource(t, oracle, "volume", 1, "")
+	for i := range oracle.Resources {
+		if oracle.Resources[i].ResourceID == touched.ResourceID {
+			oracle.Resources[i].Faults = []string{FaultMissingCreate}
+		}
+	}
+	instance := pickResource(t, oracle, "instance", 1, stateActive)
+	rows := ratedOf(t, oracle, parseModel(t, testModel))
+
+	t.Run("an export that differs on both sides", func(t *testing.T) {
+		const unknownID = "22222222-2222-2222-2222-222222222222"
+		mutated := copyRows(dropRows(rows, rowsOf(touched.ResourceID)), rowsOf(instance.ResourceID),
+			func(row []string) { row[columnResourceID] = unknownID })
+
+		report := compareRows(t, oracle, mutated, testModel)
+		if len(report.Differences) != 2 {
+			t.Fatalf("Compare() differences = %d, want two:\n%s", len(report.Differences), reported(report))
+		}
+
+		missing := differenceOf(t, report, touched.ResourceID)
+		if want := []string{FaultMissingCreate}; !slices.Equal(missing.Faults, want) {
+			t.Errorf("the difference about %s names the switches %v, want %v",
+				touched.ResourceID, missing.Faults, want)
+		}
+		if invented := differenceOf(t, report, unknownID); len(invented.Faults) != 0 {
+			t.Errorf("the difference about the resource the oracle does not hold names the switches %v, "+
+				"want none", invented.Faults)
+		}
+		if !slices.Equal(report.Faults, oracle.Faults) {
+			t.Errorf("Compare() faults = %v, want the oracle's %v", report.Faults, oracle.Faults)
+		}
+	})
+
+	t.Run("an export the oracle matches", func(t *testing.T) {
+		report := compareRows(t, oracle, rows, testModel)
+		if len(report.Differences) != 0 {
+			t.Errorf("Compare() differences = %d, want none:\n%s", len(report.Differences), reported(report))
+		}
+		line := "the month ran with the fault switches duplicates, held-back"
+		if lines := report.Lines(); !slices.Contains(lines, line) {
+			t.Errorf("Lines() = %v, want a line %q", lines, line)
+		}
+	})
+}
+
+// TestReportLinesNameTheFaultSwitches renders the reports a month with switches
+// on produces. A switch is named on the line of the resource it touched and
+// once for the month, and neither changes the verdict: whether a difference is
+// the one a switch was turned on for is what the drill's write-up decides.
+func TestReportLinesNameTheFaultSwitches(t *testing.T) {
+	const id = "1c38e4d1-42db-4271-bd32-9653e80a3603"
+	const detail = "missing from the export"
+
+	for _, tc := range []struct {
+		name   string
+		report Report
+		want   []string
+	}{
+		{
+			name: "a difference on a resource a switch touched",
+			report: Report{
+				Compared: 4,
+				Differences: []Difference{{
+					ResourceType: "instance", ResourceID: id,
+					Detail: detail, Faults: []string{FaultMissingCreate},
+				}},
+			},
+			want: []string{
+				"instance " + id + ": missing from the export (touched by missing-create)",
+				"1 of 4 resources differ from the oracle",
+			},
+		},
+		{
+			name: "a difference that carries further ones",
+			report: Report{
+				Compared: 4,
+				Differences: []Difference{{
+					ResourceType: "instance", ResourceID: id,
+					Detail: detail, More: 3, Faults: []string{FaultMissingCreate},
+				}},
+			},
+			want: []string{
+				"instance " + id + ": missing from the export (and 3 more) (touched by missing-create)",
+				"1 of 4 resources differ from the oracle",
+			},
+		},
+		{
+			name:   "the switches the month ran with",
+			report: Report{Compared: 4, Faults: []string{FaultHeldBack, FaultDuplicates}},
+			want: []string{
+				"the month ran with the fault switches duplicates, held-back",
+				"the export matches the oracle over 4 resources",
+			},
+		},
+		{
+			name: "a month no switch ran with",
+			report: Report{
+				Compared:    4,
+				Differences: []Difference{{ResourceType: "instance", ResourceID: id, Detail: detail}},
+			},
+			want: []string{
+				"instance " + id + ": missing from the export",
+				"1 of 4 resources differ from the oracle",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if lines := tc.report.Lines(); !slices.Equal(lines, tc.want) {
+				t.Errorf("Lines() = %v, want %v", lines, tc.want)
 			}
 		})
 	}

--- a/internal/providers/openstack/simulator/control.go
+++ b/internal/providers/openstack/simulator/control.go
@@ -2,9 +2,12 @@ package simulator
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -22,6 +25,16 @@ type Progress struct {
 	// in the whole month.
 	Published int
 	Total     int
+	// Held is how many notifications the held-back switch still keeps off the
+	// bus. It is 0 for a run without the switch, and 0 once a release let them
+	// out.
+	Held int
+	// Holding is whether the run waits for a release: true from the moment the
+	// last regular notification is on the bus until a release lets the held share
+	// out. It is the one signal a caller may poll before releasing, because it is
+	// the very state a release acts on, while the counts reach their hold values
+	// a moment before the run enters the hold.
+	Holding bool
 }
 
 // clockDocument is what /clock answers. The instants are RFC 3339 in UTC
@@ -32,6 +45,8 @@ type clockDocument struct {
 	Factor     float64 `json:"factor"`
 	Published  int     `json:"published"`
 	Total      int     `json:"total"`
+	Held       int     `json:"held"`
+	Holding    bool    `json:"holding"`
 	PeriodFrom string  `json:"period_from"`
 	PeriodTo   string  `json:"period_to"`
 }
@@ -42,25 +57,131 @@ type clockDocument struct {
 // three.
 const badFactorBody = `factor must be a JSON object with a number member "factor" that is zero or positive`
 
+// badReleaseOrigin is what a release a browser sent is refused with, and
+// badFactorOrigin a factor change. Both are the answer fromBrowser gives, and
+// each names what it refused, so a caller reads which of the two requests was
+// turned away.
+const (
+	badReleaseOrigin = "release does not take a request a browser sent"
+	badFactorOrigin  = "the factor does not take a request a browser sent"
+)
+
+// badReleaseType is what a POST /release with a body of another media type is
+// refused with. It is the second of the two guards: what a page sent is already
+// refused by its Origin, and a request without one is held to a body a script
+// meant to send. curl -X POST sends no content type and is unaffected.
+const badReleaseType = "release takes application/json or no body"
+
 // factorBodyMax bounds the body of PUT /clock. The request carries one number,
 // so a kilobyte is far more than it needs, and the bound keeps the endpoint
 // from reading whatever an unauthenticated caller sends.
 const factorBodyMax = 1 << 10
 
+// The three refusals POST /release answers with. Each of them names the run it
+// arrived at, because what a caller does about a release is different in all
+// three: turn the switch on, wait, or nothing.
+var (
+	errNothingHeld     = errors.New("nothing is held back: the run was started without the held-back switch")
+	errStillPublishing = errors.New(
+		"the month is still publishing; release once /clock reports holding true")
+	errAlreadyReleased = errors.New("the held-back notifications were already released")
+)
+
+// The phases a holdback runs through. A run is publishing while the regular
+// notifications go out, holding once the last of them is on the bus, and
+// released from the moment a caller asked for the rest.
+const (
+	phasePublishing int32 = iota
+	phaseHolding
+	phaseReleased
+)
+
+// holdback is what a run with the held-back switch keeps off the bus and the
+// one thing POST /release changes. The handler calls release while broadcast
+// waits on the released channel, so the answer to the request is written before
+// the held notifications go out.
+type holdback struct {
+	// count is how many notifications the run holds back, fixed when the run
+	// starts.
+	count int
+	// phase is one of the three constants above, read and written from the
+	// handler's goroutine and the publishing one.
+	phase atomic.Int32
+	// released is closed by the release that succeeds, which is what wakes the
+	// run holding on it.
+	released chan struct{}
+}
+
+// newHoldback holds count notifications back. A count of 0 is a run without the
+// switch, which refuses every release.
+func newHoldback(count int) *holdback {
+	return &holdback{count: count, released: make(chan struct{})}
+}
+
+// release lets the held notifications out, or reports why it cannot. The swap
+// is what makes the first release the only one: a second caller finds the phase
+// already moved on and closes nothing.
+func (h *holdback) release() error {
+	if h.count == 0 {
+		return errNothingHeld
+	}
+	if h.phase.CompareAndSwap(phaseHolding, phaseReleased) {
+		close(h.released)
+		return nil
+	}
+	if h.phase.Load() == phaseReleased {
+		return errAlreadyReleased
+	}
+	return errStillPublishing
+}
+
+// holding is whether a release would be granted: the run has put the last
+// regular notification on the bus and waits for one. It reads the very field
+// release swaps, so a caller that saw it true is not refused by the release it
+// sends next; the published count reaches its hold value a moment earlier and
+// is no signal to release on.
+func (h *holdback) holding() bool {
+	return h.phase.Load() == phaseHolding
+}
+
+// held is how many notifications are still off the bus, which is none once they
+// were released.
+func (h *holdback) held() int {
+	if h.phase.Load() == phaseReleased {
+		return 0
+	}
+	return h.count
+}
+
 // NewControlMux builds the routes the simulator serves while it publishes:
-// /healthz for the compose health check, and /clock to read and change how fast
-// the simulated month runs.
+// /healthz for the compose health check, /clock to read and change how fast the
+// simulated month runs, and /release to let out the notifications a run with
+// the held-back switch keeps back.
 //
-// The endpoint changes pacing and nothing else. It cannot alter the month, the
-// notifications, or where they go, which is why it carries no credential. What
-// keeps it from answering anybody is where it is bound: TALLY_SIM_HTTP_ADDR is
-// loopback unless a deployment says otherwise, and the compose stack publishes
-// its port on 127.0.0.1. Within that reach the worst a caller does is make
-// somebody's demo run at a different speed.
+// The endpoint changes when the month goes out and nothing else. It cannot
+// alter the month, the notifications, or where they go, which is why it carries
+// no credential: a release publishes the very notifications the run generated,
+// each under the timestamp it always carried. What keeps it from answering
+// anybody is where it is bound: TALLY_SIM_HTTP_ADDR is loopback unless a
+// deployment says otherwise, and the compose stack publishes its port on
+// 127.0.0.1. Within that reach the worst a caller does is make somebody's demo
+// run at a different speed, or end its hold early. What a page in a browser
+// could send there unasked is refused a step earlier: a request a page makes
+// carries Origin however the page sent it, and one that carries it answers 403
+// on both routes that change something, without reaching the clock or the hold.
+// Beyond that a release takes a JSON body or none, and a form-encoded one
+// answers 415.
+//
+// A nil release is a run that holds nothing back, and every request to /release
+// is refused as one.
 //
 // It takes no logger because the command sets the default one, and the only
-// line it writes is the factor change.
-func NewControlMux(clock *Clock, progress func() Progress) *http.ServeMux {
+// lines it writes are the factor change and the release.
+func NewControlMux(clock *Clock, progress func() Progress, release func() error) *http.ServeMux {
+	if release == nil {
+		release = func() error { return errNothingHeld }
+	}
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -72,6 +193,10 @@ func NewControlMux(clock *Clock, progress func() Progress) *http.ServeMux {
 	})
 
 	mux.HandleFunc("PUT /clock", func(w http.ResponseWriter, r *http.Request) {
+		if fromBrowser(r) {
+			writeText(w, http.StatusForbidden, badFactorOrigin)
+			return
+		}
 		var body struct {
 			// The pointer is what tells a missing member from a factor of 0, and 0
 			// is a value the clock accepts: it stops virtual time and lets the run
@@ -95,7 +220,50 @@ func NewControlMux(clock *Clock, progress func() Progress) *http.ServeMux {
 		writeDocument(w, document(clock, progress))
 	})
 
+	mux.HandleFunc("POST /release", func(w http.ResponseWriter, r *http.Request) {
+		if fromBrowser(r) {
+			writeText(w, http.StatusForbidden, badReleaseOrigin)
+			return
+		}
+		if contentType := r.Header.Get("Content-Type"); contentType != "" &&
+			!strings.HasPrefix(contentType, "application/json") {
+			writeText(w, http.StatusUnsupportedMediaType, badReleaseType)
+			return
+		}
+		// The document is read before the release rather than after it, because a
+		// release wakes the run at once: read afterwards, the published count would
+		// lie somewhere between the month before the release and the month after
+		// it, at a different place on every run.
+		doc := document(clock, progress)
+		if err := release(); err != nil {
+			writeText(w, http.StatusConflict, err.Error())
+			return
+		}
+
+		slog.Info("the held-back notifications were released")
+		// What the answer reports is the month one release short, and the release
+		// this request granted: the two members the release changed are stated as
+		// it left them rather than as they stood a line earlier.
+		doc.Held = 0
+		doc.Holding = false
+		writeDocument(w, doc)
+	})
+
 	return mux
+}
+
+// fromBrowser is whether a page in a browser sent the request. A browser
+// appends Origin to every request whose method is neither GET nor HEAD, the
+// same-origin ones included, and Sec-Fetch-Site alongside it, whatever mode the
+// page used and whatever content type it managed to set. That is what both
+// routes that change a run are guarded with: a form submit is stopped by its
+// content type already, while a bodyless fetch sets none of its own and needs
+// no preflight. A cross-origin PUT is stopped a step earlier, by the preflight
+// the mux answers 405, but a page that resolved the endpoint's address itself
+// sends one same-origin, where no preflight stands in the way either. curl and
+// a script send neither header and are unaffected.
+func fromBrowser(r *http.Request) bool {
+	return r.Header.Get("Origin") != "" || r.Header.Get("Sec-Fetch-Site") != ""
 }
 
 // document reads the state both /clock routes answer with. The clock and the
@@ -108,6 +276,8 @@ func document(clock *Clock, progress func() Progress) clockDocument {
 		Factor:     clock.Factor(),
 		Published:  p.Published,
 		Total:      p.Total,
+		Held:       p.Held,
+		Holding:    p.Holding,
 		PeriodFrom: instant(p.From),
 		PeriodTo:   instant(p.To),
 	}
@@ -129,7 +299,7 @@ func writeText(w http.ResponseWriter, status int, body string) {
 
 // writeDocument answers with the clock document. The encoding is done before
 // the status is written so that a failure can still be reported as one, though
-// with two strings, a float, and two ints there is nothing here that fails to
+// with two strings, a float, and three ints there is nothing here that fails to
 // marshal.
 func writeDocument(w http.ResponseWriter, doc clockDocument) {
 	encoded, err := json.Marshal(doc)

--- a/internal/providers/openstack/simulator/control_test.go
+++ b/internal/providers/openstack/simulator/control_test.go
@@ -2,10 +2,12 @@ package simulator
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -18,18 +20,21 @@ var controlProgress = Progress{
 	To:        time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
 	Published: 12,
 	Total:     231,
+	Held:      7,
+	Holding:   true,
 }
 
 // controlServer serves the endpoint over a clock whose wall time is frozen, so
 // the virtual now the document reports is the month's first instant however
 // long the test takes. The clock comes back with the server because what a
-// request did to the factor is asserted on it.
-func controlServer(t *testing.T) (*Clock, *httptest.Server) {
+// request did to the factor is asserted on it. release is what POST /release
+// calls, and a nil one is a run that holds nothing back.
+func controlServer(t *testing.T, release func() error) (*Clock, *httptest.Server) {
 	t.Helper()
 
 	wall := time.Unix(0, 0)
 	clock := NewClock(clockStart, 744, func() time.Time { return wall })
-	server := httptest.NewServer(NewControlMux(clock, func() Progress { return controlProgress }))
+	server := httptest.NewServer(NewControlMux(clock, func() Progress { return controlProgress }, release))
 	t.Cleanup(server.Close)
 	return clock, server
 }
@@ -39,9 +44,31 @@ func controlServer(t *testing.T) (*Clock, *httptest.Server) {
 func request(t *testing.T, server *httptest.Server, method, path, body string) (int, string, string) {
 	t.Helper()
 
+	return requestWithType(t, server, method, path, "", body)
+}
+
+// requestWithType sends one request under a content type of its own. An empty
+// one sends none, the way curl sends none for a request without a body.
+func requestWithType(t *testing.T, server *httptest.Server, method, path, contentType, body string,
+) (int, string, string) {
+	t.Helper()
+
+	return requestWithHeader(t, server, method, path, "Content-Type", contentType, body)
+}
+
+// requestWithHeader sends one request carrying a header of its own, which is
+// how a case sends what a browser puts on a request a page makes. An empty
+// value sends the header not at all.
+func requestWithHeader(t *testing.T, server *httptest.Server, method, path, header, value, body string,
+) (int, string, string) {
+	t.Helper()
+
 	req, err := http.NewRequestWithContext(t.Context(), method, server.URL+path, strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("building %s %s: %v", method, path, err)
+	}
+	if value != "" {
+		req.Header.Set(header, value)
 	}
 	resp, err := server.Client().Do(req)
 	if err != nil {
@@ -68,7 +95,7 @@ func decodeDocument(t *testing.T, body string) clockDocument {
 }
 
 func TestClockEndpointReportsTheState(t *testing.T) {
-	_, server := controlServer(t)
+	_, server := controlServer(t, nil)
 
 	status, contentType, body := request(t, server, http.MethodGet, "/clock", "")
 	if status != http.StatusOK {
@@ -84,6 +111,8 @@ func TestClockEndpointReportsTheState(t *testing.T) {
 		Factor:     744,
 		Published:  12,
 		Total:      231,
+		Held:       7,
+		Holding:    true,
 		PeriodFrom: "2026-07-01T00:00:00Z",
 		PeriodTo:   "2026-08-01T00:00:00Z",
 	}
@@ -107,7 +136,7 @@ func TestClockEndpointReportsTheState(t *testing.T) {
 // value a missing member would otherwise be taken for, and the one an operator
 // reaches for to let a run finish as fast as the broker takes it.
 func TestClockEndpointSetsTheFactor(t *testing.T) {
-	clock, server := controlServer(t)
+	clock, server := controlServer(t, nil)
 
 	status, _, body := request(t, server, http.MethodPut, "/clock", `{"factor": 0}`)
 	if status != http.StatusOK {
@@ -142,7 +171,7 @@ func TestClockEndpointRefusesABadBody(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			clock, server := controlServer(t)
+			clock, server := controlServer(t, nil)
 
 			status, contentType, body := request(t, server, http.MethodPut, "/clock", c.body)
 			if status != http.StatusBadRequest {
@@ -164,11 +193,51 @@ func TestClockEndpointRefusesABadBody(t *testing.T) {
 	}
 }
 
+// TestClockEndpointRefusesARequestABrowserSent covers the guard the release
+// carries too. A cross-origin PUT is stopped by the preflight the mux answers
+// 405, but a page that resolved the endpoint's address itself sends one
+// same-origin, where no preflight stands in the way and the browser still
+// appends the two headers this refuses on.
+func TestClockEndpointRefusesARequestABrowserSent(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "a page's own Origin", header: "Origin", value: "http://127.0.0.1:8091"},
+		{name: "the mark the browser put on it", header: "Sec-Fetch-Site", value: "same-origin"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clock, server := controlServer(t, nil)
+
+			status, contentType, body := requestWithHeader(t, server, http.MethodPut, "/clock",
+				c.header, c.value, `{"factor": 0}`)
+			if status != http.StatusForbidden {
+				t.Fatalf("PUT /clock from a page = %d, want %d (body %q)",
+					status, http.StatusForbidden, body)
+			}
+			if !strings.HasPrefix(contentType, "text/plain") {
+				t.Errorf("PUT /clock Content-Type = %q, want it to start with text/plain", contentType)
+			}
+			if body != badFactorOrigin {
+				t.Errorf("PUT /clock body = %q, want %q", body, badFactorOrigin)
+			}
+			// The refusal leaves the run at the pace it was started with rather
+			// than at the one the page asked for.
+			if got := clock.Factor(); got != 744 {
+				t.Errorf("Factor() after the refusal = %g, want 744", got)
+			}
+		})
+	}
+}
+
 // TestClockEndpointRefusesOtherMethods holds the routes to the method they were
 // registered with: the mux answers 405 itself, so neither handler ever sees a
 // request it was not written for.
 func TestClockEndpointRefusesOtherMethods(t *testing.T) {
-	_, server := controlServer(t)
+	_, server := controlServer(t, nil)
 
 	status, _, body := request(t, server, http.MethodPost, "/clock", `{"factor": 1}`)
 	if status != http.StatusMethodNotAllowed {
@@ -178,6 +247,253 @@ func TestClockEndpointRefusesOtherMethods(t *testing.T) {
 	status, _, body = request(t, server, http.MethodDelete, "/healthz", "")
 	if status != http.StatusMethodNotAllowed {
 		t.Errorf("DELETE /healthz = %d, want %d (body %q)", status, http.StatusMethodNotAllowed, body)
+	}
+}
+
+// TestHoldbackReleasesOnce covers the three answers a release gets and the one
+// state change it makes: the first release closes the channel broadcast waits
+// on, and every release after it finds nothing left to let out.
+func TestHoldbackReleasesOnce(t *testing.T) {
+	if err := newHoldback(0).release(); !errors.Is(err, errNothingHeld) {
+		t.Errorf("release() on a run holding nothing = %v, want %v", err, errNothingHeld)
+	}
+
+	hb := newHoldback(3)
+	if err := hb.release(); !errors.Is(err, errStillPublishing) {
+		t.Errorf("release() while the month publishes = %v, want %v", err, errStillPublishing)
+	}
+	if got := hb.held(); got != 3 {
+		t.Errorf("held() while the month publishes = %d, want 3", got)
+	}
+
+	hb.phase.Store(phaseHolding)
+	if err := hb.release(); err != nil {
+		t.Fatalf("release() while holding = %v, want nil", err)
+	}
+	if got := hb.held(); got != 0 {
+		t.Errorf("held() after the release = %d, want 0", got)
+	}
+	select {
+	case <-hb.released:
+	default:
+		t.Error("the released channel is open after the release, want it closed: it is what the run waits on")
+	}
+
+	if err := hb.release(); !errors.Is(err, errAlreadyReleased) {
+		t.Errorf("a second release() = %v, want %v", err, errAlreadyReleased)
+	}
+}
+
+// TestReleaseEndpointAnswersEachRefusal holds the endpoint to what it says
+// about a release it cannot grant. Each refusal is the whole answer, because
+// what the caller does about it is read off that one line.
+func TestReleaseEndpointAnswersEachRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"a run started without the switch", errNothingHeld},
+		{"a month that is still publishing", errStillPublishing},
+		{"a release that already happened", errAlreadyReleased},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, server := controlServer(t, func() error { return tc.err })
+
+			status, contentType, body := request(t, server, http.MethodPost, "/release", "")
+			if status != http.StatusConflict {
+				t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusConflict, body)
+			}
+			if want := "text/plain; charset=utf-8"; contentType != want {
+				t.Errorf("POST /release Content-Type = %q, want %q", contentType, want)
+			}
+			if body != tc.err.Error() {
+				t.Errorf("POST /release body = %q, want %q", body, tc.err.Error())
+			}
+		})
+	}
+
+	t.Run("a run holding notifications back", func(t *testing.T) {
+		_, server := controlServer(t, func() error { return nil })
+
+		status, contentType, body := request(t, server, http.MethodPost, "/release", "")
+		if status != http.StatusOK {
+			t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusOK, body)
+		}
+		if !strings.HasPrefix(contentType, "application/json") {
+			t.Errorf("POST /release Content-Type = %q, want it to start with application/json", contentType)
+		}
+		if got := decodeDocument(t, body).Total; got != controlProgress.Total {
+			t.Errorf("POST /release document total = %d, want %d", got, controlProgress.Total)
+		}
+	})
+
+	t.Run("a body a page in a browser could send unasked", func(t *testing.T) {
+		_, server := controlServer(t, func() error {
+			t.Error("the release ran, want the content type to have refused the request first")
+			return nil
+		})
+
+		status, contentType, body := requestWithType(t, server, http.MethodPost, "/release",
+			"application/x-www-form-urlencoded", "release=1")
+		if status != http.StatusUnsupportedMediaType {
+			t.Fatalf("POST /release as a form = %d, want %d (body %q)",
+				status, http.StatusUnsupportedMediaType, body)
+		}
+		if !strings.HasPrefix(contentType, "text/plain") {
+			t.Errorf("POST /release Content-Type = %q, want it to start with text/plain", contentType)
+		}
+		if body != badReleaseType {
+			t.Errorf("POST /release body = %q, want %q", body, badReleaseType)
+		}
+	})
+
+	t.Run("a bodyless request a page in a browser could send unasked", func(t *testing.T) {
+		_, server := controlServer(t, func() error {
+			t.Error("the release ran, want the Origin to have refused the request first")
+			return nil
+		})
+
+		// A fetch without a body sends no content type at all, and needs no
+		// preflight to reach loopback. What is left of it to refuse is the Origin
+		// the browser put on it.
+		status, contentType, body := requestWithHeader(t, server, http.MethodPost, "/release",
+			"Origin", "https://example.invalid", "")
+		if status != http.StatusForbidden {
+			t.Fatalf("POST /release from a page = %d, want %d (body %q)",
+				status, http.StatusForbidden, body)
+		}
+		if !strings.HasPrefix(contentType, "text/plain") {
+			t.Errorf("POST /release Content-Type = %q, want it to start with text/plain", contentType)
+		}
+		if body != badReleaseOrigin {
+			t.Errorf("POST /release body = %q, want %q", body, badReleaseOrigin)
+		}
+	})
+
+	t.Run("a request a browser marked with Sec-Fetch-Site", func(t *testing.T) {
+		_, server := controlServer(t, func() error {
+			t.Error("the release ran, want Sec-Fetch-Site to have refused the request first")
+			return nil
+		})
+
+		status, _, body := requestWithHeader(t, server, http.MethodPost, "/release",
+			"Sec-Fetch-Site", "cross-site", "")
+		if status != http.StatusForbidden {
+			t.Fatalf("POST /release from a page = %d, want %d (body %q)",
+				status, http.StatusForbidden, body)
+		}
+		if body != badReleaseOrigin {
+			t.Errorf("POST /release body = %q, want %q", body, badReleaseOrigin)
+		}
+	})
+
+	t.Run("a JSON body a script sent on purpose", func(t *testing.T) {
+		_, server := controlServer(t, func() error { return nil })
+
+		status, _, body := requestWithType(t, server, http.MethodPost, "/release",
+			"application/json", "{}")
+		if status != http.StatusOK {
+			t.Fatalf("POST /release as JSON = %d, want %d (body %q)", status, http.StatusOK, body)
+		}
+	})
+
+	t.Run("a method the route was not registered with", func(t *testing.T) {
+		_, server := controlServer(t, func() error { return nil })
+
+		status, _, body := request(t, server, http.MethodGet, "/release", "")
+		if status != http.StatusMethodNotAllowed {
+			t.Errorf("GET /release = %d, want %d (body %q)", status, http.StatusMethodNotAllowed, body)
+		}
+	})
+
+	t.Run("a mux built without a release", func(t *testing.T) {
+		_, server := controlServer(t, nil)
+
+		status, _, body := request(t, server, http.MethodPost, "/release", "")
+		if status != http.StatusConflict {
+			t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusConflict, body)
+		}
+		if body != errNothingHeld.Error() {
+			t.Errorf("POST /release body = %q, want %q", body, errNothingHeld.Error())
+		}
+	})
+}
+
+// TestReleaseFollowsTheHoldingTheDocumentReports ties the document a caller
+// polls to the release it sends next. The counts reach their hold values while
+// the run is still on its way into the hold, so holding is the one member a
+// script may act on, and the document the release answers with is the month one
+// release short however fast the run publishes the rest.
+func TestReleaseFollowsTheHoldingTheDocumentReports(t *testing.T) {
+	const total, held = 231, 7
+
+	hb := newHoldback(held)
+	var published atomic.Int64
+	// The last regular notification is on the bus: the count says so before the
+	// run has entered the hold, which is where a caller polling on it is refused.
+	published.Store(total - held)
+
+	wall := time.Unix(0, 0)
+	clock := NewClock(clockStart, 744, func() time.Time { return wall })
+	progress := func() Progress {
+		return Progress{
+			From: clockStart, To: controlProgress.To,
+			Published: int(published.Load()), Total: total,
+			Held: hb.held(), Holding: hb.holding(),
+		}
+	}
+	// A run at factor 0 publishes the held share as fast as the broker confirms
+	// it, which is what a document read after the release would count.
+	release := func() error {
+		err := hb.release()
+		if err == nil {
+			published.Add(held)
+		}
+		return err
+	}
+	server := httptest.NewServer(NewControlMux(clock, progress, release))
+	t.Cleanup(server.Close)
+
+	status, _, body := request(t, server, http.MethodGet, "/clock", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if doc := decodeDocument(t, body); doc.Holding {
+		t.Errorf("GET /clock holding = true with %d of %d published, want false: "+
+			"the run has not entered the hold", doc.Published, doc.Total)
+	}
+	status, _, body = request(t, server, http.MethodPost, "/release", "")
+	if status != http.StatusConflict {
+		t.Fatalf("POST /release before the hold = %d, want %d (body %q)",
+			status, http.StatusConflict, body)
+	}
+
+	// What broadcast does once the last regular line is confirmed.
+	hb.phase.Store(phaseHolding)
+
+	status, _, body = request(t, server, http.MethodGet, "/clock", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if doc := decodeDocument(t, body); !doc.Holding {
+		t.Fatal("GET /clock holding = false while the run holds, want true: " +
+			"it is the signal a release is sent on")
+	}
+
+	status, _, body = request(t, server, http.MethodPost, "/release", "")
+	if status != http.StatusOK {
+		t.Fatalf("POST /release on a reported hold = %d, want %d (body %q)",
+			status, http.StatusOK, body)
+	}
+	doc := decodeDocument(t, body)
+	if doc.Published != total-held {
+		t.Errorf("POST /release document published = %d, want %d: the answer states the month "+
+			"one release short, not however far the release got before it was written",
+			doc.Published, total-held)
+	}
+	if doc.Held != 0 || doc.Holding {
+		t.Errorf("POST /release document held = %d, holding = %t, want 0 and false",
+			doc.Held, doc.Holding)
 	}
 }
 

--- a/internal/providers/openstack/simulator/faults.go
+++ b/internal/providers/openstack/simulator/faults.go
@@ -172,3 +172,15 @@ func (t touchedResources) names(key resourceKey) []string {
 func (g *generator) touch(resourceType, resourceID, fault string) {
 	g.touched.add(resourceKey{resourceType: resourceType, resourceID: resourceID}, fault)
 }
+
+// What the two pre-existing switches draw: one in preExistingShare of the
+// classic tenants' instances starts before the month, between
+// preExistingLeadMin and preExistingLeadMax before it begins.
+//
+// The share is a package constant rather than a flag, because a drill wants a
+// known effect it can reproduce and not one it dials in.
+const (
+	preExistingShare   = 3
+	preExistingLeadMin = day
+	preExistingLeadMax = 30 * day
+)

--- a/internal/providers/openstack/simulator/faults.go
+++ b/internal/providers/openstack/simulator/faults.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"math/rand/v2"
 	"slices"
 	"strings"
@@ -184,3 +185,308 @@ const (
 	preExistingLeadMin = day
 	preExistingLeadMax = 30 * day
 )
+
+// What the four switches that change the publication stream draw. The shares
+// are package constants rather than flags, for the reason the pre-existing
+// share is one: a drill wants a known effect it can reproduce.
+const (
+	// heldBackShare is what is held back: one in 20 billable transitions.
+	heldBackShare = 20
+	// reorderShare is what is reordered: one in 10 of the resources with two
+	// billable transitions has its first two published the wrong way round.
+	reorderShare = 10
+	// duplicateShare is what is repeated: one in 20 billable transitions is
+	// published twice.
+	duplicateShare = 20
+	// duplicateDistance is how many notifications of the stream stand between a
+	// duplicate and the transition it repeats.
+	duplicateDistance = 10
+	// refusedShapeDraw is the denominator of the three refused shapes: one draw
+	// in it picks an oversized twin, two a truncated one, and twenty a
+	// versioned one.
+	refusedShapeDraw = 400
+	// oversizedPadding is how much padding the oversized twin carries, which
+	// puts its body past what the collector reads. It repeats bodyMax in
+	// internal/providers/openstack/osloamqp.go, which is unexported and stays
+	// so, the way collectorQueue in publish.go repeats the collector's queue
+	// name.
+	oversizedPadding = 1 << 20
+)
+
+// novaExchange is the exchange the versioned twin is published on. The
+// versioned format is nova's, so no other service has a twin of that shape.
+const novaExchange = "nova"
+
+// applyStreamFaults builds the stream a run publishes out of the schedule the
+// simulated cloud produced, and returns the transitions held-back keeps off the
+// bus beside it.
+//
+// The schedule is left as it stands: every transition once, sorted by its
+// instant. That is what WriteEvents and the oracle read, so neither of them
+// knows about the duplicates and the refused twins, which are in the stream
+// alone. A held transition stays in the schedule, because the collector records
+// it once the run releases it.
+//
+// The four passes run in the order held-back, reordering, duplicates,
+// refused-shapes, and each of them draws its picks by walking the schedule's
+// billable transitions with the stream of its own name. What one switch picks
+// therefore follows from the seed and the switch alone, and turning another
+// switch on beside it moves nothing. A pick is keyed by the message id, and a
+// pass applies it to the first transition of that id it meets in the stream it
+// is transforming: a transition an earlier pass copied is twinned once, and a
+// pick whose transition is held never applies.
+func applyStreamFaults(schedule Schedule, seed uint64, faults Faults, touched touchedResources) (stream, held Schedule) {
+	stream = slices.Clone(schedule)
+	held = Schedule{}
+	if faults.HeldBack {
+		stream, held = holdBack(stream, schedule, seed, touched)
+	}
+	if faults.Reordering {
+		stream = reorder(stream, schedule, seed, held, touched)
+	}
+	if faults.Duplicates {
+		stream = duplicate(stream, schedule, seed, touched)
+	}
+	if faults.RefusedShapes {
+		stream = refuseShapes(stream, schedule, seed, touched)
+	}
+	return stream, held
+}
+
+// billableKey names the resource the oracle records a billable transition
+// under. Every transition a stream pass picks comes from Schedule.Billable, so
+// its type is in the table.
+func billableKey(t Transition) resourceKey {
+	return resourceKey{resourceType: billableTypes[t.EventType].resourceType, resourceID: t.ResourceID}
+}
+
+// holdBack keeps one in heldBackShare of the billable transitions off the bus
+// and hands them back beside the rest. They come back in the order of the
+// stream they were taken out of, which is instant order, so a run releases them
+// in the order the cloud produced them.
+func holdBack(stream, schedule Schedule, seed uint64, touched touchedResources) (kept, held Schedule) {
+	draw := faultStream(seed, FaultHeldBack)
+	picked := make(map[string]bool)
+	for _, transition := range schedule.Billable() {
+		if draw.IntN(heldBackShare) == 0 {
+			picked[transition.MessageID] = true
+		}
+	}
+
+	kept = make(Schedule, 0, len(stream))
+	held = make(Schedule, 0, len(picked))
+	for _, transition := range stream {
+		if !picked[transition.MessageID] {
+			kept = append(kept, transition)
+			continue
+		}
+		delete(picked, transition.MessageID)
+		held = append(held, transition)
+		touched.add(billableKey(transition), FaultHeldBack)
+	}
+	return kept, held
+}
+
+// reorder publishes the first billable transition of one in reorderShare of the
+// resources directly behind its second. The instants do not change, so the
+// notification about what happened first arrives second, which is the order the
+// projection and the engine have to undo.
+//
+// A resource with one billable transition is never drawn, because it has no
+// pair to swap. A pair one of whose members held-back is holding is left where
+// it stands: moving a transition behind one that is not on the bus is no
+// reordering.
+func reorder(stream, schedule Schedule, seed uint64, held Schedule, touched touchedResources) Schedule {
+	holding := make(map[string]bool, len(held))
+	for _, transition := range held {
+		holding[transition.MessageID] = true
+	}
+
+	// moves maps the message id of a first transition to the id of the second
+	// its notification is published behind.
+	draw := faultStream(seed, FaultReordering)
+	counts := make(map[string]int)
+	firsts := make(map[string]Transition)
+	moves := make(map[string]string)
+	for _, transition := range schedule.Billable() {
+		counts[transition.ResourceID]++
+		switch counts[transition.ResourceID] {
+		case 1:
+			firsts[transition.ResourceID] = transition
+		case 2:
+			if draw.IntN(reorderShare) != 0 {
+				continue
+			}
+			first := firsts[transition.ResourceID]
+			if holding[first.MessageID] || holding[transition.MessageID] {
+				continue
+			}
+			moves[first.MessageID] = transition.MessageID
+			touched.add(billableKey(first), FaultReordering)
+		}
+	}
+
+	out := make(Schedule, 0, len(stream))
+	waiting := make(map[string]Transition, len(moves))
+	for _, transition := range stream {
+		if second, ok := moves[transition.MessageID]; ok {
+			delete(moves, transition.MessageID)
+			waiting[second] = transition
+			continue
+		}
+		out = append(out, transition)
+		if first, ok := waiting[transition.MessageID]; ok {
+			delete(waiting, transition.MessageID)
+			out = append(out, first)
+		}
+	}
+	return out
+}
+
+// duplicate publishes one in duplicateShare of the billable transitions a
+// second time, byte for byte and duplicateDistance notifications later. The
+// copy carries the message id of the original, which is what the Reporting API
+// deduplicates on, so a collector that consumes both records one event.
+func duplicate(stream, schedule Schedule, seed uint64, touched touchedResources) Schedule {
+	draw := faultStream(seed, FaultDuplicates)
+	picked := make(map[string]bool)
+	for _, transition := range schedule.Billable() {
+		if draw.IntN(duplicateShare) == 0 {
+			picked[transition.MessageID] = true
+		}
+	}
+
+	out := make(Schedule, 0, len(stream)+len(picked))
+	for i, transition := range stream {
+		out = append(out, transition)
+		if picked[transition.MessageID] {
+			touched.add(billableKey(transition), FaultDuplicates)
+		}
+		// The distance is counted over the transitions of the input rather than
+		// over what goes out, so one copy does not push the next one further away.
+		if i >= duplicateDistance && picked[stream[i-duplicateDistance].MessageID] {
+			out = append(out, stream[i-duplicateDistance])
+		}
+	}
+	// A transition picked in the last duplicateDistance of the month has no room
+	// left for its distance, and its copy goes out behind the last notification.
+	for _, transition := range stream[max(0, len(stream)-duplicateDistance):] {
+		if picked[transition.MessageID] {
+			out = append(out, transition)
+		}
+	}
+	return out
+}
+
+// twinBuilder turns a transition into the refused twin that follows it on the
+// bus. The twin is handed the message id it publishes under, because the id is
+// drawn when the twin is placed rather than when it is picked.
+type twinBuilder func(t Transition, messageID string) Transition
+
+// refuseShapes puts a twin of a billable transition on the bus directly behind
+// it: one draw in refusedShapeDraw picks an oversized twin, two a truncated
+// one, and twenty a versioned one. The versioned twin is drawn for nova alone,
+// since the versioned format is nova's.
+//
+// The collector refuses all three. It counts the oversized and the truncated
+// one as unparseable, because the first is past its body bound and the second
+// carries half a document, and the versioned one as skipped, because the
+// mapping table claims nothing for the type. A run that publishes them
+// therefore expects the very events it expects without them.
+func refuseShapes(stream, schedule Schedule, seed uint64, touched touchedResources) Schedule {
+	draw := faultStream(seed, FaultRefusedShapes)
+	picked := make(map[string]twinBuilder)
+	for _, transition := range schedule.Billable() {
+		switch d := draw.IntN(refusedShapeDraw); {
+		case d == 0:
+			picked[transition.MessageID] = oversizedTwin
+		case d <= 2:
+			picked[transition.MessageID] = truncatedTwin
+		case d <= 22 && transition.Exchange == novaExchange:
+			picked[transition.MessageID] = versionedTwin
+		}
+	}
+
+	// The twins take their message ids from the switch's own stream, behind the
+	// draws that picked them. No collector stores such an id: it names a
+	// notification nothing is recorded for.
+	ids := idReader{src: draw}
+	out := make(Schedule, 0, len(stream)+len(picked))
+	for _, transition := range stream {
+		out = append(out, transition)
+		build, ok := picked[transition.MessageID]
+		if !ok {
+			continue
+		}
+		delete(picked, transition.MessageID)
+		out = append(out, build(transition, ids.nextUUID()))
+		touched.add(billableKey(transition), FaultRefusedShapes)
+	}
+	return out
+}
+
+// refusedTwin is the copy the three shapes are built from: the original with a
+// message id of its own, billable to nobody, and outside the noise catalogue.
+// It keeps the instant, the exchange, and the addressing of the original, so
+// the twin travels the route the notification it follows travels.
+func refusedTwin(t Transition, messageID string) Transition {
+	t.MessageID = messageID
+	t.Billable = false
+	t.noise = false
+	return t
+}
+
+// versionedTwin is the notification a nova configured for versioned
+// notifications would have sent instead. It carries another type name and wraps
+// the payload in nova_object.data, which is the format
+// docs/openstack-collector.md refuses under "Required OpenStack service
+// settings": ParseEnvelope reads it, and the mapping table claims nothing for
+// the type, so the collector counts it as skipped.
+func versionedTwin(t Transition, messageID string) Transition {
+	twin := refusedTwin(t, messageID)
+	twin.EventType = versionedType(t.EventType)
+	twin.PublisherID = "nova-compute:" + strings.TrimPrefix(t.PublisherID, "compute.")
+
+	// The versioned payload names the server uuid where the unversioned one
+	// names it instance_id.
+	data := maps.Clone(t.Payload)
+	if id, ok := data["instance_id"]; ok {
+		delete(data, "instance_id")
+		data["uuid"] = id
+	}
+	twin.Payload = map[string]any{
+		"nova_object.name":      "InstanceActionPayload",
+		"nova_object.namespace": "nova",
+		"nova_object.version":   "1.8",
+		"nova_object.data":      data,
+	}
+	return twin
+}
+
+// versionedType is the name nova publishes an unversioned compute type under
+// when it is configured for versioned notifications. The verb of a finished
+// resize is the other way round there, so compute.instance.finish_resize.end
+// becomes instance.resize_finish.end.
+func versionedType(eventType string) string {
+	name := strings.TrimPrefix(eventType, "compute.instance.")
+	return "instance." + strings.Replace(name, "finish_resize", "resize_finish", 1)
+}
+
+// truncatedTwin is a notification that arrives cut in half. Render cuts the
+// inner message of a transition marked this way, and the collector's second
+// decode fails on what is left, which it counts as unparseable.
+func truncatedTwin(t Transition, messageID string) Transition {
+	twin := refusedTwin(t, messageID)
+	twin.truncated = true
+	return twin
+}
+
+// oversizedTwin is a notification padded past the body bound the collector
+// reads with. The collector measures the delivery before it parses it, so this
+// twin is counted as unparseable without ever being decoded.
+func oversizedTwin(t Transition, messageID string) Transition {
+	twin := refusedTwin(t, messageID)
+	twin.Payload = maps.Clone(t.Payload)
+	twin.Payload["fault_padding"] = strings.Repeat("x", oversizedPadding)
+	return twin
+}

--- a/internal/providers/openstack/simulator/faults.go
+++ b/internal/providers/openstack/simulator/faults.go
@@ -1,0 +1,154 @@
+package simulator
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math/rand/v2"
+	"strings"
+)
+
+// The six fault switches, under the names --faults takes them by. A switch
+// changes what the bus carries and never what the simulated cloud did, so the
+// oracle of a month states the same usage whichever switches are on.
+const (
+	FaultPreExisting   = "pre-existing"
+	FaultMissingCreate = "missing-create"
+	FaultDuplicates    = "duplicates"
+	FaultReordering    = "reordering"
+	FaultRefusedShapes = "refused-shapes"
+	FaultHeldBack      = "held-back"
+)
+
+// FaultNames holds the six switches in the order everything that lists them
+// uses: the help of the flag, the switches a run logs, and the switches the
+// oracle names per resource.
+var FaultNames = []string{
+	FaultPreExisting,
+	FaultMissingCreate,
+	FaultDuplicates,
+	FaultReordering,
+	FaultRefusedShapes,
+	FaultHeldBack,
+}
+
+// Faults is the set of switches one run turns on, one field per name in
+// FaultNames. The zero value is every switch off, which is the run nobody
+// passed --faults to.
+type Faults struct {
+	PreExisting, MissingCreate, Duplicates, Reordering, RefusedShapes, HeldBack bool
+}
+
+// ParseFaults reads the switch names --faults was given. An empty list is every
+// switch off, and a name given twice is the run a name given once is.
+//
+// pre-existing and missing-create are refused together. Both of them pick the
+// instances they work on from the same set, so a run with both on would have
+// the two switches compete for the same instances.
+func ParseFaults(names []string) (Faults, error) {
+	var faults Faults
+	for _, name := range names {
+		switch name {
+		case FaultPreExisting:
+			faults.PreExisting = true
+		case FaultMissingCreate:
+			faults.MissingCreate = true
+		case FaultDuplicates:
+			faults.Duplicates = true
+		case FaultReordering:
+			faults.Reordering = true
+		case FaultRefusedShapes:
+			faults.RefusedShapes = true
+		case FaultHeldBack:
+			faults.HeldBack = true
+		default:
+			return Faults{}, fmt.Errorf("unknown fault switch %q; the switches are %s",
+				name, strings.Join(FaultNames, ", "))
+		}
+	}
+	if faults.PreExisting && faults.MissingCreate {
+		return Faults{}, errors.New("pre-existing and missing-create exclude each other")
+	}
+	return faults, nil
+}
+
+// Names returns the switches that are on, in FaultNames order. It is never nil:
+// the names go into the oracle of the month, and a run with no switch on has to
+// render there as [] rather than as null.
+func (f Faults) Names() []string {
+	on := []bool{f.PreExisting, f.MissingCreate, f.Duplicates, f.Reordering, f.RefusedShapes, f.HeldBack}
+	names := make([]string, 0, len(FaultNames))
+	for i, name := range FaultNames {
+		if on[i] {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// faultSalt mixes a switch's name into the state of its stream, the way
+// identifierSalt (workload.go) mixes the cloud and the billing month into the
+// identifier stream's.
+func faultSalt(name string) uint64 {
+	digest := fnv.New64a()
+	// A hash.Hash never fails a write, which is why the error is not examined.
+	_, _ = digest.Write([]byte("fault\x00" + name))
+	return digest.Sum64()
+}
+
+// faultStream is the generator one switch draws from: the seed of the run
+// together with the switch's own name.
+//
+// Every switch draws from the stream of its own name and never from the shape
+// stream. A month with every switch off therefore consumes the three streams of
+// GenerateMonth exactly as it does without the switches and renders
+// byte-identical files, and which resources or notifications one switch touches
+// does not move when another switch is on beside it.
+//
+// missing-create draws from the pre-existing stream on purpose. The two exclude
+// each other, and one stream between them means both pick the same instances
+// with the same leads for one seed.
+//
+// A fault stream carries neither the cloud nor the billing month. The
+// identifier stream carries both because a collector stores what it draws, and
+// a fault stream draws no such identifier: the one it hands out is the message
+// id of a refused twin, which no collector stores.
+func faultStream(seed uint64, name string) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, faultSalt(name)))
+}
+
+// touchedResources records which switches touched which resource of a month. It
+// is keyed the way the oracle keys a resource, so the switches of one are read
+// out by its type and its id together.
+type touchedResources map[resourceKey]map[string]bool
+
+// add records that the switch touched the resource. One switch added twice is
+// the same as one added once: what a reader asks is which switches touched a
+// resource, not how often each of them did.
+func (t touchedResources) add(key resourceKey, fault string) {
+	if t[key] == nil {
+		t[key] = make(map[string]bool)
+	}
+	t[key][fault] = true
+}
+
+// names returns the switches that touched the resource, in FaultNames order. It
+// is never nil, for the reason Faults.Names is not: a resource no switch
+// touched renders as [] rather than as null.
+func (t touchedResources) names(key resourceKey) []string {
+	touched := t[key]
+	names := make([]string, 0, len(touched))
+	for _, name := range FaultNames {
+		if touched[name] {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// touch records that the switch touched the resource the type and the id name.
+// It is the one call the generator records a touched resource through, so no
+// caller builds the key itself.
+func (g *generator) touch(resourceType, resourceID, fault string) {
+	g.touched.add(resourceKey{resourceType: resourceType, resourceID: resourceID}, fault)
+}

--- a/internal/providers/openstack/simulator/faults.go
+++ b/internal/providers/openstack/simulator/faults.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand/v2"
+	"slices"
 	"strings"
 )
 
@@ -84,6 +85,25 @@ func (f Faults) Names() []string {
 		}
 	}
 	return names
+}
+
+// sortedFaultNames returns the names in FaultNames order, with a name outside
+// FaultNames behind every switch and in the order it arrived in. It leaves the
+// slice it was given as it stands.
+//
+// It exists because an oracle read from disk states the switches in whatever
+// order the document spells them, and the lines a comparison prints name them
+// in the one order everything else does.
+func sortedFaultNames(names []string) []string {
+	order := func(name string) int {
+		if i := slices.Index(FaultNames, name); i >= 0 {
+			return i
+		}
+		return len(FaultNames)
+	}
+	sorted := slices.Clone(names)
+	slices.SortStableFunc(sorted, func(a, b string) int { return order(a) - order(b) })
+	return sorted
 }
 
 // faultSalt mixes a switch's name into the state of its stream, the way

--- a/internal/providers/openstack/simulator/faults_test.go
+++ b/internal/providers/openstack/simulator/faults_test.go
@@ -160,6 +160,45 @@ func TestTouchedResourcesNameTheSwitchesInOrder(t *testing.T) {
 	}
 }
 
+// TestSortedFaultNames holds the order the switches are printed in. An oracle
+// read from disk states them in the order the document spells them, and one an
+// older build wrote may name a switch this build knows nothing about.
+func TestSortedFaultNames(t *testing.T) {
+	reversed := slices.Clone(FaultNames)
+	slices.Reverse(reversed)
+
+	for _, tc := range []struct {
+		name  string
+		names []string
+		want  []string
+	}{
+		{name: "no switch at all", names: []string{}, want: []string{}},
+		{
+			name:  "the switches in the order they are named in",
+			names: []string{FaultPreExisting, FaultDuplicates, FaultHeldBack},
+			want:  []string{FaultPreExisting, FaultDuplicates, FaultHeldBack},
+		},
+		{name: "the switches in reverse", names: reversed, want: FaultNames},
+		{
+			name:  "a name this build does not know",
+			names: []string{"bogus", FaultHeldBack, FaultPreExisting},
+			want:  []string{FaultPreExisting, FaultHeldBack, "bogus"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			given := slices.Clone(tc.names)
+
+			if got := sortedFaultNames(given); !slices.Equal(got, tc.want) {
+				t.Errorf("sortedFaultNames(%v) = %v, want %v", tc.names, got, tc.want)
+			}
+			if !slices.Equal(given, tc.names) {
+				t.Errorf("sortedFaultNames(%v) left it as %v, want the list it was given untouched",
+					tc.names, given)
+			}
+		})
+	}
+}
+
 // TestFaultStreamsAreSeededByTheirName holds a switch's stream to the seed and
 // the name together. Two switches drawing one sequence would mean which
 // resources one of them touches follows from the other being on beside it.

--- a/internal/providers/openstack/simulator/faults_test.go
+++ b/internal/providers/openstack/simulator/faults_test.go
@@ -1,9 +1,17 @@
 package simulator
 
 import (
+	"bytes"
+	"maps"
 	"math/rand/v2"
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
 )
 
 // unknownSwitch is the whole error a name outside FaultNames is refused with.
@@ -227,4 +235,695 @@ func draws(stream *rand.Rand) [4]uint64 {
 		drawn[i] = stream.Uint64()
 	}
 	return drawn
+}
+
+// messageIDs returns the message ids of a schedule in the order they stand in
+// it. The stream passes move, repeat and add notifications, and the id is what
+// tells one of them from another.
+func messageIDs(schedule Schedule) []string {
+	ids := make([]string, 0, len(schedule))
+	for _, transition := range schedule {
+		ids = append(ids, transition.MessageID)
+	}
+	return ids
+}
+
+// renderedBodies renders every transition of a schedule or fails the test. Two
+// schedules that render the same bytes are the same month on the wire, down to
+// their message ids.
+func renderedBodies(t *testing.T, schedule Schedule) []string {
+	t.Helper()
+
+	bodies := make([]string, 0, len(schedule))
+	for _, transition := range schedule {
+		bodies = append(bodies, string(render(t, transition)))
+	}
+	return bodies
+}
+
+// writeEvents writes the events a schedule expects and hands the file back, or
+// fails the test. It is what the switches that only change the stream are held
+// to: the file states what the collector has to record, and a switch may not
+// move it.
+func writeEvents(t *testing.T, schedule Schedule) []byte {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	if err := WriteEvents(path, testCloud, schedule); err != nil {
+		t.Fatalf("WriteEvents(%q, %q) error = %v, want nil", path, testCloud, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return data
+}
+
+// transitionKey lines the transitions of two months up: the type of a
+// notification together with the resource it is about.
+type transitionKey struct {
+	eventType  string
+	resourceID string
+}
+
+// transitionCounts counts a schedule's transitions by type and resource, which
+// is what two months hold in common when one of them moved a share of its
+// instants.
+func transitionCounts(schedule Schedule) map[transitionKey]int {
+	counts := make(map[transitionKey]int, len(schedule))
+	for _, transition := range schedule {
+		counts[transitionKey{eventType: transition.EventType, resourceID: transition.ResourceID}]++
+	}
+	return counts
+}
+
+// billableInstants returns, per type and resource, the instants of the billable
+// transitions in schedule order.
+func billableInstants(schedule Schedule) map[transitionKey][]time.Time {
+	instants := make(map[transitionKey][]time.Time)
+	for _, transition := range schedule {
+		if !transition.Billable {
+			continue
+		}
+		key := transitionKey{eventType: transition.EventType, resourceID: transition.ResourceID}
+		instants[key] = append(instants[key], transition.At)
+	}
+	return instants
+}
+
+// billableIDsByResource groups the message ids of a schedule's billable
+// transitions by their resource, in schedule order.
+func billableIDsByResource(schedule Schedule) map[string][]string {
+	byResource := make(map[string][]string)
+	for _, transition := range schedule {
+		if transition.Billable {
+			byResource[transition.ResourceID] = append(byResource[transition.ResourceID], transition.MessageID)
+		}
+	}
+	return byResource
+}
+
+// firstPositions returns where the first transition of each message id stands,
+// which is where a stream pass applies its pick.
+func firstPositions(schedule Schedule) map[string]int {
+	positions := make(map[string]int, len(schedule))
+	for i, transition := range schedule {
+		if _, ok := positions[transition.MessageID]; !ok {
+			positions[transition.MessageID] = i
+		}
+	}
+	return positions
+}
+
+// duplicatedIDs returns the message ids a stream carries more than once.
+func duplicatedIDs(stream Schedule) map[string]bool {
+	seen := make(map[string]bool, len(stream))
+	duplicated := make(map[string]bool)
+	for _, transition := range stream {
+		if seen[transition.MessageID] {
+			duplicated[transition.MessageID] = true
+			continue
+		}
+		seen[transition.MessageID] = true
+	}
+	return duplicated
+}
+
+// twinnedIDs returns the message ids of the transitions a refused twin follows.
+// A twin is told by its own message id, which is drawn when it is placed and is
+// therefore in no schedule.
+func twinnedIDs(month Month) map[string]bool {
+	scheduled := make(map[string]bool, len(month.Schedule))
+	for _, transition := range month.Schedule {
+		scheduled[transition.MessageID] = true
+	}
+
+	twinned := make(map[string]bool)
+	for i, transition := range month.Stream {
+		if i > 0 && !scheduled[transition.MessageID] {
+			twinned[month.Stream[i-1].MessageID] = true
+		}
+	}
+	return twinned
+}
+
+// reorderedResources returns the resources the oracle names the reordering
+// switch on, sorted, so a failure reports them in one order.
+func reorderedResources(oracle Oracle) []string {
+	var ids []string
+	for key, resource := range touchedResourcesOf(oracle) {
+		if slices.Contains(resource.Faults, FaultReordering) {
+			ids = append(ids, key.resourceID)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// touchedInstances returns the servers the oracle names a switch on, sorted.
+func touchedInstances(oracle Oracle) []string {
+	var ids []string
+	for key := range touchedResourcesOf(oracle) {
+		if key.resourceType == "instance" {
+			ids = append(ids, key.resourceID)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// sortedIDs returns a schedule's message ids as a multiset, which is what two
+// sequences of one month hold in common when one of them was reordered.
+func sortedIDs(schedule Schedule) []string {
+	ids := messageIDs(schedule)
+	slices.Sort(ids)
+	return ids
+}
+
+// TestEverySwitchOffLeavesTheMonthAsItWas covers the property the four stream
+// switches are held to: a switch changes what the bus carries and never what
+// the simulated cloud did. The schedule of a month with one of them on renders
+// the very bytes the schedule of the month without it renders, so the oracle
+// and the expected events of the two months are one.
+//
+// pre-existing is the switch that does move the schedule, because what it
+// changes is when a server was created. It is held to its transitions instead:
+// the month holds the same notifications about the same resources, and every
+// resource the oracle names no switch on keeps its instants.
+func TestEverySwitchOffLeavesTheMonthAsItWas(t *testing.T) {
+	plain := faultyMonth(t, 1, Faults{})
+	plainBodies := renderedBodies(t, plain.Schedule)
+
+	if got, want := renderedBodies(t, plain.Stream), plainBodies; !slices.Equal(got, want) {
+		t.Errorf("a month with no switch on publishes %d notifications and its schedule holds %d, "+
+			"want the stream to be the schedule", len(got), len(want))
+	}
+	if len(plain.Held) != 0 {
+		t.Errorf("a month with no switch on holds %d transitions back, want none", len(plain.Held))
+	}
+	if plain.Oracle.Faults == nil || len(plain.Oracle.Faults) != 0 {
+		t.Errorf("Oracle.Faults = %#v, want an empty non-nil list", plain.Oracle.Faults)
+	}
+	for _, resource := range plain.Oracle.Resources {
+		if resource.Faults == nil || len(resource.Faults) != 0 {
+			t.Errorf("%s %s reports Faults = %#v, want an empty non-nil list",
+				resource.ResourceType, resource.ResourceID, resource.Faults)
+		}
+	}
+
+	for _, faults := range []Faults{
+		{Duplicates: true}, {Reordering: true}, {RefusedShapes: true}, {HeldBack: true},
+	} {
+		t.Run(strings.Join(faults.Names(), " "), func(t *testing.T) {
+			month := faultyMonth(t, 1, faults)
+
+			if got := renderedBodies(t, month.Schedule); !slices.Equal(got, plainBodies) {
+				t.Errorf("the schedule of a month with %v on renders other bytes than the plain month's, "+
+					"want the switch to change the stream alone", faults.Names())
+			}
+		})
+	}
+
+	t.Run(FaultPreExisting, func(t *testing.T) {
+		month := faultyMonth(t, 1, Faults{PreExisting: true})
+
+		if got, want := transitionCounts(month.Schedule), transitionCounts(plain.Schedule); !maps.Equal(got, want) {
+			t.Errorf("the month holds %d kinds of transition and the plain month %d, want the switch to "+
+				"move what it moves and to publish the same notifications about the same resources",
+				len(got), len(want))
+		}
+
+		untouched := make(map[string]bool)
+		for _, resource := range month.Oracle.Resources {
+			if len(resource.Faults) == 0 {
+				untouched[resource.ResourceID] = true
+			}
+		}
+		want := billableInstants(plain.Schedule)
+		for key, instants := range billableInstants(month.Schedule) {
+			if !untouched[key.resourceID] {
+				continue
+			}
+			if !slices.EqualFunc(instants, want[key], time.Time.Equal) {
+				t.Errorf("%s of %s is at %v and was at %v, want a resource the oracle names no switch on "+
+					"to keep its instants", key.eventType, key.resourceID, instants, want[key])
+			}
+		}
+	})
+}
+
+// TestHeldBackHoldsAShareOfTheBillableMonth covers the switch that keeps a
+// share of the month off the bus. What it holds is the month's own
+// notifications rather than copies of them, so the stream and the held
+// transitions together are the schedule, and the schedule is what the run still
+// expects the collector to record: the run releases them before it ends.
+func TestHeldBackHoldsAShareOfTheBillableMonth(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{HeldBack: true})
+	billable := month.Schedule.Billable()
+
+	if len(month.Held) == 0 {
+		t.Fatalf("the switch held nothing back of %d billable transitions, want one in %d of them",
+			len(billable), heldBackShare)
+	}
+	for i, transition := range month.Held {
+		if !transition.Billable {
+			t.Errorf("the switch holds %s of %s back, want the billable transitions alone",
+				transition.EventType, transition.ResourceID)
+		}
+		if i > 0 && transition.At.Before(month.Held[i-1].At) {
+			t.Errorf("held transition %d is at %s behind one at %s, want them in instant order",
+				i, transition.At.Format(time.RFC3339), month.Held[i-1].At.Format(time.RFC3339))
+		}
+	}
+
+	published := make(map[string]bool, len(month.Stream))
+	for _, transition := range month.Stream {
+		published[transition.MessageID] = true
+	}
+	for _, transition := range month.Held {
+		if published[transition.MessageID] {
+			t.Errorf("the bus carries %s, which the switch holds back, want the two disjoint",
+				transition.MessageID)
+		}
+	}
+
+	got := sortedIDs(append(slices.Clone(month.Stream), month.Held...))
+	if want := sortedIDs(month.Schedule); !slices.Equal(got, want) {
+		t.Errorf("the stream and the held transitions hold %d notifications and the schedule %d, "+
+			"want the two together to be the schedule", len(got), len(want))
+	}
+
+	touched := touchedResourcesOf(month.Oracle)
+	for _, transition := range month.Held {
+		key := billableKey(transition)
+		if resource, ok := touched[key]; !ok || !slices.Contains(resource.Faults, FaultHeldBack) {
+			t.Errorf("%s of %s %s is held back and the oracle names %v on the resource, want it to name %q",
+				transition.EventType, key.resourceType, key.resourceID, resource.Faults, FaultHeldBack)
+		}
+	}
+
+	// The events the run expects are the whole billable month, held transitions
+	// and all: what is held back is published before the run ends.
+	if got, want := bytes.Count(writeEvents(t, month.Schedule), []byte("\n")), len(billable); got != want {
+		t.Errorf("the events of the month hold %d lines, want the %d billable transitions of the schedule",
+			got, want)
+	}
+}
+
+// TestReorderingSwapsTheFirstTwoTransitionsOfAResource covers the switch that
+// publishes the first billable transition of a resource behind its second. The
+// instants do not move, so what the collector receives disagrees with the
+// timestamps it receives it under, which is the arrival order the projection
+// and the engine have to undo.
+func TestReorderingSwapsTheFirstTwoTransitionsOfAResource(t *testing.T) {
+	plain := faultyMonth(t, 1, Faults{})
+	month := faultyMonth(t, 1, Faults{Reordering: true})
+
+	reordered := reorderedResources(month.Oracle)
+	if len(reordered) == 0 {
+		t.Fatalf("the switch moved nothing, want it to move one in %d of the resources with two "+
+			"billable transitions", reorderShare)
+	}
+
+	byResource := billableIDsByResource(month.Schedule)
+	inStream := firstPositions(month.Stream)
+	inSchedule := firstPositions(month.Schedule)
+	moved := make(map[string]bool, len(reordered))
+	for _, resourceID := range reordered {
+		ids := byResource[resourceID]
+		if len(ids) < 2 {
+			t.Errorf("the switch moved %s, which has %d billable transitions, want a resource with two",
+				resourceID, len(ids))
+			continue
+		}
+		first, second := ids[0], ids[1]
+		moved[first] = true
+
+		if inSchedule[first] > inSchedule[second] {
+			t.Errorf("%s stands at %d in the schedule of %s and its second transition at %d, "+
+				"want the schedule to say what the cloud did", first, inSchedule[first], resourceID,
+				inSchedule[second])
+		}
+		if inStream[first] != inStream[second]+1 {
+			t.Errorf("%s stands at %d in the stream of %s and its second transition at %d, "+
+				"want the first published directly behind the second", first, inStream[first], resourceID,
+				inStream[second])
+		}
+	}
+
+	// What is left once the moved transitions are taken out is the order the
+	// cloud produced: the switch moves them and nothing else.
+	if got, want := withoutIDs(month.Stream, moved), withoutIDs(month.Schedule, moved); !slices.Equal(got, want) {
+		t.Error("the stream without the moved transitions is not the schedule without them, " +
+			"want the switch to move the picked firsts alone")
+	}
+	if got, want := sortedIDs(month.Stream), sortedIDs(month.Schedule); !slices.Equal(got, want) {
+		t.Errorf("the stream carries %d notifications and the schedule holds %d, "+
+			"want the switch to move them rather than to add or drop one", len(got), len(want))
+	}
+
+	if len(month.Schedule) != len(plain.Schedule) {
+		t.Fatalf("the month holds %d transitions and the plain month %d, want the switch to leave "+
+			"the schedule as it is", len(month.Schedule), len(plain.Schedule))
+	}
+	for i := range month.Schedule {
+		if !month.Schedule[i].At.Equal(plain.Schedule[i].At) {
+			t.Errorf("transition %d is at %s and was at %s, want the switch to move no instant",
+				i, month.Schedule[i].At.Format(time.RFC3339), plain.Schedule[i].At.Format(time.RFC3339))
+		}
+	}
+}
+
+// withoutIDs returns the message ids of a schedule with the named ones left
+// out, in the order they stand in.
+func withoutIDs(schedule Schedule, without map[string]bool) []string {
+	var ids []string
+	for _, transition := range schedule {
+		if !without[transition.MessageID] {
+			ids = append(ids, transition.MessageID)
+		}
+	}
+	return ids
+}
+
+// TestDuplicatesRepeatATransitionTenLinesLater covers the switch that publishes
+// a notification twice. The copy carries the message id of the original, which
+// is what the Reporting API deduplicates on, and the schedule knows nothing
+// about it: what the collector has to record is the month without the
+// redelivery.
+func TestDuplicatesRepeatATransitionTenLinesLater(t *testing.T) {
+	plain := faultyMonth(t, 1, Faults{})
+	month := faultyMonth(t, 1, Faults{Duplicates: true})
+	bodies := renderedBodies(t, month.Stream)
+
+	// The input of the pass is the schedule, so the transitions of the stream
+	// that are not repetitions are counted to hold a copy to its distance.
+	original := make(map[string]int, len(month.Stream))
+	firstBody := make(map[string]string, len(month.Stream))
+	inputs, duplicates := 0, 0
+	for i, transition := range month.Stream {
+		at, repeated := original[transition.MessageID]
+		if !repeated {
+			original[transition.MessageID] = inputs
+			firstBody[transition.MessageID] = bodies[i]
+			inputs++
+			continue
+		}
+
+		duplicates++
+		if bodies[i] != firstBody[transition.MessageID] {
+			t.Errorf("the copy of %s renders other bytes than the notification it repeats, "+
+				"want the two byte for byte the same", transition.MessageID)
+		}
+		if behind := inputs - at - 1; behind != duplicateDistance && inputs != len(month.Schedule) {
+			t.Errorf("the copy of %s stands %d notifications behind it, want %d or the end of the month",
+				transition.MessageID, behind, duplicateDistance)
+		}
+	}
+
+	if duplicates == 0 {
+		t.Fatalf("the switch repeated nothing of %d billable transitions, want one in %d of them",
+			len(month.Schedule.Billable()), duplicateShare)
+	}
+	if got, want := len(month.Stream), len(month.Schedule)+duplicates; got != want {
+		t.Errorf("the stream carries %d notifications and the schedule holds %d beside %d copies, want %d",
+			got, len(month.Schedule), duplicates, want)
+	}
+
+	if got := renderedBodies(t, month.Schedule); !slices.Equal(got, renderedBodies(t, plain.Schedule)) {
+		t.Error("the schedule of the month renders other bytes than the plain month's, " +
+			"want the switch to change the stream alone")
+	}
+	if !slices.Equal(month.Oracle.Counts, plain.Oracle.Counts) {
+		t.Error("the oracle counts other events than the plain month's, " +
+			"want a redelivery to be no second event")
+	}
+	if !bytes.Equal(writeEvents(t, month.Schedule), writeEvents(t, plain.Schedule)) {
+		t.Error("the events of the month are not the plain month's, want a redelivery to be no second event")
+	}
+}
+
+// TestRefusedShapesTwinTheirOriginals covers the switch that puts a
+// notification the collector refuses behind a notification it books. The three
+// shapes are refused for three reasons, and none of them adds an event: the
+// oversized and the truncated twin are unparseable, one past the body bound and
+// one half a document, and the versioned twin parses and is skipped, because
+// the mapping table claims nothing for a versioned type.
+func TestRefusedShapesTwinTheirOriginals(t *testing.T) {
+	plain := faultyMonth(t, 1, Faults{})
+	month := faultyMonth(t, 1, Faults{RefusedShapes: true})
+
+	// A twin is told by its message id and not by being unbillable: the plain
+	// month carries unbillable notifications of its own, the image.create that
+	// precedes an upload among them.
+	scheduled := make(map[string]bool, len(month.Schedule))
+	for _, transition := range month.Schedule {
+		scheduled[transition.MessageID] = true
+	}
+
+	shapes := make(map[string]int)
+	for i, twin := range month.Stream {
+		if scheduled[twin.MessageID] {
+			continue
+		}
+		if i == 0 {
+			t.Fatalf("the stream opens with %s, which is in no schedule, want a twin behind the "+
+				"notification it doubles", twin.EventType)
+		}
+
+		of := month.Stream[i-1]
+		if !twin.At.Equal(of.At) || twin.ResourceID != of.ResourceID || twin.Exchange != of.Exchange {
+			t.Errorf("the twin %s of %s at %s on %s follows %s of %s at %s on %s, want it to follow "+
+				"the notification it doubles", twin.EventType, twin.ResourceID,
+				twin.At.Format(time.RFC3339), twin.Exchange, of.EventType, of.ResourceID,
+				of.At.Format(time.RFC3339), of.Exchange)
+			continue
+		}
+		if twin.Billable {
+			t.Errorf("the twin %s of %s is marked billable, want the collector to record nothing for it",
+				twin.EventType, twin.ResourceID)
+		}
+
+		body := render(t, twin)
+		switch {
+		case strings.HasPrefix(twin.EventType, "instance."):
+			shapes["versioned"]++
+			if _, ok := openstack.MapNotification(parse(t, body), testCloud); ok {
+				t.Errorf("the mapping claims an event for the versioned %s, want it skipped", twin.EventType)
+			}
+		case twin.truncated:
+			shapes["truncated"]++
+			if _, err := openstack.ParseEnvelope(body); err == nil {
+				t.Errorf("the collector parses the truncated twin of %s, want it refused", of.EventType)
+			}
+		default:
+			// oversizedPadding is the collector's own body bound, which is what
+			// the twin has to stand past.
+			shapes["oversized"]++
+			if len(body) <= oversizedPadding {
+				t.Errorf("the oversized twin of %s renders %d bytes, want more than the %d the collector reads",
+					of.EventType, len(body), oversizedPadding)
+			}
+		}
+	}
+
+	for _, shape := range []string{"versioned", "truncated", "oversized"} {
+		if shapes[shape] == 0 {
+			t.Errorf("the month carries no %s twin, want one in %d billable transitions of every shape",
+				shape, refusedShapeDraw)
+		}
+	}
+
+	if got := renderedBodies(t, month.Schedule); !slices.Equal(got, renderedBodies(t, plain.Schedule)) {
+		t.Error("the schedule of the month renders other bytes than the plain month's, " +
+			"want the switch to change the stream alone")
+	}
+
+	// The versioned names stand beside the ones the plain month carries, and the
+	// collector admits openstack.LabelValueLimit distinct event_type values
+	// before it folds the rest into event_type="other".
+	types := make(map[string]struct{}, len(month.Stream))
+	for _, transition := range month.Stream {
+		types[transition.EventType] = struct{}{}
+	}
+	if len(types) >= openstack.LabelValueLimit {
+		t.Errorf("the stream renders %d distinct event types and the collector admits %d, "+
+			"want fewer than the bound", len(types), openstack.LabelValueLimit)
+	}
+}
+
+// TestVersionedTwinOfAFinishResize covers the twin nova would have published
+// had it been left on the versioned notification format
+// docs/openstack-collector.md refuses. The type is renamed, the payload moves
+// under nova_object.data, and the server is named uuid there rather than
+// instance_id.
+func TestVersionedTwinOfAFinishResize(t *testing.T) {
+	const (
+		serverID = "8f7e6d5c-4b3a-4291-8071-6f5e4d3c2b1a"
+		twinID   = "1b2c3d4e-5f60-4718-8293-a4b5c6d7e8f9"
+	)
+	original := Transition{
+		At:          july2026.Add(time.Hour),
+		EventType:   "compute.instance.finish_resize.end",
+		Exchange:    novaExchange,
+		Billable:    true,
+		PublisherID: "compute.compute-01",
+		ResourceID:  serverID,
+		Payload:     map[string]any{"instance_id": serverID, "state": "active"},
+	}
+
+	twin := versionedTwin(original, twinID)
+
+	if want := "instance.resize_finish.end"; twin.EventType != want {
+		t.Errorf("versionedTwin(%q).EventType = %q, want %q", original.EventType, twin.EventType, want)
+	}
+	if want := "nova-compute:"; !strings.HasPrefix(twin.PublisherID, want) {
+		t.Errorf("versionedTwin(%q).PublisherID = %q, want it to start with %q",
+			original.EventType, twin.PublisherID, want)
+	}
+	if twin.MessageID != twinID || twin.Billable {
+		t.Errorf("versionedTwin() = message id %q, billable %t, want %q and false",
+			twin.MessageID, twin.Billable, twinID)
+	}
+
+	payload := parse(t, render(t, twin)).Payload
+	data, ok := payload["nova_object.data"].(map[string]any)
+	if !ok {
+		t.Fatalf("the rendered payload = %v, want a nova_object.data object", payload)
+	}
+	if data["uuid"] != serverID {
+		t.Errorf("nova_object.data holds uuid = %v, want %q", data["uuid"], serverID)
+	}
+	if _, ok := data["instance_id"]; ok {
+		t.Errorf("nova_object.data holds instance_id = %v, want the versioned format's uuid alone",
+			data["instance_id"])
+	}
+	if original.Payload["instance_id"] != serverID {
+		t.Errorf("the payload of the original holds instance_id = %v, want the twin to leave it at %q",
+			original.Payload["instance_id"], serverID)
+	}
+
+	cases := []struct {
+		oslo      string
+		versioned string
+	}{
+		{"compute.instance.create.end", "instance.create.end"},
+		{"compute.instance.delete.end", "instance.delete.end"},
+		{"compute.instance.resize.end", "instance.resize.end"},
+		{"compute.instance.finish_resize.end", "instance.resize_finish.end"},
+		{"compute.instance.shelve_offload.end", "instance.shelve_offload.end"},
+		{"compute.instance.unshelve.end", "instance.unshelve.end"},
+		{"compute.instance.power_off.end", "instance.power_off.end"},
+		{"compute.instance.power_on.end", "instance.power_on.end"},
+	}
+	covered := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		covered[c.oslo] = true
+		t.Run(c.oslo, func(t *testing.T) {
+			if got := versionedType(c.oslo); got != c.versioned {
+				t.Errorf("versionedType(%q) = %q, want %q", c.oslo, got, c.versioned)
+			}
+		})
+	}
+	// The table covers every nova type the oracle books, so a type added there
+	// is named here as well.
+	for eventType := range billableTypes {
+		if exchangeFor(eventType) == novaExchange && !covered[eventType] {
+			t.Errorf("the table names no versioned type for %s, want every nova type the oracle books",
+				eventType)
+		}
+	}
+}
+
+// TestStreamFaultPicksAreIndependentOfEachOther covers the rule every switch
+// draws by: each of them walks the schedule with the stream of its own name, so
+// what it picks follows from the seed and the switch alone. Held-back is the
+// switch the others are held against, because it is the one that takes a
+// transition away: a pick whose transition is held simply never applies, and
+// every other pick stands where it stood.
+func TestStreamFaultPicksAreIndependentOfEachOther(t *testing.T) {
+	held := faultyMonth(t, 1, Faults{HeldBack: true})
+	holding := make(map[string]bool, len(held.Held))
+	for _, transition := range held.Held {
+		holding[transition.MessageID] = true
+	}
+
+	t.Run(FaultDuplicates, func(t *testing.T) {
+		requireSamePicks(t, "the copy of",
+			duplicatedIDs(faultyMonth(t, 1, Faults{Duplicates: true}).Stream),
+			duplicatedIDs(faultyMonth(t, 1, Faults{Duplicates: true, HeldBack: true}).Stream),
+			holding)
+	})
+
+	t.Run(FaultRefusedShapes, func(t *testing.T) {
+		requireSamePicks(t, "the twin of",
+			twinnedIDs(faultyMonth(t, 1, Faults{RefusedShapes: true})),
+			twinnedIDs(faultyMonth(t, 1, Faults{RefusedShapes: true, HeldBack: true})),
+			holding)
+	})
+
+	t.Run(FaultReordering, func(t *testing.T) {
+		alone := faultyMonth(t, 1, Faults{Reordering: true})
+		beside := faultyMonth(t, 1, Faults{Reordering: true, HeldBack: true})
+		byResource := billableIDsByResource(alone.Schedule)
+
+		moved := make(map[string]bool)
+		for _, resourceID := range reorderedResources(beside.Oracle) {
+			moved[resourceID] = true
+		}
+		for _, resourceID := range reorderedResources(alone.Oracle) {
+			ids := byResource[resourceID]
+			if len(ids) < 2 {
+				t.Errorf("the switch moved %s, which has %d billable transitions, want two", resourceID, len(ids))
+				continue
+			}
+			// A pair one of whose members is held is no reordering: the switch
+			// leaves it where it stands rather than moving a transition behind one
+			// that is not on the bus.
+			want := !holding[ids[0]] && !holding[ids[1]]
+			if moved[resourceID] != want {
+				t.Errorf("reordering moved %s beside held-back = %t, want %t: held-back holds its "+
+					"first transition = %t and its second = %t", resourceID, moved[resourceID], want,
+					holding[ids[0]], holding[ids[1]])
+			}
+			delete(moved, resourceID)
+		}
+		for resourceID := range moved {
+			t.Errorf("reordering moved %s beside held-back and not on its own, want the picks of one "+
+				"switch to follow from the seed and the switch alone", resourceID)
+		}
+	})
+
+	t.Run("pre-existing and missing-create pick the same servers", func(t *testing.T) {
+		pre := touchedInstances(faultyMonth(t, 1, Faults{PreExisting: true}).Oracle)
+		missing := touchedInstances(faultyMonth(t, 1, Faults{MissingCreate: true}).Oracle)
+
+		if len(pre) == 0 {
+			t.Fatalf("pre-existing touched no server, want one in %d of the classic tenants'", preExistingShare)
+		}
+		if !slices.Equal(pre, missing) {
+			t.Errorf("pre-existing touched %v and missing-create %v, want the two switches to pick the "+
+				"same servers from the one stream they share", pre, missing)
+		}
+	})
+}
+
+// requireSamePicks holds the picks a switch made beside held-back against the
+// ones it made on its own: a pick whose transition is held never applies, and
+// every other one stands.
+func requireSamePicks(t *testing.T, what string, alone, beside, holding map[string]bool) {
+	t.Helper()
+
+	for id := range alone {
+		if want := !holding[id]; beside[id] != want {
+			t.Errorf("%s %s beside held-back = %t, want %t: held-back holds it = %t",
+				what, id, beside[id], want, holding[id])
+		}
+	}
+	for id := range beside {
+		if !alone[id] {
+			t.Errorf("%s %s stands beside held-back and not on its own, want the picks of one switch "+
+				"to follow from the seed and the switch alone", what, id)
+		}
+	}
 }

--- a/internal/providers/openstack/simulator/faults_test.go
+++ b/internal/providers/openstack/simulator/faults_test.go
@@ -1,0 +1,191 @@
+package simulator
+
+import (
+	"math/rand/v2"
+	"slices"
+	"testing"
+)
+
+// unknownSwitch is the whole error a name outside FaultNames is refused with.
+// It lists the six, because a mistyped switch is answered with the ones that
+// exist rather than with the name that does not.
+const unknownSwitch = `unknown fault switch "bogus"; the switches are ` +
+	`pre-existing, missing-create, duplicates, reordering, refused-shapes, held-back`
+
+func TestParseFaults(t *testing.T) {
+	cases := []struct {
+		name  string
+		names []string
+		// want is the parsed set and wantNames what it names itself by. Both are
+		// read only where wantErr is empty.
+		want      Faults
+		wantNames []string
+		wantErr   string
+	}{
+		{
+			name:      "no switch at all",
+			names:     nil,
+			want:      Faults{},
+			wantNames: []string{},
+		},
+		{
+			name:      "an empty list of switches",
+			names:     []string{},
+			want:      Faults{},
+			wantNames: []string{},
+		},
+		{
+			name:      "one switch on its own",
+			names:     []string{FaultDuplicates},
+			want:      Faults{Duplicates: true},
+			wantNames: []string{FaultDuplicates},
+		},
+		{
+			// Every switch but missing-create, which excludes pre-existing. They
+			// come in reverse and one of them twice, which is what the order of
+			// Names and the set behind it are read from.
+			name: "every switch that stands beside the others, in reverse and one twice",
+			names: []string{
+				FaultHeldBack, FaultRefusedShapes, FaultReordering,
+				FaultDuplicates, FaultPreExisting, FaultHeldBack,
+			},
+			want: Faults{
+				PreExisting: true, Duplicates: true,
+				Reordering: true, RefusedShapes: true, HeldBack: true,
+			},
+			wantNames: []string{
+				FaultPreExisting, FaultDuplicates, FaultReordering,
+				FaultRefusedShapes, FaultHeldBack,
+			},
+		},
+		{
+			name:    "a switch nobody named that way",
+			names:   []string{"bogus"},
+			wantErr: unknownSwitch,
+		},
+		{
+			name:    "an unknown switch beside a known one",
+			names:   []string{FaultDuplicates, "bogus"},
+			wantErr: unknownSwitch,
+		},
+		{
+			name:    "the two switches that exclude each other",
+			names:   []string{FaultPreExisting, FaultMissingCreate},
+			wantErr: "pre-existing and missing-create exclude each other",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseFaults(c.names)
+
+			if c.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseFaults(%q) error = nil, want %q", c.names, c.wantErr)
+				}
+				if err.Error() != c.wantErr {
+					t.Errorf("ParseFaults(%q) error = %q, want %q", c.names, err, c.wantErr)
+				}
+				if got != (Faults{}) {
+					t.Errorf("ParseFaults(%q) = %+v, want the zero Faults beside the error", c.names, got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseFaults(%q) error = %v, want nil", c.names, err)
+			}
+			if got != c.want {
+				t.Errorf("ParseFaults(%q) = %+v, want %+v", c.names, got, c.want)
+			}
+			if names := got.Names(); !slices.Equal(names, c.wantNames) {
+				t.Errorf("ParseFaults(%q).Names() = %v, want %v", c.names, names, c.wantNames)
+			}
+		})
+	}
+}
+
+// TestFaultsNamesRunInSwitchOrder holds the set with every switch on to
+// FaultNames. It is built here rather than parsed, because ParseFaults never
+// returns it: pre-existing and missing-create exclude each other.
+func TestFaultsNamesRunInSwitchOrder(t *testing.T) {
+	all := Faults{
+		PreExisting: true, MissingCreate: true, Duplicates: true,
+		Reordering: true, RefusedShapes: true, HeldBack: true,
+	}
+	if got := all.Names(); !slices.Equal(got, FaultNames) {
+		t.Errorf("Names() of every switch = %v, want %v", got, FaultNames)
+	}
+}
+
+// TestFaultsNamesIsNeverNil holds both name lists to the empty slice. They are
+// rendered into the oracle, where a nil slice becomes null and an empty one the
+// [] whoever reads a month expects.
+func TestFaultsNamesIsNeverNil(t *testing.T) {
+	if names := (Faults{}).Names(); names == nil || len(names) != 0 {
+		t.Errorf("Faults{}.Names() = %#v, want an empty non-nil slice", names)
+	}
+	if names := (touchedResources{}).names(resourceKey{}); names == nil || len(names) != 0 {
+		t.Errorf("touchedResources{}.names(resourceKey{}) = %#v, want an empty non-nil slice", names)
+	}
+}
+
+func TestTouchedResourcesNameTheSwitchesInOrder(t *testing.T) {
+	instanceKey := resourceKey{resourceType: "instance", resourceID: "i-1"}
+	volumeKey := resourceKey{resourceType: "volume", resourceID: "v-1"}
+
+	touched := make(touchedResources)
+	// Out of FaultNames order and with one switch added twice, which is what the
+	// order of the answer and the set behind it are read from.
+	touched.add(instanceKey, FaultHeldBack)
+	touched.add(instanceKey, FaultPreExisting)
+	touched.add(instanceKey, FaultHeldBack)
+
+	want := []string{FaultPreExisting, FaultHeldBack}
+	if got := touched.names(instanceKey); !slices.Equal(got, want) {
+		t.Errorf("names(%+v) = %v, want %v", instanceKey, got, want)
+	}
+	if got := touched.names(volumeKey); got == nil || len(got) != 0 {
+		t.Errorf("names(%+v) = %#v, want an empty non-nil slice for a resource nothing touched", volumeKey, got)
+	}
+
+	g := &generator{touched: make(touchedResources)}
+	g.touch(volumeKey.resourceType, volumeKey.resourceID, FaultDuplicates)
+	if got := g.touched.names(volumeKey); !slices.Equal(got, []string{FaultDuplicates}) {
+		t.Errorf("touch(%q, %q, %q) recorded %v under %+v, want %v",
+			volumeKey.resourceType, volumeKey.resourceID, FaultDuplicates, got, volumeKey, []string{FaultDuplicates})
+	}
+	if got := g.touched.names(instanceKey); len(got) != 0 {
+		t.Errorf("touch recorded %v under %+v, want it under %+v alone", got, instanceKey, volumeKey)
+	}
+}
+
+// TestFaultStreamsAreSeededByTheirName holds a switch's stream to the seed and
+// the name together. Two switches drawing one sequence would mean which
+// resources one of them touches follows from the other being on beside it.
+func TestFaultStreamsAreSeededByTheirName(t *testing.T) {
+	first := draws(faultStream(1, FaultPreExisting))
+
+	if again := draws(faultStream(1, FaultPreExisting)); again != first {
+		t.Errorf("faultStream(1, %q) drew %v and then %v, want the same draws twice",
+			FaultPreExisting, first, again)
+	}
+	if other := draws(faultStream(1, FaultDuplicates)); other == first {
+		t.Errorf("faultStream(1, %q) drew %v, want another sequence than %q's",
+			FaultDuplicates, other, FaultPreExisting)
+	}
+	if other := draws(faultStream(2, FaultPreExisting)); other == first {
+		t.Errorf("faultStream(2, %q) drew %v, want another sequence than seed 1's",
+			FaultPreExisting, other)
+	}
+}
+
+// draws takes the first four values of a stream, which is enough to tell two
+// generators apart.
+func draws(stream *rand.Rand) [4]uint64 {
+	var drawn [4]uint64
+	for i := range drawn {
+		drawn[i] = stream.Uint64()
+	}
+	return drawn
+}

--- a/internal/providers/openstack/simulator/oracle.go
+++ b/internal/providers/openstack/simulator/oracle.go
@@ -149,6 +149,11 @@ type fact struct {
 	projectID  string
 	workload   string
 	effect     effect
+	// dropped marks a transition the bus never carried, which is what the
+	// missing-create switch does to the ones before the month. The collector
+	// records no event for it, so no count states it. The fold still reads it: a
+	// dropped create is still what the cloud did.
+	dropped bool
 }
 
 // billableType is what the collector's mapping makes of one oslo type: the
@@ -303,6 +308,11 @@ type countKey struct {
 // mapping gives its oslo type. The transfer of the spare volume therefore
 // counts under the accepting project.
 //
+// A dropped fact is folded with every other one and counted with none of them.
+// The intervals state what the cloud did, and a create the bus never carried is
+// part of that; the counts state what the collector records, and it records
+// nothing for a notification it never received.
+//
 // The switches the month ran with are stated on the document, and the ones that
 // touched a resource on that resource. A ledger no switch was recorded for
 // takes a nil touched, which names no switch for any resource.
@@ -319,6 +329,9 @@ func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time,
 		}
 		key := resourceKey{resourceType: billable.resourceType, resourceID: f.resourceID}
 		grouped[key] = append(grouped[key], f)
+		if f.dropped {
+			continue
+		}
 		counts[countKey{projectID: f.projectID, eventType: billable.eventType}]++
 	}
 

--- a/internal/providers/openstack/simulator/oracle.go
+++ b/internal/providers/openstack/simulator/oracle.go
@@ -214,7 +214,9 @@ var billableTypes = map[string]billableType{
 // The guard runs both ways: ReadOracle refuses a document of another format,
 // and DisallowUnknownFields refuses one that states a member this build does
 // not read.
-const oracleFormat = 1
+//
+// Format 2 added the faults member on the document and on every resource.
+const oracleFormat = 2
 
 // Oracle is the generator's statement of what a month contained: for every
 // billable resource the intervals of constant state, size and project it
@@ -228,6 +230,9 @@ type Oracle struct {
 	PeriodTo   time.Time        `json:"period_to"`
 	Resources  []OracleResource `json:"resources"`
 	Counts     []OracleCount    `json:"counts"`
+	// Faults holds the fault switches the month ran with, in FaultNames order.
+	// A month nobody passed --faults to states an empty list.
+	Faults []string `json:"faults"`
 }
 
 // OracleResource is one billable resource of the month and the intervals it
@@ -237,6 +242,9 @@ type OracleResource struct {
 	ResourceID   string           `json:"resource_id"`
 	Workload     string           `json:"workload"`
 	Intervals    []OracleInterval `json:"intervals"`
+	// Faults holds the fault switches that touched this resource, in FaultNames
+	// order. A resource none of them touched states an empty list.
+	Faults []string `json:"faults"`
 }
 
 // OracleInterval is a half-open span [From, To) over which a resource's state,
@@ -294,7 +302,13 @@ type countKey struct {
 // fact, under the project the request ran in and the Tally event type the
 // mapping gives its oslo type. The transfer of the spare volume therefore
 // counts under the accepting project.
-func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time) (Oracle, error) {
+//
+// The switches the month ran with are stated on the document, and the ones that
+// touched a resource on that resource. A ledger no switch was recorded for
+// takes a nil touched, which names no switch for any resource.
+func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time,
+	faults Faults, touched touchedResources,
+) (Oracle, error) {
 	grouped := make(map[resourceKey][]fact)
 	counts := make(map[countKey]int)
 
@@ -330,6 +344,7 @@ func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time) (O
 			ResourceID:   key.resourceID,
 			Workload:     group[0].workload,
 			Intervals:    intervals,
+			Faults:       touched.names(key),
 		})
 	}
 	slices.SortFunc(resources, func(a, b OracleResource) int {
@@ -347,6 +362,7 @@ func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time) (O
 		PeriodTo:   to,
 		Resources:  resources,
 		Counts:     sortedCounts(counts),
+		Faults:     faults.Names(),
 	}, nil
 }
 

--- a/internal/providers/openstack/simulator/oracle_test.go
+++ b/internal/providers/openstack/simulator/oracle_test.go
@@ -129,7 +129,7 @@ func TestOracleAgreesWithTheMapping(t *testing.T) {
 		holdFactAgainstEvent(t, f, mapped)
 	}
 
-	oracle, err := buildOracle(g.facts, 1, testCloud, july2026, july2026.AddDate(0, 1, 0))
+	oracle, err := buildOracle(g.facts, 1, testCloud, july2026, july2026.AddDate(0, 1, 0), Faults{}, nil)
 	if err != nil {
 		t.Fatalf("buildOracle() error = %v, want nil", err)
 	}
@@ -379,7 +379,7 @@ func TestOracleUsesNoEngineFold(t *testing.T) {
 func TestOracleIntervalsFollowTheLives(t *testing.T) {
 	g := buildMonth(t, 1)
 
-	oracle, err := buildOracle(g.facts, 1, testCloud, july2026, july2026.AddDate(0, 1, 0))
+	oracle, err := buildOracle(g.facts, 1, testCloud, july2026, july2026.AddDate(0, 1, 0), Faults{}, nil)
 	if err != nil {
 		t.Fatalf("buildOracle() error = %v, want nil", err)
 	}
@@ -553,7 +553,7 @@ func TestBuildOracleClipsToTheMonth(t *testing.T) {
 		},
 	}
 
-	oracle, err := buildOracle(facts, 7, testCloud, from, to)
+	oracle, err := buildOracle(facts, 7, testCloud, from, to, Faults{}, nil)
 	if err != nil {
 		t.Fatalf("buildOracle() error = %v, want nil", err)
 	}
@@ -619,7 +619,7 @@ func TestBuildOracleClipsToTheMonth(t *testing.T) {
 	})
 
 	t.Run("an empty ledger states an empty month", func(t *testing.T) {
-		empty, err := buildOracle(nil, 7, testCloud, from, to)
+		empty, err := buildOracle(nil, 7, testCloud, from, to, Faults{}, nil)
 		if err != nil {
 			t.Fatalf("buildOracle(nil) error = %v, want nil", err)
 		}
@@ -663,7 +663,7 @@ func TestBuildOracleKeepsAFactThatRestatesTheOpenInterval(t *testing.T) {
 		},
 	}
 
-	oracle, err := buildOracle(facts, 1, testCloud, from, to)
+	oracle, err := buildOracle(facts, 1, testCloud, from, to, Faults{}, nil)
 	if err != nil {
 		t.Fatalf("buildOracle() error = %v, want nil", err)
 	}
@@ -701,7 +701,7 @@ func TestBuildOracleRefusesTwoFactsAtOneInstant(t *testing.T) {
 			},
 		}
 
-		_, err := buildOracle(facts, 1, testCloud, from, to)
+		_, err := buildOracle(facts, 1, testCloud, from, to, Faults{}, nil)
 		want := fmt.Sprintf("volume vol-1 reports two billable transitions at %s, which the projection "+
 			"cannot order", at.UTC().Format(time.RFC3339))
 		if err == nil || err.Error() != want {
@@ -716,7 +716,7 @@ func TestBuildOracleRefusesTwoFactsAtOneInstant(t *testing.T) {
 			effect: alive(stateActive, instanceSizeOf(flavors[0])),
 		}}
 
-		_, err := buildOracle(facts, 1, testCloud, from, to)
+		_, err := buildOracle(facts, 1, testCloud, from, to, Faults{}, nil)
 		want := "the oracle knows no resource type for compute.instance.reboot.end"
 		if err == nil || err.Error() != want {
 			t.Fatalf("buildOracle() error = %v, want %q", err, want)
@@ -743,7 +743,7 @@ func TestBuildOracleRefusesTwoFactsAtOneInstant(t *testing.T) {
 func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 	// surface is the format the lists below are stated for. A change to any of
 	// them raises this number and oracleFormat with it.
-	const surface = 1
+	const surface = 2
 
 	if oracleFormat != surface {
 		t.Fatalf("oracleFormat = %d and the surface below is stated for format %d, want the two "+
@@ -826,11 +826,14 @@ func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 		}{
 			{
 				named: "Oracle", typ: reflect.TypeFor[Oracle](),
-				want: []string{"format", "cloud", "seed", "period_from", "period_to", "resources", "counts"},
+				want: []string{
+					"format", "cloud", "seed", "period_from", "period_to", "resources", "counts",
+					"faults",
+				},
 			},
 			{
 				named: "OracleResource", typ: reflect.TypeFor[OracleResource](),
-				want: []string{"resource_type", "resource_id", "workload", "intervals"},
+				want: []string{"resource_type", "resource_id", "workload", "intervals", "faults"},
 			},
 			{
 				named: "OracleInterval", typ: reflect.TypeFor[OracleInterval](),
@@ -872,9 +875,9 @@ func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 // emptyOracleDocument is an oracle of a month that states no resource, written
 // out by hand because buildOracle only folds one from a ledger the generator
 // never produces.
-const emptyOracleDocument = `{"format":1,"cloud":"os-test","seed":1,` +
+const emptyOracleDocument = `{"format":2,"cloud":"os-test","seed":1,` +
 	`"period_from":"2026-07-01T00:00:00Z",` +
-	`"period_to":"2026-08-01T00:00:00Z","resources":[],"counts":[]}`
+	`"period_to":"2026-08-01T00:00:00Z","resources":[],"counts":[],"faults":[]}`
 
 // completeOracleDocument is the smallest document ReadOracle accepts, and
 // oracleIntervalDocument the one interval it holds. The cases that hold the
@@ -883,10 +886,10 @@ const emptyOracleDocument = `{"format":1,"cloud":"os-test","seed":1,` +
 const oracleIntervalDocument = `{"from":"2026-07-01T00:00:00Z","to":"2026-07-02T00:00:00Z",` +
 	`"state":"available","project_id":"p1","size":{"size_gb":50}}`
 
-const completeOracleDocument = `{"format":1,"cloud":"os-test","seed":1,` +
+const completeOracleDocument = `{"format":2,"cloud":"os-test","seed":1,` +
 	`"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z",` +
 	`"resources":[{"resource_type":"volume","resource_id":"v","workload":"classic",` +
-	`"intervals":[` + oracleIntervalDocument + `]}],"counts":[]}`
+	`"intervals":[` + oracleIntervalDocument + `],"faults":[]}],"counts":[],"faults":[]}`
 
 // generatedOracle is the oracle of one generated month, or a failed test.
 func generatedOracle(t *testing.T, seed uint64) Oracle {
@@ -944,6 +947,54 @@ func TestOracleRoundTrips(t *testing.T) {
 	}
 	if !strings.HasSuffix(text, "\n") {
 		t.Errorf("%s ends with %q, want a trailing newline", path, text[max(len(text)-20, 0):])
+	}
+}
+
+// TestOracleRoundTripsTheFaultSwitches holds the two faults members through a
+// write and a read. They are what tells a difference the drill's write-up
+// explains from a finding about the engine, and a resource nothing touched has
+// to come back as the empty list it was written as rather than as null.
+func TestOracleRoundTripsTheFaultSwitches(t *testing.T) {
+	month, err := GenerateMonth(1, july2026, july2026.AddDate(0, 1, 0), testCloud,
+		Faults{RefusedShapes: true, HeldBack: true})
+	if err != nil {
+		t.Fatalf("GenerateMonth() error = %v, want nil", err)
+	}
+	oracle := month.Oracle
+	if want := []string{FaultRefusedShapes, FaultHeldBack}; !slices.Equal(oracle.Faults, want) {
+		t.Fatalf("the oracle states the switches %v, want %v", oracle.Faults, want)
+	}
+	// No switch touches a resource yet, so one is named by hand: a file that
+	// stated the member nowhere would round-trip whatever the read left behind.
+	oracle.Resources[0].Faults = []string{FaultMissingCreate}
+
+	path := filepath.Join(t.TempDir(), "oracle.json")
+	if err := WriteOracle(path, oracle); err != nil {
+		t.Fatalf("WriteOracle() error = %v, want nil", err)
+	}
+	read, err := ReadOracle(path)
+	if err != nil {
+		t.Fatalf("ReadOracle() error = %v, want nil", err)
+	}
+
+	if !reflect.DeepEqual(read.Faults, oracle.Faults) {
+		t.Errorf("ReadOracle().Faults = %v, want %v", read.Faults, oracle.Faults)
+	}
+	if !reflect.DeepEqual(read.Resources[0].Faults, oracle.Resources[0].Faults) {
+		t.Errorf("ReadOracle().Resources[0].Faults = %v, want %v",
+			read.Resources[0].Faults, oracle.Resources[0].Faults)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	text := string(content)
+	if !strings.Contains(text, `"faults": []`) {
+		t.Errorf("%s states no empty switch list, want [] for a resource no switch touched", path)
+	}
+	if strings.Contains(text, `"faults": null`) {
+		t.Errorf("%s states a null switch list, want [] for a resource no switch touched", path)
 	}
 }
 
@@ -1009,11 +1060,11 @@ func TestReadOracleRefusesWhatIsNotAnOracle(t *testing.T) {
 	})
 
 	t.Run("an oracle written to another format", func(t *testing.T) {
-		path := writeOracleFile(t, strings.Replace(completeOracleDocument, `"format":1`, `"format":2`, 1))
+		path := writeOracleFile(t, strings.Replace(completeOracleDocument, `"format":2`, `"format":1`, 1))
 
 		_, err := ReadOracle(path)
 
-		want := fmt.Sprintf("%s states format 2 and this build writes format %d", path, oracleFormat)
+		want := fmt.Sprintf("%s states format 1 and this build writes format %d", path, oracleFormat)
 		if err == nil || err.Error() != want {
 			t.Fatalf("ReadOracle() error = %v, want %q", err, want)
 		}
@@ -1092,12 +1143,12 @@ func TestReadOracleRefusesWhatIsNotAnOracle(t *testing.T) {
 		path := writeOracleFile(t, `{"cloud":"os-test","seed":1,`+
 			`"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z",`+
 			`"resources":[{"resource_type":"volume","resource_id":"v","workload":"classic",`+
-			`"faults":[],"intervals":[]}],"counts":[]}`)
+			`"notes":[],"intervals":[]}],"counts":[]}`)
 
 		_, err := ReadOracle(path)
 
-		if err == nil || !strings.Contains(err.Error(), "faults") {
-			t.Fatalf("ReadOracle() error = %v, want it to name the unknown member faults", err)
+		if err == nil || !strings.Contains(err.Error(), "notes") {
+			t.Fatalf("ReadOracle() error = %v, want it to name the unknown member notes", err)
 		}
 	})
 }

--- a/internal/providers/openstack/simulator/oracle_test.go
+++ b/internal/providers/openstack/simulator/oracle_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/timeline"
 	"github.com/b42labs/tally/internal/engine/metering"
 	"github.com/b42labs/tally/internal/engine/rating"
 	"github.com/b42labs/tally/internal/providers/openstack"
@@ -245,64 +246,79 @@ func holdMemberAgainst(t *testing.T, eventType, member string, booked, want any,
 // two folds are written from the same rules and share no code, so a month they
 // disagree on is a bug in one of them rather than a comparison that agrees with
 // itself.
+//
+// The pre-existing switch is folded as well, because it is the one thing that
+// puts an event before the month on the bus. The engine receives that history
+// whole and cuts it at the month's first instant, which is where the oracle's
+// clip puts a resource the month inherited too.
 func TestOracleAgreesWithTheEngineFold(t *testing.T) {
 	to := july2026.AddDate(0, 1, 0)
 
-	for seed := uint64(1); seed <= 5; seed++ {
-		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
-			month, err := GenerateMonth(seed, july2026, to, testCloud, Faults{})
-			if err != nil {
-				t.Fatalf("GenerateMonth(%d, %s, %q) error = %v, want nil", seed,
-					july2026.Format(time.RFC3339), testCloud, err)
-			}
+	cases := []struct {
+		name   string
+		faults Faults
+	}{
+		{name: "no switch at all", faults: Faults{}},
+		{name: "servers the month inherited", faults: Faults{PreExisting: true}},
+	}
 
-			history := make(map[resourceKey][]event.Stored)
-			for _, transition := range month.Schedule.Billable() {
-				mapped, ok := openstack.MapNotification(parse(t, render(t, transition)), testCloud)
-				if !ok {
-					t.Fatalf("the mapping records nothing for %s at %s, want an event per billable transition",
-						transition.EventType, transition.At.Format(time.RFC3339))
-				}
-				key := resourceKey{resourceType: mapped.ResourceType, resourceID: mapped.ResourceID}
-				history[key] = append(history[key], event.Stored{Event: mapped})
-			}
-
-			metered := make(map[resourceKey][]metering.UsageDraft, len(history))
-			for key, events := range history {
-				drafts, err := metering.MeterResource(events, july2026, to)
+	for _, c := range cases {
+		for seed := uint64(1); seed <= 5; seed++ {
+			t.Run(fmt.Sprintf("%s, seed %d", c.name, seed), func(t *testing.T) {
+				month, err := GenerateMonth(seed, july2026, to, testCloud, c.faults)
 				if err != nil {
-					t.Fatalf("MeterResource(%s %s) error = %v, want nil", key.resourceType,
-						key.resourceID, err)
+					t.Fatalf("GenerateMonth(%d, %s, %q, %v) error = %v, want nil", seed,
+						july2026.Format(time.RFC3339), testCloud, c.faults.Names(), err)
 				}
-				// A resource the period bills nothing for is one the oracle leaves
-				// out as well, so it is not held against an interval it has none of.
-				if len(drafts) == 0 {
-					continue
-				}
-				metered[key] = drafts
-			}
 
-			stated := make(map[resourceKey]OracleResource, len(month.Oracle.Resources))
-			for _, resource := range month.Oracle.Resources {
-				stated[resourceKey{resourceType: resource.ResourceType, resourceID: resource.ResourceID}] = resource
-			}
+				history := make(map[resourceKey][]event.Stored)
+				for _, transition := range month.Schedule.Billable() {
+					mapped, ok := openstack.MapNotification(parse(t, render(t, transition)), testCloud)
+					if !ok {
+						t.Fatalf("the mapping records nothing for %s at %s, want an event per billable transition",
+							transition.EventType, transition.At.Format(time.RFC3339))
+					}
+					key := resourceKey{resourceType: mapped.ResourceType, resourceID: mapped.ResourceID}
+					history[key] = append(history[key], event.Stored{Event: mapped})
+				}
 
-			for key, drafts := range metered {
-				resource, ok := stated[key]
-				if !ok {
-					t.Errorf("the engine bills %s %s over %d intervals, and the oracle states none",
-						key.resourceType, key.resourceID, len(drafts))
-					continue
+				metered := make(map[resourceKey][]metering.UsageDraft, len(history))
+				for key, events := range history {
+					drafts, err := metering.MeterResource(events, july2026, to)
+					if err != nil {
+						t.Fatalf("MeterResource(%s %s) error = %v, want nil", key.resourceType,
+							key.resourceID, err)
+					}
+					// A resource the period bills nothing for is one the oracle leaves
+					// out as well, so it is not held against an interval it has none of.
+					if len(drafts) == 0 {
+						continue
+					}
+					metered[key] = drafts
 				}
-				holdIntervalsAgainstDrafts(t, resource, drafts)
-			}
-			for key := range stated {
-				if _, ok := metered[key]; !ok {
-					t.Errorf("the oracle states %s %s, and the engine bills nothing for it",
-						key.resourceType, key.resourceID)
+
+				stated := make(map[resourceKey]OracleResource, len(month.Oracle.Resources))
+				for _, resource := range month.Oracle.Resources {
+					stated[resourceKey{resourceType: resource.ResourceType, resourceID: resource.ResourceID}] = resource
 				}
-			}
-		})
+
+				for key, drafts := range metered {
+					resource, ok := stated[key]
+					if !ok {
+						t.Errorf("the engine bills %s %s over %d intervals, and the oracle states none",
+							key.resourceType, key.resourceID, len(drafts))
+						continue
+					}
+					holdIntervalsAgainstDrafts(t, resource, drafts)
+				}
+				for key := range stated {
+					if _, ok := metered[key]; !ok {
+						t.Errorf("the oracle states %s %s, and the engine bills nothing for it",
+							key.resourceType, key.resourceID)
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -334,6 +350,53 @@ func holdIntervalsAgainstDrafts(t *testing.T, resource OracleResource, drafts []
 		for member, value := range interval.Size {
 			holdMemberAgainst(t, resource.ResourceType, member, value, draft.Usage[member], draft.Usage)
 		}
+	}
+}
+
+// TestMissingCreateStartsTheHistoryWithoutACreate holds the switch against the
+// projection it is written for: a server whose create the bus never carried
+// reaches the collector as a history that begins with something else, and the
+// timeline says so. Nothing else of the month does, so the warning names the
+// touched resources and none besides them.
+func TestMissingCreateStartsTheHistoryWithoutACreate(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{MissingCreate: true})
+	touched := touchedResourcesOf(month.Oracle)
+
+	history := make(map[resourceKey][]event.Stored)
+	for _, transition := range month.Schedule.Billable() {
+		mapped, ok := openstack.MapNotification(parse(t, render(t, transition)), testCloud)
+		if !ok {
+			t.Fatalf("the mapping records nothing for %s at %s, want an event per billable transition",
+				transition.EventType, transition.At.Format(time.RFC3339))
+		}
+		key := resourceKey{resourceType: mapped.ResourceType, resourceID: mapped.ResourceID}
+		history[key] = append(history[key], event.Stored{Event: mapped})
+	}
+
+	// A resource whose every billable transition was dropped reaches the
+	// collector with no event at all, so there is no history of it to fold and
+	// no warning to hold against one.
+	warned := 0
+	for key, events := range history {
+		_, isTouched := touched[key]
+		startsWithoutCreate := slices.Contains(timeline.Build(events).Warnings,
+			timeline.WarningHistoryStartsWithoutCreate)
+
+		switch {
+		case isTouched && !startsWithoutCreate:
+			t.Errorf("the timeline of %s %s carries no %s, want the switch to have taken its create "+
+				"off the bus", key.resourceType, key.resourceID,
+				timeline.WarningHistoryStartsWithoutCreate)
+		case !isTouched && startsWithoutCreate:
+			t.Errorf("the timeline of %s %s carries %s, and no switch touched it", key.resourceType,
+				key.resourceID, timeline.WarningHistoryStartsWithoutCreate)
+		case isTouched:
+			warned++
+		}
+	}
+	if warned == 0 {
+		t.Errorf("no touched resource reports inside the month, want the switch to leave a history " +
+			"the collector receives without its create")
 	}
 }
 

--- a/internal/providers/openstack/simulator/oracle_test.go
+++ b/internal/providers/openstack/simulator/oracle_test.go
@@ -250,7 +250,7 @@ func TestOracleAgreesWithTheEngineFold(t *testing.T) {
 
 	for seed := uint64(1); seed <= 5; seed++ {
 		t.Run(fmt.Sprintf("seed %d", seed), func(t *testing.T) {
-			month, err := GenerateMonth(seed, july2026, to, testCloud)
+			month, err := GenerateMonth(seed, july2026, to, testCloud, Faults{})
 			if err != nil {
 				t.Fatalf("GenerateMonth(%d, %s, %q) error = %v, want nil", seed,
 					july2026.Format(time.RFC3339), testCloud, err)
@@ -892,7 +892,7 @@ const completeOracleDocument = `{"format":1,"cloud":"os-test","seed":1,` +
 func generatedOracle(t *testing.T, seed uint64) Oracle {
 	t.Helper()
 
-	month, err := GenerateMonth(seed, july2026, july2026.AddDate(0, 1, 0), testCloud)
+	month, err := GenerateMonth(seed, july2026, july2026.AddDate(0, 1, 0), testCloud, Faults{})
 	if err != nil {
 		t.Fatalf("GenerateMonth(%d, %s, %q) error = %v, want nil", seed,
 			july2026.Format(time.RFC3339), testCloud, err)

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"maps"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -185,6 +187,129 @@ func waitFor(t *testing.T, why string, condition func() bool) {
 		time.Sleep(pollInterval)
 	}
 	t.Fatalf("timed out after %v waiting until %s", pollDeadline, why)
+}
+
+// capturedLogger is the run's logger over a writer that keeps a copy of what it
+// wrote, for the cases that assert on a line the run logged. It logs at info,
+// so the copy holds the run's own lines rather than the debug line of every
+// published notification.
+func capturedLogger(t *testing.T) (*slog.Logger, *captureWriter) {
+	t.Helper()
+
+	writer := &captureWriter{t: t}
+	return slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{Level: slog.LevelInfo})), writer
+}
+
+// captureWriter passes the log through to the test and keeps it, so a case that
+// reads one line back still has the whole log under a failure.
+type captureWriter struct {
+	t  *testing.T
+	mu sync.Mutex
+	sb strings.Builder
+}
+
+func (w *captureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.sb.Write(p)
+	w.mu.Unlock()
+
+	w.t.Log(strings.TrimSuffix(string(p), "\n"))
+	return len(p), nil
+}
+
+// String is everything the run has logged so far.
+func (w *captureWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.sb.String()
+}
+
+// reservePort takes a free port off the operating system and hands it straight
+// back, so a case knows the port a run's control endpoint will bind. A run
+// picks its own with a configured port of 0, and that one it never reports
+// anywhere a test reads.
+func reservePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("the reserved address is %v, want a TCP one", listener.Addr())
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("giving the reserved port back: %v", err)
+	}
+	return addr.Port
+}
+
+// controlRequest sends one request to the control endpoint of a run on port and
+// returns the status and the body. The bool is false when nothing answered: a
+// run dials the broker and waits for the collector before it binds its port, so
+// a poll can arrive before the endpoint is there.
+func controlRequest(t *testing.T, port int, method, path string) (int, string, bool) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
+	req, err := http.NewRequestWithContext(t.Context(), method, url, nil)
+	if err != nil {
+		t.Fatalf("building %s %s: %v", method, url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the answer to %s %s: %v", method, url, err)
+	}
+	return resp.StatusCode, string(body), true
+}
+
+// waitForHold polls the control endpoint until the run reports that it holds
+// the last share of the month back, and returns the document it saw there. It
+// is how a case reaches the hold: the last notifications of a month may be
+// noise nothing else waits for.
+//
+// The wait is on holding rather than on the counts, the way a script driving a
+// drill waits: the published count reaches total minus held while the run is
+// still on its way into the hold, and a release sent on it is refused.
+func waitForHold(t *testing.T, port, held int) clockDocument {
+	t.Helper()
+
+	var doc clockDocument
+	waitFor(t, "the run holds the last share of the month back", func() bool {
+		status, body, answered := controlRequest(t, port, http.MethodGet, "/clock")
+		if !answered {
+			return false
+		}
+		if status != http.StatusOK {
+			t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+		}
+		doc = decodeDocument(t, body)
+		return doc.Holding && doc.Held == held
+	})
+	return doc
+}
+
+// depthStaysAt fails the test when the outbox moves off depth within a second.
+// It is what tells a run that holds notifications back from one that is merely
+// slow: a held share never arrives on its own.
+func depthStaysAt(t *testing.T, outbox *openstack.Outbox, depth int64) {
+	t.Helper()
+
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+		if got := outbox.Depth(); got != depth {
+			t.Fatalf("Depth() = %d, want it to stay at %d: the held notifications went out unasked",
+				got, depth)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 // counterValue reads one counter out of the collector's registry, through the
@@ -593,5 +718,303 @@ func TestConnectFailsWhenTheBrokerIsGone(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "dialing the broker") {
 		t.Errorf("Connect() error = %q, want it to name the dial", err)
+	}
+}
+
+// TestRunHoldsBackUntilReleased is the held-back switch end to end: the month
+// goes out but for the share the switch keeps, the run stays there until
+// somebody asks for it, and what the collector ends up holding is the whole
+// month either way. It is the drill the switch exists for, where a backlog is
+// let go long after the notifications it holds were timestamped.
+func TestRunHoldsBackUntilReleased(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, _, _ := startCollector(t, url, ServiceExchanges)
+
+	month := faultyMonth(t, 1, Faults{HeldBack: true})
+	want := billableMessageIDs(t, month.Schedule)
+	held := len(month.Held)
+	if held == 0 {
+		t.Fatal("the month holds nothing back, want the switch to have picked notifications")
+	}
+
+	port := reservePort(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(t.Context(), Config{Cloud: testCloud, HTTPPort: port}, RunOptions{
+			Period:           "2026-07",
+			Seed:             1,
+			Factor:           0,
+			Faults:           []string{FaultHeldBack},
+			WaitForCollector: pollDeadline,
+		}, publisher, testLogger(t))
+	}()
+
+	onTheBus := int64(len(want) - held)
+	waitFor(t, "every billable notification but the held ones is buffered", func() bool {
+		return outbox.Depth() == onTheBus
+	})
+	doc := waitForHold(t, port, held)
+	if doc.Published != doc.Total-held {
+		t.Errorf("GET /clock reports %d of %d published, want %d: the month is holding",
+			doc.Published, doc.Total, doc.Total-held)
+	}
+	depthStaysAt(t, outbox, onTheBus)
+
+	status, body, answered := controlRequest(t, port, http.MethodPost, "/release")
+	if !answered {
+		t.Fatal("POST /release reached nothing, want the endpoint to serve the hold")
+	}
+	if status != http.StatusOK {
+		t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if got := decodeDocument(t, body).Held; got != 0 {
+		t.Errorf("POST /release document held = %d, want 0", got)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil", err)
+		}
+	case <-time.After(pollDeadline):
+		t.Fatalf("Run() did not finish within %v after the release", pollDeadline)
+	}
+
+	waitFor(t, "the released notifications are buffered too", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
+		t.Errorf("buffered event ids = %v, want %v", got, want)
+	}
+}
+
+// TestRunStoppedWhileHoldingKeepsTheHeldNotificationsBack is what SIGINT does
+// to a run that is holding: the process ends with exit status 0, and the share
+// it held never reaches the bus. That is the other half of the drill, where the
+// backlog is thrown away rather than let go.
+func TestRunStoppedWhileHoldingKeepsTheHeldNotificationsBack(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, _, _ := startCollector(t, url, ServiceExchanges)
+
+	month := faultyMonth(t, 1, Faults{HeldBack: true})
+	want := billableMessageIDs(t, month.Schedule)
+	held := len(month.Held)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	logger, log := capturedLogger(t)
+	port := reservePort(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{Cloud: testCloud, HTTPPort: port}, RunOptions{
+			Period:           "2026-07",
+			Seed:             1,
+			Factor:           0,
+			Faults:           []string{FaultHeldBack},
+			WaitForCollector: pollDeadline,
+		}, publisher, logger)
+	}()
+
+	waitForHold(t, port, held)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil: a stop while holding is a clean stop", err)
+		}
+	case <-time.After(pollDeadline):
+		t.Fatalf("Run() did not finish within %v after the stop", pollDeadline)
+	}
+	if !strings.Contains(log.String(), "stopped") {
+		t.Errorf("the run logged %q, want it to report the stop", log.String())
+	}
+
+	onTheBus := int64(len(want) - held)
+	waitFor(t, "everything the run published is buffered", func() bool {
+		return outbox.Depth() == onTheBus
+	})
+	depthStaysAt(t, outbox, onTheBus)
+}
+
+// TestReleaseFailsWhenTheBrokerIsGone covers the release that cannot publish
+// what it let out. The endpoint answers it, because all a release does is close
+// a channel, and the run reports the failed publish afterwards: a broker that
+// went away during the hold is no clean stop.
+func TestReleaseFailsWhenTheBrokerIsGone(t *testing.T) {
+	url, stopBroker := startBroker(t)
+	// Dialled here rather than through connect: the broker is terminated while
+	// the run holds, and a close of a connection that is already gone is not what
+	// this case is about.
+	publisher, err := Connect(url)
+	if err != nil {
+		t.Fatalf("Connect() error = %v, want nil", err)
+	}
+	defer func() { _ = publisher.Close() }()
+
+	held := len(faultyMonth(t, 1, Faults{HeldBack: true}).Held)
+	port := reservePort(t)
+	done := make(chan error, 1)
+	go func() {
+		// No collector, so the wait for one is disabled: what this case needs of
+		// the broker is that it takes the month and then stops existing.
+		done <- Run(t.Context(), Config{Cloud: testCloud, HTTPPort: port}, RunOptions{
+			Period:           "2026-07",
+			Seed:             1,
+			Factor:           0,
+			Faults:           []string{FaultHeldBack},
+			WaitForCollector: 0,
+		}, publisher, testLogger(t))
+	}()
+
+	waitForHold(t, port, held)
+	stopBroker()
+
+	status, body, answered := controlRequest(t, port, http.MethodPost, "/release")
+	if !answered {
+		t.Fatal("POST /release reached nothing, want the endpoint to serve the hold")
+	}
+	if status != http.StatusOK {
+		t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "publishing to") {
+			t.Fatalf("Run() error = %v, want it to name the publish that failed", err)
+		}
+	case <-time.After(pollDeadline):
+		t.Fatalf("Run() did not finish within %v after the release", pollDeadline)
+	}
+}
+
+// TestRunPublishesDuplicatesTheCollectorHandsOn is the duplicates switch
+// against the collector: a copy carries the message id of the notification it
+// repeats, so the collector buffers both and the Reporting API books one. What
+// this case holds is the collector's half of that, the depth the outbox reaches
+// with both copies in it.
+func TestRunPublishesDuplicatesTheCollectorHandsOn(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, reg, _ := startCollector(t, url, ServiceExchanges)
+
+	month := faultyMonth(t, 1, Faults{Duplicates: true})
+	want := billableMessageIDs(t, month.Schedule)
+	duplicates := len(month.Stream) - len(month.Schedule)
+	if duplicates == 0 {
+		t.Fatalf("the stream repeats nothing, want one in %d billable transitions twice", duplicateShare)
+	}
+
+	err := Run(t.Context(), Config{Cloud: testCloud, HTTPPort: 0}, RunOptions{
+		Period:           "2026-07",
+		Seed:             1,
+		Factor:           0,
+		Faults:           []string{FaultDuplicates},
+		WaitForCollector: pollDeadline,
+	}, publisher, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	waitFor(t, "both copies of every repeated notification are buffered", func() bool {
+		return outbox.Depth() == int64(len(want)+duplicates)
+	})
+	// A copy is the bytes of its original, so nothing about it is unparseable:
+	// the collector hands it on and ingestion is what drops it.
+	if got := counterValue(t, reg, "tally_collector_unparseable_total", "", ""); got != 0 {
+		t.Errorf("tally_collector_unparseable_total = %v, want 0", got)
+	}
+}
+
+// TestRunPublishesRefusedShapesTheCollectorRefuses is the refused-shapes switch
+// against the collector: the oversized and the truncated twin are counted as
+// unparseable, the versioned one as skipped under the type it arrived as, and
+// the outbox ends up holding the very events a month without the switch
+// produces.
+func TestRunPublishesRefusedShapesTheCollectorRefuses(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, reg, _ := startCollector(t, url, ServiceExchanges)
+
+	month := faultyMonth(t, 1, Faults{RefusedShapes: true})
+	want := billableMessageIDs(t, month.Schedule)
+
+	// A twin is told by its message id: it stands in the stream and in no
+	// schedule. The three shapes are told apart the way faults.go builds them.
+	scheduled := make(map[string]bool, len(month.Schedule))
+	for _, transition := range month.Schedule {
+		scheduled[transition.MessageID] = true
+	}
+	versioned := make(map[string]int)
+	unparseable := 0
+	for _, twin := range month.Stream {
+		switch {
+		case scheduled[twin.MessageID]:
+		case twin.truncated, twin.Payload["fault_padding"] != nil:
+			unparseable++
+		case strings.HasPrefix(twin.EventType, "instance."):
+			versioned[twin.EventType]++
+		default:
+			t.Fatalf("the stream carries a twin of no known shape: %s", twin.EventType)
+		}
+	}
+	if unparseable == 0 || len(versioned) == 0 {
+		t.Fatalf("the stream carries %d unparseable twins and %d versioned types, want both shapes",
+			unparseable, len(versioned))
+	}
+
+	err := Run(t.Context(), Config{Cloud: testCloud, HTTPPort: 0}, RunOptions{
+		Period:           "2026-07",
+		Seed:             1,
+		Factor:           0,
+		Faults:           []string{FaultRefusedShapes},
+		WaitForCollector: pollDeadline,
+	}, publisher, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	waitFor(t, "every twin the collector cannot parse is counted", func() bool {
+		return counterValue(t, reg, "tally_collector_unparseable_total", "", "") == float64(unparseable)
+	})
+
+	// The skips of the month and the versioned twins together, waited for as a
+	// sum before any one type is read: a type is only worth comparing once the
+	// whole month has been handled.
+	skippedTotal := 0
+	for _, transition := range month.Schedule {
+		if !transition.Billable {
+			skippedTotal++
+		}
+	}
+	for _, count := range versioned {
+		skippedTotal += count
+	}
+	waitFor(t, "every skipped notification is counted", func() bool {
+		return skippedSum(t, reg) == float64(skippedTotal)
+	})
+	for _, eventType := range slices.Sorted(maps.Keys(versioned)) {
+		got := counterValue(t, reg, "tally_collector_skipped_total", "event_type", eventType)
+		if got != float64(versioned[eventType]) {
+			t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want %d",
+				eventType, got, versioned[eventType])
+		}
+	}
+	// The versioned names stand beside the month's own and still leave the label
+	// inside the bound the collector admits.
+	if got := counterValue(t, reg, "tally_collector_skipped_total",
+		"event_type", cardinality.Overflow); got != 0 {
+		t.Errorf("tally_collector_skipped_total{event_type=%q} = %v, want 0", cardinality.Overflow, got)
+	}
+
+	// And the events are the ones a month without the switch produces: a refused
+	// twin is refused, not booked.
+	waitFor(t, "every billable notification is buffered", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
+		t.Errorf("buffered event ids = %v, want %v", got, want)
 	}
 }

--- a/internal/providers/openstack/simulator/render.go
+++ b/internal/providers/openstack/simulator/render.go
@@ -74,6 +74,16 @@ func Render(t Transition) ([]byte, error) {
 		return nil, fmt.Errorf("rendering %s: %w", t.EventType, err)
 	}
 
+	// The truncated twin of the refused-shapes switch (faults.go) cuts the inner
+	// message and not the outer body, so the envelope stays a JSON document:
+	// WriteStream carries every line as json.RawMessage, which cannot hold a
+	// body that is not one. The collector's second decode, of oslo.message,
+	// fails on the half that is left, and handle counts the delivery as
+	// unparseable.
+	if t.truncated {
+		inner = inner[:len(inner)/2]
+	}
+
 	body, err := json.Marshal(map[string]string{
 		"oslo.version": "2.0",
 		"oslo.message": string(inner),

--- a/internal/providers/openstack/simulator/render_test.go
+++ b/internal/providers/openstack/simulator/render_test.go
@@ -690,3 +690,31 @@ func TestAuditPayloadReportsTheStatusOnTheResponse(t *testing.T) {
 			got, want)
 	}
 }
+
+// TestRenderTruncatesATwinPastTheCollectorsParser covers the one shape the
+// renderer knows about: the truncated twin of the refused-shapes switch
+// (faults.go). The cut runs through the inner message and not through the
+// outer body, so the envelope stays a JSON document and the stream file can
+// carry it, while the collector's second decode fails on the half that is left.
+func TestRenderTruncatesATwinPastTheCollectorsParser(t *testing.T) {
+	original := generateMonth(t, 1, july2026, testCloud).Billable()[0]
+	twin := truncatedTwin(original, "7c8d9e0f-1a2b-4c3d-8e4f-5a6b7c8d9e0f")
+
+	body := render(t, twin)
+
+	if !json.Valid(body) {
+		t.Errorf("the truncated twin of %s renders %s, want a JSON document WriteStream can carry as a line",
+			original.EventType, body)
+	}
+	if _, err := openstack.ParseEnvelope(body); err == nil {
+		t.Errorf("ParseEnvelope of the truncated twin of %s error = nil, want the collector to refuse it",
+			original.EventType)
+	}
+
+	untruncated := twin
+	untruncated.truncated = false
+	if whole := render(t, untruncated); len(body) >= len(whole) {
+		t.Errorf("the truncated twin of %s renders %d bytes and the twin itself %d, want the cut to "+
+			"shorten it", original.EventType, len(body), len(whole))
+	}
+}

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"math"
 	"net"
@@ -56,7 +57,8 @@ type RunOptions struct {
 	// unbounded: the month goes out as fast as the broker takes it.
 	Factor float64
 	// Out is the directory notifications.jsonl, events.jsonl and oracle.json are
-	// written to. Empty writes nothing.
+	// written to, and held-back.jsonl beside them when a switch holds something
+	// back. Empty writes nothing.
 	Out string
 	// WaitForCollector is how long to wait for a consumer on the collector's
 	// queue before the first notification goes out. Zero disables the wait.
@@ -154,8 +156,10 @@ type queued struct {
 // publisher is file mode, where the month is written out and nothing reaches a
 // bus.
 //
-// All three files are complete before the first notification is published, so a
-// run that is interrupted halfway still leaves a whole month on disk to replay.
+// The files are complete before the first notification is published, so a run
+// that is interrupted halfway still leaves a whole month on disk to replay.
+// There are three of them, and a fourth, held-back.jsonl, when the held-back
+// switch keeps part of the month off the bus.
 //
 // A cancelled context is a clean stop: what went out stays out, and Run returns
 // nil, so SIGINT and SIGTERM leave exit status 0 the way they do for the
@@ -196,6 +200,8 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		"faults", faults.Names(),
 		"transitions", len(schedule),
 		"billable", len(schedule.Billable()),
+		"stream", len(month.Stream),
+		"held", len(month.Held),
 		"resources", len(month.Oracle.Resources),
 		"broker", publisher != nil,
 		"out", opts.Out)
@@ -204,7 +210,27 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		if err := os.MkdirAll(opts.Out, outDirMode); err != nil {
 			return fmt.Errorf("creating %s: %w", opts.Out, err)
 		}
-		if err := WriteStream(filepath.Join(opts.Out, "notifications.jsonl"), schedule); err != nil {
+		// The files of an earlier run go first, all four of them and before the
+		// first of this month's is written: written over one by one, whichever
+		// ones a failed write never reached would stay beside this month's, and a
+		// directory reused across runs would carry another month's oracle, events,
+		// or held share into a replay or a drill. A removal that fails does not
+		// stop the others, and every one of them that failed is named, so the
+		// paths a failed run reports are what is left of the earlier month in the
+		// directory.
+		var removeErr error
+		for _, name := range []string{
+			"notifications.jsonl", "events.jsonl", "oracle.json", "held-back.jsonl",
+		} {
+			path := filepath.Join(opts.Out, name)
+			if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				removeErr = errors.Join(removeErr, fmt.Errorf("removing %s: %w", path, err))
+			}
+		}
+		if removeErr != nil {
+			return removeErr
+		}
+		if err := WriteStream(filepath.Join(opts.Out, "notifications.jsonl"), month.Stream); err != nil {
 			return err
 		}
 		if err := WriteEvents(filepath.Join(opts.Out, "events.jsonl"), cfg.Cloud, schedule); err != nil {
@@ -213,18 +239,39 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		if err := WriteOracle(filepath.Join(opts.Out, "oracle.json"), month.Oracle); err != nil {
 			return err
 		}
+		// The fourth file, when the switch holds something back.
+		if len(month.Held) > 0 {
+			if err := WriteStream(filepath.Join(opts.Out, "held-back.jsonl"), month.Held); err != nil {
+				return err
+			}
+		}
 	}
 
 	if publisher == nil {
-		logger.Info("completed", "published", 0, "total", len(schedule))
+		logger.Info("completed", "published", 0, "total", len(month.Stream)+len(month.Held))
 		return nil
 	}
 
+	lines, err := renderQueue(month.Stream)
+	if err != nil {
+		return err
+	}
+	held, err := renderQueue(month.Held)
+	if err != nil {
+		return err
+	}
+	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines, held)
+}
+
+// renderQueue turns a schedule into the notifications the bus carries. The
+// whole of it is rendered before the first one is published, so a rendering
+// error ends the run with nothing published rather than halfway through.
+func renderQueue(schedule Schedule) ([]queued, error) {
 	lines := make([]queued, 0, len(schedule))
 	for _, transition := range schedule {
 		body, err := Render(transition)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		lines = append(lines, queued{
 			exchange:   transition.Exchange,
@@ -235,7 +282,7 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 			body:       body,
 		})
 	}
-	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines)
+	return lines, nil
 }
 
 // Replay publishes a month a run recorded, in the order the file holds it.
@@ -294,30 +341,42 @@ func Replay(ctx context.Context, cfg Config, opts ReplayOptions, publisher *Publ
 		"from", from.Format(time.RFC3339),
 		"to", to.Format(time.RFC3339))
 
-	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines)
+	return broadcast(ctx, cfg, publisher, logger, opts.Factor, opts.WaitForCollector, from, to, lines, nil)
 }
 
 // broadcast puts the lines on the bus in the order they stand in, paced by a
-// virtual clock that starts at from, and serves the control endpoint while it
-// does.
+// virtual clock that starts at from, holds the held ones back until a release
+// arrives, and serves the control endpoint through all of it.
 //
-// The endpoint is served for the length of the publishing and no longer,
-// because pacing is the only thing it changes and there is nothing to pace
-// before the first notification or after the last one.
+// The endpoint is served for the length of the run and no longer. It changes
+// when the month goes out, and there is nothing left to decide before the first
+// notification or after the last one, so it comes up with the publishing and
+// stays up through the hold.
 //
-// Lines go out in their own order rather than in timestamp order. One whose
-// instant lies before the previous one is published at once, because SleepUntil
-// returns immediately when the clock has already passed it, so a recorded file
-// that is not perfectly sorted still replays whole.
+// A held share is published after the last regular line, once POST /release
+// asks for it. Every held instant lies before the clock by then, so the
+// notifications go out as fast as the broker confirms them, each under the
+// timestamp inside the month it always carried. A context that ends during the
+// hold is a clean stop with the held share never published.
 func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *slog.Logger,
-	factor float64, wait time.Duration, from, to time.Time, lines []queued,
+	factor float64, wait time.Duration, from, to time.Time, lines, held []queued,
 ) error {
-	if err := publisher.AwaitConsumer(ctx, collectorQueue, wait); err != nil {
-		if ctx.Err() != nil {
-			logger.Info("stopped", "published", 0, "total", len(lines))
-			return nil
+	hb := newHoldback(len(held))
+	total := len(lines) + len(held)
+	var published atomic.Int64
+	// How every end of a run is answered: a cancelled context is a clean stop,
+	// reported as one and answered with nil, and anything else is the error it
+	// is. SIGINT and SIGTERM leave exit status 0 through this.
+	stop := func(err error) error {
+		if ctx.Err() == nil {
+			return err
 		}
-		return err
+		logger.Info("stopped", "published", published.Load(), "total", total, "held", hb.held())
+		return nil
+	}
+
+	if err := publisher.AwaitConsumer(ctx, collectorQueue, wait); err != nil {
+		return stop(err)
 	}
 
 	// The endpoint carries no credential, so it binds the address the
@@ -332,12 +391,15 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 	}
 
 	clock := NewClock(from, factor, time.Now)
-	var published atomic.Int64
 	progress := func() Progress {
-		return Progress{From: from, To: to, Published: int(published.Load()), Total: len(lines)}
+		return Progress{
+			From: from, To: to,
+			Published: int(published.Load()), Total: total,
+			Held: hb.held(), Holding: hb.holding(),
+		}
 	}
 	server := &http.Server{
-		Handler:           NewControlMux(clock, progress),
+		Handler:           NewControlMux(clock, progress, hb.release),
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       readTimeout,
 		WriteTimeout:      writeTimeout,
@@ -365,16 +427,57 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 	}
 	logger.Info("listening", "port", port)
 
+	if err := publishLines(ctx, clock, publisher, logger, lines, &published); err != nil {
+		return stop(err)
+	}
+
+	if len(held) > 0 {
+		hb.phase.Store(phaseHolding)
+		logger.Info("holding", "held", len(held), "hint", "POST /release")
+		select {
+		case <-ctx.Done():
+			return stop(ctx.Err())
+		case <-hb.released:
+			logger.Info("releasing", "held", len(held))
+			// A failed publish here is the error it is during the month: what the
+			// operator does about it is rerun the same seed, period and cloud.
+			if err := publishLines(ctx, clock, publisher, logger, held, &published); err != nil {
+				return stop(err)
+			}
+		}
+	}
+
+	// A control endpoint that never came up is reported here rather than while
+	// the month runs: the month is what the operator asked for, and losing the
+	// endpoint is no reason to stop publishing it.
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serving HTTP: %w", err)
+		}
+	default:
+	}
+
+	logger.Info("completed", "published", published.Load(), "total", total)
+	return nil
+}
+
+// publishLines puts the lines on the bus in the order they stand in, paced by
+// the clock, and counts every one the broker confirmed.
+//
+// Lines go out in their own order rather than in timestamp order. One whose
+// instant lies before the previous one is published at once, because SleepUntil
+// returns immediately when the clock has already passed it, so a recorded file
+// that is not perfectly sorted still replays whole.
+func publishLines(ctx context.Context, clock *Clock, publisher *Publisher, logger *slog.Logger,
+	lines []queued, published *atomic.Int64,
+) error {
 	for _, line := range lines {
 		err := clock.SleepUntil(ctx, line.at)
 		if err == nil {
 			err = publisher.Publish(ctx, line.exchange, line.routingKey, line.body)
 		}
 		if err != nil {
-			if ctx.Err() != nil {
-				logger.Info("stopped", "published", published.Load(), "total", len(lines))
-				return nil
-			}
 			return err
 		}
 		published.Add(1)
@@ -384,18 +487,5 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 			"message_id", line.messageID,
 			"timestamp", line.at.Format(time.RFC3339))
 	}
-
-	// A control endpoint that never came up is reported here rather than while
-	// the month runs: the month is what the operator asked for, and losing the
-	// pacing endpoint is no reason to stop publishing it.
-	select {
-	case err := <-serveErr:
-		if !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("serving HTTP: %w", err)
-		}
-	default:
-	}
-
-	logger.Info("completed", "published", published.Load(), "total", len(lines))
 	return nil
 }

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -61,6 +61,9 @@ type RunOptions struct {
 	// WaitForCollector is how long to wait for a consumer on the collector's
 	// queue before the first notification goes out. Zero disables the wait.
 	WaitForCollector time.Duration
+	// Faults are the switch names of --faults, which ParseFaults reads. Empty is
+	// every switch off.
+	Faults []string
 }
 
 // Validate checks the options and returns the month Period names.
@@ -84,6 +87,9 @@ func (o RunOptions) Validate() (from, to time.Time, err error) {
 	}
 	if err := validatePacing(o.Factor, o.WaitForCollector); err != nil {
 		return time.Time{}, time.Time{}, err
+	}
+	if _, err := ParseFaults(o.Faults); err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("--faults: %w", err)
 	}
 	return from, to, nil
 }
@@ -169,7 +175,14 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		return errors.New("set " + envAMQPURL + " or pass --out: the run has nowhere to publish")
 	}
 
-	month, err := GenerateMonth(opts.Seed, from, to, cfg.Cloud)
+	// Validate has read the switches once already; this is the parsed value
+	// itself, which it does not hand back.
+	faults, err := ParseFaults(opts.Faults)
+	if err != nil {
+		return fmt.Errorf("--faults: %w", err)
+	}
+
+	month, err := GenerateMonth(opts.Seed, from, to, cfg.Cloud, faults)
 	if err != nil {
 		return err
 	}
@@ -180,6 +193,7 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		"period", opts.Period,
 		"cloud", cfg.Cloud,
 		"factor", opts.Factor,
+		"faults", faults.Names(),
 		"transitions", len(schedule),
 		"billable", len(schedule.Billable()),
 		"resources", len(month.Oracle.Resources),

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -44,6 +44,11 @@ type Transition struct {
 	// tells the noise apart from the one skipped billable type when the message
 	// ids are drawn, so the catalogue takes its ids from its own stream.
 	noise bool
+	// truncated marks a transition that is rendered as an envelope whose
+	// oslo.message is cut in half, so the collector's ParseEnvelope refuses it.
+	// Nothing on the wire names it: it is set on the truncated twin of the
+	// refused-shapes switch (faults.go) and read by Render alone.
+	truncated bool
 	// Workload names which of the three workloads emitted the transition, one of
 	// the workload constants. Nothing on the wire carries it: it is what a test
 	// and the later reconciliation oracle tell the workloads of one month apart
@@ -176,8 +181,18 @@ const shapeStream = 1
 // Month is one generated month: the transitions the simulated cloud publishes
 // and the oracle of what they were meant to mean.
 type Month struct {
+	// Schedule is what the simulated cloud did: every transition once, sorted by
+	// its instant. It is what the oracle and WriteEvents are read from.
 	Schedule Schedule
-	Oracle   Oracle
+	// Stream is the notifications in publication order, which is what
+	// notifications.jsonl holds and what the bus carries. The switches of
+	// faults.go move, repeat, and add to it. With every switch off it is the
+	// schedule.
+	Stream Schedule
+	// Held holds the transitions the held-back switch keeps off the bus until a
+	// run releases them, in instant order. It is empty unless that switch is on.
+	Held   Schedule
+	Oracle Oracle
 }
 
 // GenerateMonth builds one month of the simulated cloud's lifecycle
@@ -258,11 +273,15 @@ func GenerateMonth(seed uint64, from, to time.Time, cloud string, faults Faults)
 		g.schedule[i].MessageID = identifiers.nextUUID()
 	}
 
+	// The stream passes run before the oracle is folded, because they record the
+	// resources they touched and the oracle states those per resource.
+	stream, held := applyStreamFaults(g.schedule, seed, faults, g.touched)
+
 	oracle, err := buildOracle(g.facts, seed, cloud, start, start.AddDate(0, 1, 0), faults, g.touched)
 	if err != nil {
 		return Month{}, err
 	}
-	return Month{Schedule: g.schedule, Oracle: oracle}, nil
+	return Month{Schedule: g.schedule, Stream: stream, Held: held, Oracle: oracle}, nil
 }
 
 // identifierSalt mixes the cloud and the billing month into the identifier

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -208,7 +208,14 @@ type Month struct {
 // down to the message ids: a noise transition takes its own from the third
 // stream, so a catalogue that grows by one transition renumbers nothing the
 // collector bills.
-func GenerateMonth(seed uint64, from, to time.Time, cloud string) (Month, error) {
+//
+// The fault switches (faults.go) draw from streams of their own, one per switch
+// and seeded by the seed together with the switch's name. None of them draws
+// from the shape stream, so a month with every switch off consumes the three
+// streams above exactly as it would without the switches, and missing-create
+// draws from the pre-existing stream, which is what makes the two pick the same
+// instances for one seed.
+func GenerateMonth(seed uint64, from, to time.Time, cloud string, faults Faults) (Month, error) {
 	// A caller that reached here without going through period.Parse is caught
 	// before it produces a month that no billing period covers.
 	start := time.Date(from.UTC().Year(), from.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
@@ -221,6 +228,7 @@ func GenerateMonth(seed uint64, from, to time.Time, cloud string) (Month, error)
 
 	g := newGenerator(shape, identifiers, noiseIdentifiers(seed, cloud, start),
 		start, start.AddDate(0, 1, 0), cloud)
+	g.faults = faults
 	g.run()
 	if len(g.schedule) == 0 {
 		return Month{}, errors.New("the generated month holds no transitions")
@@ -307,6 +315,9 @@ type generator struct {
 	from     time.Time
 	to       time.Time
 	cloud    string
+	// faults are the switches this month runs with (faults.go). The zero value
+	// is every switch off.
+	faults Faults
 
 	// networkID is the external network the month's addresses come from. There
 	// is one per month, the way a deployment has one.
@@ -329,6 +340,9 @@ type generator struct {
 	// facts holds one entry per booked transition: what that transition left
 	// behind on its resource. The oracle of the month is folded from them.
 	facts []fact
+	// touched holds the resources a switch touched, keyed the way the oracle
+	// keys a resource.
+	touched touchedResources
 }
 
 // newGenerator draws the identifiers of the world a month starts from and
@@ -357,6 +371,7 @@ func newGenerator(shape *rand.Rand, identifiers, noiseIDs idReader,
 	g := &generator{
 		shape: shape, identifiers: identifiers, noiseIDs: noiseIDs,
 		from: from, to: to, cloud: cloud,
+		touched: make(touchedResources),
 	}
 
 	g.networkID = identifiers.nextUUID()

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -249,7 +249,7 @@ func GenerateMonth(seed uint64, from, to time.Time, cloud string, faults Faults)
 		g.schedule[i].MessageID = identifiers.nextUUID()
 	}
 
-	oracle, err := buildOracle(g.facts, seed, cloud, start, start.AddDate(0, 1, 0))
+	oracle, err := buildOracle(g.facts, seed, cloud, start, start.AddDate(0, 1, 0), faults, g.touched)
 	if err != nil {
 		return Month{}, err
 	}

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -229,7 +229,16 @@ func GenerateMonth(seed uint64, from, to time.Time, cloud string, faults Faults)
 	g := newGenerator(shape, identifiers, noiseIdentifiers(seed, cloud, start),
 		start, start.AddDate(0, 1, 0), cloud)
 	g.faults = faults
+	// missing-create draws from the pre-existing stream on purpose: the two
+	// exclude each other, and one stream between them means both pick the same
+	// instances with the same leads for one seed.
+	if faults.PreExisting || faults.MissingCreate {
+		g.preExisting = faultStream(seed, FaultPreExisting)
+	}
 	g.run()
+	if faults.MissingCreate {
+		g.dropBeforeMonth()
+	}
 	if len(g.schedule) == 0 {
 		return Month{}, errors.New("the generated month holds no transitions")
 	}
@@ -318,6 +327,10 @@ type generator struct {
 	// faults are the switches this month runs with (faults.go). The zero value
 	// is every switch off.
 	faults Faults
+	// preExisting is the stream the two pre-existing switches pick their
+	// instances and their leads from. It is nil unless pre-existing or
+	// missing-create is on.
+	preExisting *rand.Rand
 
 	// networkID is the external network the month's addresses come from. There
 	// is one per month, the way a deployment has one.
@@ -498,6 +511,24 @@ func (g *generator) run() {
 	g.audits()
 }
 
+// dropBeforeMonth takes every transition that lies before the month out of the
+// schedule and marks the fact behind it as dropped. It is the missing-create
+// switch: the simulated cloud did emit these transitions, and the bus never
+// carried them, so the collector first hears of such a resource through a
+// notification from inside the month.
+//
+// The audits stay. They are a pass over the finished schedule (noise.go) and
+// they ran before this one, so an instance whose create was dropped is still
+// reported by the daily compute.instance.exists of the month.
+func (g *generator) dropBeforeMonth() {
+	g.schedule = slices.DeleteFunc(g.schedule, func(t Transition) bool { return t.At.Before(g.from) })
+	for i := range g.facts {
+		if g.facts[i].at.Before(g.from) {
+			g.facts[i].dropped = true
+		}
+	}
+}
+
 // emit records one transition. The project is the one the request ran in, which
 // is the owner everywhere except on a transfer, where the accepting project
 // makes the request that moves the volume to itself. The effect is what the
@@ -564,6 +595,24 @@ func (g *generator) instances(p *project) {
 		}
 		inst.host = computeHosts[g.shape.IntN(len(computeHosts))]
 		inst.createdAt = g.from.Add(span(g.shape, 2*time.Hour, 6*time.Hour))
+		// The two pre-existing switches start a share of the classic tenants'
+		// servers before the month, and the volumes and the address of such a
+		// server follow it there. Both the pick and the lead are drawn from
+		// the fault stream and never from the shape stream, so a month with a
+		// switch on keeps the shape of the month with it off, and a seed whose
+		// stream picks nothing yields the month the switches-off run yields.
+		if g.preExisting != nil && g.preExisting.IntN(preExistingShare) == 0 {
+			inst.createdAt = g.from.Add(-span(g.preExisting, preExistingLeadMin, preExistingLeadMax))
+			name := FaultPreExisting
+			if g.faults.MissingCreate {
+				name = FaultMissingCreate
+			}
+			g.touch("instance", inst.id, name)
+			for _, vol := range inst.volumes {
+				g.touch("volume", vol.id, name)
+			}
+			g.touch("floating_ip", inst.fip.id, name)
+		}
 		inst.imageID = p.images[g.shape.IntN(len(p.images))].id
 
 		g.createInstance(p, inst, p.network, inst.createdAt)

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -44,6 +44,33 @@ func generateMonth(t *testing.T, seed uint64, from time.Time, cloud string) Sche
 	return month.Schedule
 }
 
+// faultyMonth generates July 2026 over testCloud with the switches on, or fails
+// the test. It hands back the whole month, because a switch is read off the
+// oracle as much as off the schedule.
+func faultyMonth(t *testing.T, seed uint64, faults Faults) Month {
+	t.Helper()
+
+	month, err := GenerateMonth(seed, july2026, july2026.AddDate(0, 1, 0), testCloud, faults)
+	if err != nil {
+		t.Fatalf("GenerateMonth(%d, %s, %q, %v) error = %v, want nil", seed,
+			july2026.Format(time.RFC3339), testCloud, faults.Names(), err)
+	}
+	return month
+}
+
+// touchedResourcesOf returns the resources the oracle names a switch on, keyed
+// the way the oracle keys one.
+func touchedResourcesOf(oracle Oracle) map[resourceKey]OracleResource {
+	touched := make(map[resourceKey]OracleResource)
+	for _, resource := range oracle.Resources {
+		if len(resource.Faults) == 0 {
+			continue
+		}
+		touched[resourceKey{resourceType: resource.ResourceType, resourceID: resource.ResourceID}] = resource
+	}
+	return touched
+}
+
 // requireDisjoint fails the test when the two schedules share a value of the
 // field, which is what salting the identifiers is supposed to rule out.
 func requireDisjoint(t *testing.T, field string, first, second Schedule, of func(Transition) string) {
@@ -336,6 +363,250 @@ func TestGenerateStaysInsideThePeriod(t *testing.T) {
 			t.Errorf("Billable()[%d] is %s, want %s", i, got[i].MessageID, want[i].MessageID)
 		}
 	}
+}
+
+// TestPreExistingInstancesStartBeforeTheMonth holds what the pre-existing
+// switch does to a month: a share of the classic tenants' servers, with the
+// volumes and the address that belong to them, is created before the month
+// begins and reports every transition of that history. The month still bills
+// them from its first instant, because the oracle clips an interval that starts
+// before the month to the month.
+func TestPreExistingInstancesStartBeforeTheMonth(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{PreExisting: true})
+	touched := touchedResourcesOf(month.Oracle)
+
+	before := 0
+	for _, transition := range month.Schedule {
+		if !transition.At.Before(july2026) {
+			continue
+		}
+		before++
+		if transition.Workload != workloadClassic {
+			t.Errorf("%s of a %s resource is at %s, want the switch to work on the classic tenants alone",
+				transition.EventType, transition.Workload, transition.At.Format(time.RFC3339))
+		}
+		if !transition.Billable {
+			continue
+		}
+		billable, ok := billableTypes[transition.EventType]
+		if !ok {
+			t.Fatalf("the oracle knows no resource type for the billable %s", transition.EventType)
+		}
+		key := resourceKey{resourceType: billable.resourceType, resourceID: transition.ResourceID}
+		if resource, ok := touched[key]; !ok || !slices.Contains(resource.Faults, FaultPreExisting) {
+			t.Errorf("%s %s reports %s at %s, and the oracle names no switch on it",
+				key.resourceType, key.resourceID, transition.EventType,
+				transition.At.Format(time.RFC3339))
+		}
+	}
+	if before == 0 {
+		t.Fatalf("no transition of the month lies before %s, want the switch to move a share of "+
+			"the classic servers behind it", july2026.Format(time.RFC3339))
+	}
+
+	created := make(map[string]time.Time)
+	for _, transition := range month.Schedule {
+		if transition.EventType == "compute.instance.create.end" {
+			created[transition.ResourceID] = transition.At
+		}
+	}
+
+	for key, resource := range touched {
+		switch key.resourceType {
+		case "instance", "volume", "floating_ip":
+		default:
+			t.Errorf("the switch touched the %s %s, want the servers of the classic tenants with "+
+				"their volumes and their addresses", key.resourceType, key.resourceID)
+		}
+		if resource.Workload != workloadClassic {
+			t.Errorf("the switch touched %s %s of the %s workload, want the classic one",
+				key.resourceType, key.resourceID, resource.Workload)
+		}
+		for i, interval := range resource.Intervals {
+			if interval.From.Before(july2026) {
+				t.Errorf("%s %s interval %d starts at %s, want the clip to hold it at %s",
+					key.resourceType, key.resourceID, i, interval.From.Format(time.RFC3339),
+					july2026.Format(time.RFC3339))
+			}
+		}
+		if from := resource.Intervals[0].From; !from.Equal(july2026) {
+			t.Errorf("%s %s is billed from %s, want it billed from the month's first instant %s",
+				key.resourceType, key.resourceID, from.Format(time.RFC3339),
+				july2026.Format(time.RFC3339))
+		}
+		if key.resourceType != "instance" {
+			continue
+		}
+		at, ok := created[key.resourceID]
+		if !ok {
+			t.Errorf("instance %s reports no create, want the whole history of a server the month "+
+				"inherited", key.resourceID)
+			continue
+		}
+		if at.Before(july2026.Add(-preExistingLeadMax)) || at.After(july2026.Add(-preExistingLeadMin)) {
+			t.Errorf("instance %s was created at %s, want it inside [%s, %s]", key.resourceID,
+				at.Format(time.RFC3339), july2026.Add(-preExistingLeadMax).Format(time.RFC3339),
+				july2026.Add(-preExistingLeadMin).Format(time.RFC3339))
+		}
+	}
+}
+
+// TestMissingCreateDropsWhatLiesBeforeTheMonth holds the other half of the
+// pair: missing-create picks the very same servers and then keeps every
+// transition of theirs that happened before the month off the bus. The oracle
+// still states them, because what the bus carried is not what the cloud did,
+// and the daily audits still report them, because the audits are a pass over
+// the schedule that ran before the drop.
+func TestMissingCreateDropsWhatLiesBeforeTheMonth(t *testing.T) {
+	to := july2026.AddDate(0, 1, 0)
+	month := faultyMonth(t, 1, Faults{MissingCreate: true})
+	touched := touchedResourcesOf(month.Oracle)
+
+	for _, transition := range month.Schedule {
+		if transition.At.Before(july2026) {
+			t.Errorf("%s of %s is at %s, want every transition the bus carries inside the month",
+				transition.EventType, transition.ResourceID, transition.At.Format(time.RFC3339))
+		}
+	}
+
+	t.Run("the two switches pick the same resources", func(t *testing.T) {
+		want := touchedResourcesOf(faultyMonth(t, 1, Faults{PreExisting: true}).Oracle)
+
+		if len(touched) != len(want) {
+			t.Fatalf("missing-create touched %d resources and pre-existing %d, want the same ones "+
+				"for one seed", len(touched), len(want))
+		}
+		for key, resource := range want {
+			if !slices.Equal(resource.Faults, []string{FaultPreExisting}) {
+				t.Errorf("pre-existing names %v on %s %s, want %v alone", resource.Faults,
+					key.resourceType, key.resourceID, []string{FaultPreExisting})
+			}
+			got, ok := touched[key]
+			if !ok {
+				t.Errorf("pre-existing touched %s %s and missing-create touched it not",
+					key.resourceType, key.resourceID)
+				continue
+			}
+			if !slices.Equal(got.Faults, []string{FaultMissingCreate}) {
+				t.Errorf("missing-create names %v on %s %s, want %v alone", got.Faults,
+					key.resourceType, key.resourceID, []string{FaultMissingCreate})
+			}
+		}
+	})
+
+	t.Run("no touched resource reports its create", func(t *testing.T) {
+		for _, transition := range month.Schedule {
+			if !strings.HasSuffix(transition.EventType, ".create.end") {
+				continue
+			}
+			for key := range touched {
+				if key.resourceID == transition.ResourceID {
+					t.Errorf("%s %s reports %s at %s, want its create off the bus", key.resourceType,
+						key.resourceID, transition.EventType, transition.At.Format(time.RFC3339))
+				}
+			}
+		}
+	})
+
+	t.Run("the oracle states every touched resource from the month's first instant", func(t *testing.T) {
+		for key, resource := range touched {
+			if from := resource.Intervals[0].From; !from.Equal(july2026) {
+				t.Errorf("%s %s is billed from %s, want it billed from %s", key.resourceType,
+					key.resourceID, from.Format(time.RFC3339), july2026.Format(time.RFC3339))
+			}
+		}
+	})
+
+	t.Run("the counts state the creates the collector receives", func(t *testing.T) {
+		// A create that never reached the bus is a create the collector records
+		// no event for, so it counts under nothing. The project of a touched
+		// server is read off the oracle, since its create is gone.
+		missing := make(map[string]int)
+		classic := make(map[string]bool)
+		for _, resource := range month.Oracle.Resources {
+			if resource.ResourceType != "instance" || resource.Workload != workloadClassic {
+				continue
+			}
+			project := resource.Intervals[0].ProjectID
+			classic[project] = true
+			if _, ok := touched[resourceKey{resourceType: "instance", resourceID: resource.ResourceID}]; ok {
+				missing[project]++
+			}
+		}
+		if len(classic) != projectCount {
+			t.Fatalf("the oracle states classic servers in %d projects, want %d", len(classic), projectCount)
+		}
+
+		counts := make(map[countKey]int, len(month.Oracle.Counts))
+		for _, count := range month.Oracle.Counts {
+			counts[countKey{projectID: count.ProjectID, eventType: count.EventType}] = count.Count
+		}
+		for project := range classic {
+			key := countKey{projectID: project, eventType: "compute.instance.create.end"}
+			want := instancesPerProject - missing[project]
+			if got := counts[key]; got != want {
+				t.Errorf("project %s is expected to record %d server creates, want the %d of its %d "+
+					"servers whose create the bus carried", project, got, want, instancesPerProject)
+			}
+		}
+	})
+
+	t.Run("the audits report a touched server on every day of the month", func(t *testing.T) {
+		deleted := make(map[string]time.Time)
+		for _, transition := range month.Schedule {
+			if transition.EventType == "compute.instance.delete.end" {
+				deleted[transition.ResourceID] = transition.At
+			}
+		}
+
+		// An audit sits at a midnight or, when the server already reports a
+		// transition in that second, whole seconds after it, so the audits are
+		// counted per day and not per instant. The existence notification a
+		// delete sequence carries (noise.go) is none of the daily audits and is
+		// left out of the count.
+		audited := make(map[string]map[time.Time]int)
+		for _, transition := range month.Schedule {
+			if transition.EventType != "compute.instance.exists" {
+				continue
+			}
+			if at, ok := deleted[transition.ResourceID]; ok &&
+				transition.At.Equal(at.Add(-instanceDeleteLead+time.Second)) {
+				continue
+			}
+			if audited[transition.ResourceID] == nil {
+				audited[transition.ResourceID] = make(map[time.Time]int)
+			}
+			audited[transition.ResourceID][transition.At.UTC().Truncate(day)]++
+		}
+		// The audit pass reports at every midnight of the month a transition
+		// stands at or after, and a deleted server is reported one last time at
+		// the midnight that follows its delete.
+		last := month.Schedule[len(month.Schedule)-1].At
+
+		for key := range touched {
+			if key.resourceType != "instance" {
+				continue
+			}
+			var want []time.Time
+			for midnight := july2026.Add(day); midnight.Before(to) && !midnight.After(last); midnight = midnight.Add(day) {
+				if at, ok := deleted[key.resourceID]; ok && !midnight.Before(at.Add(day)) {
+					break
+				}
+				want = append(want, midnight)
+			}
+
+			if len(audited[key.resourceID]) != len(want) {
+				t.Errorf("instance %s is audited on %d days, want %d", key.resourceID,
+					len(audited[key.resourceID]), len(want))
+			}
+			for _, midnight := range want {
+				if got := audited[key.resourceID][midnight]; got != 1 {
+					t.Errorf("instance %s reports %d audits on %s, want one", key.resourceID, got,
+						midnight.Format(time.RFC3339))
+				}
+			}
+		}
+	})
 }
 
 func TestGenerateRefusesANonMonth(t *testing.T) {

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -37,7 +37,7 @@ const collectorTopic = "notifications.info"
 func generateMonth(t *testing.T, seed uint64, from time.Time, cloud string) Schedule {
 	t.Helper()
 
-	month, err := GenerateMonth(seed, from, from.AddDate(0, 1, 0), cloud)
+	month, err := GenerateMonth(seed, from, from.AddDate(0, 1, 0), cloud, Faults{})
 	if err != nil {
 		t.Fatalf("GenerateMonth(%d, %s, %q) error = %v, want nil", seed, from.Format(time.RFC3339), cloud, err)
 	}
@@ -358,7 +358,7 @@ func TestGenerateRefusesANonMonth(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := GenerateMonth(1, c.from, c.to, testCloud)
+			_, err := GenerateMonth(1, c.from, c.to, testCloud, Faults{})
 			if err == nil {
 				t.Fatalf("GenerateMonth(1, %s, %s, %q) error = nil, want a refusal",
 					c.from.Format(time.RFC3339), c.to.Format(time.RFC3339), testCloud)


### PR DESCRIPTION
The simulator gains six fault switches, every one off by default, passed to `run` as `--faults <name>[,<name>...]`: `pre-existing`, `missing-create`, `duplicates`, `reordering`, `refused-shapes` and `held-back`. A switch changes what the bus carries and never what the simulated cloud did, so the oracle keeps stating the month the generator built and gains, per resource, the switches that touched it.

Closes #88

## The change set, in commit order

**`44e5eb4` Add the fault switches and thread them into the generator**
New `internal/providers/openstack/simulator/faults.go`: the `Faults` type, the six name constants and `FaultNames`, `ParseFaults` (unknown name, duplicate names allowed, `pre-existing` and `missing-create` refused together), `Names()`, and `faultStream`/`faultSalt` — one PCG stream per switch, seeded by the run's seed and the switch's FNV-64a salt. `RunOptions` gains `Faults []string` behind `--faults`, `Validate` reports `--faults: %w`, and `GenerateMonth` takes a trailing `faults Faults`. The generator gains `faults`, `preExisting` and `touched touchedResources`. No switch has an effect on a month yet: none of them draws from the shape stream, so a switches-off month consumes the three existing streams exactly as before and renders byte-identical files.

**`3610888` Record the fault switches in the oracle and the comparison**
`Oracle` gains `faults` (the month's switches) and `OracleResource` gains `faults` (the switches that touched it), both empty non-nil slices. `oracleFormat` moves to 2, so a document an earlier build wrote is refused rather than read in part — without the member it would decode to `null` and claim every resource untouched. `Report` and `Difference` carry the switches through, and `Lines` appends ` (touched by a, b)` to a difference and prints the month's switches before the verdict. Neither the verdict nor the exit status changes.

**`5fae527` Let picked classic instances exist before the month**
`pre-existing` starts one in three of the classic tenants' servers between a day and thirty days before the month; the server's volumes and address follow it there, and its whole pre-month history goes on the bus in a burst, because the virtual clock starts at the month start and `SleepUntil` returns at once for an instant that has passed. `clipIntervals` bills such a resource from the month's first instant. `missing-create` picks the same servers from the same stream and then drops every transition of theirs before the month, so the collector first hears of the server from inside the month and the engine warns `history_starts_without_create`. The drop runs after `g.run()` and therefore after the audit pass, so the daily `compute.instance.exists` still reports the server. `buildOracle` folds a dropped fact and counts it with none: the intervals state what the cloud did, the counts what the collector records. Per the author decision of 2026-08-30, both switches cover the classic tenants' instances alone — never the Gardener shoots, never the CI tenant.

**`55505c9` Build the publication stream with its four fault passes**
`Month` gains `Stream` (what the bus carries) and `Held`; `Schedule` keeps meaning every transition once, sorted by instant, and stays what the oracle and `WriteEvents` are folded from. `applyStreamFaults` runs four passes, each drawing its picks by walking the schedule's billable transitions with its own stream, so one switch's picks stand whatever else is on. `held-back` keeps one in twenty off the bus; `reordering` publishes the first billable transition of one in ten resources directly behind its second, without moving an instant; `duplicates` repeats one in twenty ten notifications later, byte for byte under the original's message id; `refused-shapes` inserts an oversized, a truncated, or (for nova) a versioned twin behind the notification it doubles. The duplicates and the refused twins are in no schedule, so no count of the month knows about them; a held transition stays in the schedule, because the collector records it once released.

**`d804d8c` Hold a share of the month back and release it on `POST /release`**
`Run` publishes `month.Stream` rather than the schedule and writes `held-back.jsonl` beside the other three files when something is held, removing a stale one an earlier run left. After the last regular line `broadcast` logs `holding` and waits for a release or the context; a stop while holding is a clean exit 0 with the held share never published. The new unexported `holdback` in `control.go` carries the three phases and the `POST /release` route, which answers 409 in plain text for `errNothingHeld`, `errStillPublishing` and `errAlreadyReleased`, and 200 with the clock document on success — written *before* the held share goes out, so the published count of `/clock` rises after the answer. A released notification carries the timestamp inside the month it always had.

**`745fff7` Pass `--faults` through the compose stack**
`SIM_FAULTS` (empty by default) is written into `deploy/compose/.env` as `TALLY_SIM_FAULTS` and the simulator service hands it on as `--faults`. An empty value reaches cobra as `--faults ""`, which pflag's `StringSlice` reads as an empty list, and an empty list is every switch off — an unchanged `make simulator-up` stays the month it was. The compose test requires the flag the way it requires the period, the seed and the factor.

**`09871ad` Document the fault switches**
`docs/openstack-simulator.md` gains `## The fault switches` with one subsection per switch: its share, what the collector's counters show, the engine warning it produces, what the comparison reports, and the measured counts for seed 1 over 2026-07. The held-back subsection walks the late path from the run through `finalize`, `POST /release`, `detect-late`, `correct` and the two comparisons. The control-endpoint, file-mode, determinism, running and configuration sections pick up `POST /release`, `held-back.jsonl`, the fault streams, `SIM_FAULTS` and `--faults`. The counts under "What the collector shows" stay as they are, because they describe a switches-off run; one sentence now says so.

## Where the diff diverges from the issue

- **The truncated twin cuts the inner `oslo.message`, not the outer body** (`render.go`). The envelope has to stay a JSON document, because `WriteStream` carries every line as `json.RawMessage` and a stream file could not hold a body that is not one. The collector's second decode fails on the half that is left, so the delivery is counted unparseable either way. Called out in `55505c9`'s message and in a comment at the cut.
- **`/clock` gains a `holding` member beside `held`**, and `errStillPublishing` reads `release once /clock reports holding true` rather than the issue's "published equal to total minus held". The published count reaches its hold value a moment before the run enters the hold, so it is not a signal a caller can release on; `holding` reads the very field `release` swaps.
- **`POST /release` and `PUT /clock` refuse a request a browser sent** (403 on `Origin` or `Sec-Fetch-Site`), and `/release` takes `application/json` or no body (415 otherwise). Not asked for in the issue; it keeps a page from ending somebody's hold or changing their factor unasked. `curl` and a script send neither header and are unaffected.

## Verification

`go test ./internal/providers/openstack/simulator/... ./cmd/tally-openstack-simulator/... ./deploy/compose/...` passes. New tests live in `faults_test.go` and `publish_integration_test.go`, with the existing suites extended for the oracle's format 2, the comparison's touched-by mark, the control endpoint's release, and the compose command's flag list.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 7ea363b with Claude:claude-opus-5_
