### PR TITLE
Register the simulated Gardener projects and their tenants with the project registry on request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMAGES := $(SERVICES) tally-openstack-collector tally-openstack-simulator
 SIM_IMAGES := tally-openstack-collector tally-openstack-simulator
 
 # The simulator stack, deploy/compose/compose.yaml: a broker, the collector, and
-# the simulator, run beside the dev cluster rather than in it. The five SIM_
+# the simulator, run beside the dev cluster rather than in it. The seven SIM_
 # values below are what `simulator-up` writes into the .env file compose reads.
 # A factor of 744 puts a 31-day month on the bus in an hour.
 SIM_CLOUD ?= os-sim
@@ -53,6 +53,13 @@ SIM_PERIOD ?=
 # The fault switches to turn on, comma-separated: pre-existing, missing-create,
 # duplicates, reordering, refused-shapes, held-back. Empty is every switch off.
 SIM_FAULTS ?=
+# Registers the month's tenants and Gardener projects with the dev registry
+# before the first notification goes out: true or false. Off by default because
+# the rows outlive `simulator-down`, which touches the dev registry not at all.
+SIM_REGISTER_PROJECTS ?= false
+# The cloud the two Gardener projects are registered under. It differs from
+# SIM_CLOUD because a cloud is one installation of one platform.
+SIM_GARDEN_CLOUD ?= garden-sim
 COMPOSE := docker compose -f deploy/compose/compose.yaml
 
 # Every kubectl call names the cluster explicitly. Creating a kind cluster
@@ -169,15 +176,33 @@ dev:
 # recreated since the last one, and a new database knows none of the tokens the
 # old one handed out. A stale token is quiet: the Reporting API answers 401, the
 # collector keeps the events and retries the batch once per flush, and the only
-# sign of it is a line in the collector's log.
+# sign of it is a line in the collector's log. With SIM_REGISTER_PROJECTS=true
+# a second credential, an admin api token for the project registry, is issued
+# the same way; with the switch off it is the empty string. The file is removed
+# and written again under umask 077, because that api token writes the whole
+# registry and the default umask of a shell would leave it readable by every
+# other user of the machine, as would the mode of a file an earlier run left
+# behind. `tally-reporting-admin revoke-api-token <id>` is what ends it; the id
+# is the one the issuing line above prints, and `simulator-down` revokes
+# nothing.
 ## simulator-up: run the simulator, the collector, and a broker against the dev cluster
 simulator-up:
 	@[ -n '$(SIM_PERIOD)' ] || { echo 'ERROR: set SIM_PERIOD to the past month to simulate, e.g. make simulator-up SIM_PERIOD=2026-07' >&2; exit 1; }
+	@case '$(SIM_REGISTER_PROJECTS)' in true|false) ;; *) echo 'ERROR: SIM_REGISTER_PROJECTS must be true or false' >&2; exit 1;; esac
 	$(MAKE) images IMAGES='$(SIM_IMAGES)'
 	@echo '==> writing the dev CA to tally-ca.crt'
 	$(MAKE) -s ca > tally-ca.crt
 	@echo '==> issuing an ingest credential for $(SIM_CLOUD)'
-	@token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud '$(SIM_CLOUD)' --description 'openstack simulator')"; printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_SIM_FAULTS=%s\nTALLY_OSC_TOKEN=%s\n' '$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' '$(SIM_FAULTS)' "$$token" > deploy/compose/.env
+	@token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-ingest-credential --platform openstack --cloud '$(SIM_CLOUD)' --description 'openstack simulator')"; \
+	api_token=''; \
+	if [ '$(SIM_REGISTER_PROJECTS)' = true ]; then \
+		echo '==> issuing an admin api token for the project registry'; \
+		api_token="$$(TALLY_REPORTING_DB_URL='$(TALLY_DEV_DB_URL)' go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'openstack simulator')"; \
+	fi; \
+	rm -f deploy/compose/.env; \
+	umask 077; \
+	printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_SIM_FAULTS=%s\nTALLY_SIM_REGISTER_PROJECTS=%s\nTALLY_SIM_GARDEN_CLOUD=%s\nTALLY_OSC_TOKEN=%s\nTALLY_SIM_API_TOKEN=%s\n' \
+		'$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' '$(SIM_FAULTS)' '$(SIM_REGISTER_PROJECTS)' '$(SIM_GARDEN_CLOUD)' "$$token" "$$api_token" > deploy/compose/.env
 	$(COMPOSE) up -d
 	@echo
 	@echo 'Simulator stack is up:'
@@ -190,6 +215,8 @@ simulator-up:
 	@echo "  curl -X PUT -d '{\"factor\": 0}' http://127.0.0.1:8091/clock"
 	@echo "Release the held-back notifications of a run with SIM_FAULTS=held-back with:"
 	@echo "  curl -X POST http://127.0.0.1:8091/release"
+	@echo "Inspect the registry with the admin token in deploy/compose/.env:"
+	@echo "  curl --cacert tally-ca.crt -H \"Authorization: Bearer \$$(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)\" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=$(SIM_CLOUD)'"
 
 # Dropping the volumes empties the outbox and the broker's queue, so the next
 # `simulator-up` starts from nothing rather than delivering what the last run

--- a/cmd/tally-openstack-simulator/.env.example
+++ b/cmd/tally-openstack-simulator/.env.example
@@ -5,6 +5,7 @@
 # convention, which is how a Kubernetes Secret volume reaches the process
 # without the value appearing in a pod spec:
 # TALLY_SIM_AMQP_URL_FILE=/run/secrets/tally/amqp-url
+# TALLY_SIM_API_TOKEN_FILE=/run/secrets/tally/api-token
 # Setting a secret and its *_FILE companion at the same time is an error.
 #
 # The simulator has three subcommands. run generates a month from a seed and
@@ -41,3 +42,30 @@ TALLY_SIM_AMQP_URL=
 # the salt of every generated identifier and the cloud of events.jsonl, and a
 # guessed one books usage to the wrong cloud. replay does not read it.
 TALLY_SIM_CLOUD=
+
+# Reporting API the projects are registered with. run reads it with
+# --register-projects and ignores it otherwise, so a run that only puts a month
+# on the bus needs none of the four variables below. It has to be absolute and
+# carry a host, with no query and no fragment: the registry route is appended to
+# it. https unless TALLY_SIM_REPORTING_INSECURE says otherwise.
+TALLY_SIM_REPORTING_URL=
+
+# Allow a plaintext Reporting API. The api token below travels in a header on
+# every request and is of role admin, so it is not scoped to one cloud the way
+# an ingest token is: whoever reads it off the wire writes the whole project
+# registry. Set this to true only for a simulator and an API on the same
+# machine, such as the ones a development stack runs.
+TALLY_SIM_REPORTING_INSECURE=false
+
+# API token the registration authenticates with. It has to be of role admin,
+# because POST /api/v1/projects and POST /api/v1/projects/{id}/relations demand
+# that role: tally-reporting-admin create-api-token --role admin writes one. It
+# is a secret, so it supports TALLY_SIM_API_TOKEN_FILE, and setting both is an
+# error. Read with --register-projects alone.
+TALLY_SIM_API_TOKEN=
+
+# Cloud the two Gardener projects are registered under. It has to differ from
+# TALLY_SIM_CLOUD, because a cloud is one installation of one platform and the
+# Gardener projects are not rows of the OpenStack installation their shoots run
+# on. Read with --register-projects alone.
+TALLY_SIM_GARDEN_CLOUD=

--- a/cmd/tally-openstack-simulator/commands.go
+++ b/cmd/tally-openstack-simulator/commands.go
@@ -63,6 +63,13 @@ func newRunCmd() *cobra.Command {
 			if _, _, err := opts.Validate(); err != nil {
 				return err
 			}
+			// The switch is checked here too, so a missing token is reported before
+			// a broker is dialled, the way a mistyped period is.
+			if opts.RegisterProjects {
+				if err := cfg.ValidateRegistration(); err != nil {
+					return fmt.Errorf("checking the configuration: %w", err)
+				}
+			}
 
 			logger := newLogger(cmd.OutOrStdout(), cfg)
 
@@ -95,6 +102,9 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.Faults, "faults", nil,
 		"fault switches to turn on, comma-separated: "+strings.Join(simulator.FaultNames, ", ")+
 			"; every switch is off by default")
+	cmd.Flags().BoolVar(&opts.RegisterProjects, "register-projects", false,
+		"register every tenant of the month, the Gardener projects, and their infrastructure_tenant "+
+			"relations with the Reporting API TALLY_SIM_REPORTING_URL names; off by default")
 	cmd.Flags().BoolVar(&allowRemoteBroker, allowRemoteBrokerFlag, false, allowRemoteBrokerUsage)
 	_ = cmd.MarkFlagRequired("period")
 	return cmd

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -7,7 +7,10 @@
 // events.jsonl and oracle.json instead, and to held-back.jsonl beside them when
 // a switch holds notifications back; with both it does both. With --faults it
 // turns fault switches on, each of which changes what the bus carries and never
-// the month the oracle states; the run help names the six.
+// the month the oracle states; the run help names the six. With
+// --register-projects the run registers the month's tenants, its two Gardener
+// projects and their infrastructure_tenant relations with the Reporting API
+// TALLY_SIM_REPORTING_URL names before it writes or publishes anything.
 // The replay subcommand publishes a notifications.jsonl an earlier run wrote,
 // which puts the same month on a bus again without the generator behind it. The
 // compare subcommand reads the oracle a run wrote, an engine export of the

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -7,13 +7,17 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/event"
@@ -40,6 +44,33 @@ const closedBroker = "amqp://guest:guest@127.0.0.1:1/"
 // remoteBroker is an AMQP URL of a broker somewhere else, which is the shape of
 // a production URL copied into the simulator's environment.
 const remoteBroker = "amqp://guest:hunter2@rabbit.control-plane.example:5672/"
+
+// closedRegistry is a Reporting API URL nothing listens on. It is a usable URL
+// on loopback, so a registration gets as far as posting the first project and
+// fails there rather than at the check of the environment. https, because the
+// admin api token travels on it and plaintext is refused unless it is asked
+// for.
+const closedRegistry = "https://127.0.0.1:1"
+
+// testAPIToken is the credential a registration authenticates with. The case
+// about a registry nothing listens on searches the failure for it, because a
+// message carrying the token would put it into whatever an operator pastes it
+// into.
+const testAPIToken = "tly_a_test"
+
+// gardenCloud is the cloud the two Gardener projects are registered under. It
+// differs from simulatedCloud because a cloud is one installation of one
+// platform, and the registry keys a row by its cloud.
+const gardenCloud = "garden-sim"
+
+// What seed 1 over endedMonth registers: a row per tenant of the month plus one
+// per Gardener project, and one infrastructure_tenant relation per Gardener
+// project. RegistrationsOf decides them, and these are the numbers that have to
+// reach the registry over the wire.
+const (
+	registeredProjects  = 8
+	registeredRelations = 2
+)
 
 // nonBillableNotifications is how many notifications of a month the collector
 // maps to no event: the unsized image.create, one per image, and every
@@ -317,14 +348,207 @@ func TestRunWritesTheHeldBackFileInFileMode(t *testing.T) {
 	})
 }
 
+// registryStub stands in for the project registry of the Reporting API. It
+// counts the projects and the relations it was posted and keeps every
+// credential it was sent, which is what a case holds a registration against.
+type registryStub struct {
+	*httptest.Server
+	mu             sync.Mutex
+	projects       int
+	relations      int
+	authorizations []string
+}
+
+// newRegistryStub starts a registry that holds nothing yet: every post is a row
+// that did not exist, so every answer is a 201 carrying the id the relations
+// address the row by.
+func newRegistryStub(t *testing.T) *registryStub {
+	t.Helper()
+
+	stub := &registryStub{}
+	stub.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stub.mu.Lock()
+		stub.authorizations = append(stub.authorizations, r.Header.Get("Authorization"))
+		if r.Method == http.MethodPost {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/relations"):
+				stub.relations++
+			case r.URL.Path == "/api/v1/projects":
+				stub.projects++
+			}
+		}
+		stub.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		// The registration reads what a project is already related to before it
+		// creates a relation, and this registry holds none.
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/relations") {
+			if _, err := fmt.Fprint(w, `{"items":[]}`); err != nil {
+				t.Errorf("answering %s %s: %v", r.Method, r.URL.Path, err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		if _, err := fmt.Fprintf(w, `{"id":%q}`, uuid.New()); err != nil {
+			t.Errorf("answering %s %s: %v", r.Method, r.URL.Path, err)
+		}
+	}))
+	t.Cleanup(stub.Close)
+	return stub
+}
+
+// counts is how many projects and relations the stub was posted.
+func (s *registryStub) counts() (projects, relations int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.projects, s.relations
+}
+
+// credentials is the Authorization header of every request the stub was sent.
+func (s *registryStub) credentials() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.authorizations)
+}
+
+// holdCredentialsTo holds every credential the stub was sent against that
+// token. A stub that was sent nothing fails the case rather than passing it: a
+// check over an empty list is a registration that never happened.
+func holdCredentialsTo(t *testing.T, stub *registryStub, token string) {
+	t.Helper()
+
+	credentials := stub.credentials()
+	if len(credentials) == 0 {
+		t.Fatalf("the registry was sent no request at all, want the month registered")
+	}
+	for _, credential := range credentials {
+		if want := "Bearer " + token; credential != want {
+			t.Errorf("the registry was sent the credential %q, want %q", credential, want)
+		}
+	}
+}
+
+// logLine is the JSON log line the run wrote under that message. The run logs
+// through the command's own output, so what a case reads is the stdout runCLI
+// hands back.
+func logLine(t *testing.T, stdout, message string) map[string]any {
+	t.Helper()
+
+	for _, raw := range strings.Split(strings.TrimSuffix(stdout, "\n"), "\n") {
+		var line map[string]any
+		if err := json.Unmarshal([]byte(raw), &line); err != nil {
+			continue
+		}
+		if line["msg"] == message {
+			return line
+		}
+	}
+	t.Fatalf("the run logged no %q line, and the case needs one:\n%s", message, stdout)
+	return nil
+}
+
+// TestRunRegistersTheMonthInFileMode covers --register-projects: the tenants of
+// the month, the two Gardener projects, and the relation that attributes a
+// tenant's cost to the project running on it reach the registry before the
+// month is written. File mode registers as well, because that is how an
+// operator prepares the registry for a replay of the recorded month.
+func TestRunRegistersTheMonthInFileMode(t *testing.T) {
+	useCloud(t)
+	stub := newRegistryStub(t)
+	t.Setenv("TALLY_SIM_REPORTING_URL", stub.URL)
+	// The stub serves plaintext on this machine, which is the one place a
+	// registration may carry the admin api token in the clear, and it has to be
+	// asked for the way a deployment asks for it.
+	t.Setenv("TALLY_SIM_REPORTING_INSECURE", "true")
+	t.Setenv("TALLY_SIM_API_TOKEN", testAPIToken)
+	t.Setenv("TALLY_SIM_GARDEN_CLOUD", gardenCloud)
+
+	dir := t.TempDir()
+	stdout, stderr, err := runCLI(t,
+		"run", "--register-projects", "--period", endedMonth, "--seed", "1", "--out", dir)
+	if err != nil {
+		t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+	}
+
+	projects, relations := stub.counts()
+	if projects != registeredProjects || relations != registeredRelations {
+		t.Errorf("the registry was posted %d projects and %d relations, want %d and %d: "+
+			"a row per tenant, a row per Gardener project, and a relation per Gardener project",
+			projects, relations, registeredProjects, registeredRelations)
+	}
+	holdCredentialsTo(t, stub, testAPIToken)
+
+	// The month is written too, and after the registration: a run that registers
+	// leaves the same three files behind as one that does not.
+	for _, name := range []string{"notifications.jsonl", "events.jsonl", "oracle.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("Stat(%s) error = %v, want nil", filepath.Join(dir, name), err)
+		}
+	}
+
+	// The log is what an operator reads the registration off, so it states that
+	// the switch was on and what the registry answered.
+	if starting := logLine(t, stdout, "starting"); starting["register"] != true {
+		t.Errorf("the starting line carries register = %v, want true", starting["register"])
+	}
+	registered := logLine(t, stdout, "registered")
+	if got := registered["reporting_url"]; got != stub.URL {
+		t.Errorf("the registered line carries reporting_url = %v, want %q", got, stub.URL)
+	}
+	for key, want := range map[string]float64{
+		"projects_created":   registeredProjects,
+		"projects_existing":  0,
+		"relations_created":  registeredRelations,
+		"relations_existing": 0,
+	} {
+		if got, ok := registered[key].(float64); !ok || got != want {
+			t.Errorf("the registered line carries %s = %v, want %v", key, registered[key], want)
+		}
+	}
+
+	t.Run("without the flag", func(t *testing.T) {
+		quiet := newRegistryStub(t)
+		t.Setenv("TALLY_SIM_REPORTING_URL", quiet.URL)
+
+		if _, stderr, err := runCLI(t,
+			"run", "--period", endedMonth, "--seed", "1", "--out", t.TempDir()); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		if projects, relations := quiet.counts(); projects+relations > 0 {
+			t.Errorf("the registry was posted %d projects and %d relations, want nothing at all: "+
+				"a run without --register-projects registers no row", projects, relations)
+		}
+	})
+
+	t.Run("the token comes from a file", func(t *testing.T) {
+		fromFile := newRegistryStub(t)
+		t.Setenv("TALLY_SIM_REPORTING_URL", fromFile.URL)
+		t.Setenv("TALLY_SIM_API_TOKEN", "")
+		t.Setenv("TALLY_SIM_API_TOKEN_FILE", writeFile(t, t.TempDir(), "api-token", "tly_a_x\n"))
+
+		if _, stderr, err := runCLI(t, "run", "--register-projects", "--period", endedMonth,
+			"--seed", "1", "--out", t.TempDir()); err != nil {
+			t.Fatalf("run error = %v, want nil (stderr %q)", err, stderr)
+		}
+		// The trailing newline a Kubernetes Secret volume writes is not part of
+		// the credential.
+		holdCredentialsTo(t, fromFile, "tly_a_x")
+	})
+}
+
 func TestRunRefusesBadInput(t *testing.T) {
 	notADirectory := writeFile(t, t.TempDir(), "notifications.jsonl", "")
 	urlFile := writeFile(t, t.TempDir(), "amqp-url", closedBroker)
 	emptyURLFile := writeFile(t, t.TempDir(), "empty-amqp-url", "")
+	tokenFile := writeFile(t, t.TempDir(), "api-token", "tly_a_x\n")
+	emptyTokenFile := writeFile(t, t.TempDir(), "empty-api-token", "")
 	// The output directory of the case about an unknown fault switch. It is held
 	// outside the case so the body can read it back: a refused switch has to end
 	// the run before the month is written.
 	faultOut := t.TempDir()
+	// The same for the case about a registry nothing listens on: a registration
+	// that fails ends the run before the month is written.
+	registerOut := t.TempDir()
 
 	for _, tc := range []struct {
 		name string
@@ -441,6 +665,83 @@ func TestRunRefusesBadInput(t *testing.T) {
 			},
 			want: "--faults: pre-existing and missing-create exclude each other",
 		},
+		{
+			name: "a registration without a Reporting API",
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: TALLY_SIM_REPORTING_URL: " +
+				"must be set when --register-projects is on",
+		},
+		{
+			name: "a registration without a token",
+			env:  map[string]string{"TALLY_SIM_REPORTING_URL": closedRegistry},
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: TALLY_SIM_API_TOKEN: " +
+				"must be set when --register-projects is on",
+		},
+		{
+			name: "a registration without a cloud for the Gardener projects",
+			env: map[string]string{
+				"TALLY_SIM_REPORTING_URL": closedRegistry,
+				"TALLY_SIM_API_TOKEN":     testAPIToken,
+			},
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: TALLY_SIM_GARDEN_CLOUD: " +
+				"must be set when --register-projects is on",
+		},
+		{
+			name: "the Gardener projects under the tenants' cloud",
+			env: map[string]string{
+				"TALLY_SIM_REPORTING_URL": closedRegistry,
+				"TALLY_SIM_API_TOKEN":     testAPIToken,
+				"TALLY_SIM_GARDEN_CLOUD":  simulatedCloud,
+			},
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: `checking the configuration: TALLY_SIM_GARDEN_CLOUD: "os-sim" must differ from ` +
+				"TALLY_SIM_CLOUD: a cloud is one installation of one platform",
+		},
+		{
+			name: "a Reporting API that is not an HTTP URL",
+			env: map[string]string{
+				"TALLY_SIM_REPORTING_URL": "ftp://api",
+				"TALLY_SIM_API_TOKEN":     testAPIToken,
+				"TALLY_SIM_GARDEN_CLOUD":  gardenCloud,
+			},
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: " +
+				`TALLY_SIM_REPORTING_URL: "ftp://api" must be an absolute http(s) URL with no ` +
+				"query or fragment, because the registry route is appended to it",
+		},
+		{
+			name: "a token given twice",
+			env: map[string]string{
+				"TALLY_SIM_API_TOKEN":      testAPIToken,
+				"TALLY_SIM_API_TOKEN_FILE": tokenFile,
+			},
+			args: []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			want: "loading the configuration: set TALLY_SIM_API_TOKEN or TALLY_SIM_API_TOKEN_FILE, not both",
+		},
+		{
+			name:     "a token file nobody filled",
+			env:      map[string]string{"TALLY_SIM_API_TOKEN_FILE": emptyTokenFile},
+			args:     []string{"--register-projects", "--period", endedMonth, "--out", t.TempDir()},
+			contains: fmt.Sprintf("TALLY_SIM_API_TOKEN_FILE: file %s is empty", emptyTokenFile),
+		},
+		{
+			name: "a registry nothing listens on",
+			env: map[string]string{
+				"TALLY_SIM_REPORTING_URL": closedRegistry,
+				"TALLY_SIM_API_TOKEN":     testAPIToken,
+				"TALLY_SIM_GARDEN_CLOUD":  gardenCloud,
+			},
+			args:     []string{"--register-projects", "--period", endedMonth, "--out", registerOut},
+			contains: "registering the projects: POST /api/v1/projects:",
+			// The failure names the route and the dial, and the token stays out of
+			// it: an operator pastes such a message into a ticket.
+			absent: testAPIToken,
+			// The registration runs before the month is written, so a run that
+			// cannot register leaves no file behind either.
+			emptyDir: registerOut,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useCloud(t)
@@ -491,6 +792,23 @@ func TestRunHelpListsTheFaultSwitches(t *testing.T) {
 		if !strings.Contains(stdout, name) {
 			t.Errorf("run --help does not name the fault switch %q, want all of %v listed",
 				name, simulator.FaultNames)
+		}
+	}
+}
+
+// TestRunHelpListsTheRegistrySwitch holds the help of run to the switch that
+// registers the month. A switch the help does not name is one nobody reaches
+// without reading the source.
+func TestRunHelpListsTheRegistrySwitch(t *testing.T) {
+	blankEnvironment(t)
+
+	stdout, stderr, err := runCLI(t, "run", "--help")
+	if err != nil {
+		t.Fatalf("run --help error = %v, want nil (stderr %q)", err, stderr)
+	}
+	for _, want := range []string{"--register-projects", "TALLY_SIM_REPORTING_URL"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("run --help does not name %q, want it in the help of the switch", want)
 		}
 	}
 }

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -16,7 +16,9 @@
 # The values interpolated below come from deploy/compose/.env, which
 # `make simulator-up` writes and git ignores. It carries the cloud, the period,
 # the seed, the factor, the fault switches, and the ingest token issued for that
-# cloud.
+# cloud. It also carries the registry switch, the cloud the simulated Gardener
+# projects are registered under, and the admin api token that registers them,
+# which is the empty string unless the switch is on.
 #
 # A named volume of one of these images belongs under /home/nonroot; the
 # collector's outbox below says why.
@@ -99,6 +101,20 @@ services:
       # loopback inside the container is reachable from nothing. The port below
       # is what publishes it, on the host's 127.0.0.1 alone.
       TALLY_SIM_HTTP_ADDR: 0.0.0.0
+      # The three below are read only with --register-projects and ignored
+      # otherwise. The CA is here for the reason the collector's comment gives:
+      # the registrar posts to the Gateway over the same kind of plain
+      # http.Client, so this file is what makes its certificate verify.
+      TALLY_SIM_REPORTING_URL: https://api.tally.127-0-0-1.nip.io:8443
+      TALLY_SIM_API_TOKEN: ${TALLY_SIM_API_TOKEN}
+      TALLY_SIM_GARDEN_CLOUD: ${TALLY_SIM_GARDEN_CLOUD}
+      SSL_CERT_FILE: /etc/tally/tally-ca.crt
+    # Both mirror the collector's above and are there for the reasons given
+    # with them.
+    extra_hosts:
+      - "api.tally.127-0-0-1.nip.io:host-gateway"
+    volumes:
+      - "../../tally-ca.crt:/etc/tally/tally-ca.crt:ro"
     # --faults is empty unless SIM_FAULTS names a switch. An empty value reaches
     # the binary as --faults "", which is an empty list of switch names, and an
     # empty list is the run with every switch off.
@@ -108,7 +124,11 @@ services:
     # container next door, and what it carries is thrown away with the stack; a
     # URL that named a control plane's broker would put a month of invented usage
     # into that deployment's billing data, which is why the flag has to be typed.
-    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--faults", "${TALLY_SIM_FAULTS}", "--allow-remote-broker"]
+    #
+    # --register-projects carries its value in the same argument because that is
+    # where pflag reads a boolean flag's value from. A separate `false` would
+    # reach the binary as a positional argument, and cobra.NoArgs refuses those.
+    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--faults", "${TALLY_SIM_FAULTS}", "--register-projects=${TALLY_SIM_REGISTER_PROJECTS}", "--allow-remote-broker"]
     ports:
       # the control endpoint: GET /clock, PUT /clock, POST /release, GET /healthz
       - "127.0.0.1:8091:8080"

--- a/deploy/compose/compose_test.go
+++ b/deploy/compose/compose_test.go
@@ -186,6 +186,24 @@ func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 		}
 	}
 
+	ca := mountFrom(t, svc, caSource)
+	if path := svc.Environment["SSL_CERT_FILE"]; path != ca.target {
+		t.Errorf("SSL_CERT_FILE = %q, want %q, where %s is mounted; without it the registrar rejects the Gateway's certificate and the run registers nothing",
+			path, ca.target, caSource)
+	}
+	if ca.options != "ro" {
+		t.Errorf("the %s mount carries the options %q, want %q; the simulator has no reason to write the CA", caSource, ca.options, "ro")
+	}
+
+	if hosts := []string{gatewayHost + ":host-gateway"}; !slices.Equal(svc.ExtraHosts, hosts) {
+		t.Errorf("extra_hosts = %v, want %v; the name is otherwise resolved in the container's network, where the dev cluster is not",
+			svc.ExtraHosts, hosts)
+	}
+	if url := svc.Environment["TALLY_SIM_REPORTING_URL"]; !strings.HasPrefix(url, reportingURL) {
+		t.Errorf("TALLY_SIM_REPORTING_URL = %q, want it to start with %q, which is the name extra_hosts maps and the port kind publishes on the host",
+			url, reportingURL)
+	}
+
 	if len(svc.Command) == 0 || svc.Command[0] != "run" {
 		t.Fatalf("command = %v, want it to start with %q; the entrypoint's root command prints its help text and exits zero, which is a container that succeeds without publishing a notification",
 			svc.Command, "run")
@@ -195,11 +213,26 @@ func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 	// a pace nobody chose. A dropped --faults leaves SIM_FAULTS with nowhere to
 	// arrive, so a stack asked for a fault switch publishes the month without it.
 	// Without --allow-remote-broker the container refuses the broker beside it,
-	// which is a stack that starts and publishes nothing.
+	// which is a stack that starts and publishes nothing. A dropped
+	// --register-projects costs SIM_REGISTER_PROJECTS the same way, and it is
+	// checked below rather than in this loop.
 	for _, flag := range []string{"--period", "--seed", "--factor", "--faults", "--allow-remote-broker"} {
 		if !slices.Contains(svc.Command, flag) {
 			t.Errorf("command = %v, want %s among the arguments", svc.Command, flag)
 		}
+	}
+	// Checked by prefix because a boolean flag carries its value in the same
+	// argument, and a dropped one leaves SIM_REGISTER_PROJECTS with nowhere to
+	// arrive: the stack publishes the month and registers none of it.
+	registers := false
+	for _, arg := range svc.Command {
+		if strings.HasPrefix(arg, "--register-projects=") {
+			registers = true
+			break
+		}
+	}
+	if !registers {
+		t.Errorf("command = %v, want an argument starting with %q", svc.Command, "--register-projects=")
 	}
 }
 

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -14,11 +14,12 @@ It has no fake OpenStack API and no metrics endpoint of its own. #65 is the meta
 issue the simulated workloads belong to, and this document describes its first
 stage. The noise, the notifications the collector does not bill, is rendered and
 described under "The noise" below. The oracle of a month and the comparison
-against an engine export are described under "The oracle" below, and the six
-fault switches under "The fault switches"; #89 owns the project registry; #66
-the fake API and the clock seam; #67 the traffic series and `/metrics`. The
-drill #51 cites this simulator as the way a month reaches the Reporting API. The
-workload renders octavia's three load balancer types from the shoots' load
+against an engine export are described under "The oracle" below, the six fault
+switches under "The fault switches", and the registration of the month's tenants
+and Gardener projects with the project registry under "The project registry".
+#66 owns the fake API and the clock seam; #67 the traffic series and `/metrics`.
+The drill #51 cites this simulator as the way a month reaches the Reporting API.
+The workload renders octavia's three load balancer types from the shoots' load
 balancers.
 
 ## The world and the workload
@@ -552,14 +553,27 @@ make simulator-up SIM_PERIOD=2026-07
 factor of 744 puts a 31-day month on the bus in an hour. `SIM_FAULTS` is empty,
 which is every fault switch off; it takes the switch names of "The fault
 switches" below, comma-separated, as in `SIM_FAULTS=held-back`.
+`SIM_REGISTER_PROJECTS` is `false`, and `true` registers the month's tenants and
+Gardener projects with the dev registry before the first notification goes out,
+the way "The project registry" describes; any other value is refused with
+`ERROR: SIM_REGISTER_PROJECTS must be true or false` before an image is built.
+`SIM_GARDEN_CLOUD` defaults to `garden-sim` and is the cloud the two Gardener
+rows are registered under.
 
 The target builds the collector and the simulator image, writes the dev CA to
-`tally-ca.crt`, issues an ingest credential for `SIM_CLOUD` with
-`tally-reporting-admin create-ingest-credential`, writes the cloud, the period,
-the seed, the factor, the fault switches as `TALLY_SIM_FAULTS`, and that token
-into `deploy/compose/.env`, and starts the three containers of
-[`../deploy/compose/compose.yaml`](../deploy/compose/compose.yaml): the broker,
-the collector image, and the simulator.
+`tally-ca.crt`, and issues an ingest credential for `SIM_CLOUD` with
+`tally-reporting-admin create-ingest-credential`; with
+`SIM_REGISTER_PROJECTS=true` it issues an admin api token beside it with
+`tally-reporting-admin create-api-token --role admin`. It writes the cloud, the
+period, the seed, the factor, the fault switches as `TALLY_SIM_FAULTS`, the
+switch as `TALLY_SIM_REGISTER_PROJECTS`, the garden cloud as
+`TALLY_SIM_GARDEN_CLOUD`, and the two tokens as `TALLY_OSC_TOKEN` and
+`TALLY_SIM_API_TOKEN` into `deploy/compose/.env`, where the api token is the
+empty string with the switch off. The file is removed and written again under
+`umask 077`, because an admin api token in a world-readable file is one every
+other user of the machine can register with. Then it starts the three containers
+of [`../deploy/compose/compose.yaml`](../deploy/compose/compose.yaml): the
+broker, the collector image, and the simulator.
 
 It does not rebuild what runs in the cluster and applies no migration: loading
 the Reporting API image into kind and applying the migration chain are both
@@ -582,7 +596,9 @@ Every host port is bound to `127.0.0.1` and lies above 1024;
 `deploy/kind/kind.yaml` states why. The collector's container reaches the
 cluster through `extra_hosts`, which maps `api.tally.127-0-0-1.nip.io` to
 `host-gateway`, and `tally-ca.crt` is mounted read-only at the path
-`SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify.
+`SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify. The
+simulator's container carries the same three: a registration posts to the
+Gateway over the same kind of client the collector delivers with.
 
 The collector service of the stack lists all eight exchanges in
 `TALLY_OSC_EXCHANGES`:
@@ -657,6 +673,9 @@ token="$(TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.12
 curl --cacert tally-ca.crt -H "Authorization: Bearer $token" \
   'https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources?cloud=os-sim'
 ```
+
+A run started with `SIM_REGISTER_PROJECTS=true` carries one already:
+`deploy/compose/.env` holds it as `TALLY_SIM_API_TOKEN`.
 
 ## What the collector shows
 
@@ -1231,6 +1250,186 @@ publishes, 1812 once the release is through, and 13915 skipped either way. Seed
 `notifications.jsonl` has 15643 lines, `held-back.jsonl` 84, and the month books
 the 1812 events of the month with the switch off.
 
+## The project registry
+
+`run --register-projects` registers the month with the project registry of the
+Reporting API, before the first file is written and before the first
+notification goes out. The switch is off by default: a run without it puts a
+month on a bus or into files and reads no registry at all.
+
+Four variables carry what a registration needs, and a run without the switch
+reads them and ignores them. `TALLY_SIM_REPORTING_URL` is the Reporting API the
+rows are posted to. It has to be absolute and carry a host, with no query and
+no fragment, because the registry route is appended to it, and it has to be
+`https`: the api token travels in a header on every request, and that token is
+of role `admin`, so it is not scoped to one `(platform, cloud)` pair the way an
+ingest token is, and whoever reads it off the wire writes the whole registry.
+`TALLY_SIM_REPORTING_INSECURE=true` is how a plaintext one is asked for, the way
+the collector's `TALLY_OSC_REPORTING_INSECURE` is; the compose stack posts to
+the Gateway over `https` and sets neither. `TALLY_SIM_API_TOKEN` is the
+credential, an api token of role `admin`, because `POST /api/v1/projects` and
+`POST /api/v1/projects/{id}/relations` demand that role; it is a secret, so
+`TALLY_SIM_API_TOKEN_FILE` carries it as well, and setting both is an error.
+`TALLY_SIM_GARDEN_CLOUD` is the cloud the two Gardener rows are registered
+under, and it has to differ from `TALLY_SIM_CLOUD`: a cloud is one installation
+of one platform, so a Gardener project keyed under the tenants' cloud would be a
+row of the OpenStack installation, and its relation would then point it at
+itself. A missing or mistyped value ends the subcommand with `checking the
+configuration: ...` before a broker is dialled.
+
+A month registers eight rows and two relations. Six rows are `openstack` rows
+under `TALLY_SIM_CLOUD`, keyed by the keystone project id of the tenant and
+named `tenant-01`, `tenant-02`, `tenant-03`, `ci`,
+`Infrastructure tenant of alpha`, and `Infrastructure tenant of beta`. Nothing
+on the bus carries a tenant name, so the registry is the one place the ids of a
+month are given one. The other two are `gardener` rows under
+`TALLY_SIM_GARDEN_CLOUD`, with the external ids `alpha` and `beta` and the
+names `Gardener project alpha` and `Gardener project beta`. Each Gardener row
+then takes one relation of type `infrastructure_tenant` to the tenant its shoots
+run on, valid from the first instant of the month (`valid_from`
+`2026-07-01T00:00:00Z` for `2026-07`) and with no end. Every row and every
+relation carries `created_by: tally-openstack-simulator` in its metadata, and a
+relation's metadata carries `shoots` beside it: `["api-prod", "api-dev"]` for
+`alpha`, `["batch"]` for `beta`.
+
+A rerun of the same seed, period, cloud, and garden cloud posts the same eight
+rows again. A `409` on a project is a row the registry already holds: it is
+looked up by its `(cloud, external_id)` key, its id is what the relations point
+at, and neither its name nor its metadata is patched. A `409` on a relation is
+one that is already active, and it stays as it stands. The run goes on and logs
+`registered` with `projects_existing` 8 and `relations_existing` 2.
+
+A rerun under another period, seed, or cloud is refused at the first relation.
+The Gardener rows are keyed by `alpha` and `beta` and are the ones the earlier
+run registered, while the tenants are keyed by identifiers the month is salted
+into, so the second run would relate one Gardener project to a second tenant.
+The registry keys an open relation by `(source_id, target_id, relation_type)`,
+which makes that a new relation rather than a `409`, and two relations
+attributing at once put two months of a tenant's cost into one statement. Every
+relation is therefore preceded by two reads of
+`GET /api/v1/projects/{id}/relations?direction=outgoing&relation_type=infrastructure_tenant`,
+one at `at=<the first instant of the month>` and one as the relations stand now,
+and a relation to another tenant in either answer ends the run. What the message
+says is decided by when that relation starts. One that started in an earlier
+month is ended where this month begins, so the message names the
+`PATCH /api/v1/projects/{id}/relations/{relation_id}` that does it and the
+instant it has to end at. One that starts at or after the first instant of this
+month cannot be: `PATCH` answers a `valid_to` that is not after the stored
+`valid_from` with `422`, so there is no such instant, and the message says so
+and leaves registering this month under another garden cloud
+(`TALLY_SIM_GARDEN_CLOUD`) as the way on.
+
+Two reads, because the engine bills a period by the relations that overlap it
+(`valid_from < period_to AND (valid_to IS NULL OR valid_to > period_from)`) and
+not by the ones that are open while it runs. The read at the first instant of
+the month is one instant the period is billed by, and it finds a relation that
+was closed after the month as well: `DELETE /api/v1/projects/{id}/relations/{relation_id}`
+sets `valid_to` to now, which is after every instant of a simulated period, so
+such a relation goes on attributing that period. The read as they stand now
+finds a relation that starts after this month and would attribute beside the new
+one from its own start on. A relation that ends no later than the first instant
+of the month is left alone by both: it attributes nothing of the month being
+registered.
+
+Two reads at two instants are less than that overlap, though, so this check is
+what one run can see and not a rule the registry enforces. A relation that
+starts inside the month and was closed no later than now is valid at neither
+instant, and it attributes the month all the same: such a relation passes the
+check, and a second one is created beside it. Reading the overlap itself would
+need a `from`/`to` filter on the route, which this API does not offer; the
+invariant the check stands in for belongs to the Reporting API, as one open
+attributing relation per `(source_id, relation_type)`, answered `409`. Two
+registrations running at once are past the check for the same reason: both can
+read an answer without the other's relation and both create one.
+
+A registration that fails ends the run with exit status 1, with no file written
+and no notification published. A refused token is the one failure whose fix is
+not in the answer, so its message ends with
+`TALLY_SIM_API_TOKEN has to be an api token of role admin`; an unreachable API
+and any other unexpected status end the run the same way. The rows such a run
+got through stay in the registry, and the rerun finds them. SIGINT while the
+registration runs is the clean stop the rest of a run answers a signal with,
+exit status 0.
+
+File mode registers as well.
+`run --register-projects --period 2026-07 --out /tmp/m` needs no broker and
+registers the month it writes, which is how an operator prepares the registry
+before a `replay` puts that month on a bus. `replay` itself registers nothing,
+because the recorded notifications are all it reads.
+
+The log carries the registration. `starting` says `register=true`, and
+`registered` closes the registration with `reporting_url`, `projects_created`,
+`projects_existing`, `relations_created`, and `relations_existing`. Every step
+ahead of it is one `Info` line of its own: `registered project` or
+`project already registered` per row, `related` or `relation already active`
+per relation. A registration that ends early logs `registration incomplete` with
+the same four counts instead, whether it was refused or stopped: the rows it got
+through stay in the registry, and that line is where the whole of what reached
+it is.
+
+The broker of a run is refused unless it is on this machine, and
+`--allow-remote-broker` is the confirmation that lets one through. The Reporting
+API is guarded by its scheme instead: a plaintext one is refused unless
+`TALLY_SIM_REPORTING_INSECURE=true` is set, because the admin token travels on
+it. Which deployment the rows land in is not guarded beyond that — registering
+needs an api token of role `admin`, and issuing one against a deployment is that
+decision already.
+
+The registry of the compose stack is readable with the admin token
+`simulator-up` wrote into `deploy/compose/.env`. That file is written under
+`umask 077`, because the token in it writes the whole registry; the id it was
+issued under is on the `simulator-up` output, and
+`tally-reporting-admin revoke-api-token <id>` is what ends it, because
+`simulator-down` deletes the file and revokes nothing.
+
+```sh
+curl --cacert tally-ca.crt \
+  -H "Authorization: Bearer $(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim'
+```
+
+The relations hang below the row they start at, so walking alpha's takes its id
+first: the `id` of the `garden-sim`/`alpha` row that
+`GET /api/v1/projects?cloud=garden-sim` lists.
+
+```sh
+curl --cacert tally-ca.crt \
+  -H "Authorization: Bearer $(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" \
+  'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/<alpha id>/related?relation_type=infrastructure_tenant'
+```
+
+The rows outlive `make simulator-down`, which drops the containers and the
+outbox volume and touches the dev registry not at all, so a second
+`simulator-up` for a later period is the rerun the registration refuses until
+the relations of the first one end no later than the first instant of the second
+period. No subcommand of `tally-reporting-admin` deletes a project, and a
+relation is never removed: `PATCH /api/v1/projects/{id}/relations/{relation_id}`
+with a `valid_to` is what ends one at a chosen instant, and
+`DELETE /api/v1/projects/{id}/relations/{relation_id}` ends one at now, which is
+after the period a simulated month covers and therefore no way past the check.
+A second `simulator-up` for the same period or an earlier one has no instant to
+end them at either, because they start at or after that period's first instant:
+those runs need a garden cloud of their own, `TALLY_SIM_GARDEN_CLOUD`.
+
+What the rows are for shows once the month is billed. The engine's default
+attributing relation type is `infrastructure_tenant`, so
+
+```sh
+tally-engine run --period 2026-07
+tally-engine export --run <id> --format json --out /tmp/statements
+```
+
+writes `statement-garden-sim%2Falpha.json` and
+`statement-garden-sim%2Fbeta.json`. The two Gardener projects have no usage of
+their own, and a statement is opened for each of them all the same: their
+`related_costs` carry the line items of the tenant the shoots run on, under the
+relation type `infrastructure_tenant`. The two Gardener tenants get no statement
+of their own, and `runs.stats.unregistered_projects` names nothing, because
+every tenant the month books usage for is registered. `rated.csv` does not
+change and neither does `compare`: a rated record carries the tenant that owned
+the resource as `project_id`, the attribution stands in the statements alone,
+and `compare` reads `rated.csv`.
+
 ## The control endpoint
 
 Both subcommands serve a control endpoint on `TALLY_SIM_HTTP_ADDR` and
@@ -1311,12 +1510,16 @@ lists every variable with its default and its meaning.
 | `TALLY_SIM_HTTP_PORT` | `8080` | both, while publishing | port of the control endpoint. |
 | `TALLY_SIM_AMQP_URL` | none | `run` optional, `replay` required | broker the notifications are published to. It carries the broker password, so it also accepts `TALLY_SIM_AMQP_URL_FILE`; setting both is an error. |
 | `TALLY_SIM_CLOUD` | none | `run` | cloud the month belongs to: the salt of every generated identifier and the cloud of `events.jsonl`. |
+| `TALLY_SIM_REPORTING_URL` | none | `run` with `--register-projects` | Reporting API the projects are registered with. It has to be absolute and carry a host, with no query and no fragment, because the registry route is appended to it, and it has to be `https` unless `TALLY_SIM_REPORTING_INSECURE` says otherwise. A run without the switch reads it and ignores it. |
+| `TALLY_SIM_REPORTING_INSECURE` | `false` | `run` with `--register-projects` | allow a plaintext Reporting API. The api token travels in a header on every request and is of role `admin`, so it is not scoped to one cloud the way an ingest token is. |
+| `TALLY_SIM_API_TOKEN` | none | `run` with `--register-projects` | credential of the registration, an api token of role `admin`, which `POST /api/v1/projects` and `POST /api/v1/projects/{id}/relations` demand. It also accepts `TALLY_SIM_API_TOKEN_FILE`; setting both is an error. |
+| `TALLY_SIM_GARDEN_CLOUD` | none | `run` with `--register-projects` | cloud the two Gardener rows are registered under. It has to differ from `TALLY_SIM_CLOUD`: a cloud is one installation of one platform. |
 
 An empty `TALLY_SIM_AMQP_URL` puts `run` in file mode, where `--out` is what it
 writes to instead, and `replay` refuses to start without one.
 
-The broker is the one setting that reaches off this machine, and what a run puts
-on it is not a test message. The exchanges, the declare arguments, and the shape
+The broker reaches off this machine, and what a run puts on it is not a test
+message. The exchanges, the declare arguments, and the shape
 of every notification are the ones a real deployment carries, the wire format
 names no cloud, and a collector books what it consumes under its own
 `TALLY_OSC_CLOUD` whatever `TALLY_SIM_CLOUD` said. A month published onto a
@@ -1328,11 +1531,15 @@ reason, and `--allow-remote-broker` is the confirmation that lets one through.
 The compose stack passes it, because its broker is the container next door.
 
 `run` takes `--period` (required, `YYYY-MM`), `--seed` (1), `--factor` (744),
-`--out` (empty), `--wait-for-collector` (two minutes), `--faults` (empty), and
-`--allow-remote-broker` (off). `--faults` takes the six switch names
-`pre-existing`, `missing-create`, `duplicates`, `reordering`, `refused-shapes`,
-and `held-back`, comma-separated; empty is every switch off, and "The fault
-switches" describes what each of them does. `replay` takes `--in` (required),
+`--out` (empty), `--wait-for-collector` (two minutes), `--faults` (empty),
+`--register-projects` (off), and `--allow-remote-broker` (off). `--faults` takes
+the six switch names `pre-existing`, `missing-create`, `duplicates`,
+`reordering`, `refused-shapes`, and `held-back`, comma-separated; empty is every
+switch off, and "The fault switches" describes what each of them does.
+`--register-projects` registers the month's tenants, the two Gardener projects,
+and their `infrastructure_tenant` relations before anything is written or
+published, which "The project registry" describes. `replay` takes `--in`
+(required),
 `--factor` (744), `--wait-for-collector` (two minutes), and
 `--allow-remote-broker` (off). `compare` takes `--oracle`, `--export`, and
 `--pricing`, all three required, and reads no variable of the table at all: it

--- a/internal/providers/openstack/simulator/config.go
+++ b/internal/providers/openstack/simulator/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -28,7 +29,8 @@ import (
 
 // fileSuffix names the companion variable of a secret: the value of
 // TALLY_SIM_AMQP_URL is read from the file at TALLY_SIM_AMQP_URL_FILE when that
-// variable holds a path.
+// variable holds a path, and TALLY_SIM_API_TOKEN from TALLY_SIM_API_TOKEN_FILE
+// the same way.
 const fileSuffix = "_FILE"
 
 // The variables this package reads. They are named here because the errors
@@ -39,11 +41,16 @@ const (
 	envHTTPPort = "TALLY_SIM_HTTP_PORT"
 	envAMQPURL  = "TALLY_SIM_AMQP_URL"
 	envCloud    = "TALLY_SIM_CLOUD"
+
+	envReportingURL      = "TALLY_SIM_REPORTING_URL"
+	envReportingInsecure = "TALLY_SIM_REPORTING_INSECURE"
+	envAPIToken          = "TALLY_SIM_API_TOKEN"
+	envGardenCloud       = "TALLY_SIM_GARDEN_CLOUD"
 )
 
-// EnvNames is every variable this package reads, including the *_FILE companion
-// of the secret. Tests blank all of them, so a value in the developer's shell
-// never reaches the code under test.
+// EnvNames is every variable this package reads, including the *_FILE
+// companions of the secrets. Tests blank all of them, so a value in the
+// developer's shell never reaches the code under test.
 var EnvNames = []string{
 	envLogLevel,
 	envHTTPAddr,
@@ -51,6 +58,11 @@ var EnvNames = []string{
 	envAMQPURL,
 	envAMQPURL + fileSuffix,
 	envCloud,
+	envReportingURL,
+	envReportingInsecure,
+	envAPIToken,
+	envAPIToken + fileSuffix,
+	envGardenCloud,
 }
 
 // loopback is the address the control endpoint binds unless a deployment names
@@ -93,12 +105,28 @@ type Config struct {
 	// and the cloud of events.jsonl. It has no default because a guessed cloud
 	// silently books usage to the wrong one.
 	Cloud string `env:"TALLY_SIM_CLOUD"`
+	// ReportingURL is the Reporting API the projects are registered with. run
+	// reads it when --register-projects is on and ignores it otherwise. It must
+	// be an absolute https URL, because the api token travels on it;
+	// ReportingInsecure is what allows a plaintext one.
+	ReportingURL string `env:"TALLY_SIM_REPORTING_URL"`
+	// ReportingInsecure allows an http Reporting API. It exists for a simulator
+	// and an API on the same machine, and for development; anywhere else it puts
+	// an api token of role admin on the wire in cleartext.
+	ReportingInsecure bool `env:"TALLY_SIM_REPORTING_INSECURE" envDefault:"false"`
+	// APIToken is an api token of role admin, which POST /api/v1/projects and
+	// POST /api/v1/projects/{id}/relations demand. It supports the *_FILE
+	// convention.
+	APIToken string `env:"TALLY_SIM_API_TOKEN"`
+	// GardenCloud is the cloud the two Gardener projects are registered under.
+	// It has no default, for the reason Cloud has none.
+	GardenCloud string `env:"TALLY_SIM_GARDEN_CLOUD"`
 }
 
-// Load reads the environment, resolves the file-backed broker URL, and checks
-// the log level. It does not check whether the required values are present:
-// which ones are required depends on the subcommand, which is what ValidateRun
-// and ValidateReplay decide.
+// Load reads the environment, resolves the file-backed secrets, and checks the
+// log level. It does not check whether the required values are present: which
+// ones are required depends on the subcommand and on its switches, which is
+// what ValidateRun, ValidateReplay, and ValidateRegistration decide.
 func Load() (Config, error) {
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
@@ -106,6 +134,9 @@ func Load() (Config, error) {
 	}
 
 	if cfg.AMQPURL, err = resolveFileSecret(envAMQPURL, cfg.AMQPURL); err != nil {
+		return Config{}, err
+	}
+	if cfg.APIToken, err = resolveFileSecret(envAPIToken, cfg.APIToken); err != nil {
 		return Config{}, err
 	}
 
@@ -158,6 +189,67 @@ func (c Config) ValidateRun() error {
 func (c Config) ValidateReplay() error {
 	if c.AMQPURL == "" {
 		return fmt.Errorf("%s: must be set", envAMQPURL)
+	}
+	return nil
+}
+
+// ValidateRegistration is the gate of run --register-projects. It asks for the
+// Reporting API, an api token for it, and the cloud the Gardener projects are
+// registered under, none of which a run without the switch reads.
+//
+// The two clouds have to differ because a cloud is one installation of one
+// platform: a Gardener project registered under the tenants' cloud would key a
+// row of the OpenStack installation, and the relation would then point the
+// project at itself.
+func (c Config) ValidateRegistration() error {
+	if c.ReportingURL == "" {
+		return fmt.Errorf("%s: must be set when --register-projects is on", envReportingURL)
+	}
+	if err := c.validateReportingURL(); err != nil {
+		return err
+	}
+	// The token is named and never quoted: an error an operator pastes into a
+	// ticket must not carry the credential it is about.
+	if c.APIToken == "" {
+		return fmt.Errorf("%s: must be set when --register-projects is on", envAPIToken)
+	}
+	if c.GardenCloud == "" {
+		return fmt.Errorf("%s: must be set when --register-projects is on", envGardenCloud)
+	}
+	if c.GardenCloud == c.Cloud {
+		return fmt.Errorf("%s: %q must differ from %s: a cloud is one installation of one platform",
+			envGardenCloud, c.GardenCloud, envCloud)
+	}
+	return nil
+}
+
+// validateReportingURL holds the destination of a registration to what the
+// registrar does with it. The URL carries no credential, unlike the broker URL,
+// so the refusals quote it: what an operator mistyped is what they need to see.
+//
+// The scheme is checked for the reason the collector's is, in
+// internal/providers/openstack/config.go, and with more at stake: the token
+// travels in a header on every request, and it is of role admin, so it is not
+// scoped to one (platform, cloud) pair the way an ingest token is. Anybody on
+// the path of a plaintext registration reads a credential that writes the whole
+// project registry.
+func (c Config) validateReportingURL() error {
+	parsed, err := url.Parse(c.ReportingURL)
+	// The query and the fragment are looked for in the value itself rather than
+	// in the parsed URL, because an empty one of either does not survive the
+	// parse: a trailing "?" is recorded in ForceQuery and leaves RawQuery empty,
+	// and a "#" with nothing behind it parses to an empty Fragment. Both would
+	// pass a check on the parsed fields and then swallow the appended route —
+	// https://host# becomes https://host#/api/v1/projects, which posts the token
+	// and the row to / instead.
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") ||
+		strings.ContainsAny(c.ReportingURL, "?#") {
+		return fmt.Errorf("%s: %q must be an absolute http(s) URL with no query or fragment, "+
+			"because the registry route is appended to it", envReportingURL, c.ReportingURL)
+	}
+	if parsed.Scheme != "https" && !c.ReportingInsecure {
+		return fmt.Errorf("%s: %q must use https, because the admin api token travels on it; "+
+			"set %s=true to allow plaintext", envReportingURL, c.ReportingURL, envReportingInsecure)
 	}
 	return nil
 }

--- a/internal/providers/openstack/simulator/config_test.go
+++ b/internal/providers/openstack/simulator/config_test.go
@@ -1,0 +1,183 @@
+package simulator
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRegistrationAsksForWhatARegistrationNeeds covers the gate of
+// run --register-projects. Each refusal names the variable an operator sets,
+// and the token is the one value no message quotes: an error pasted into a
+// ticket must not carry the credential it is about.
+func TestValidateRegistrationAsksForWhatARegistrationNeeds(t *testing.T) {
+	// The environment of a registration that works, which every refusal below
+	// takes one value out of or spoils.
+	complete := Config{
+		Cloud:        "os-sim",
+		ReportingURL: "https://reporting.example",
+		APIToken:     "tly_a_secret-of-the-test",
+		GardenCloud:  "garden-sim",
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "no Reporting API",
+			cfg:  Config{Cloud: "os-sim", APIToken: "tly_a_x", GardenCloud: "garden-sim"},
+			want: "TALLY_SIM_REPORTING_URL: must be set when --register-projects is on",
+		},
+		{
+			name: "a Reporting API that is not an HTTP URL",
+			cfg: Config{
+				Cloud: "os-sim", ReportingURL: "ftp://api",
+				APIToken: "tly_a_x", GardenCloud: "garden-sim",
+			},
+			want: `TALLY_SIM_REPORTING_URL: "ftp://api" must be an absolute http(s) URL with no ` +
+				"query or fragment, because the registry route is appended to it",
+		},
+		{
+			name: "a Reporting API without a host",
+			cfg: Config{
+				Cloud: "os-sim", ReportingURL: "https://",
+				APIToken: "tly_a_x", GardenCloud: "garden-sim",
+			},
+			want: `TALLY_SIM_REPORTING_URL: "https://" must be an absolute http(s) URL with no ` +
+				"query or fragment, because the registry route is appended to it",
+		},
+		{
+			name: "no token",
+			cfg: Config{
+				Cloud: "os-sim", ReportingURL: "https://reporting.example",
+				GardenCloud: "garden-sim",
+			},
+			want: "TALLY_SIM_API_TOKEN: must be set when --register-projects is on",
+		},
+		{
+			name: "no cloud for the Gardener projects",
+			cfg: Config{
+				Cloud: "os-sim", ReportingURL: "https://reporting.example",
+				APIToken: "tly_a_x",
+			},
+			want: "TALLY_SIM_GARDEN_CLOUD: must be set when --register-projects is on",
+		},
+		{
+			name: "the Gardener projects under the tenants' cloud",
+			cfg: Config{
+				Cloud: "os-sim", ReportingURL: "https://reporting.example",
+				APIToken: "tly_a_x", GardenCloud: "os-sim",
+			},
+			want: `TALLY_SIM_GARDEN_CLOUD: "os-sim" must differ from TALLY_SIM_CLOUD: ` +
+				"a cloud is one installation of one platform",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.ValidateRegistration()
+			if err == nil {
+				t.Fatalf("ValidateRegistration() error = nil, want %q", tc.want)
+			}
+			if err.Error() != tc.want {
+				t.Errorf("ValidateRegistration() error = %q, want %q", err, tc.want)
+			}
+			if got := err.Error(); tc.cfg.APIToken != "" && strings.Contains(got, tc.cfg.APIToken) {
+				t.Errorf("ValidateRegistration() error = %q, want it to keep the token out", got)
+			}
+		})
+	}
+
+	t.Run("an environment that registers", func(t *testing.T) {
+		if err := complete.ValidateRegistration(); err != nil {
+			t.Errorf("ValidateRegistration() error = %v, want nil", err)
+		}
+	})
+}
+
+// TestValidateRegistrationChecksTheReportingURL covers the value the registrar
+// builds its routes from and sends the api token to: a shape it can post to at
+// all, and a scheme that does not put that token on the wire in cleartext. The
+// token is of role admin, so a plaintext registration hands whoever reads it
+// the whole project registry, which is why plaintext has to be typed for the
+// way the collector's is.
+func TestValidateRegistrationChecksTheReportingURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		insecure bool
+		wants    string
+	}{
+		{name: "an https URL passes", url: "https://reporting.example"},
+		{name: "a base path passes", url: "https://reporting.example/reporting"},
+		{
+			name:     "an http URL passes once it is allowed explicitly",
+			url:      "http://127.0.0.1:8080",
+			insecure: true,
+		},
+		{
+			name:  "an http URL is refused by default",
+			url:   "http://reporting.example",
+			wants: envReportingInsecure,
+		},
+		{
+			name:  "a host without a scheme is refused",
+			url:   "reporting.example:8080",
+			wants: envReportingURL,
+		},
+		// The registry route is appended to this value, so a query or a fragment
+		// swallows it: https://host# becomes https://host#/api/v1/projects, which
+		// the client sends as a POST to / carrying the admin token. url.Parse hides
+		// the empty forms of both, so the value itself is what is searched.
+		{
+			name:  "a query is refused",
+			url:   "https://reporting.example?tenant=acme",
+			wants: envReportingURL,
+		},
+		{
+			name:  "a fragment is refused",
+			url:   "https://reporting.example#tenant",
+			wants: envReportingURL,
+		},
+		{
+			name:  "a trailing question mark is refused",
+			url:   "https://reporting.example?",
+			wants: envReportingURL,
+		},
+		{
+			name:  "a trailing hash is refused",
+			url:   "https://reporting.example#",
+			wants: envReportingURL,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Cloud:             "os-sim",
+				ReportingURL:      tc.url,
+				ReportingInsecure: tc.insecure,
+				APIToken:          "tly_a_secret-of-the-test",
+				GardenCloud:       "garden-sim",
+			}
+
+			err := cfg.ValidateRegistration()
+
+			if tc.wants == "" {
+				if err != nil {
+					t.Fatalf("ValidateRegistration() error = %v, want nil for %q", err, tc.url)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateRegistration() error = nil, want %q refused naming %s",
+					tc.url, tc.wants)
+			}
+			if !strings.Contains(err.Error(), tc.wants) {
+				t.Errorf("ValidateRegistration() error = %q, want it to name %s", err, tc.wants)
+			}
+			if strings.Contains(err.Error(), cfg.APIToken) {
+				t.Errorf("ValidateRegistration() error = %q, want it to keep the token out", err)
+			}
+		})
+	}
+}

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -839,6 +839,41 @@ func TestRunStoppedWhileHoldingKeepsTheHeldNotificationsBack(t *testing.T) {
 	depthStaysAt(t, outbox, onTheBus)
 }
 
+// TestRunStoppedWhileRegisteringWritesNothing is what SIGINT does to a run that
+// is registering: the process ends with exit status 0, the log says how far the
+// registration came, and neither a file nor a notification is left behind that
+// the run never got to. The registration is the one step of a run that turns a
+// failure into a clean stop, so the two halves of it are held here.
+func TestRunStoppedWhileRegisteringWritesNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	logger, log := capturedLogger(t)
+	out := t.TempDir()
+
+	// https and a closed port: the registration is checked before it is sent, and
+	// the cancelled context ends it before anything is dialled.
+	err := Run(ctx, Config{
+		Cloud:        testCloud,
+		ReportingURL: "https://127.0.0.1:1",
+		APIToken:     "tly_a_secret-of-the-test",
+		GardenCloud:  gardenCloud,
+	}, RunOptions{Period: "2026-07", Seed: 1, Out: out, RegisterProjects: true}, nil, logger)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil: a stop while registering is a clean stop", err)
+	}
+	for _, want := range []string{"registration incomplete", "stopped"} {
+		if !strings.Contains(log.String(), want) {
+			t.Errorf("the run logged %q, want a %q line: what reached the registry is what an "+
+				"operator has to know after a stop", log.String(), want)
+		}
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil || len(entries) != 0 {
+		t.Errorf("the output directory holds %v (error %v), want nothing: the month is written after "+
+			"the registration", entries, err)
+	}
+}
+
 // TestReleaseFailsWhenTheBrokerIsGone covers the release that cannot publish
 // what it let out. The endpoint answers it, because all a release does is close
 // a channel, and the run reports the failed publish afterwards: a broker that

--- a/internal/providers/openstack/simulator/registrations.go
+++ b/internal/providers/openstack/simulator/registrations.go
@@ -1,0 +1,97 @@
+// This file states what one generated month registers with the project
+// registry of the Reporting API: a row per tenant, a row per Gardener project,
+// and the relation that attributes a tenant's cost to the project running on
+// it. The rows are decided from the month alone, without a network, so what a
+// run would register is a value a test can hold against the oracle.
+package simulator
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ProjectKey is the pair the registry keys a project by.
+type ProjectKey struct{ Cloud, ExternalID string }
+
+// ProjectRegistration is one projects row to register.
+type ProjectRegistration struct {
+	Platform string
+	Key      ProjectKey
+	Name     string
+	Metadata map[string]any
+}
+
+// RelationRegistration is one relation to create between two registered rows.
+type RelationRegistration struct {
+	Source, Target ProjectKey
+	RelationType   string
+	Metadata       map[string]any
+	ValidFrom      time.Time
+}
+
+// Registrations is what one month registers: the rows first, the relations
+// between them second.
+type Registrations struct {
+	Projects  []ProjectRegistration
+	Relations []RelationRegistration
+}
+
+// relationInfrastructureTenant is the relation type that attributes a tenant's
+// cost to the Gardener project, the default of the engine and of the Reporting
+// API. It is mirrored here rather than imported, the way sender.go mirrors the
+// ingest result: the simulator is a client of the API.
+const relationInfrastructureTenant = "infrastructure_tenant"
+
+// createdBy is the metadata member every row and relation carries, so an
+// operator reading the registry sees what wrote it.
+const createdBy = "tally-openstack-simulator"
+
+// RegistrationsOf returns the rows and relations the month registers: one
+// openstack row per tenant under the cloud the month was rendered for, one
+// gardener row per Gardener project under gardenCloud, and one
+// infrastructure_tenant relation per Gardener project, pointing at the tenant
+// its shoots run on and valid from the start of the month.
+//
+// The two clouds have to differ because a cloud is one installation of one
+// platform. A Gardener project registered under the tenants' cloud would key a
+// row of the OpenStack installation, and the relation would then point the
+// project at itself.
+func RegistrationsOf(month Month, gardenCloud string) (Registrations, error) {
+	if gardenCloud == "" {
+		return Registrations{}, errors.New("the garden cloud is empty")
+	}
+	if gardenCloud == month.Oracle.Cloud {
+		return Registrations{}, fmt.Errorf(
+			"the garden cloud %q is the tenants' cloud: a cloud is one installation of one platform",
+			gardenCloud)
+	}
+
+	var registrations Registrations
+	for _, tenant := range month.Tenants {
+		registrations.Projects = append(registrations.Projects, ProjectRegistration{
+			Platform: "openstack",
+			Key:      ProjectKey{Cloud: month.Oracle.Cloud, ExternalID: tenant.ID},
+			Name:     tenant.Name,
+			Metadata: map[string]any{"created_by": createdBy},
+		})
+	}
+	for _, gp := range month.GardenerProjects {
+		registrations.Projects = append(registrations.Projects, ProjectRegistration{
+			Platform: "gardener",
+			Key:      ProjectKey{Cloud: gardenCloud, ExternalID: gp.Name},
+			Name:     "Gardener project " + gp.Name,
+			Metadata: map[string]any{"created_by": createdBy},
+		})
+	}
+	for _, gp := range month.GardenerProjects {
+		registrations.Relations = append(registrations.Relations, RelationRegistration{
+			Source:       ProjectKey{Cloud: gardenCloud, ExternalID: gp.Name},
+			Target:       ProjectKey{Cloud: month.Oracle.Cloud, ExternalID: gp.TenantID},
+			RelationType: relationInfrastructureTenant,
+			Metadata:     map[string]any{"created_by": createdBy, "shoots": gp.Shoots},
+			ValidFrom:    month.Oracle.PeriodFrom,
+		})
+	}
+	return registrations, nil
+}

--- a/internal/providers/openstack/simulator/registrations_test.go
+++ b/internal/providers/openstack/simulator/registrations_test.go
@@ -1,0 +1,211 @@
+package simulator
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// The two clouds the registrations of a month are read under. They differ
+// because the tenants belong to an OpenStack installation and the Gardener
+// projects to a Gardener installation, and the registry keys a row by its
+// cloud.
+const (
+	tenantsCloud = "os-sim"
+	gardenCloud  = "garden-sim"
+)
+
+// TestRegistrationsNameEveryTenantOnce covers what a month registers. Every row
+// the registry is meant to hold is decided here, so the test holds the
+// registrations against the month they were read from: a tenant without a row
+// is usage nobody can bill, a duplicate key is a row the registry refuses, and
+// a relation pointing at a tenant the month never ran in attributes the cost of
+// a Gardener project to nothing.
+func TestRegistrationsNameEveryTenantOnce(t *testing.T) {
+	month := namedMonth(t, 1, july2026, tenantsCloud)
+
+	registrations, err := RegistrationsOf(month, gardenCloud)
+	if err != nil {
+		t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", gardenCloud, err)
+	}
+
+	wantProjects := len(month.Tenants) + len(month.GardenerProjects)
+	if len(registrations.Projects) != wantProjects {
+		t.Fatalf("the month registers %d projects, want %d: a row per tenant and a row per Gardener "+
+			"project", len(registrations.Projects), wantProjects)
+	}
+	for i, tenant := range month.Tenants {
+		got := registrations.Projects[i]
+		want := ProjectRegistration{
+			Platform: "openstack",
+			Key:      ProjectKey{Cloud: tenantsCloud, ExternalID: tenant.ID},
+			Name:     tenant.Name,
+			Metadata: map[string]any{"created_by": "tally-openstack-simulator"},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("project %d = %+v, want %+v: a tenant is registered under the cloud it ran in, by "+
+				"the id its notifications carry", i, got, want)
+		}
+	}
+
+	wantGardener := []ProjectRegistration{
+		{
+			Platform: "gardener",
+			Key:      ProjectKey{Cloud: gardenCloud, ExternalID: "alpha"},
+			Name:     "Gardener project alpha",
+			Metadata: map[string]any{"created_by": "tally-openstack-simulator"},
+		},
+		{
+			Platform: "gardener",
+			Key:      ProjectKey{Cloud: gardenCloud, ExternalID: "beta"},
+			Name:     "Gardener project beta",
+			Metadata: map[string]any{"created_by": "tally-openstack-simulator"},
+		},
+	}
+	if got := registrations.Projects[len(month.Tenants):]; !reflect.DeepEqual(got, wantGardener) {
+		t.Errorf("the Gardener rows are %+v, want %+v: a project is registered under the garden cloud, by "+
+			"the name an operator knows its shoots under", got, wantGardener)
+	}
+
+	// The registry keys a row by its cloud and external id, so two rows on one
+	// key are one row, and the second registration would overwrite or be refused.
+	keys := make(map[ProjectKey]int, len(registrations.Projects))
+	openstackIDs := make(map[string]bool, len(month.Tenants))
+	for i, project := range registrations.Projects {
+		if first, ok := keys[project.Key]; ok {
+			t.Errorf("project %d and project %d both carry the key %+v, want %d distinct keys: two rows on "+
+				"one key are one row", first, i, project.Key, wantProjects)
+		}
+		keys[project.Key] = i
+		if project.Platform == "openstack" {
+			openstackIDs[project.Key.ExternalID] = true
+		}
+	}
+
+	// One report per unregistered id rather than one per interval, because a
+	// tenant without a row carries hundreds of them.
+	unregistered := make(map[string]string)
+	for _, resource := range month.Oracle.Resources {
+		for _, interval := range resource.Intervals {
+			if !openstackIDs[interval.ProjectID] {
+				unregistered[interval.ProjectID] = resource.ResourceType + " " + resource.ResourceID
+			}
+		}
+	}
+	for id, resource := range unregistered {
+		t.Errorf("the oracle bills the %s to the project %s, which no registration names, want every "+
+			"project of the month registered: usage under an unregistered id is booked against no row",
+			resource, id)
+	}
+
+	if len(registrations.Relations) != len(month.GardenerProjects) {
+		t.Fatalf("the month registers %d relations, want %d: one per Gardener project",
+			len(registrations.Relations), len(month.GardenerProjects))
+	}
+	if want := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC); !month.Oracle.PeriodFrom.Equal(want) {
+		t.Fatalf("the oracle states the period from %s, want %s: the relations are valid from the start of "+
+			"the month", month.Oracle.PeriodFrom.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	for i, relation := range registrations.Relations {
+		if relation.RelationType != "infrastructure_tenant" {
+			t.Errorf("relation %d is of type %q, want %q: it is the type the engine attributes along by "+
+				"default", i, relation.RelationType, "infrastructure_tenant")
+		}
+		if !relation.ValidFrom.Equal(month.Oracle.PeriodFrom) {
+			t.Errorf("relation %d is valid from %s, want %s: usage of the first day is attributed too",
+				i, relation.ValidFrom.Format(time.RFC3339), month.Oracle.PeriodFrom.Format(time.RFC3339))
+		}
+		if _, ok := keys[relation.Source]; !ok {
+			t.Errorf("relation %d points from %+v, which no registration names, want a registered row: "+
+				"the registry refuses a relation to a row it does not hold", i, relation.Source)
+		}
+		if _, ok := keys[relation.Target]; !ok {
+			t.Errorf("relation %d points at %+v, which no registration names, want a registered row",
+				i, relation.Target)
+		}
+	}
+
+	first := registrations.Relations[0]
+	wantSource := ProjectKey{Cloud: gardenCloud, ExternalID: "alpha"}
+	wantTarget := ProjectKey{Cloud: tenantsCloud, ExternalID: month.GardenerProjects[0].TenantID}
+	if first.Source != wantSource || first.Target != wantTarget {
+		t.Errorf("relation 0 points from %+v at %+v, want from %+v at %+v: the project is the source and "+
+			"the tenant it runs on the target", first.Source, first.Target, wantSource, wantTarget)
+	}
+
+	wantShoots := [][]string{{"api-prod", "api-dev"}, {"batch"}}
+	for i, want := range wantShoots {
+		got, ok := registrations.Relations[i].Metadata["shoots"].([]string)
+		if !ok || !reflect.DeepEqual(got, want) {
+			t.Errorf("relation %d states the shoots %v, want %v: the metadata says which shoots the "+
+				"attributed tenant runs", i, registrations.Relations[i].Metadata["shoots"], want)
+		}
+	}
+
+	for i, project := range registrations.Projects {
+		if got := project.Metadata["created_by"]; got != "tally-openstack-simulator" {
+			t.Errorf("project %d states created_by = %v, want %q: an operator reading the registry sees "+
+				"what wrote the row", i, got, "tally-openstack-simulator")
+		}
+	}
+	for i, relation := range registrations.Relations {
+		if got := relation.Metadata["created_by"]; got != "tally-openstack-simulator" {
+			t.Errorf("relation %d states created_by = %v, want %q", i, got, "tally-openstack-simulator")
+		}
+	}
+}
+
+// TestRegistrationsOfRefusesTheWrongGardenCloud covers the two garden clouds
+// that name no Gardener installation. A cloud is one installation of one
+// platform, so the Gardener projects cannot be keyed under the cloud the
+// tenants are keyed under, and a run that registered them there would point
+// every relation at a row of the OpenStack installation.
+func TestRegistrationsOfRefusesTheWrongGardenCloud(t *testing.T) {
+	month := namedMonth(t, 1, july2026, tenantsCloud)
+
+	tests := []struct {
+		name        string
+		gardenCloud string
+		wantErr     string
+	}{
+		{
+			name:        "empty",
+			gardenCloud: "",
+			wantErr:     "the garden cloud is empty",
+		},
+		{
+			name:        "the tenants' cloud",
+			gardenCloud: tenantsCloud,
+			wantErr: `the garden cloud "os-sim" is the tenants' cloud: a cloud is one installation of one ` +
+				`platform`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RegistrationsOf(month, tt.gardenCloud)
+
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("RegistrationsOf(month, %q) error = %v, want %q", tt.gardenCloud, err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, Registrations{}) {
+				t.Errorf("RegistrationsOf(month, %q) = %+v, want nothing: a refused call registers no row",
+					tt.gardenCloud, got)
+			}
+		})
+	}
+}
+
+// TestRegistrationsOfAnEmptyMonth covers a month that names no tenant. It
+// registers nothing rather than failing, because an empty world is a world, and
+// what the registry is fed is read off the month rather than assumed of it.
+func TestRegistrationsOfAnEmptyMonth(t *testing.T) {
+	got, err := RegistrationsOf(Month{}, gardenCloud)
+	if err != nil {
+		t.Fatalf("RegistrationsOf(Month{}, %q) error = %v, want nil", gardenCloud, err)
+	}
+
+	if len(got.Projects) != 0 || len(got.Relations) != 0 {
+		t.Errorf("a month naming no tenant registers %d projects and %d relations, want none of either",
+			len(got.Projects), len(got.Relations))
+	}
+}

--- a/internal/providers/openstack/simulator/registry.go
+++ b/internal/providers/openstack/simulator/registry.go
@@ -1,0 +1,475 @@
+// This file posts what RegistrationsOf decided to the project registry of the
+// Reporting API: a row per project first, the relations between them second.
+// The simulator is a client of that API the way the collector's sender is, so
+// the documents on the wire are mirrored here rather than imported, and a
+// registration carries no retry: an operator who reruns the seed, the period
+// and the cloud registers the same rows again, and the ones an earlier run got
+// through are found in place.
+package simulator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The bounds one registration request is taken under. They repeat the sender's,
+// in sender.go, because the simulator posts to the same API and shares no code
+// with the collector.
+const (
+	// registrationTimeout bounds one request. A destination that accepts the
+	// connection and then stops answering would otherwise hold the run for as
+	// long as it stays that way.
+	registrationTimeout = 30 * time.Second
+	// refusalBodyMax is how much of a refused answer the error quotes. What
+	// arrives there is whatever answered, which may be a proxy's HTML error page
+	// rather than the API's problem document.
+	refusalBodyMax = 512
+	// answerBodyMax bounds an accepted answer that is decoded. A registered
+	// project is a few hundred bytes, so a megabyte covers every answer the
+	// Reporting API gives. What it rules out is a destination that answers 201
+	// and then streams for as long as the timeout allows.
+	answerBodyMax = 1 << 20
+)
+
+// projectsRoute is the registry route, appended to the configured base URL of
+// the Reporting API. The relations of a project hang below it.
+const projectsRoute = "/api/v1/projects"
+
+// adminTokenHint is added to the message of an answer that refused the token.
+// Registering is an admin operation, so a token that delivers notifications is
+// not one that registers the projects they arrive under.
+const adminTokenHint = "; TALLY_SIM_API_TOKEN has to be an api token of role admin"
+
+// createProjectDocument is the body POST /api/v1/projects takes. It mirrors the
+// documented contract instead of importing the server's type, the way sender.go
+// mirrors the ingest result: the simulator is a client of that API, and
+// importing the server would pull its router, its schema validation and its
+// database driver into this binary.
+type createProjectDocument struct {
+	Platform   string         `json:"platform"`
+	Cloud      string         `json:"cloud"`
+	ExternalID string         `json:"external_id"`
+	Name       string         `json:"name"`
+	Metadata   map[string]any `json:"metadata"`
+}
+
+// createRelationDocument is the body POST /api/v1/projects/{id}/relations
+// takes. The source is the project the route names, so the body carries the
+// target alone.
+type createRelationDocument struct {
+	TargetID     uuid.UUID      `json:"target_id"`
+	RelationType string         `json:"relation_type"`
+	Metadata     map[string]any `json:"metadata"`
+	ValidFrom    string         `json:"valid_from"`
+}
+
+// registeredRelation is a relation as the registry answers it, as much of it as
+// a registration reads: which project it reaches, the id the route that ends it
+// names, and the instant it starts at, which decides whether that route can end
+// it before the month being registered begins. Whether it was valid is not read
+// off the row, because the answer holds the relations valid at the instant the
+// read named.
+type registeredRelation struct {
+	ID        uuid.UUID `json:"id"`
+	TargetID  uuid.UUID `json:"target_id"`
+	ValidFrom time.Time `json:"valid_from"`
+}
+
+// relationList is what GET /api/v1/projects/{id}/relations answers: the
+// relations of one project as they stood at the instant the request named.
+type relationList struct {
+	Items []registeredRelation `json:"items"`
+}
+
+// registeredProject is a project as the registry answers it, as much of it as a
+// registration reads: the id the relations address it by.
+type registeredProject struct {
+	ID uuid.UUID `json:"id"`
+}
+
+// projectList is one page of GET /api/v1/projects. A lookup by cloud and
+// external id has at most one page, because that pair is the key.
+type projectList struct {
+	Items []registeredProject `json:"items"`
+}
+
+// Registrar registers the projects and relations of a month with one
+// Reporting API.
+type Registrar struct {
+	endpoint string // the base URL without a trailing slash
+	token    string
+	client   *http.Client
+	logger   *slog.Logger
+}
+
+// RegistrationReport counts what one Register call found and did.
+type RegistrationReport struct {
+	ProjectsCreated, ProjectsExisting, RelationsCreated, RelationsExisting int
+}
+
+// NewRegistrar builds the client that registers with the Reporting API at
+// reportingURL, holding token as its credential. One trailing slash is trimmed
+// off the URL, so a base URL written either way builds the same routes.
+//
+// logger may be nil, which logs through the default logger.
+func NewRegistrar(reportingURL, token string, logger *slog.Logger) *Registrar {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Registrar{
+		endpoint: strings.TrimSuffix(reportingURL, "/"),
+		token:    token,
+		client: &http.Client{
+			Timeout: registrationTimeout,
+			// A redirect is answered rather than followed. The registry routes are
+			// fixed paths under a configured base, so the API documents none, and Go
+			// strips the Authorization header across hosts alone: a same-host redirect
+			// to http:// would carry the admin token over in the clear, which is what
+			// the https check on the configured URL exists to rule out. A followed
+			// redirect that kept the token would be no better, because Go turns a
+			// redirected POST into a GET on 301, 302 and 303, which makes a
+			// registration a read that registers nothing.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		logger: logger,
+	}
+}
+
+// Register posts every project of regs and then every relation between them,
+// and reports how many rows it created and how many the registry already held.
+//
+// The order is what makes it work twice. A relation needs both of its ends
+// registered, so the rows go first, and a key the registry already holds is
+// answered 409 rather than replaced: that row is looked up by its key and its
+// id is what the relations point at. A relation that is already active is
+// answered 409 too and left as it stands. Rerunning the same seed, period and
+// cloud therefore ends in the registry the first run meant to leave behind,
+// which is what an operator does after a run that failed halfway.
+//
+// A rerun under another seed, period or cloud is not that: its tenants are new
+// rows, while the Gardener rows are the ones the earlier run registered, so the
+// relations of the two runs would attribute two months to one statement. Such a
+// registration is refused at the relation, naming the route that ends the
+// earlier one and the instant it has to end at, or, when that relation begins no
+// earlier than this month and can therefore not be ended before it, the garden
+// cloud of its own this month needs instead.
+//
+// The first answer no path can use ends the registration, and the report then
+// counts what got through before it. A set naming a relation whose ends it does
+// not register is refused before the first request, because the rows of a set
+// like that are rows without the relation that gives them their meaning.
+func (r *Registrar) Register(ctx context.Context, regs Registrations) (RegistrationReport, error) {
+	var report RegistrationReport
+
+	registered := make(map[ProjectKey]bool, len(regs.Projects))
+	for _, project := range regs.Projects {
+		registered[project.Key] = true
+	}
+	for _, relation := range regs.Relations {
+		if !registered[relation.Source] || !registered[relation.Target] {
+			source, target := relation.Source, relation.Target
+			return report, fmt.Errorf(
+				"the relation from (%s, %s) to (%s, %s) names a project the registrations do not hold",
+				source.Cloud, source.ExternalID, target.Cloud, target.ExternalID)
+		}
+	}
+
+	ids := make(map[ProjectKey]uuid.UUID, len(regs.Projects))
+	for _, project := range regs.Projects {
+		id, existed, err := r.registerProject(ctx, project)
+		if err != nil {
+			return report, err
+		}
+		ids[project.Key] = id
+		message := "registered project"
+		if existed {
+			report.ProjectsExisting++
+			message = "project already registered"
+		} else {
+			report.ProjectsCreated++
+		}
+		r.logger.Info(message, "platform", project.Platform, "cloud", project.Key.Cloud,
+			"external_id", project.Key.ExternalID, "id", id)
+	}
+
+	for _, relation := range regs.Relations {
+		source, target := ids[relation.Source], ids[relation.Target]
+		existed, err := r.relate(ctx, source, target, relation)
+		if err != nil {
+			return report, err
+		}
+		message := "related"
+		if existed {
+			report.RelationsExisting++
+			message = "relation already active"
+		} else {
+			report.RelationsCreated++
+		}
+		r.logger.Info(message, "source", source, "target", target,
+			"relation_type", relation.RelationType)
+	}
+
+	return report, nil
+}
+
+// registerProject registers one project and returns the id it is now addressed
+// by, and whether the registry already held it.
+func (r *Registrar) registerProject(ctx context.Context, project ProjectRegistration) (uuid.UUID, bool, error) {
+	status, body, err := r.do(ctx, http.MethodPost, projectsRoute, nil, createProjectDocument{
+		Platform:   project.Platform,
+		Cloud:      project.Key.Cloud,
+		ExternalID: project.Key.ExternalID,
+		Name:       project.Name,
+		Metadata:   project.Metadata,
+	})
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+
+	switch status {
+	case http.StatusCreated:
+		var created registeredProject
+		if err := json.Unmarshal(body, &created); err != nil {
+			return uuid.Nil, false, fmt.Errorf("decoding the registered project: %w", err)
+		}
+		// The relations are addressed by this id, so an answer without one leaves
+		// the registration nothing to point at.
+		if created.ID == uuid.Nil {
+			return uuid.Nil, false, errors.New("the Reporting API answered 201 without a project id")
+		}
+		return created.ID, false, nil
+	case http.StatusConflict:
+		id, err := r.lookUpProject(ctx, project.Key)
+		return id, true, err
+	default:
+		return uuid.Nil, false, refused(status, http.MethodPost, projectsRoute, body)
+	}
+}
+
+// lookUpProject reads the id of a row the registry answered 409 for. The key is
+// the pair the registry is keyed by, so an answer carrying anything but one row
+// describes a registry this registration cannot address.
+func (r *Registrar) lookUpProject(ctx context.Context, key ProjectKey) (uuid.UUID, error) {
+	query := url.Values{"cloud": {key.Cloud}, "external_id": {key.ExternalID}}
+	status, body, err := r.do(ctx, http.MethodGet, projectsRoute, query, nil)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if status != http.StatusOK {
+		return uuid.Nil, refused(status, http.MethodGet, projectsRoute, body)
+	}
+
+	var list projectList
+	if err := json.Unmarshal(body, &list); err != nil {
+		return uuid.Nil, fmt.Errorf("decoding the listed projects: %w", err)
+	}
+	switch len(list.Items) {
+	case 1:
+		return list.Items[0].ID, nil
+	case 0:
+		return uuid.Nil, fmt.Errorf(
+			"the Reporting API refused (%s, %s) as registered and lists no such project",
+			key.Cloud, key.ExternalID)
+	default:
+		return uuid.Nil, fmt.Errorf("the Reporting API lists %d projects for (%s, %s), want one",
+			len(list.Items), key.Cloud, key.ExternalID)
+	}
+}
+
+// relate creates one relation and reports whether it was already active. The
+// answer carries the stored relation, which nothing here reads: the ids it
+// holds are the two this call passed.
+func (r *Registrar) relate(ctx context.Context, source, target uuid.UUID,
+	relation RelationRegistration,
+) (bool, error) {
+	route := projectsRoute + "/" + source.String() + "/relations"
+	start := relation.ValidFrom.UTC().Format(time.RFC3339)
+	// The registry keys an open relation by (source, target, type), so a source
+	// already related to another project is not a conflict: the creation would
+	// succeed and leave two relations attributing side by side. The export then
+	// walks both and sums two months of a tenant's cost into one statement. That
+	// is what an earlier run under another period, seed or cloud leaves behind:
+	// the Gardener row is keyed by its name and stays, while the tenant it points
+	// at is keyed by an identifier the month is salted into.
+	//
+	// The check is advisory and not a safety property: the registry enforces one
+	// open relation per (source, target, type) and nothing below this read stops
+	// two registrations that both read an empty list from both creating one. The
+	// invariant it stands in for belongs to the Reporting API, as one open
+	// relation per (source, type) of an attributing type, answered 409.
+	//
+	// The relations are read at two instants, because the registry answers the
+	// ones valid at one alone. The relation this run creates is valid from the
+	// start of its period and has no end, so anything of its type that attributes
+	// at or after that start stands beside it. The read at the start of the period
+	// is one instant the engine bills the period by: it finds a relation that was
+	// closed afterwards too, and DELETE closes one at now, which is after every
+	// instant of a simulated month. The read at now finds one that starts after
+	// this period and would attribute beside this one in every month from there
+	// on.
+	//
+	// Two point-in-time reads are less than the overlap the engine bills by
+	// (valid_from < period_to AND (valid_to IS NULL OR valid_to > period_from)),
+	// and the gap between them is a second shape this read lets through: a
+	// relation that starts inside the period and was closed no later than now is
+	// valid at neither instant and attributes the period all the same. Closing it
+	// would need an overlap filter on the route, which the Reporting API does not
+	// offer, or the invariant above, which is where it belongs.
+	for _, at := range []string{start, ""} {
+		stale, err := r.relationBesides(ctx, source, target, relation.RelationType, at)
+		if err != nil {
+			return false, err
+		}
+		if stale.ID != uuid.Nil {
+			// PATCH refuses a valid_to that is not after the stored valid_from with
+			// 422, so ending the earlier relation where this month begins is a way out
+			// only while that relation began earlier. When it began at or after this
+			// month, the registry holds no instant it could be ended at, and naming
+			// the route would send an operator into that refusal.
+			if !stale.ValidFrom.Before(relation.ValidFrom.UTC()) {
+				return false, fmt.Errorf(
+					"%s is already related to %s by %s from %s on, and this run relates it to %s from "+
+						"%s on: two relations attributing at once put both tenants into one statement; "+
+						"that relation cannot be ended before it starts, so register this month under "+
+						"another garden cloud",
+					source, stale.TargetID, relation.RelationType,
+					stale.ValidFrom.UTC().Format(time.RFC3339), target, start)
+			}
+			return false, fmt.Errorf(
+				"%s is already related to %s by %s, and this run relates it to %s from %s on: two "+
+					"relations attributing at once put both tenants into one statement; end the "+
+					"earlier one no later than %s with PATCH %s/%s, or register this month under "+
+					"another garden cloud",
+				source, stale.TargetID, relation.RelationType, target, start, start, route, stale.ID)
+		}
+	}
+
+	status, body, err := r.do(ctx, http.MethodPost, route, nil, createRelationDocument{
+		TargetID:     target,
+		RelationType: relation.RelationType,
+		Metadata:     relation.Metadata,
+		ValidFrom:    start,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	switch status {
+	case http.StatusCreated:
+		return false, nil
+	case http.StatusConflict:
+		return true, nil
+	default:
+		return false, refused(status, http.MethodPost, route, body)
+	}
+}
+
+// relationBesides reads the relations of source that were valid at at, and
+// answers the first one of relationType that reaches a project other than
+// target. An empty at reads them as they stand now, which is what the registry
+// answers a request naming no instant. A zero value is a source this run may
+// relate at that instant: either it carries no such relation, or the one it
+// carries is the relation this run would create.
+func (r *Registrar) relationBesides(ctx context.Context, source, target uuid.UUID,
+	relationType, at string,
+) (registeredRelation, error) {
+	route := projectsRoute + "/" + source.String() + "/relations"
+	query := url.Values{"direction": {"outgoing"}, "relation_type": {relationType}}
+	if at != "" {
+		query.Set("at", at)
+	}
+	status, body, err := r.do(ctx, http.MethodGet, route, query, nil)
+	if err != nil {
+		return registeredRelation{}, err
+	}
+	if status != http.StatusOK {
+		return registeredRelation{}, refused(status, http.MethodGet, route, body)
+	}
+
+	var list relationList
+	if err := json.Unmarshal(body, &list); err != nil {
+		return registeredRelation{}, fmt.Errorf("decoding the relations of a project: %w", err)
+	}
+	for _, stored := range list.Items {
+		if stored.TargetID != target {
+			return stored, nil
+		}
+	}
+	return registeredRelation{}, nil
+}
+
+// do sends one request to route and returns the status and the answer. A body
+// is encoded as JSON, and a nil one sends none, which is what tells the two
+// posts from the lookup.
+func (r *Registrar) do(ctx context.Context, method, route string, query url.Values, body any,
+) (int, []byte, error) {
+	target := r.endpoint + route
+	if len(query) > 0 {
+		target += "?" + query.Encode()
+	}
+
+	var payload io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("encoding the body of %s %s: %w", method, route, err)
+		}
+		payload = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, target, payload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%s %s: %w", method, route, err)
+	}
+	request.Header.Set("Authorization", "Bearer "+r.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, err := r.client.Do(request)
+	if err != nil {
+		// The cause stays wrapped, so a caller that cancelled the context reads its
+		// own cancellation back out of the error rather than a message about it.
+		return 0, nil, fmt.Errorf("%s %s: %w", method, route, err)
+	}
+	// Reading the rest of the answer before closing it is what lets the connection
+	// be used again by the request that follows, of which there are as many as the
+	// month has projects and relations.
+	defer func() {
+		_, _ = io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+	}()
+
+	answer, err := io.ReadAll(io.LimitReader(response.Body, answerBodyMax))
+	if err != nil {
+		return 0, nil, fmt.Errorf("reading the answer of %s %s: %w", method, route, err)
+	}
+	return response.StatusCode, answer, nil
+}
+
+// refused is the error an answer no caller can use ends the registration with.
+// It quotes the beginning of the body, because what answered may be a proxy in
+// front of the API rather than the API itself, and it names the route without
+// the host and the query, so that a message can be pasted into a ticket.
+func refused(status int, method, route string, body []byte) error {
+	message := fmt.Sprintf("the Reporting API answered %d for %s %s: %s",
+		status, method, route, body[:min(len(body), refusalBodyMax)])
+	// A refused token is the one failure whose fix is not in the answer: the
+	// registration needs a role beyond the one that delivers notifications.
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		message += adminTokenHint
+	}
+	return errors.New(message)
+}

--- a/internal/providers/openstack/simulator/registry_integration_test.go
+++ b/internal/providers/openstack/simulator/registry_integration_test.go
@@ -1,0 +1,602 @@
+// This file holds the registrar against the Reporting API itself: the wire
+// documents registry.go mirrors are posted to the contract's request validator
+// and through the role guard every route carries, into the registry tables of a
+// real database. Neither is something the httptest stand-in of registry_test.go
+// can state. That server answers whatever a case tells it to, so a document the
+// contract refuses and a role a route would not grant pass it alike.
+package simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	"github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+	"github.com/b42labs/tally/internal/reporting/store/storetest"
+)
+
+// testRouterInternalToken guards the /internal routes of the API this test
+// starts. A registration calls none of them, and the router takes the secret
+// either way.
+const testRouterInternalToken = "internal-token-of-the-registry-integration-test"
+
+// The clouds the refused registration is read under. They differ from the pair
+// in registrations_test.go because both cases run against one registry: rows
+// counted under the clouds the first case registered would be its rows rather
+// than none.
+const (
+	readOnlyTenantsCloud = "os-readonly"
+	readOnlyGardenCloud  = "garden-readonly"
+)
+
+// The clouds the second month is read under, for the same reason: the case that
+// registers two months has to count its own relations and nobody else's.
+const (
+	secondMonthTenantsCloud = "os-second-month"
+	secondMonthGardenCloud  = "garden-second-month"
+)
+
+// The clouds the month behind a closed relation is registered under, for the
+// same reason again.
+const (
+	closedTenantsCloud = "os-closed-relation"
+	closedGardenCloud  = "garden-closed-relation"
+)
+
+// TestRegisterAgainstTheReportingAPI registers a generated month with the real
+// project registry: the router cmd/tally-reporting builds, over a migrated
+// TimescaleDB in a container, with authentication enforced.
+//
+// What it covers is the seam between the two. Whether the documents this
+// package mirrors are the documents the contract takes, whether the rows and
+// relations they create are the ones a tenant's cost is attributed by, and
+// whether a run started with a token that may read the registry stops before it
+// writes into it.
+func TestRegisterAgainstTheReportingAPI(t *testing.T) {
+	db := storetest.NewDB(t)
+	queries := sqlcgen.New(db.Store.Pool())
+	server := startReportingAPI(t, db, queries)
+	adminToken := seedAPIToken(t, queries, auth.RoleAdmin)
+	readAllToken := seedAPIToken(t, queries, auth.RoleReadAll)
+
+	t.Run("a registry that holds nothing, then the same month again", func(t *testing.T) {
+		month := namedMonth(t, 1, july2026, tenantsCloud)
+		registrations, err := RegistrationsOf(month, gardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", gardenCloud, err)
+		}
+
+		report, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), registrations)
+		if err != nil {
+			t.Fatalf("Register() error = %v, want nil", err)
+		}
+		want := RegistrationReport{ProjectsCreated: 8, RelationsCreated: 2}
+		if report != want {
+			t.Errorf("Register() = %+v, want %+v: the six tenants and the two Gardener projects are "+
+				"registered, and each Gardener project is related to the tenant its shoots run on",
+				report, want)
+		}
+
+		// Rerunning the same seed, period and cloud is what an operator does after a
+		// run that failed halfway, so the second registration has to find every row
+		// and every relation in place rather than end on one of them.
+		again, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), registrations)
+		if err != nil {
+			t.Fatalf("the second Register() error = %v, want nil: a row the registry holds is not a "+
+				"failed registration", err)
+		}
+		wantAgain := RegistrationReport{ProjectsExisting: 8, RelationsExisting: 2}
+		if again != wantAgain {
+			t.Errorf("the second Register() = %+v, want %+v: the month is registered, so the second "+
+				"run creates nothing", again, wantAgain)
+		}
+
+		// What the two runs left in the registry. A row written twice would be
+		// counted here, and a platform the API stored otherwise would put a Gardener
+		// project into the OpenStack installation.
+		wantRows := map[projectGroup]int{
+			{cloud: tenantsCloud, platform: "openstack"}: 6,
+			{cloud: gardenCloud, platform: "gardener"}:   2,
+		}
+		if got := projectCounts(t, db, tenantsCloud, gardenCloud); !maps.Equal(got, wantRows) {
+			t.Errorf("the registry holds %v, want %v: a tenant is a row of the installation it ran "+
+				"in, a Gardener project a row of the garden", got, wantRows)
+		}
+
+		// Nothing else in this database writes a relation, so the whole table is what
+		// the registrations put there.
+		stored := storedRelations(t, db)
+		if len(stored) != 2 {
+			t.Fatalf("the registry holds %d relations, want 2: one per Gardener project, and the "+
+				"second run reuses the ones the first created", len(stored))
+		}
+		for i, relation := range stored {
+			if relation.relationType != relationInfrastructureTenant {
+				t.Errorf("relation %d is of type %q, want %q: this is the type the cost of a tenant "+
+					"is attributed by", i, relation.relationType, relationInfrastructureTenant)
+			}
+			if !relation.validFrom.Equal(july2026) {
+				t.Errorf("relation %d is valid from %s, want %s: the attribution covers the whole "+
+					"month the usage falls in", i, relation.validFrom.Format(time.RFC3339),
+					july2026.Format(time.RFC3339))
+			}
+			if relation.validTo != nil {
+				t.Errorf("relation %d is closed at %s, want an open relation: a closed one attributes "+
+					"nothing after its end", i, relation.validTo.Format(time.RFC3339))
+			}
+		}
+
+		// The registry answers the walk the attribution is read by, so alpha reaching
+		// its tenant over infrastructure_tenant is what the registration was for. It
+		// is read over the route rather than out of the table, because the route is
+		// what a consumer of the registry sees.
+		var alpha uuid.UUID
+		if err := db.Store.Pool().QueryRow(t.Context(),
+			`SELECT id FROM projects WHERE cloud = $1 AND external_id = $2`,
+			gardenCloud, "alpha").Scan(&alpha); err != nil {
+			t.Fatalf("reading the id of the Gardener project alpha: %v", err)
+		}
+		wantReached := []reachedProject{{
+			cloud:        tenantsCloud,
+			externalID:   month.GardenerProjects[0].TenantID,
+			relationType: relationInfrastructureTenant,
+		}}
+		got := relatedProjects(t, server.URL, adminToken, alpha)
+		if !slices.Equal(got, wantReached) {
+			t.Errorf("alpha reaches %+v, want %+v: the shoots of alpha run on that tenant, and its "+
+				"cost is what the relation attributes", got, wantReached)
+		}
+	})
+
+	t.Run("a second month against the same garden cloud", func(t *testing.T) {
+		// The Gardener rows are keyed by their names, so the second month finds
+		// them in place; its tenants are keyed by identifiers the month is salted
+		// into, so the relation it would create points somewhere else. The
+		// registry keys an open relation by (source_id, target_id, relation_type),
+		// which makes that a second open relation rather than a 409, and a
+		// statement of alpha would then carry the cost of both months' tenants.
+		first, err := RegistrationsOf(
+			namedMonth(t, 1, july2026, secondMonthTenantsCloud), secondMonthGardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", secondMonthGardenCloud, err)
+		}
+		if _, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), first); err != nil {
+			t.Fatalf("Register() error = %v, want nil", err)
+		}
+
+		second, err := RegistrationsOf(
+			namedMonth(t, 1, june2026, secondMonthTenantsCloud), secondMonthGardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", secondMonthGardenCloud, err)
+		}
+		report, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), second)
+		if err == nil {
+			t.Fatalf("the second Register() error = nil, want the run refused: two open relations " +
+				"out of one Gardener project attribute two tenants to it")
+		}
+		if want := "is already related to"; !strings.Contains(err.Error(), want) {
+			t.Errorf("the second Register() error = %q, want it to contain %q", err, want)
+		}
+		// The earlier relation starts in July and this run registers June, so the
+		// close the guard names elsewhere would set a valid_to before that start,
+		// which the API answers 422 for. What is left is a garden cloud of its own.
+		if want := "register this month under another garden cloud"; !strings.Contains(err.Error(), want) {
+			t.Errorf("the second Register() error = %q, want it to contain %q: the earlier relation "+
+				"starts after this month, so no close ends it before this month begins", err, want)
+		}
+		if unwanted := "PATCH "; strings.Contains(err.Error(), unwanted) {
+			t.Errorf("the second Register() error = %q, want it to name no %q: the close it would "+
+				"stand for is refused", err, unwanted)
+		}
+		assertCloseRefused(t, db, server.URL, adminToken, secondMonthGardenCloud, june2026)
+		if report.RelationsCreated != 0 || report.RelationsExisting != 0 {
+			t.Errorf("the second Register() = %+v, want no relation touched", report)
+		}
+
+		if got := relationsOutOf(t, db, secondMonthGardenCloud); got != 2 {
+			t.Errorf("the two runs left %d relations out of %s, want 2: one per Gardener project, "+
+				"and the second run created none beside them", got, secondMonthGardenCloud)
+		}
+	})
+
+	t.Run("a second month behind a relation closed with DELETE", func(t *testing.T) {
+		// DELETE closes a relation at now, and every simulated period is in the
+		// past, so a relation closed that way still covers the month a second run
+		// registers: the engine bills a period by the relations that overlap it, not
+		// by the ones open when it runs. Registering beside such a relation is
+		// therefore the same double attribution as registering beside an open one,
+		// and the guard has to refuse it against the API's own point-in-time reads
+		// rather than against the valid_to it reads off a row.
+		first, err := RegistrationsOf(
+			namedMonth(t, 1, july2026, closedTenantsCloud), closedGardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", closedGardenCloud, err)
+		}
+		if _, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), first); err != nil {
+			t.Fatalf("Register() error = %v, want nil", err)
+		}
+		if closed := closeRelations(t, db, server.URL, adminToken, closedGardenCloud); closed != 2 {
+			t.Fatalf("the case closed %d relations, want 2: one per Gardener project", closed)
+		}
+
+		// Another seed over the same period: the Gardener rows stay, and the tenants
+		// the relations would point at are new ones.
+		second, err := RegistrationsOf(
+			namedMonth(t, 2, july2026, closedTenantsCloud), closedGardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", closedGardenCloud, err)
+		}
+		report, err := NewRegistrar(server.URL, adminToken, testLogger(t)).
+			Register(t.Context(), second)
+		if err == nil {
+			t.Fatalf("the second Register() error = nil, want the run refused: a relation closed at " +
+				"now still attributes the month this run registers")
+		}
+		// The earlier relation starts where this month starts, so there is no
+		// valid_to that is both after its start and no later than the month it
+		// attributes: PATCH answers 422 for one, and the message says so instead of
+		// naming the route.
+		if want := "register this month under another garden cloud"; !strings.Contains(err.Error(), want) {
+			t.Errorf("the second Register() error = %q, want it to contain %q: the earlier relation "+
+				"starts where this month does and cannot be ended before it", err, want)
+		}
+		if unwanted := "PATCH "; strings.Contains(err.Error(), unwanted) {
+			t.Errorf("the second Register() error = %q, want it to name no %q: the close it would "+
+				"stand for is refused", err, unwanted)
+		}
+		assertCloseRefused(t, db, server.URL, adminToken, closedGardenCloud, july2026)
+		if report.RelationsCreated != 0 || report.RelationsExisting != 0 {
+			t.Errorf("the second Register() = %+v, want no relation touched", report)
+		}
+		if got := relationsOutOf(t, db, closedGardenCloud); got != 2 {
+			t.Errorf("the two runs left %d relations out of %s, want 2: the closed ones, and none "+
+				"created beside them", got, closedGardenCloud)
+		}
+	})
+
+	t.Run("a token without the admin role", func(t *testing.T) {
+		// A month under clouds of its own, because the registry is the one the case
+		// above wrote into: rows counted under its clouds would be its rows.
+		month := namedMonth(t, 1, july2026, readOnlyTenantsCloud)
+		registrations, err := RegistrationsOf(month, readOnlyGardenCloud)
+		if err != nil {
+			t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", readOnlyGardenCloud, err)
+		}
+
+		_, err = NewRegistrar(server.URL, readAllToken, testLogger(t)).
+			Register(t.Context(), registrations)
+		if err == nil {
+			t.Fatalf("Register() error = nil, want the registration refused: reading the registry is " +
+				"not writing into it")
+		}
+		const refusal = "the Reporting API answered 403 for POST /api/v1/projects"
+		if !strings.Contains(err.Error(), refusal) {
+			t.Errorf("Register() error = %q, want it to contain %q: the route answers the role it "+
+				"demands", err, refusal)
+		}
+		const hint = "TALLY_SIM_API_TOKEN has to be an api token of role admin"
+		if !strings.HasSuffix(err.Error(), hint) {
+			t.Errorf("Register() error = %q, want it to end in %q: the fix for a refused token is not "+
+				"in the answer", err, hint)
+		}
+
+		if got := projectCounts(t, db, readOnlyTenantsCloud, readOnlyGardenCloud); len(got) != 0 {
+			t.Errorf("the registry holds %v under the two clouds, want nothing: the first project is "+
+				"refused, so no row is written", got)
+		}
+	})
+}
+
+// startReportingAPI serves the Reporting API over db for the length of the test
+// and returns the server it listens on. The options are the ones the API's own
+// integration tests build the router with
+// (internal/reporting/httpapi/events_integration_test.go): the request
+// validator in front of every handler, authentication enforced so each route
+// asks for the role its guard names, and infrastructure_tenant as the
+// attributing type, which is what the registrar creates.
+func startReportingAPI(t *testing.T, db storetest.DB, q *sqlcgen.Queries) *httptest.Server {
+	t.Helper()
+
+	handler, err := httpapi.NewRouter(httpapi.Options{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                       db.Store,
+		UnhealthyThreshold:       time.Minute,
+		Queries:                  q,
+		Store:                    db.Store,
+		AuthMode:                 auth.ModeEnforced,
+		InternalToken:            testRouterInternalToken,
+		Authenticator:            auth.NewStaticTokenAuthenticator(q),
+		Pipeline:                 ingest.New(registry.New(), false, nil, nil),
+		AttributingRelationTypes: []string{relationInfrastructureTenant},
+		Syncer: reconciliation.New(db.Store, ingest.New(registry.New(), false, nil, nil),
+			reconciliation.Config{}, map[string]reconciliation.Adapter{}, time.Now, nil),
+	})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v, want nil", err)
+	}
+
+	// Plain HTTP: what a simulated run needs from the API is its rules, and a
+	// server whose certificate the registrar had to trust would add nothing to
+	// them.
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// seedAPIToken issues an API token of the given role and stores its hash, the
+// way the API's own integration tests seed one
+// (internal/reporting/httpapi/resourcetypes_integration_test.go).
+func seedAPIToken(t *testing.T, q *sqlcgen.Queries, role auth.Role) string {
+	t.Helper()
+
+	token, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("generating the %s token: %v", role, err)
+	}
+	// project_ids is NOT NULL, so a token that names no project carries an empty
+	// array rather than a nil slice, which pgx would send as NULL.
+	if _, err := q.CreateAPIToken(t.Context(), sqlcgen.CreateAPITokenParams{
+		TokenHash:   auth.HashToken(token),
+		Role:        string(role),
+		ProjectIds:  []uuid.UUID{},
+		Description: pgtype.Text{String: "simulator registry integration test", Valid: true},
+	}); err != nil {
+		t.Fatalf("CreateAPIToken() error = %v, want nil", err)
+	}
+	return token
+}
+
+// projectGroup is what the registered rows are counted by: the installation a
+// row belongs to, and the platform that installation runs.
+type projectGroup struct{ cloud, platform string }
+
+// projectCounts reads how many projects the registry holds under each of the
+// clouds, by platform. A cloud without a row is absent from the result rather
+// than counted as zero.
+func projectCounts(t *testing.T, db storetest.DB, clouds ...string) map[projectGroup]int {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT cloud, platform, count(*) FROM projects WHERE cloud = ANY($1) GROUP BY cloud, platform`,
+		clouds)
+	if err != nil {
+		t.Fatalf("querying the registered projects: %v", err)
+	}
+	defer rows.Close()
+
+	counted := map[projectGroup]int{}
+	for rows.Next() {
+		var group projectGroup
+		var count int
+		if err := rows.Scan(&group.cloud, &group.platform, &count); err != nil {
+			t.Fatalf("scanning a count of registered projects: %v", err)
+		}
+		counted[group] = count
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the registered projects: %v", err)
+	}
+	return counted
+}
+
+// storedRelation is one row of project_relations, as much of it as this test
+// reads. A nil validTo is an active relation.
+type storedRelation struct {
+	relationType string
+	validFrom    time.Time
+	validTo      *time.Time
+}
+
+// storedRelations reads every relation the registry holds.
+func storedRelations(t *testing.T, db storetest.DB) []storedRelation {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT relation_type, valid_from, valid_to FROM project_relations`)
+	if err != nil {
+		t.Fatalf("querying the stored relations: %v", err)
+	}
+	defer rows.Close()
+
+	var stored []storedRelation
+	for rows.Next() {
+		var relation storedRelation
+		if err := rows.Scan(&relation.relationType, &relation.validFrom, &relation.validTo); err != nil {
+			t.Fatalf("scanning a stored relation: %v", err)
+		}
+		stored = append(stored, relation)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the stored relations: %v", err)
+	}
+	return stored
+}
+
+// relationsOutOf counts the relations leaving the projects of one cloud, which
+// is how many attributions a run left behind there.
+func relationsOutOf(t *testing.T, db storetest.DB, cloud string) int {
+	t.Helper()
+
+	var count int
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		`SELECT count(*) FROM project_relations r JOIN projects p ON p.id = r.source_id
+		 WHERE p.cloud = $1`, cloud).Scan(&count); err != nil {
+		t.Fatalf("counting the relations out of %s: %v", cloud, err)
+	}
+	return count
+}
+
+// closeRelations closes every open relation leaving the projects of one cloud
+// over DELETE /api/v1/projects/{id}/relations/{relation_id}, and answers how
+// many it closed. That route is what an operator reaches for to make room for
+// another month, so a case about what such a registry answers has to leave the
+// relations behind the way the route does.
+func closeRelations(t *testing.T, db storetest.DB, serverURL, token, cloud string) int {
+	t.Helper()
+
+	rows, err := db.Store.Pool().Query(t.Context(),
+		`SELECT r.id, r.source_id FROM project_relations r JOIN projects p ON p.id = r.source_id
+		 WHERE p.cloud = $1 AND r.valid_to IS NULL`, cloud)
+	if err != nil {
+		t.Fatalf("querying the open relations out of %s: %v", cloud, err)
+	}
+	defer rows.Close()
+
+	var routes []string
+	for rows.Next() {
+		var relation, source uuid.UUID
+		if err := rows.Scan(&relation, &source); err != nil {
+			t.Fatalf("scanning an open relation out of %s: %v", cloud, err)
+		}
+		routes = append(routes, projectsRoute+"/"+source.String()+"/relations/"+relation.String())
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the open relations out of %s: %v", cloud, err)
+	}
+
+	for _, route := range routes {
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, serverURL+route, nil)
+		if err != nil {
+			t.Fatalf("building the request that closes %s: %v", route, err)
+		}
+		request.Header.Set("Authorization", "Bearer "+token)
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatalf("closing %s: %v", route, err)
+		}
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatalf("reading the answer of DELETE %s: %v", route, err)
+		}
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusNoContent {
+			t.Fatalf("DELETE %s is answered %d %s, want 204", route, response.StatusCode, body)
+		}
+	}
+	return len(routes)
+}
+
+// assertCloseRefused ends the first relation leaving the projects of one cloud
+// at instant, over PATCH /api/v1/projects/{id}/relations/{relation_id}, and
+// demands the 422 the API answers a valid_to that is not after the stored
+// valid_from with. That close is what the guard names when the earlier relation
+// began in an earlier month, so a case about a refusal that names none has to
+// state why: it would send an operator into this answer.
+func assertCloseRefused(t *testing.T, db storetest.DB, serverURL, token, cloud string,
+	instant time.Time,
+) {
+	t.Helper()
+
+	var relation, source uuid.UUID
+	if err := db.Store.Pool().QueryRow(t.Context(),
+		`SELECT r.id, r.source_id FROM project_relations r JOIN projects p ON p.id = r.source_id
+		 WHERE p.cloud = $1 ORDER BY r.id LIMIT 1`, cloud).Scan(&relation, &source); err != nil {
+		t.Fatalf("reading a relation out of %s: %v", cloud, err)
+	}
+
+	route := projectsRoute + "/" + source.String() + "/relations/" + relation.String()
+	end := instant.UTC().Format(time.RFC3339)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, serverURL+route,
+		strings.NewReader(fmt.Sprintf(`{"valid_to":%q}`, end)))
+	if err != nil {
+		t.Fatalf("building the request that ends %s: %v", route, err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("ending %s at %s: %v", route, end, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	answer, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading the answer of PATCH %s: %v", route, err)
+	}
+	if response.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("PATCH %s with valid_to %s is answered %d %s, want 422: the earlier relation does "+
+			"not start before that instant, so ending it there is no way out of this registry",
+			route, end, response.StatusCode, answer)
+	}
+}
+
+// reachedProject is one project a walk over the relations arrived at, flattened
+// out of the RelatedProject of api/reporting/openapi.yaml.
+type reachedProject struct{ cloud, externalID, relationType string }
+
+// relatedProjects walks the infrastructure_tenant relations out of project over
+// GET /api/v1/projects/{id}/related and returns what the walk reached, in the
+// order the answer lists it.
+func relatedProjects(t *testing.T, serverURL, token string, project uuid.UUID) []reachedProject {
+	t.Helper()
+
+	target := serverURL + "/api/v1/projects/" + project.String() +
+		"/related?relation_type=" + relationInfrastructureTenant
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("building the request for the related projects: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("reading the related projects: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading the answer of the related projects: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("the related projects of %s are answered %d %s, want 200",
+			project, response.StatusCode, body)
+	}
+
+	// The answer is the RelatedProjectList of api/reporting/openapi.yaml: an item
+	// per project the walk reached, carrying the registry row and the type of the
+	// relation the walk arrived on.
+	var answer struct {
+		Items []struct {
+			Project struct {
+				Cloud      string `json:"cloud"`
+				ExternalID string `json:"external_id"`
+			} `json:"project"`
+			RelationType string `json:"relation_type"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &answer); err != nil {
+		t.Fatalf("decoding the related projects: %v", err)
+	}
+
+	reached := make([]reachedProject, 0, len(answer.Items))
+	for _, item := range answer.Items {
+		reached = append(reached, reachedProject{
+			cloud:        item.Project.Cloud,
+			externalID:   item.Project.ExternalID,
+			relationType: item.RelationType,
+		})
+	}
+	return reached
+}

--- a/internal/providers/openstack/simulator/registry_test.go
+++ b/internal/providers/openstack/simulator/registry_test.go
@@ -1,0 +1,1010 @@
+package simulator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// testAPIToken is the credential the registrar is built with. It is a literal
+// the cases search the errors and the log for, because a message that carried
+// the token would put it into whatever an operator pastes it into.
+const testAPIToken = "tly_a_secret-of-the-test"
+
+// conflictProblem is what the Reporting API answers a key it already holds, and
+// a relation triple that is already active.
+const conflictProblem = `{"type":"urn:tally:error:conflict","title":"already registered","status":409}`
+
+// recordedRequest is one request the stand-in registry was sent, as much of it
+// as the cases read.
+type recordedRequest struct {
+	method        string
+	path          string
+	rawQuery      string
+	authorization string
+	contentType   string
+	body          map[string]any
+}
+
+// registryAnswer answers one request and reports whether it did. A case states
+// the answers it needs and leaves the rest to the registry that holds nothing.
+type registryAnswer func(w http.ResponseWriter, r *http.Request, body map[string]any) bool
+
+// registryServer stands in for the project registry of the Reporting API. It
+// records every request it was sent and answers by the case's function, so a
+// case states what the API answers and holds the requests against it afterwards.
+type registryServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	requests []recordedRequest
+	// ids is the id every registered key was created under. A relation names its
+	// ends by id, so this is what lets a case tell the id of alpha's tenant from
+	// the id of any other row.
+	ids map[ProjectKey]uuid.UUID
+}
+
+func newRegistryServer(t *testing.T, answer registryAnswer) *registryServer {
+	t.Helper()
+
+	server := &registryServer{ids: make(map[ProjectKey]uuid.UUID)}
+	server.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading the body of %s %s: %v", r.Method, r.URL.Path, err)
+		}
+		var body map[string]any
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("%s %s carries the body %q, want a JSON document: %v",
+					r.Method, r.URL.Path, raw, err)
+			}
+		}
+		server.mu.Lock()
+		server.requests = append(server.requests, recordedRequest{
+			method:        r.Method,
+			path:          r.URL.Path,
+			rawQuery:      r.URL.RawQuery,
+			authorization: r.Header.Get("Authorization"),
+			contentType:   r.Header.Get("Content-Type"),
+			body:          body,
+		})
+		server.mu.Unlock()
+
+		if answer != nil && answer(w, r, body) {
+			return
+		}
+		server.answerAsEmptyRegistry(w, r, body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// answerAsEmptyRegistry is what a registry holding none of the rows answers: a
+// project is created under a fresh id, kept by its key, a relation is created,
+// and a lookup serves the row its key names.
+func (s *registryServer) answerAsEmptyRegistry(w http.ResponseWriter, r *http.Request, body map[string]any) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == projectsRoute:
+		cloud, _ := body["cloud"].(string)
+		externalID, _ := body["external_id"].(string)
+		id := uuid.New()
+		s.mu.Lock()
+		s.ids[ProjectKey{Cloud: cloud, ExternalID: externalID}] = id
+		s.mu.Unlock()
+		writeAnswer(w, http.StatusCreated, fmt.Sprintf(`{"id":%q}`, id))
+	case r.Method == http.MethodGet && r.URL.Path == projectsRoute:
+		query := r.URL.Query()
+		id := s.idOf(ProjectKey{Cloud: query.Get("cloud"), ExternalID: query.Get("external_id")})
+		writeAnswer(w, http.StatusOK, fmt.Sprintf(`{"items":[{"id":%q}],"next_cursor":null}`, id))
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/relations"):
+		// A registry holding no relation of the source, which is what the check in
+		// front of every creation reads.
+		writeAnswer(w, http.StatusOK, `{"items":[]}`)
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/relations"):
+		writeAnswer(w, http.StatusCreated, fmt.Sprintf(`{"id":%q}`, uuid.New()))
+	default:
+		writeAnswer(w, http.StatusNotFound,
+			fmt.Sprintf(`{"type":"urn:tally:error:not_found","title":%q}`, r.Method+" "+r.URL.Path))
+	}
+}
+
+// received is what the server was sent, in order.
+func (s *registryServer) received() []recordedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]recordedRequest(nil), s.requests...)
+}
+
+// idOf is the id the server answered the registration of key with.
+func (s *registryServer) idOf(key ProjectKey) uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.ids[key]
+}
+
+func writeAnswer(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+}
+
+// answersEverythingWith replies to every request the same way, which is what a
+// destination that refuses the first project does to the whole registration.
+func answersEverythingWith(status int, body string) registryAnswer {
+	return func(w http.ResponseWriter, _ *http.Request, _ map[string]any) bool {
+		writeAnswer(w, status, body)
+		return true
+	}
+}
+
+// holdsEveryProject refuses every project as already registered and serves list
+// as the lookup that follows.
+func holdsEveryProject(list string) registryAnswer {
+	return func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.Method == http.MethodGet && r.URL.Path == projectsRoute {
+			writeAnswer(w, http.StatusOK, list)
+			return true
+		}
+		writeAnswer(w, http.StatusConflict, conflictProblem)
+		return true
+	}
+}
+
+// heldRelation is a relation the stand-in registry holds, as much of it as the
+// filter below needs. An empty validTo is a relation that was never closed.
+type heldRelation struct {
+	id, target         uuid.UUID
+	validFrom, validTo string
+}
+
+// holdsRelations answers every read of a project's relations with the ones of
+// stored that were valid at the instant the read names, which is now when it
+// names none. That filter is the registry's own
+// (valid_from <= at AND (valid_to IS NULL OR valid_to > at)), and the guard in
+// front of a creation depends on it: a stand-in that served every relation it
+// holds would let a case pass that says nothing about what the API answers.
+//
+// The bounds are parsed here rather than in the handler, because the handler
+// runs on the server's goroutine, where a t.Fatalf would stop that goroutine
+// instead of the case.
+func holdsRelations(t *testing.T, stored ...heldRelation) registryAnswer {
+	t.Helper()
+
+	type bounded struct {
+		item               string
+		validFrom, validTo time.Time
+	}
+	relations := make([]bounded, len(stored))
+	for i, relation := range stored {
+		relations[i] = bounded{
+			item: fmt.Sprintf(`{"id":%q,"target_id":%q,"valid_from":%q}`,
+				relation.id, relation.target, relation.validFrom),
+			validFrom: relationInstant(t, relation.validFrom),
+		}
+		if relation.validTo != "" {
+			relations[i].validTo = relationInstant(t, relation.validTo)
+		}
+	}
+
+	return func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/relations") {
+			return false
+		}
+		at := time.Now()
+		if raw := r.URL.Query().Get("at"); raw != "" {
+			parsed, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				t.Errorf("the read asks for the relations at %q, want an RFC 3339 instant: %v", raw, err)
+			}
+			at = parsed
+		}
+		items := make([]string, 0, len(relations))
+		for _, relation := range relations {
+			if !relation.validFrom.After(at) && (relation.validTo.IsZero() || relation.validTo.After(at)) {
+				items = append(items, relation.item)
+			}
+		}
+		writeAnswer(w, http.StatusOK, fmt.Sprintf(`{"items":[%s]}`, strings.Join(items, ",")))
+		return true
+	}
+}
+
+// relationInstant parses one of the instants a held relation is bounded by.
+func relationInstant(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parsing the instant %q of a held relation: %v", value, err)
+	}
+	return parsed
+}
+
+// monthRegistrations is what the seeded month registers: a row per tenant, a row
+// per Gardener project, and the relation between each pair of them.
+func monthRegistrations(t *testing.T, month Month) Registrations {
+	t.Helper()
+
+	registrations, err := RegistrationsOf(month, gardenCloud)
+	if err != nil {
+		t.Fatalf("RegistrationsOf(month, %q) error = %v, want nil", gardenCloud, err)
+	}
+	return registrations
+}
+
+// TestRegistrarRegistersEveryProjectBeforeTheFirstRelation covers a run against
+// a registry that holds nothing yet. The order is what makes the registration
+// work at all: a relation names its two ends by the ids the registry answered
+// the rows with, so a relation posted before its ends would be refused for a
+// target the registry does not hold.
+func TestRegistrarRegistersEveryProjectBeforeTheFirstRelation(t *testing.T) {
+	month := namedMonth(t, 1, july2026, tenantsCloud)
+	registrations := monthRegistrations(t, month)
+	server := newRegistryServer(t, nil)
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+	if err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
+	// Six tenants and two Gardener projects are eight rows, and the two Gardener
+	// projects are two relations. A registry that held nothing created all of them.
+	want := RegistrationReport{ProjectsCreated: 8, RelationsCreated: 2}
+	if report != want {
+		t.Errorf("Register() = %+v, want %+v: an empty registry creates every row and every relation",
+			report, want)
+	}
+
+	requests := server.received()
+	if len(requests) != 14 {
+		t.Fatalf("the registration sent %d requests, want 14: one per project, and per relation the "+
+			"two reads of what the source is already related to and the creation", len(requests))
+	}
+	for i, request := range requests {
+		if want := "Bearer " + testAPIToken; request.authorization != want {
+			t.Errorf("request %d (%s %s) carries the authorization %q, want %q: every route of the "+
+				"Reporting API is authenticated", i, request.method, request.path,
+				request.authorization, want)
+		}
+		if request.method == http.MethodPost && request.contentType != "application/json" {
+			t.Errorf("request %d posts %s as %q, want application/json: the API refuses another type",
+				i, request.path, request.contentType)
+		}
+	}
+	for i, request := range requests[:8] {
+		if request.method != http.MethodPost || request.path != projectsRoute {
+			t.Errorf("request %d is %s %s, want POST %s: the eight rows go first",
+				i, request.method, request.path, projectsRoute)
+		}
+	}
+
+	alpha := month.GardenerProjects[0]
+	alphaRelation := requests[10]
+	wantRoute := projectsRoute + "/" + server.idOf(ProjectKey{Cloud: gardenCloud, ExternalID: alpha.Name}).String() +
+		"/relations"
+	// The two reads in front of the creation are what keep a second month from
+	// being related beside the first: they ask for the relations of this type
+	// leaving this project, one as they stood when the month starts and one as
+	// they stand now. Neither instant alone is the set that would attribute
+	// beside the relation this run creates.
+	wantChecks := []string{
+		"at=2026-07-01T00%3A00%3A00Z&direction=outgoing&relation_type=" + relationInfrastructureTenant,
+		"direction=outgoing&relation_type=" + relationInfrastructureTenant,
+	}
+	for i, check := range requests[8:10] {
+		if check.method != http.MethodGet || check.path != wantRoute {
+			t.Errorf("request %d is %s %s, want GET %s: what the source is already related to is read "+
+				"before the relation is created", 8+i, check.method, check.path, wantRoute)
+		}
+		if got := check.rawQuery; got != wantChecks[i] {
+			t.Errorf("check %d asks %q, want %q", i, got, wantChecks[i])
+		}
+	}
+	if alphaRelation.method != http.MethodPost || alphaRelation.path != wantRoute {
+		t.Errorf("relation 0 is %s %s, want POST %s: a relation leaves the project the route names",
+			alphaRelation.method, alphaRelation.path, wantRoute)
+	}
+	wantTarget := server.idOf(ProjectKey{Cloud: tenantsCloud, ExternalID: alpha.TenantID}).String()
+	if got := alphaRelation.body["target_id"]; got != wantTarget {
+		t.Errorf("relation 0 points at %v, want %s: the target is the id the tenant of %s was registered "+
+			"under", got, wantTarget, alpha.Name)
+	}
+	// The relation is valid from the first instant of the month, so the usage of
+	// the first day is attributed too.
+	if got := alphaRelation.body["valid_from"]; got != "2026-07-01T00:00:00Z" {
+		t.Errorf("relation 0 is valid from %v, want %q", got, "2026-07-01T00:00:00Z")
+	}
+	if got := requests[13]; got.method != http.MethodPost || !strings.HasSuffix(got.path, "/relations") {
+		t.Errorf("request 13 is %s %s, want the second relation posted below a project",
+			got.method, got.path)
+	}
+
+	first := requests[0].body
+	wantMembers := map[string]any{
+		"platform":    "openstack",
+		"cloud":       tenantsCloud,
+		"external_id": month.Tenants[0].ID,
+		"name":        month.Tenants[0].Name,
+	}
+	for member, want := range wantMembers {
+		if got := first[member]; got != want {
+			t.Errorf("project 0 states %s = %v, want %v: the row is keyed by its cloud and external id",
+				member, got, want)
+		}
+	}
+	metadata, ok := first["metadata"].(map[string]any)
+	if !ok || metadata["created_by"] != "tally-openstack-simulator" {
+		t.Errorf("project 0 states the metadata %v, want created_by = %q: an operator reading the "+
+			"registry sees what wrote the row", first["metadata"], "tally-openstack-simulator")
+	}
+}
+
+// TestRegistrarLooksUpAProjectTheRegistryAlreadyHolds covers the rerun. A run
+// that failed halfway left rows behind, and registering them again is answered
+// 409 rather than with the id the relations need. The id is read back by the key
+// the registry refused, so the second run ends in the registry the first one
+// meant to leave behind instead of relating nothing to nothing.
+func TestRegistrarLooksUpAProjectTheRegistryAlreadyHolds(t *testing.T) {
+	month := namedMonth(t, 1, july2026, tenantsCloud)
+	registrations := monthRegistrations(t, month)
+	alpha := month.GardenerProjects[0]
+	held := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	server := newRegistryServer(t, func(w http.ResponseWriter, r *http.Request, body map[string]any) bool {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == projectsRoute &&
+			body["external_id"] == alpha.TenantID:
+			writeAnswer(w, http.StatusConflict, conflictProblem)
+		case r.Method == http.MethodGet && r.URL.Path == projectsRoute:
+			writeAnswer(w, http.StatusOK, fmt.Sprintf(`{"items":[{"id":%q}],"next_cursor":null}`, held))
+		default:
+			return false
+		}
+		return true
+	})
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+	if err != nil {
+		t.Fatalf("Register() error = %v, want nil: a row the registry holds is not a failed registration",
+			err)
+	}
+	want := RegistrationReport{ProjectsCreated: 7, ProjectsExisting: 1, RelationsCreated: 2}
+	if report != want {
+		t.Errorf("Register() = %+v, want %+v: the row the registry held is reported as found, not created",
+			report, want)
+	}
+
+	var lookup recordedRequest
+	var relation recordedRequest
+	for _, request := range server.received() {
+		switch {
+		case request.method == http.MethodGet && request.path == projectsRoute:
+			lookup = request
+		case request.method == http.MethodPost && strings.HasSuffix(request.path, "/relations") &&
+			relation.method == "":
+			relation = request
+		}
+	}
+	if got := relation.body["target_id"]; got != held.String() {
+		t.Errorf("relation 0 points at %v, want %s: the target is the id the lookup read back",
+			got, held)
+	}
+	query, err := url.ParseQuery(lookup.rawQuery)
+	if err != nil {
+		t.Fatalf("the lookup query %q is unreadable: %v", lookup.rawQuery, err)
+	}
+	if query.Get("cloud") != tenantsCloud || query.Get("external_id") != alpha.TenantID {
+		t.Errorf("the lookup asks for %v, want cloud=%s and external_id=%s: the pair is the key the "+
+			"registry refused the row under", query, tenantsCloud, alpha.TenantID)
+	}
+}
+
+// TestRegistrarLeavesAnActiveRelationAsItStands covers the relation half of a
+// rerun. One triple of source, target and type carries a single open relation,
+// so the 409 says the attribution is already in place.
+func TestRegistrarLeavesAnActiveRelationAsItStands(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	// The count is guarded because the server answers each request in a goroutine
+	// of its own, and only the first relation is the one that is already active.
+	var (
+		mu        sync.Mutex
+		relations int
+	)
+	server := newRegistryServer(t, func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/relations") {
+			return false
+		}
+		mu.Lock()
+		relations++
+		first := relations == 1
+		mu.Unlock()
+		if !first {
+			return false
+		}
+		writeAnswer(w, http.StatusConflict, conflictProblem)
+		return true
+	})
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+	if err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
+	want := RegistrationReport{ProjectsCreated: 8, RelationsCreated: 1, RelationsExisting: 1}
+	if report != want {
+		t.Errorf("Register() = %+v, want %+v: the active relation is reported as found and the run "+
+			"carries on with the next one", report, want)
+	}
+}
+
+// TestRegistrarRefusesASecondMonthBesideAnOpenRelation covers the rerun under
+// another period, seed or cloud. The Gardener row is keyed by its name and is
+// the one an earlier run registered, while the tenant it points at is keyed by
+// an identifier the month is salted into, so the relation of the second run
+// names a target the first one never had. The registry keys an open relation by
+// (source, target, type), so it would take that as a new relation and hold both
+// open: the export then walks both and sums two months into one statement.
+func TestRegistrarRefusesASecondMonthBesideAnOpenRelation(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	// What the earlier run left behind: an open relation of the same type out of
+	// the same Gardener project, pointing at the tenant of that other month.
+	earlier := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	earlierTenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	server := newRegistryServer(t, holdsRelations(t, heldRelation{
+		id: earlier, target: earlierTenant, validFrom: "2026-06-01T00:00:00Z",
+	}))
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	if err == nil {
+		t.Fatalf("Register() error = nil, want the registration to end: a second open relation out of " +
+			"one project attributes two tenants to it")
+	}
+	for _, want := range []string{
+		"is already related to " + earlierTenant.String(),
+		"by " + relationInfrastructureTenant,
+		// Ending the earlier relation is what makes room for this one, and the
+		// instant it has to end at is the start of this month: a relation closed
+		// later than that still attributes the month the engine is about to bill,
+		// so DELETE, which ends one at now, is no way out of this registry.
+		"no later than 2026-07-01T00:00:00Z",
+		"PATCH " + projectsRoute + "/",
+		"/relations/" + earlier.String(),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Register() error = %q, want it to contain %q: an operator ends the earlier "+
+				"relation off this message", err, want)
+		}
+	}
+	if want := (RegistrationReport{ProjectsCreated: 8}); report != want {
+		t.Errorf("Register() = %+v, want %+v: the rows got through, the relation did not",
+			report, want)
+	}
+	for _, request := range server.received() {
+		if request.method == http.MethodPost && strings.HasSuffix(request.path, "/relations") {
+			t.Errorf("the registration posted %s %s, want no relation created beside the open one",
+				request.method, request.path)
+		}
+	}
+}
+
+// TestRegistrarRefusesAMonthBesideARelationThatOutlivesIt covers the two shapes
+// a read at one instant alone would miss, and both of them end in the same
+// registry: two relations of one Gardener project attributing at once, and a
+// statement carrying the cost of two tenants.
+//
+// A relation closed with DELETE is closed at now, which is after every instant
+// of a simulated month, so it goes on attributing the month this run registers:
+// following the message of the guard is what would otherwise get a registration
+// through that the guard exists to refuse. A relation that starts after this
+// month attributes nothing of it and everything from its own start on, which is
+// where the one this run creates would stand beside it.
+func TestRegistrarRefusesAMonthBesideARelationThatOutlivesIt(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	earlierTenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	tests := []struct {
+		name     string
+		relation heldRelation
+	}{
+		{
+			name: "a relation closed after the month it attributed",
+			relation: heldRelation{
+				validFrom: "2026-06-01T00:00:00Z",
+				validTo:   time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		{
+			name:     "a relation that starts after this month",
+			relation: heldRelation{validFrom: "2026-08-01T00:00:00Z"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relation := tt.relation
+			relation.id, relation.target = uuid.New(), earlierTenant
+			server := newRegistryServer(t, holdsRelations(t, relation))
+
+			_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+				Register(t.Context(), registrations)
+
+			if err == nil {
+				t.Fatalf("Register() error = nil, want the registration to end: the earlier relation " +
+					"attributes beside the one this run creates")
+			}
+			if want := "is already related to " + earlierTenant.String(); !strings.Contains(err.Error(), want) {
+				t.Errorf("Register() error = %q, want it to contain %q", err, want)
+			}
+			for _, request := range server.received() {
+				if request.method == http.MethodPost && strings.HasSuffix(request.path, "/relations") {
+					t.Errorf("the registration posted %s %s, want no relation created beside the "+
+						"earlier one", request.method, request.path)
+				}
+			}
+		})
+	}
+}
+
+// TestRegistrarNamesNoCloseThatCannotBeMade covers the conflicts the close the
+// message otherwise names cannot resolve. PATCH refuses a valid_to that is not
+// after the stored valid_from with 422, so ending the earlier relation where
+// this month begins is a way out only while that relation began earlier. A
+// relation of the month being registered and one of a later month both start at
+// or after the instant the close would name, so an operator who followed the
+// route would read that refusal and stand where they started.
+func TestRegistrarNamesNoCloseThatCannotBeMade(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	earlierTenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	tests := []struct {
+		name     string
+		relation heldRelation
+	}{
+		{
+			name: "a relation of this month, closed with DELETE",
+			relation: heldRelation{
+				validFrom: "2026-07-01T00:00:00Z",
+				validTo:   time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+		{
+			name:     "a relation that starts after this month",
+			relation: heldRelation{validFrom: "2026-08-01T00:00:00Z"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relation := tt.relation
+			relation.id, relation.target = uuid.New(), earlierTenant
+			server := newRegistryServer(t, holdsRelations(t, relation))
+
+			_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+				Register(t.Context(), registrations)
+
+			if err == nil {
+				t.Fatalf("Register() error = nil, want the registration to end: the earlier relation " +
+					"attributes beside the one this run creates")
+			}
+			for _, want := range []string{
+				"is already related to " + earlierTenant.String(),
+				// The instant the earlier relation starts at is what says why no close
+				// is named, so the message carries it.
+				"from " + relation.validFrom + " on",
+				"register this month under another garden cloud",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Register() error = %q, want it to contain %q", err, want)
+				}
+			}
+			for _, unwanted := range []string{"PATCH", "no later than"} {
+				if strings.Contains(err.Error(), unwanted) {
+					t.Errorf("Register() error = %q, want it to name no %q: the Reporting API answers "+
+						"422 for a valid_to that is not after the stored valid_from, so that close is "+
+						"no way out of this registry", err, unwanted)
+				}
+			}
+		})
+	}
+}
+
+// TestRegistrarRelatesBesideAClosedRelationAndAnotherType covers the two
+// relations a rerun leaves alone: one that was ended before this month began,
+// which attributes nothing of it, and one of another type, which attributes
+// nothing at all. Refusing either would leave an operator with a registry they
+// cannot register into again.
+func TestRegistrarRelatesBesideAClosedRelationAndAnotherType(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	other := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	// The relation ends where the month begins, so neither read finds it: the
+	// registry serves the relations valid at an instant, and this one is valid at
+	// none from the first instant of July on.
+	server := newRegistryServer(t, holdsRelations(t, heldRelation{
+		id: uuid.New(), target: other,
+		validFrom: "2026-06-01T00:00:00Z", validTo: "2026-07-01T00:00:00Z",
+	}))
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+	if err != nil {
+		t.Fatalf("Register() error = %v, want nil: a closed relation attributes nothing", err)
+	}
+	if want := (RegistrationReport{ProjectsCreated: 8, RelationsCreated: 2}); report != want {
+		t.Errorf("Register() = %+v, want %+v", report, want)
+	}
+	for _, request := range server.received() {
+		if request.method != http.MethodGet || !strings.HasSuffix(request.path, "/relations") {
+			continue
+		}
+		// The read asks for one type, so a relation of another one is never in the
+		// answer and never has to be told from a relation of this one.
+		if got := request.rawQuery; !strings.Contains(got, "relation_type="+relationInfrastructureTenant) {
+			t.Errorf("the check asks %q, want it to name the relation type: another type attributes "+
+				"nothing and is no reason to refuse", got)
+		}
+	}
+}
+
+// TestRegistrarStopsOnARefusedRelation covers a registry that took every row and
+// then refused the relation between two of them, which is what a contract the
+// relation document does not satisfy answers. The projects are in place, so the
+// report says how far the run came, and the message names the route an operator
+// has to look at.
+func TestRegistrarStopsOnARefusedRelation(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	server := newRegistryServer(t, func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/relations") {
+			return false
+		}
+		writeAnswer(w, http.StatusBadRequest, `{"type":"urn:tally:error:validation","status":400}`)
+		return true
+	})
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	if err == nil {
+		t.Fatalf("Register() error = nil, want a refused relation to end the registration")
+	}
+	if want := "the Reporting API answered 400 for POST " + projectsRoute + "/"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Register() error = %q, want it to contain %q: the refused route is what an operator "+
+			"looks at", err, want)
+	}
+	if want := `{"type":"urn:tally:error:validation","status":400}`; !strings.HasSuffix(err.Error(), want) {
+		t.Errorf("Register() error = %q, want it to end in %q: what the API said is the reason",
+			err, want)
+	}
+	if want := (RegistrationReport{ProjectsCreated: 8}); report != want {
+		t.Errorf("Register() = %+v, want %+v: the report counts what got through before the refusal",
+			report, want)
+	}
+}
+
+// TestRegistrarRegistersAnEmptySetWithoutARequest covers the set that names
+// nothing. It is not a failure, because a month naming no tenant registers
+// nothing, and a run against an unreachable API would otherwise fail for a
+// registration that has nothing to say.
+func TestRegistrarRegistersAnEmptySetWithoutARequest(t *testing.T) {
+	server := newRegistryServer(t, nil)
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), Registrations{})
+	if err != nil {
+		t.Fatalf("Register(ctx, Registrations{}) error = %v, want nil", err)
+	}
+	if want := (RegistrationReport{}); report != want {
+		t.Errorf("Register(ctx, Registrations{}) = %+v, want %+v", report, want)
+	}
+	if got := len(server.received()); got != 0 {
+		t.Errorf("a set naming nothing sent %d requests, want none", got)
+	}
+}
+
+// TestRegistrarRefusesARelationNamingAnUnregisteredProject covers a set whose
+// relation names a key the set does not register. It is refused before the first
+// request, because the rows of such a set would be registered and then related
+// to a project id that is the zero uuid.
+func TestRegistrarRefusesARelationNamingAnUnregisteredProject(t *testing.T) {
+	server := newRegistryServer(t, nil)
+	registrations := Registrations{
+		Projects: []ProjectRegistration{{
+			Platform: "openstack",
+			Key:      ProjectKey{Cloud: tenantsCloud, ExternalID: "p1"},
+			Name:     "p1",
+		}},
+		Relations: []RelationRegistration{{
+			Source:       ProjectKey{Cloud: gardenCloud, ExternalID: "ghost"},
+			Target:       ProjectKey{Cloud: tenantsCloud, ExternalID: "p1"},
+			RelationType: relationInfrastructureTenant,
+			ValidFrom:    july2026,
+		}},
+	}
+
+	report, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	want := "the relation from (garden-sim, ghost) to (os-sim, p1) names a project the registrations do " +
+		"not hold"
+	if err == nil || err.Error() != want {
+		t.Fatalf("Register() error = %v, want %q", err, want)
+	}
+	if got := len(server.received()); got != 0 {
+		t.Errorf("a set with a relation to an unregistered key sent %d requests, want none: nothing is "+
+			"registered that cannot be related", got)
+	}
+	if want := (RegistrationReport{}); report != want {
+		t.Errorf("Register() = %+v, want %+v", report, want)
+	}
+}
+
+// TestRegistrarFailsOnAnAnswerItCannotUse covers every answer that ends the
+// registration. What each of them costs an operator is the same: the run stops
+// and says which route answered what, so the fix is read off the message rather
+// than out of the API's log.
+func TestRegistrarFailsOnAnAnswerItCannotUse(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	tenant := registrations.Projects[0].Key.ExternalID
+
+	tests := []struct {
+		name     string
+		answer   registryAnswer
+		contains string
+		exact    string
+		suffix   string
+	}{
+		{
+			name:     "a token the API does not know",
+			answer:   answersEverythingWith(http.StatusUnauthorized, `{"status":401}`),
+			contains: "the Reporting API answered 401 for POST /api/v1/projects",
+			suffix:   "TALLY_SIM_API_TOKEN has to be an api token of role admin",
+		},
+		{
+			name:     "a token without the admin role",
+			answer:   answersEverythingWith(http.StatusForbidden, `{"status":403}`),
+			contains: "the Reporting API answered 403 for POST /api/v1/projects",
+			suffix:   "TALLY_SIM_API_TOKEN has to be an api token of role admin",
+		},
+		{
+			name:     "an API that failed",
+			answer:   answersEverythingWith(http.StatusInternalServerError, `{"type":"urn:tally:error:internal"}`),
+			contains: `the Reporting API answered 500 for POST /api/v1/projects: {"type":"urn:tally:error:internal"}`,
+		},
+		{
+			name:   "a registration without an id",
+			answer: answersEverythingWith(http.StatusCreated, `{}`),
+			exact:  "the Reporting API answered 201 without a project id",
+		},
+		{
+			name:     "a registration that is no document",
+			answer:   answersEverythingWith(http.StatusCreated, `not json`),
+			contains: "decoding the registered project:",
+		},
+		{
+			name:     "a refusal the lookup finds nothing for",
+			answer:   holdsEveryProject(`{"items":[],"next_cursor":null}`),
+			contains: fmt.Sprintf("refused (%s, %s) as registered and lists no such project", tenantsCloud, tenant),
+		},
+		{
+			name: "a lookup that finds the key twice",
+			answer: holdsEveryProject(fmt.Sprintf(`{"items":[{"id":%q},{"id":%q}],"next_cursor":null}`,
+				uuid.New(), uuid.New())),
+			contains: fmt.Sprintf("lists 2 projects for (%s, %s), want one", tenantsCloud, tenant),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newRegistryServer(t, tt.answer)
+
+			_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+				Register(t.Context(), registrations)
+
+			if err == nil {
+				t.Fatalf("Register() error = nil, want the registration to end")
+			}
+			if tt.exact != "" && err.Error() != tt.exact {
+				t.Errorf("Register() error = %q, want %q", err, tt.exact)
+			}
+			if tt.contains != "" && !strings.Contains(err.Error(), tt.contains) {
+				t.Errorf("Register() error = %q, want it to contain %q", err, tt.contains)
+			}
+			if tt.suffix != "" && !strings.HasSuffix(err.Error(), tt.suffix) {
+				t.Errorf("Register() error = %q, want it to end in %q: the answer says the token is "+
+					"refused and the message says which token it is", err, tt.suffix)
+			}
+			if strings.Contains(err.Error(), testAPIToken) {
+				t.Errorf("Register() error = %q, want it to name no token", err)
+			}
+		})
+	}
+}
+
+// TestRegistrarEncodesTheLookupKeyInTheQuery covers a key carrying the two
+// characters a query is built with. An unencoded ampersand would make the lookup
+// ask for another external id, and the answer would be a row this run never
+// registered.
+func TestRegistrarEncodesTheLookupKeyInTheQuery(t *testing.T) {
+	server := newRegistryServer(t, func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.Method == http.MethodGet {
+			writeAnswer(w, http.StatusInternalServerError, `{"type":"urn:tally:error:internal"}`)
+			return true
+		}
+		writeAnswer(w, http.StatusConflict, conflictProblem)
+		return true
+	})
+	registrations := Registrations{Projects: []ProjectRegistration{{
+		Platform: "openstack",
+		Key:      ProjectKey{Cloud: tenantsCloud, ExternalID: "id with space&x"},
+		Name:     "odd",
+	}}}
+
+	_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	want := "the Reporting API answered 500 for GET /api/v1/projects"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("Register() error = %v, want it to contain %q", err, want)
+	}
+	requests := server.received()
+	if len(requests) != 2 {
+		t.Fatalf("the registration sent %d requests, want 2: the refused POST and the lookup",
+			len(requests))
+	}
+	if got, want := requests[1].rawQuery, "cloud=os-sim&external_id=id+with+space%26x"; got != want {
+		t.Errorf("the lookup asks %q, want %q: the key goes onto the URL encoded", got, want)
+	}
+}
+
+// TestRegistrarQuotesOnlyTheFirstBytesOfARefusedAnswer covers a destination that
+// answers at length. What answers may be a proxy serving an HTML error page, and
+// the whole of it in one error line is not what an operator reads.
+func TestRegistrarQuotesOnlyTheFirstBytesOfARefusedAnswer(t *testing.T) {
+	server := newRegistryServer(t,
+		answersEverythingWith(http.StatusInternalServerError, strings.Repeat("x", 1000)))
+
+	_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud)))
+
+	if err == nil {
+		t.Fatalf("Register() error = nil, want the registration to end")
+	}
+	if !strings.Contains(err.Error(), strings.Repeat("x", refusalBodyMax)) {
+		t.Errorf("Register() error = %q, want it to quote the first %d bytes of the answer",
+			err, refusalBodyMax)
+	}
+	if strings.Contains(err.Error(), strings.Repeat("x", refusalBodyMax+1)) {
+		t.Errorf("Register() error quotes more than %d bytes of the answer, want the rest cut off",
+			refusalBodyMax)
+	}
+}
+
+// TestRegistrarNamesTheRouteAndNotTheTokenOnATransportFailure covers a Reporting
+// API that is not there. The message names the route so an operator sees how far
+// the registration came, and it carries no credential, because a failed run is
+// what gets pasted into a ticket.
+func TestRegistrarNamesTheRouteAndNotTheTokenOnATransportFailure(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+
+	_, err := NewRegistrar("http://127.0.0.1:1", testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	if err == nil {
+		t.Fatalf("Register() error = nil, want a registration against a closed port to fail")
+	}
+	if want := "POST " + projectsRoute + ":"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Register() error = %q, want it to contain %q", err, want)
+	}
+	if strings.Contains(err.Error(), testAPIToken) {
+		t.Errorf("Register() error = %q, want it to name no token", err)
+	}
+}
+
+// TestRegistrarDoesNotFollowARedirect covers a destination that answers a
+// redirect rather than the registry, which an ingress or anything terminating
+// TLS in front of the API can. Go carries the Authorization header across a
+// redirect within one host, so a 308 to http:// on that host would put the admin
+// token on the wire in the clear, which is exactly what the https check on the
+// configured URL exists to rule out; a redirect that kept the token would be no
+// better on 301, 302 and 303, where Go turns the POST into a GET and the
+// registration registers nothing. The answer is therefore taken as it stands.
+func TestRegistrarDoesNotFollowARedirect(t *testing.T) {
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	server := newRegistryServer(t, func(w http.ResponseWriter, r *http.Request, _ map[string]any) bool {
+		if r.URL.Path != projectsRoute {
+			return false
+		}
+		w.Header().Set("Location", "/moved"+projectsRoute)
+		writeAnswer(w, http.StatusPermanentRedirect, `{"status":308}`)
+		return true
+	})
+
+	_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).
+		Register(t.Context(), registrations)
+
+	if err == nil {
+		t.Fatalf("Register() error = nil, want the redirect to end the registration")
+	}
+	if want := "the Reporting API answered 308 for POST " + projectsRoute; !strings.Contains(err.Error(), want) {
+		t.Errorf("Register() error = %q, want it to contain %q: a redirect is an answer no path here "+
+			"can use", err, want)
+	}
+	for _, request := range server.received() {
+		if request.path != projectsRoute {
+			t.Errorf("the registration sent %s %s, want nothing sent to what the Location names: a "+
+				"followed redirect carries the admin token wherever it points",
+				request.method, request.path)
+		}
+	}
+}
+
+// TestRegistrarStopsOnACancelledContext covers the SIGINT that arrives while a
+// month is being registered. The cancellation reaches the caller as itself, so a
+// run that was stopped is told apart from one the API refused.
+func TestRegistrarStopsOnACancelledContext(t *testing.T) {
+	server := newRegistryServer(t, nil)
+	registrations := monthRegistrations(t, namedMonth(t, 1, july2026, tenantsCloud))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := NewRegistrar(server.URL, testAPIToken, testLogger(t)).Register(ctx, registrations)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Register() error = %v, want it to carry %v", err, context.Canceled)
+	}
+	if got := len(server.received()); got != 0 {
+		t.Errorf("a cancelled registration sent %d requests, want none", got)
+	}
+}
+
+// TestRegistrarTrimsATrailingSlashAndLogsThroughTheDefaultLogger covers the base
+// URL as an operator writes it. A trailing slash would build //api/v1/projects,
+// which is another route, and a nil logger is what a caller passes that has none
+// of its own.
+func TestRegistrarTrimsATrailingSlashAndLogsThroughTheDefaultLogger(t *testing.T) {
+	server := newRegistryServer(t, nil)
+	registrations := Registrations{Projects: []ProjectRegistration{{
+		Platform: "openstack",
+		Key:      ProjectKey{Cloud: tenantsCloud, ExternalID: "p1"},
+		Name:     "p1",
+	}}}
+	var log bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&log, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	report, err := NewRegistrar(server.URL+"/", testAPIToken, nil).Register(t.Context(), registrations)
+	if err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
+	if want := (RegistrationReport{ProjectsCreated: 1}); report != want {
+		t.Errorf("Register() = %+v, want %+v", report, want)
+	}
+	requests := server.received()
+	if len(requests) != 1 {
+		t.Fatalf("the registration sent %d requests, want 1", len(requests))
+	}
+	if requests[0].path != projectsRoute {
+		t.Errorf("the project is posted to %q, want %q: the slash of the base URL is trimmed",
+			requests[0].path, projectsRoute)
+	}
+	if got := log.String(); !strings.Contains(got, "registered project") {
+		t.Errorf("the default logger holds %q, want a line about the registered project", got)
+	}
+	if got := log.String(); strings.Contains(got, testAPIToken) {
+		t.Errorf("the default logger holds %q, want it to name no token", got)
+	}
+}

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -66,6 +66,12 @@ type RunOptions struct {
 	// Faults are the switch names of --faults, which ParseFaults reads. Empty is
 	// every switch off.
 	Faults []string
+	// RegisterProjects registers the month's tenants, its Gardener projects, and
+	// the infrastructure_tenant relation between each project and its tenant
+	// with the Reporting API before the first file is written or the first
+	// notification published. What it needs is the environment, which Config
+	// checks through ValidateRegistration.
+	RegisterProjects bool
 }
 
 // Validate checks the options and returns the month Period names.
@@ -156,6 +162,10 @@ type queued struct {
 // publisher is file mode, where the month is written out and nothing reaches a
 // bus.
 //
+// With RegisterProjects the month's tenants, its Gardener projects and the
+// relations between them are registered with the Reporting API first, before
+// anything is written or published.
+//
 // The files are complete before the first notification is published, so a run
 // that is interrupted halfway still leaves a whole month on disk to replay.
 // There are three of them, and a fourth, held-back.jsonl, when the held-back
@@ -174,6 +184,13 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 	from, to, err := opts.Validate()
 	if err != nil {
 		return err
+	}
+	// Checked here as well as in the subcommand, because an exported function
+	// cannot rely on its caller having checked.
+	if opts.RegisterProjects {
+		if err := cfg.ValidateRegistration(); err != nil {
+			return fmt.Errorf("checking the configuration: %w", err)
+		}
 	}
 	if publisher == nil && opts.Out == "" {
 		return errors.New("set " + envAMQPURL + " or pass --out: the run has nowhere to publish")
@@ -198,6 +215,7 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		"cloud", cfg.Cloud,
 		"factor", opts.Factor,
 		"faults", faults.Names(),
+		"register", opts.RegisterProjects,
 		"transitions", len(schedule),
 		"billable", len(schedule.Billable()),
 		"stream", len(month.Stream),
@@ -205,6 +223,38 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		"resources", len(month.Oracle.Resources),
 		"broker", publisher != nil,
 		"out", opts.Out)
+
+	// Between the month and the files: a registration that fails leaves neither
+	// a file nor a notification behind, so what an operator finds afterwards is
+	// the registry the run got as far as, and nothing else of the month. It runs
+	// in file mode too, which is how an operator prepares the registry before a
+	// replay puts the recorded month on a bus. A context that ends here is the
+	// clean stop the rest of the run answers a signal with.
+	if opts.RegisterProjects {
+		regs, err := RegistrationsOf(month, cfg.GardenCloud)
+		if err != nil {
+			return fmt.Errorf("registering the projects: %w", err)
+		}
+		report, err := NewRegistrar(cfg.ReportingURL, cfg.APIToken, logger).Register(ctx, regs)
+		if err != nil {
+			// The rows that got through stay in the registry and the rerun finds
+			// them, so how far the registration came is said whichever way it
+			// ended: the counts of the line below are the only place the whole of
+			// it is, and "stopped" is about the notifications rather than the rows.
+			logger.Info("registration incomplete",
+				"projects_created", report.ProjectsCreated, "projects_existing", report.ProjectsExisting,
+				"relations_created", report.RelationsCreated, "relations_existing", report.RelationsExisting)
+			if ctx.Err() != nil {
+				logger.Info("stopped", "published", 0, "total", len(month.Stream)+len(month.Held))
+				return nil
+			}
+			return fmt.Errorf("registering the projects: %w", err)
+		}
+		logger.Info("registered",
+			"reporting_url", cfg.ReportingURL,
+			"projects_created", report.ProjectsCreated, "projects_existing", report.ProjectsExisting,
+			"relations_created", report.RelationsCreated, "relations_existing", report.RelationsExisting)
+	}
 
 	if opts.Out != "" {
 		if err := os.MkdirAll(opts.Out, outDirMode); err != nil {

--- a/internal/providers/openstack/simulator/workload.go
+++ b/internal/providers/openstack/simulator/workload.go
@@ -191,8 +191,37 @@ type Month struct {
 	Stream Schedule
 	// Held holds the transitions the held-back switch keeps off the bus until a
 	// run releases them, in instant order. It is empty unless that switch is on.
-	Held   Schedule
-	Oracle Oracle
+	Held Schedule
+	// Tenants is every keystone project of the month, the classic tenants first
+	// in index order, then the CI tenant, then the Gardener tenants in project
+	// order. It is built from the world alone: nothing on the bus carries a
+	// tenant's name, and no stream is consulted, so a month with the registry
+	// switch off renders exactly the files it rendered before.
+	Tenants []Tenant
+	// GardenerProjects is the two Gardener projects and the tenant each runs
+	// on, in the order newGardenerProjects lists them.
+	GardenerProjects []GardenerProject
+	Oracle           Oracle
+}
+
+// Tenant is one keystone project of the month as the registry keys it.
+type Tenant struct {
+	// ID is the keystone project id, the external id of the registry row.
+	ID string
+	// Name is what the registry row is called; nothing on the bus carries it.
+	Name string
+	// Workload is workloadClassic, workloadGardener, or workloadCI.
+	Workload string
+}
+
+// GardenerProject is one Gardener project and the tenant its shoots run on.
+type GardenerProject struct {
+	// Name is alpha or beta, the external id of the gardener row.
+	Name string
+	// TenantID is the ID of the Tenant the shoots run on.
+	TenantID string
+	// Shoots holds the shoot names, in the order newGardenerProjects lists them.
+	Shoots []string
 }
 
 // GenerateMonth builds one month of the simulated cloud's lifecycle
@@ -281,7 +310,12 @@ func GenerateMonth(seed uint64, from, to time.Time, cloud string, faults Faults)
 	if err != nil {
 		return Month{}, err
 	}
-	return Month{Schedule: g.schedule, Stream: stream, Held: held, Oracle: oracle}, nil
+	tenants, gardenerProjects := g.tenants()
+	return Month{
+		Schedule: g.schedule, Stream: stream, Held: held,
+		Tenants: tenants, GardenerProjects: gardenerProjects,
+		Oracle: oracle,
+	}, nil
 }
 
 // identifierSalt mixes the cloud and the billing month into the identifier
@@ -492,6 +526,48 @@ func newGenerator(shape *rand.Rand, identifiers, noiseIDs idReader,
 		gp.zoneName = gp.name + "." + cloud + ".example."
 	}
 	return g
+}
+
+// tenants returns the keystone projects the month ran in and the Gardener
+// projects beside them, in the order the registry is meant to hold them:
+// the classic tenants by their index, the CI tenant, then the Gardener tenants
+// by their project.
+//
+// A tenant's name is only ever known here. Nothing on the bus carries one, so
+// the world is the one place the registry can be told what a project id is
+// called. The method draws from no stream and changes nothing on the generator,
+// which is what keeps the month it is called on the month it would have been.
+func (g *generator) tenants() ([]Tenant, []GardenerProject) {
+	tenants := make([]Tenant, 0, len(g.projects)+1+len(g.gardenerProjects))
+	for _, p := range g.projects {
+		// The name the tenant's network already carries, so that a registry row
+		// and a dumped month call one tenant the same thing.
+		tenants = append(tenants, Tenant{
+			ID:       p.id,
+			Name:     p.network.name,
+			Workload: workloadClassic,
+		})
+	}
+	tenants = append(tenants, Tenant{ID: g.ciTenant.id, Name: "ci", Workload: workloadCI})
+
+	projects := make([]GardenerProject, 0, len(g.gardenerProjects))
+	for _, gp := range g.gardenerProjects {
+		tenants = append(tenants, Tenant{
+			ID:       gp.tenant.id,
+			Name:     "Infrastructure tenant of " + gp.name,
+			Workload: workloadGardener,
+		})
+		shoots := make([]string, 0, len(gp.shoots))
+		for _, s := range gp.shoots {
+			shoots = append(shoots, s.name)
+		}
+		projects = append(projects, GardenerProject{
+			Name:     gp.name,
+			TenantID: gp.tenant.id,
+			Shoots:   shoots,
+		})
+	}
+	return tenants, projects
 }
 
 // run generates the month of every workload, one block after another, and tags

--- a/internal/providers/openstack/simulator/workload_test.go
+++ b/internal/providers/openstack/simulator/workload_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand/v2"
+	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -639,6 +641,126 @@ func TestGenerateRefusesANonMonth(t *testing.T) {
 			}
 		})
 	}
+}
+
+// keystoneID is the form keystone hands out project ids in. The registry keys a
+// row by that id, so a tenant the month names with anything else is a row no
+// usage of the month is ever booked against.
+var keystoneID = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+// namedMonth generates one month or fails the test and hands back the whole
+// month. It stands beside generateMonth because the tenants are read off the
+// month rather than off its schedule.
+func namedMonth(t *testing.T, seed uint64, from time.Time, cloud string) Month {
+	t.Helper()
+
+	month, err := GenerateMonth(seed, from, from.AddDate(0, 1, 0), cloud, Faults{})
+	if err != nil {
+		t.Fatalf("GenerateMonth(%d, %s, %q) error = %v, want nil", seed, from.Format(time.RFC3339), cloud, err)
+	}
+	return month
+}
+
+// TestMonthNamesItsTenants covers what a month states about the projects it ran
+// in. Nothing on the bus carries a tenant's name, so the registry can be fed
+// from Month alone: a tenant the month leaves out is a row the registry never
+// grows, and a project id the oracle bills but the month does not name is usage
+// that arrives under an id nobody can put a name to.
+func TestMonthNamesItsTenants(t *testing.T) {
+	month := namedMonth(t, 1, july2026, testCloud)
+
+	want := []struct {
+		name     string
+		workload string
+	}{
+		{name: "tenant-01", workload: workloadClassic},
+		{name: "tenant-02", workload: workloadClassic},
+		{name: "tenant-03", workload: workloadClassic},
+		{name: "ci", workload: workloadCI},
+		{name: "Infrastructure tenant of alpha", workload: workloadGardener},
+		{name: "Infrastructure tenant of beta", workload: workloadGardener},
+	}
+	if len(month.Tenants) != len(want) {
+		t.Fatalf("the month names %d tenants, want %d: the three classic tenants, the CI tenant, and the "+
+			"two Gardener tenants", len(month.Tenants), len(want))
+	}
+	for i, w := range want {
+		if got := month.Tenants[i]; got.Name != w.name || got.Workload != w.workload {
+			t.Errorf("tenant %d is %q of workload %q, want %q of %q: the registry is fed in this order",
+				i, got.Name, got.Workload, w.name, w.workload)
+		}
+	}
+
+	named := make(map[string]int, len(month.Tenants))
+	for i, tenant := range month.Tenants {
+		if !keystoneID.MatchString(tenant.ID) {
+			t.Errorf("the tenant %q carries the id %q, want the 32 character hex form of keystone: the "+
+				"registry keys its row by the id the notifications carry", tenant.Name, tenant.ID)
+		}
+		if first, ok := named[tenant.ID]; ok {
+			t.Errorf("tenant %d and tenant %d both carry the id %s, want six distinct ids: two tenants on "+
+				"one id are one row the registry never grows", first, i, tenant.ID)
+		}
+		named[tenant.ID] = i
+	}
+
+	wantProjects := []GardenerProject{
+		{Name: "alpha", TenantID: month.Tenants[4].ID, Shoots: []string{"api-prod", "api-dev"}},
+		{Name: "beta", TenantID: month.Tenants[5].ID, Shoots: []string{"batch"}},
+	}
+	if !reflect.DeepEqual(month.GardenerProjects, wantProjects) {
+		t.Errorf("the month states the Gardener projects %+v, want %+v: a project is the name an operator "+
+			"knows its shoots under, on the tenant Gardener bills them to",
+			month.GardenerProjects, wantProjects)
+	}
+
+	// One report per unnamed id rather than one per interval, because a tenant
+	// the month forgets to name carries hundreds of them.
+	unnamed := make(map[string]string)
+	for _, resource := range month.Oracle.Resources {
+		for _, interval := range resource.Intervals {
+			if _, ok := named[interval.ProjectID]; !ok {
+				unnamed[interval.ProjectID] = resource.ResourceType + " " + resource.ResourceID
+			}
+		}
+	}
+	for id, resource := range unnamed {
+		t.Errorf("the oracle bills the %s to the project %s, which the month names no tenant for, want "+
+			"every project of the month named: usage under an unnamed id reaches the registry as a "+
+			"stranger", resource, id)
+	}
+
+	t.Run("one seed, period, and cloud name one set of tenants", func(t *testing.T) {
+		again := namedMonth(t, 1, july2026, testCloud)
+
+		if !reflect.DeepEqual(again.Tenants, month.Tenants) {
+			t.Errorf("two runs of one seed name %+v and %+v, want the same tenants twice: a run that "+
+				"renames a tenant grows a second row for it", month.Tenants, again.Tenants)
+		}
+		if !reflect.DeepEqual(again.GardenerProjects, month.GardenerProjects) {
+			t.Errorf("two runs of one seed state the Gardener projects %+v and %+v, want the same two "+
+				"twice", month.GardenerProjects, again.GardenerProjects)
+		}
+	})
+
+	t.Run("another cloud keeps the names and renames the ids", func(t *testing.T) {
+		first, second := namedMonth(t, 1, july2026, "os-a"), namedMonth(t, 1, july2026, "os-b")
+
+		if len(first.Tenants) != len(second.Tenants) {
+			t.Fatalf("two clouds name %d and %d tenants, want the world to be the seed's alone",
+				len(first.Tenants), len(second.Tenants))
+		}
+		for i := range first.Tenants {
+			if first.Tenants[i].Name != second.Tenants[i].Name {
+				t.Errorf("tenant %d is %q on os-a and %q on os-b, want the name to come from the world, "+
+					"which the cloud does not salt", i, first.Tenants[i].Name, second.Tenants[i].Name)
+			}
+			if first.Tenants[i].ID == second.Tenants[i].ID {
+				t.Errorf("tenant %d carries the id %s on both os-a and os-b, want the ids salted by the "+
+					"cloud: one row would otherwise hold two clouds' usage", i, first.Tenants[i].ID)
+			}
+		}
+	})
 }
 
 // sizeOf maps one transition the way the collector does and returns the size


### PR DESCRIPTION
Closes #89

`tally-openstack-simulator run --register-projects` registers the simulated month with the Reporting API's project registry before the first file is written and the first notification published: the six tenants of the month as `openstack` rows under `TALLY_SIM_CLOUD`, the two Gardener projects as `gardener` rows under the new `TALLY_SIM_GARDEN_CLOUD`, and one `infrastructure_tenant` relation per Gardener project, valid from the start of the month, pointing at the tenant its shoots run on. The switch is off by default; a run without it touches no registry and renders the files it rendered before.

## The commits, in order

**`895681b` Name the tenants and Gardener projects of a month on `Month`**
`Month` gains `Tenants []Tenant` and `GardenerProjects []GardenerProject`, filled at the end of `GenerateMonth` by the new `generator.tenants()`. Nothing on the bus carries a tenant's name — a notification states a project id and stops there — so the generator is the one place the registry can be told what a project id is called. Both slices are built from the world alone and draw from no stream, so `TestGenerateIsDeterministic` and the file-mode goldens keep holding.

**`275ba77` Build the registrations of a month as a value**
New `registrations.go`: `ProjectKey`, `ProjectRegistration`, `RelationRegistration`, `Registrations`, and `RegistrationsOf(month, gardenCloud)`. What a month registers is decided without a network — 6 `openstack` rows, 2 `gardener` rows, 2 relations, every one carrying `created_by: tally-openstack-simulator` — so a unit test holds the set against the project ids the oracle bills and catches a tenant without a row before a run talks to the API. The two clouds have to differ: a Gardener project keyed under the tenants' cloud would be a row of the OpenStack installation. The `infrastructure_tenant` literal is mirrored here rather than imported, the way `sender.go` mirrors the ingest result.

**`a29fe25` Add the client that registers a month with the Reporting API**
New `registry.go`: `Registrar`, `NewRegistrar`, `Register`, and `RegistrationReport`. A plain `http.Client` with the wire documents mirrored in the package, because importing `internal/reporting/httpapi` would pull the router, the schema validation and the database driver into this binary. Projects go first, since a relation names its two ends by the ids the registry answered with; a `409` on a project is a row an earlier run left behind, looked up by its key with the id read back. Nothing is retried: what an operator does after a failed run is rerun the same seed, period and cloud, which registers the same rows and finds the ones that got through in place. The token appears in no message and in no log line, and every message names the route without the host.

**`0552976` Hold the registrar to a real Reporting API**
New `registry_integration_test.go`, over a Reporting API built the way `newAPIInMode` builds it on a `storetest.NewDB` database and served through `httptest.NewServer`. The httptest stand-in of `registry_test.go` answers whatever a case tells it to, so a document the contract refuses and a role a route would not grant pass it alike; this test posts the mirrored documents to the contract's own validator, over the role guard each route carries, into the registry tables. A second registration of the same month finds all eight rows and both relations in place, the rows are read back by cloud and platform and the relations by type, start and open end, and alpha's walk over the API reaches the tenant its shoots run on. A `read_all` token is refused on the first project and leaves the two clouds without a row.

**`7dc1862` Register the month on `run --register-projects`**
`RunOptions.RegisterProjects`, the `--register-projects` flag, the four variables in `Config`, and `Config.ValidateRegistration` as the gate. The subcommand runs the gate before the broker is dialled, so a missing token is reported the way a mistyped period is, and `Run` runs it again because an exported function cannot rely on its caller having checked. The registration sits between the month and the files: one that fails leaves neither a file nor a notification behind. File mode registers as well, which is how an operator prepares the registry before a `replay`, and a context that ends during the registration is the clean stop the rest of the run answers a signal with.

**`0d291c4` Pass `--register-projects` through the compose stack**
`simulator-up` issues an admin api token beside the ingest credential when `SIM_REGISTER_PROJECTS=true` and writes the switch, the garden cloud and the token into `deploy/compose/.env`; the value is checked before an image is built, because a mistyped one would otherwise cost two image builds first. The simulator container reaches the Gateway the way the collector does: `extra_hosts`, the dev CA mounted read-only, and `SSL_CERT_FILE` pointing at it. The flag is passed in its `=` form because pflag reads a boolean flag's value from the same argument.

**`c59cb85` Document the project registry**
A new section "The project registry" in `docs/openstack-simulator.md` states what the switch posts, the variables it reads, what a `409` means on a rerun, that a failed registration ends the run with exit status 1 before anything is written, and what the export of the billed month then carries. "Running a month against the dev cluster" and "Configuration" gain the new values and the flag, and the intro no longer points at #89 for the registry.

## Where the diff diverges from the issue

- **`TALLY_SIM_REPORTING_INSECURE` is new** (issue section 3 named three variables; this adds a fourth, and `EnvNames` and `.env.example` list it). The issue accepted any `http` or `https` URL. The token the URL carries is of role `admin` — not scoped to one `(platform, cloud)` pair the way an ingest token is — and travels in a header on every request, so `https` is required and a plaintext API has to be asked for, the way the collector's switch does. The URL is also held to no query and no fragment, checked on the raw value rather than the parsed one, because `https://host#` would otherwise swallow the appended route. The two refusal messages therefore differ in wording from the ones the issue quotes.
- **A relation is checked before it is created.** The issue treated a `409` on a relation as "already active, leave it". `Registrar.relate` additionally reads the source's outgoing relations of that type — at the start of the period and at now — and refuses when the Gardener project is already attributed to a *different* tenant, which is what a rerun under another period, seed or cloud leaves behind: the `gardener` row is keyed by its name and stays while the tenant it points at is salted with the month, so a second relation would attribute two tenants into one statement. The comment at `internal/providers/openstack/simulator/registry.go:295-330` states plainly that the check is advisory and that the invariant belongs to the Reporting API (one open relation per source and attributing type).
- **`deploy/compose/.env` is removed and rewritten under `umask 077`.** The issue's recipe kept the plain `printf`. That file now carries an admin token that writes the whole registry, and the default umask of a shell — or the mode of a file an earlier run left behind — would leave it readable by every other user of the machine.
- **A failed or cancelled registration logs `registration incomplete` with the four counts** before the run ends, which the issue's snippet did not have: the rows that got through stay in the registry, and `stopped` is about notifications rather than rows.
- **`TestRunStoppedWhileRegisteringWritesNothing`** was added to `publish_integration_test.go` beyond the tests section 8 lists, holding the clean-stop half of the step: exit status 0, both log lines, and an empty output directory.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 7ea363b with Claude:claude-opus-5_
