### PR TITLE
Prove commercial pricing end to end against the phase's golden cases

### DIFF
--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -305,12 +305,13 @@ type expectedFile struct {
 	AbsentStatements []string            `json:"absent_statements"`
 }
 
-// expectedStats is the four counts a run reports.
+// expectedStats is the five counts a run reports.
 type expectedStats struct {
-	Candidates   int `json:"candidates"`
-	UsageRecords int `json:"usage_records"`
-	RatedRecords int `json:"rated_records"`
-	Statements   int `json:"statements"`
+	Candidates        int `json:"candidates"`
+	UsageRecords      int `json:"usage_records"`
+	RatedRecords      int `json:"rated_records"`
+	Statements        int `json:"statements"`
+	AdjustmentRecords int `json:"adjustment_records"`
 }
 
 // expectedUsage is one usage_records row. Usage maps every key of the stored
@@ -350,6 +351,30 @@ type expectedStatement struct {
 	Platform      string                `json:"platform"`
 	LineItems     []expectedLineItem    `json:"line_items"`
 	RelatedCosts  []expectedRelatedCost `json:"related_costs"`
+	// BaseCost, Adjustments, NetCost and KickbackTotal are the commercial part
+	// of the document. A nil BaseCost is a statement no adjustment reached, and
+	// the document must then carry none of the four members, so a fixture that
+	// leaves it out while listing one of the others is a typo.
+	BaseCost      *decimal.Decimal     `json:"base_cost"`
+	Adjustments   []expectedAdjustment `json:"adjustments"`
+	NetCost       *decimal.Decimal     `json:"net_cost"`
+	KickbackTotal *decimal.Decimal     `json:"kickback_total"`
+}
+
+// expectedAdjustment is one line of a document's adjustments, in the order they
+// were applied. Relation is the index of the relation the line came from in the
+// relations array of registry.json, because the id of that relation is assigned
+// at seeding time and nothing can write it down beforehand.
+type expectedAdjustment struct {
+	Type           string          `json:"type"`
+	Relation       int             `json:"relation"`
+	RelationType   string          `json:"relation_type"`
+	RelationTarget string          `json:"relation_target"`
+	Scope          string          `json:"scope"`
+	Description    string          `json:"description"`
+	Rate           decimal.Decimal `json:"rate"`
+	Base           decimal.Decimal `json:"base"`
+	Amount         decimal.Decimal `json:"amount"`
 }
 
 // expectedBillingPeriod is the interval a document says it bills, written the
@@ -389,14 +414,23 @@ type expectedRelatedCost struct {
 	LineItems    []expectedLineItem `json:"line_items"`
 }
 
+// loadExpectedFile reads one expectations file of a case, named by the file it
+// sits in. The file is required: an absent or undecodable one fails the case
+// naming the path.
+func loadExpectedFile(t *testing.T, name, file string) expectedFile {
+	t.Helper()
+
+	path := filepath.Join(goldenDir, name, file)
+	var want expectedFile
+	decodeJSON(t, path, readRequired(t, path), &want)
+	return want
+}
+
 // loadExpected reads one case's expectations, which every case carries.
 func loadExpected(t *testing.T, name string) expectedFile {
 	t.Helper()
 
-	path := filepath.Join(goldenDir, name, "expected.json")
-	var want expectedFile
-	decodeJSON(t, path, readRequired(t, path), &want)
-	return want
+	return loadExpectedFile(t, name, "expected.json")
 }
 
 // readRequired reads a fixture file every case must carry. The error names the
@@ -843,7 +877,7 @@ func assertNoWarnings(t *testing.T, stats runs.Stats) {
 	}
 }
 
-// assertStats checks the four counts the run reported.
+// assertStats checks the five counts the run reported.
 func assertStats(t *testing.T, got runs.Stats, want expectedStats) {
 	t.Helper()
 
@@ -855,6 +889,7 @@ func assertStats(t *testing.T, got runs.Stats, want expectedStats) {
 		{"usage_records", got.UsageRecords, want.UsageRecords},
 		{"rated_records", got.RatedRecords, want.RatedRecords},
 		{"statements", got.Statements, want.Statements},
+		{"adjustment_records", got.AdjustmentRecords, want.AdjustmentRecords},
 	} {
 		if count.got != count.want {
 			t.Errorf("stats %s = %d, want %d", count.name, count.got, count.want)
@@ -1045,6 +1080,7 @@ func assertStatements(
 	got []statements.Statement,
 	want []expectedStatement,
 	absent []string,
+	seeded seededRegistry,
 ) {
 	t.Helper()
 
@@ -1091,6 +1127,137 @@ func assertStatements(
 		}
 		assertLineItems(t, w.Key, doc.LineItems, w.LineItems)
 		assertRelatedCosts(t, w.Key, doc.RelatedCosts, w.RelatedCosts)
+		assertAdjustments(t, w.Key, doc, w, seeded)
+	}
+}
+
+// assertAdjustments checks the commercial part of one statement document: the
+// base cost the adjustments were applied to, the lines they produced, the net
+// cost the customer pays and the kickback total a partner is owed beside it.
+//
+// A fixture statement without base_cost is a statement no adjustment reached,
+// and its document carries none of the four members. That is what a Phase 3
+// case of the suite asserts about a graph whose edges adjust nothing: the walk
+// leaves its bytes where they were.
+func assertAdjustments(
+	t *testing.T,
+	key string,
+	doc statements.Document,
+	w expectedStatement,
+	seeded seededRegistry,
+) {
+	t.Helper()
+
+	if w.BaseCost == nil {
+		// One of the other three without base_cost is a typo in the fixture:
+		// there is no statement it describes.
+		for _, member := range []struct {
+			name   string
+			listed bool
+		}{
+			{"net_cost", w.NetCost != nil},
+			{"kickback_total", w.KickbackTotal != nil},
+			{"adjustments", len(w.Adjustments) > 0},
+		} {
+			if member.listed {
+				t.Fatalf("the expectation of %s lists %s without base_cost", key, member.name)
+			}
+		}
+		if doc.BaseCost != nil || doc.NetCost != nil || doc.KickbackTotal != nil ||
+			len(doc.Adjustments) > 0 {
+			t.Errorf("the document of %s carries adjustment members, which expected.json does not list", key)
+		}
+		return
+	}
+
+	if w.NetCost == nil || w.KickbackTotal == nil {
+		t.Fatalf("the expectation of %s lists base_cost without net_cost and kickback_total", key)
+	}
+	for _, member := range []struct {
+		name    string
+		missing bool
+	}{
+		{"base_cost", doc.BaseCost == nil},
+		{"net_cost", doc.NetCost == nil},
+		{"kickback_total", doc.KickbackTotal == nil},
+	} {
+		if member.missing {
+			t.Fatalf("the document of %s carries no %s, which expected.json lists", key, member.name)
+		}
+	}
+	for _, amount := range []struct {
+		name      string
+		got, want decimal.Decimal
+	}{
+		{"base cost", doc.BaseCost.Decimal, *w.BaseCost},
+		{"net cost", doc.NetCost.Decimal, *w.NetCost},
+		{"kickback total", doc.KickbackTotal.Decimal, *w.KickbackTotal},
+	} {
+		if !amount.got.Equal(amount.want) {
+			t.Errorf("the %s of %s = %s, want %s", amount.name, key, amount.got, amount.want)
+		}
+	}
+	// A kickback is settled beside the invoice rather than added to it, so what
+	// the customer pays is the net cost and nothing a partner is owed reaches
+	// the total.
+	if !doc.Total.Equal(doc.NetCost.Decimal) {
+		t.Errorf("the total of %s = %s, want the net cost %s", key, doc.Total, doc.NetCost)
+	}
+
+	if len(doc.Adjustments) != len(w.Adjustments) {
+		t.Fatalf("the adjustments of %s = %d, want %d", key, len(doc.Adjustments), len(w.Adjustments))
+	}
+	for i, a := range w.Adjustments {
+		if a.Relation < 0 || a.Relation >= len(seeded.relations) {
+			t.Fatalf("adjustment %d of %s names the relation %d, which registry.json does not hold",
+				i, key, a.Relation)
+		}
+		g := doc.Adjustments[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"type", g.Type, a.Type},
+			{"relation_type", g.RelationType, a.RelationType},
+			{"relation_target", g.RelationTarget, a.RelationTarget},
+			{"relation_id", g.RelationID, seeded.relations[a.Relation].String()},
+			{"scope", g.Scope, a.Scope},
+			{"description", g.Description, a.Description},
+		} {
+			if field.got != field.want {
+				t.Errorf("adjustment %d of %s: %s = %q, want %q", i, key, field.name, field.got, field.want)
+			}
+		}
+		for _, amount := range []struct {
+			name      string
+			got, want decimal.Decimal
+		}{
+			{"rate", g.Rate.Decimal, a.Rate},
+			{"base", g.Base.Decimal, a.Base},
+			{"amount", g.Amount.Decimal, a.Amount},
+		} {
+			if !amount.got.Equal(amount.want) {
+				t.Errorf("adjustment %d of %s: %s = %s, want %s",
+					i, key, amount.name, amount.got, amount.want)
+			}
+		}
+	}
+
+	// Decision D7 of the roadmap: every total a document shows is the sum of
+	// the lines it shows, so a reader can add the lines up and arrive at it.
+	net := doc.BaseCost.Decimal
+	kickbacks := decimal.Zero
+	for _, line := range doc.Adjustments {
+		if line.Type == adjustment.TypeKickback {
+			kickbacks = kickbacks.Add(line.Amount.Decimal)
+			continue
+		}
+		net = net.Add(line.Amount.Decimal)
+	}
+	if !net.Equal(doc.NetCost.Decimal) {
+		t.Errorf("the base cost of %s and its adjustments add up to %s, want the net cost %s",
+			key, net, doc.NetCost)
+	}
+	if !kickbacks.Equal(doc.KickbackTotal.Decimal) {
+		t.Errorf("the kickbacks of %s add up to %s, want the kickback total %s",
+			key, kickbacks, doc.KickbackTotal)
 	}
 }
 

--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -115,9 +115,13 @@ func newGoldenFixture(t *testing.T) goldenFixture {
 // caseDBs is the pair of databases one case runs against, and the source handle
 // the engine reads the reporting side through.
 type caseDBs struct {
-	engine    *pgxpool.Pool
+	engine *pgxpool.Pool
+	// reporting is reportingStore.Pool(), the pool the fixtures seed through.
 	reporting *pgxpool.Pool
 	source    *source.DB
+	// reportingStore is the store the registry API of the auditability drill is
+	// built over.
+	reportingStore *reportingstore.Store
 }
 
 // caseDatabases creates, migrates and opens the two databases of one case, and
@@ -169,7 +173,12 @@ func (f goldenFixture) caseDatabases(t *testing.T, name string) caseDBs {
 	}
 	t.Cleanup(src.Close)
 
-	return caseDBs{engine: engineDB.Pool(), reporting: reportingDB.Pool(), source: src}
+	return caseDBs{
+		engine:         engineDB.Pool(),
+		reporting:      reportingDB.Pool(),
+		source:         src,
+		reportingStore: reportingDB,
+	}
 }
 
 // eventsFile is events.json, and late.json, which has the same shape: the

--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -28,12 +28,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/event"
+	"github.com/b42labs/tally/internal/core/money"
 	"github.com/b42labs/tally/internal/engine/counters"
 	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/pricing"
@@ -1390,6 +1392,260 @@ func assertRelatedCosts(
 		}
 		assertLineItems(t, fmt.Sprintf("the related cost %s of %s", w.ProjectID, statement),
 			g.LineItems, w.LineItems)
+	}
+}
+
+// storedAdjustment is one adjustment_records row as the suite reads it back,
+// past the packages that wrote it. The rate, the base and the amount are read
+// as text, which is what keeps the comparison off floats. hasBeneficiary
+// separates a NULL column, which every row that is not a kickback carries, from
+// a beneficiary that is the empty string.
+type storedAdjustment struct {
+	projectID, relationID        string
+	relationType, relationTarget string
+	beneficiary                  string
+	typ, scope                   string
+	rate, base, amount           string
+	currency                     string
+	hasBeneficiary               bool
+}
+
+// readAdjustmentRecords reads the adjustment records of one run, in the order
+// the query fixes. A run that adjusted nothing yields the empty slice rather
+// than nil, so the records of two runs that stored none compare equal.
+func readAdjustmentRecords(t *testing.T, dbs caseDBs, runID uuid.UUID) []storedAdjustment {
+	t.Helper()
+
+	rows, err := dbs.engine.Query(t.Context(),
+		`SELECT project_id, relation_id::text, relation_type, relation_target, beneficiary,
+		        type, scope, rate::text, base::text, amount::text, currency
+		 FROM adjustment_records WHERE run_id = $1
+		 ORDER BY project_id, relation_id, type, scope, rate, amount`, runID)
+	if err != nil {
+		t.Fatalf("reading the adjustment records of run %s: %v", runID, err)
+	}
+	defer rows.Close()
+
+	got := []storedAdjustment{}
+	for rows.Next() {
+		var row storedAdjustment
+		var beneficiary pgtype.Text
+		if err := rows.Scan(&row.projectID, &row.relationID, &row.relationType, &row.relationTarget,
+			&beneficiary, &row.typ, &row.scope, &row.rate, &row.base, &row.amount,
+			&row.currency); err != nil {
+			t.Fatalf("scanning an adjustment record of run %s: %v", runID, err)
+		}
+		row.beneficiary, row.hasBeneficiary = beneficiary.String, beneficiary.Valid
+		got = append(got, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the adjustment records of run %s: %v", runID, err)
+	}
+	return got
+}
+
+// expectedRecords is the adjustment_records rows the statements of a fixture
+// describe: one per adjustment line, in the shape the run stores it. The three
+// numbers are rendered at the scales the columns carry, so a rate written 0.15
+// in the fixture meets the 0.150000 the column holds.
+//
+// It is pure. A line whose Relation index lies outside the seeded relations is
+// a typo in the fixture, refused by assertAdjustments, which every caller runs
+// first.
+func expectedRecords(want []expectedStatement, seeded seededRegistry) []storedAdjustment {
+	var records []storedAdjustment
+	for _, w := range want {
+		for _, a := range w.Adjustments {
+			record := storedAdjustment{
+				projectID:      w.Key,
+				relationID:     seeded.relations[a.Relation].String(),
+				relationType:   a.RelationType,
+				relationTarget: a.RelationTarget,
+				typ:            a.Type,
+				scope:          a.Scope,
+				rate:           a.Rate.StringFixed(money.RatePlaces),
+				base:           a.Base.StringFixed(money.AmountPlaces),
+				amount:         a.Amount.StringFixed(money.AmountPlaces),
+				currency:       currency,
+			}
+			// The beneficiary is the partner a kickback is paid to, and the
+			// column is NULL on every other type (decision D8).
+			if a.Type == adjustment.TypeKickback {
+				record.beneficiary, record.hasBeneficiary = a.RelationTarget, true
+			}
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+// storedAdjustmentKey identifies one adjustment record among a run's: which
+// statement it sits on, which relation it came from, which element of that
+// relation's document produced it, and what that element computed. The money is
+// part of the key because the rest of it is not unique: a document may carry two
+// elements of one type, scope and rate, and the engine stores a record per
+// element. Two such records that keyed the same would collapse onto one another,
+// and a run that stored one of them wrong would be read as the other one twice.
+type storedAdjustmentKey struct{ projectID, relationID, typ, scope, rate, base, amount string }
+
+// assertAdjustmentRecords checks the rows a run stored against the adjustment
+// lines its statements show. What a partner is paid is a sum over these rows
+// rather than over the documents, so the two sides are held against each other
+// rather than one of them taken on trust. A case whose statements list no lines
+// and whose run stored no rows passes.
+func assertAdjustmentRecords(
+	t *testing.T,
+	dbs caseDBs,
+	runID uuid.UUID,
+	want []expectedStatement,
+	seeded seededRegistry,
+) {
+	t.Helper()
+
+	got := readAdjustmentRecords(t, dbs, runID)
+	expected := expectedRecords(want, seeded)
+	if len(got) != len(expected) {
+		t.Fatalf("adjustment records = %d, want %d", len(got), len(expected))
+	}
+
+	key := func(record storedAdjustment) storedAdjustmentKey {
+		return storedAdjustmentKey{
+			projectID: record.projectID, relationID: record.relationID,
+			typ: record.typ, scope: record.scope, rate: record.rate,
+			base: record.base, amount: record.amount,
+		}
+	}
+	byKey := make(map[storedAdjustmentKey]storedAdjustment, len(got))
+	for _, record := range got {
+		byKey[key(record)] = record
+	}
+
+	matched := make(map[storedAdjustmentKey]bool, len(expected))
+	for _, w := range expected {
+		record, found := byKey[key(w)]
+		if !found {
+			t.Errorf("no %s adjustment of relation %s on %s at the rate %s "+
+				"with the base %s and the amount %s",
+				w.typ, w.relationID, w.projectID, w.rate, w.base, w.amount)
+			continue
+		}
+		matched[key(w)] = true
+		adjustmentName := fmt.Sprintf("the %s adjustment of relation %s on %s",
+			w.typ, w.relationID, w.projectID)
+
+		for _, field := range []struct{ name, got, want string }{
+			{"relation_type", record.relationType, w.relationType},
+			{"relation_target", record.relationTarget, w.relationTarget},
+			{"beneficiary", record.beneficiary, w.beneficiary},
+			{"currency", record.currency, w.currency},
+		} {
+			if field.got != field.want {
+				t.Errorf("%s: %s = %q, want %q", adjustmentName, field.name, field.got, field.want)
+			}
+		}
+		if record.hasBeneficiary != w.hasBeneficiary {
+			t.Errorf("%s carries a beneficiary = %t, want %t",
+				adjustmentName, record.hasBeneficiary, w.hasBeneficiary)
+		}
+	}
+
+	for _, record := range got {
+		if !matched[key(record)] {
+			t.Errorf("the run stored a %s adjustment of relation %s on %s at the rate %s "+
+				"with the base %s and the amount %s, which expected.json does not list",
+				record.typ, record.relationID, record.projectID,
+				record.rate, record.base, record.amount)
+		}
+	}
+}
+
+// kickbackKey identifies one kickback among a run's: which statement it was
+// applied to, which relation it came from, which scope of that relation's
+// document produced it, and what it settles. The rate and the money are part of
+// the key for the reason they are part of storedAdjustmentKey: one relation may
+// settle twice in one scope, and a payout read off a settlement that collapsed
+// onto another one is a partner paid what the other one earned.
+type kickbackKey struct{ statementKey, relationID, scope, rate, base, amount string }
+
+// assertKickbacks checks what a run settles for its partners against the
+// kickback lines its statements show. The export is what a payout is made from,
+// so a run whose statements carry no kickback line has to settle nothing rather
+// than settle a list nobody wrote down.
+func assertKickbacks(t *testing.T, got []export.Kickback, want []expectedStatement, seeded seededRegistry) {
+	t.Helper()
+
+	var expected []export.Kickback
+	for _, w := range want {
+		cloud, projectID, err := statements.ParseKey(w.Key)
+		if err != nil {
+			t.Fatalf("the statement key of the expectation: %v", err)
+		}
+		for _, a := range w.Adjustments {
+			if a.Type != adjustment.TypeKickback {
+				continue
+			}
+			expected = append(expected, export.Kickback{
+				Beneficiary:  a.RelationTarget,
+				Currency:     currency,
+				StatementKey: w.Key,
+				Cloud:        cloud,
+				ProjectID:    projectID,
+				RelationID:   seeded.relations[a.Relation],
+				Scope:        a.Scope,
+				Rate:         a.Rate,
+				Base:         a.Base,
+				Amount:       a.Amount,
+			})
+		}
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("kickbacks = %d, want %d", len(got), len(expected))
+	}
+
+	key := func(k export.Kickback) kickbackKey {
+		return kickbackKey{
+			statementKey: k.StatementKey, relationID: k.RelationID.String(), scope: k.Scope,
+			rate:   k.Rate.StringFixed(money.RatePlaces),
+			base:   k.Base.StringFixed(money.AmountPlaces),
+			amount: k.Amount.StringFixed(money.AmountPlaces),
+		}
+	}
+	byKey := make(map[kickbackKey]export.Kickback, len(got))
+	for _, k := range got {
+		byKey[key(k)] = k
+	}
+
+	matched := make(map[kickbackKey]bool, len(expected))
+	for _, w := range expected {
+		k, found := byKey[key(w)]
+		if !found {
+			t.Errorf("no kickback of relation %s on %s in the scope %s at the rate %s "+
+				"with the base %s and the amount %s",
+				w.RelationID, w.StatementKey, w.Scope, w.Rate, w.Base, w.Amount)
+			continue
+		}
+		matched[key(w)] = true
+		kickbackName := fmt.Sprintf("the kickback of relation %s on %s", w.RelationID, w.StatementKey)
+
+		for _, field := range []struct{ name, got, want string }{
+			{"beneficiary", k.Beneficiary, w.Beneficiary},
+			{"currency", k.Currency, w.Currency},
+			{"cloud", k.Cloud, w.Cloud},
+			{"project_id", k.ProjectID, w.ProjectID},
+		} {
+			if field.got != field.want {
+				t.Errorf("%s: %s = %q, want %q", kickbackName, field.name, field.got, field.want)
+			}
+		}
+	}
+
+	for _, k := range got {
+		if !matched[key(k)] {
+			t.Errorf("the run settles a kickback of relation %s on %s in the scope %s at the rate %s "+
+				"with the base %s and the amount %s, which expected.json does not list",
+				k.RelationID, k.StatementKey, k.Scope, k.Rate, k.Base, k.Amount)
+		}
 	}
 }
 

--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/core/event"
 	"github.com/b42labs/tally/internal/engine/counters"
 	"github.com/b42labs/tally/internal/engine/export"
@@ -215,6 +216,10 @@ type registryRelation struct {
 	RelationType string     `json:"relation_type"`
 	ValidFrom    time.Time  `json:"valid_from"`
 	ValidTo      *time.Time `json:"valid_to"`
+	// Metadata is the relation's metadata document, which is where the pricing
+	// adjustments of a commercial case sit. An absent or empty member seeds the
+	// empty document {}, the one the column defaults to.
+	Metadata json.RawMessage `json:"metadata"`
 }
 
 // projectRef names a registered project the way a resource does, by cloud and
@@ -618,10 +623,19 @@ func replay(t *testing.T, dbs caseDBs, events []event.Event) {
 	}
 }
 
-// seedRegistry registers the projects of a case and the relations between them.
-// A project the registry does not hold gets no statement of its own, so every
-// project a case's resources name belongs here.
-func seedRegistry(t *testing.T, dbs caseDBs, reg registryFile) {
+// seededRegistry is the ids one case's registry assigned. relations holds them
+// in the order of the relations array of registry.json, so seeded.relations[0]
+// is the id of the first relation of the file: an expected.json names a
+// relation by that index, because the id itself is assigned at seeding time.
+type seededRegistry struct {
+	projects  map[projectRef]uuid.UUID
+	relations []uuid.UUID
+}
+
+// seedRegistry registers the projects of a case and the relations between them,
+// and reports the ids it assigned. A project the registry does not hold gets no
+// statement of its own, so every project a case's resources name belongs here.
+func seedRegistry(t *testing.T, dbs caseDBs, reg registryFile) seededRegistry {
 	t.Helper()
 
 	ctx := t.Context()
@@ -636,6 +650,7 @@ func seedRegistry(t *testing.T, dbs caseDBs, reg registryFile) {
 		ids[projectRef{Cloud: p.Cloud, ExternalID: p.ExternalID}] = id
 	}
 
+	relationIDs := make([]uuid.UUID, 0, len(reg.Relations))
 	for _, r := range reg.Relations {
 		edge := fmt.Sprintf("%s/%s -> %s/%s",
 			r.Source.Cloud, r.Source.ExternalID, r.Target.Cloud, r.Target.ExternalID)
@@ -648,13 +663,32 @@ func seedRegistry(t *testing.T, dbs caseDBs, reg registryFile) {
 			}
 			return id
 		}
-		if _, err := dbs.reporting.Exec(ctx,
-			`INSERT INTO project_relations (source_id, target_id, relation_type, valid_from, valid_to)
-			 VALUES ($1, $2, $3, $4, $5)`,
-			resolve(r.Source), resolve(r.Target), r.RelationType, r.ValidFrom, r.ValidTo); err != nil {
+		// The Reporting API validates the adjustments of a relation before it
+		// writes them (internal/reporting/httpapi/projectrelations.go), so a
+		// fixture that goes around the API by raw SQL is held to the same
+		// schema, the way checkSize holds a fixture event to the size schema. A
+		// document the API would refuse is refused here, before the insert.
+		if len(r.Metadata) > 0 {
+			if err := adjustment.ValidateMetadata(r.Metadata); err != nil {
+				t.Fatalf("relation %s: metadata: %v", edge, err)
+			}
+		}
+		metadata := []byte(r.Metadata)
+		if len(metadata) == 0 {
+			metadata = []byte("{}")
+		}
+		var id uuid.UUID
+		if err := dbs.reporting.QueryRow(ctx,
+			`INSERT INTO project_relations (source_id, target_id, relation_type, valid_from, valid_to, metadata)
+			 VALUES ($1, $2, $3, $4, $5, $6::jsonb) RETURNING id`,
+			resolve(r.Source), resolve(r.Target), r.RelationType,
+			r.ValidFrom, r.ValidTo, metadata).Scan(&id); err != nil {
 			t.Fatalf("relating %s: %v", edge, err)
 		}
+		relationIDs = append(relationIDs, id)
 	}
+
+	return seededRegistry{projects: ids, relations: relationIDs}
 }
 
 // seedLate writes the events of late.json, which arrive after a case's first

--- a/internal/engine/golden_fixture_test.go
+++ b/internal/engine/golden_fixture_test.go
@@ -2,11 +2,14 @@
 // pair of databases each case gets, the fixtures a case is seeded from, and the
 // assertions its expectations are checked with.
 //
-// Every case bills March 2026, [2026-03-01T00:00:00Z, 2026-04-01T00:00:00Z).
-// The values in testdata/golden/<case>/expected.json are derived by hand from
-// README section 3.4 ("Metering Output Examples") and pricing/2026-03.yaml.
-// They are never regenerated from what the engine produced: a number the engine
-// wrote says nothing about whether the engine is right.
+// Every case bills March 2026, [2026-03-01T00:00:00Z, 2026-04-01T00:00:00Z),
+// and the temporal case bills the April after it as well. The values in
+// testdata/golden/<case>/expected.json are derived by hand from README section
+// 3.4 ("Metering Output Examples"), from the WP 5.6 table of
+// roadmap/05-phase-5-commercial-pricing.md (the Phase 5 cases and the
+// adjustments they carry) and from pricing/2026-03.yaml. They are never
+// regenerated from what the engine produced: a number the engine wrote says
+// nothing about whether the engine is right.
 //
 // Events are inserted into the events table and folded into current_resources
 // by projection.Replay, the writer the ingest path folds through, so a case is
@@ -92,6 +95,8 @@ var attributingRelationTypes = []string{"infrastructure_tenant"}
 // walks for every case, the defaults of the deployment. The managed_by and
 // member_of edges of virtual_relations carry no adjustments, so a run of the
 // suite proves that walking them leaves every statement at the Phase 3 bytes.
+// The Phase 5 cases carry their adjustments in the metadata of registry.json,
+// on edges of those two types.
 var adjustmentRelationTypes = []string{"managed_by", "member_of"}
 
 const adjustmentDepth = 3

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -323,6 +323,7 @@ func TestGolden(t *testing.T) {
 	t.Run("phase3_regression", func(t *testing.T) { goldenPhase3Regression(t, f) })
 	t.Run("adjusted_reproducibility", func(t *testing.T) { goldenAdjustedReproducibility(t, f) })
 	t.Run("auditability_drill", func(t *testing.T) { goldenAuditabilityDrill(t, f) })
+	t.Run("adjusted_correction", func(t *testing.T) { goldenAdjustedCorrection(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -1774,5 +1775,465 @@ func goldenAuditabilityDrill(t *testing.T, f goldenFixture) {
 					row.relationID, row.typ, row.scope, row.rate)
 			}
 		}
+	}
+}
+
+// goldenAdjustedCorrection runs the correction chain over an adjusted month. It
+// is the phase's fourth exit criterion. The reseller case is billed, finalized,
+// reached by a power cycle that arrives after the invoice, and corrected: the
+// late events move the base, and the credit note has to carry the discount's and
+// the kickback's share of that move beside the usage deltas, so that the credit
+// note and the partner's settlement follow the corrected usage line for line. A
+// second correction after the first is finalized finds nothing left to credit.
+func goldenAdjustedCorrection(t *testing.T, f goldenFixture) {
+	const (
+		cloud = "os-golden-reseller"
+		key   = cloud + "/customer-proj-1"
+	)
+
+	c := loadCase(t, "reseller")
+	want := loadExpected(t, "reseller")
+	dbs := f.caseDatabases(t, "adjusted_correction")
+	ctx := t.Context()
+
+	seeded := seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	// The month as it was invoiced: the instance from 2026-03-07 at the base
+	// cost 1200.00, the 15 % discount off it, and the partner's 10 % on the net
+	// cost it leaves. The case writes those numbers down, so the run is held to
+	// its expectations whole rather than to totals spelled out again here.
+	regular, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, regular)
+	assertStats(t, regular.Stats, want.Stats)
+	assertUsage(t, dbs, regular.RunID, want.Usage)
+
+	run, err := export.Load(ctx, dbs.engine, regular.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	assertRated(t, run.Rated, want.Rated)
+	assertStatements(t, run.Statements, want.Statements, want.AbsentStatements, seeded)
+	assertAdjustmentRecords(t, dbs, regular.RunID, want.Statements, seeded)
+	assertKickbacks(t, run.Kickbacks, want.Statements, seeded)
+
+	kind, err := runs.Finalize(ctx, dbs.engine, periodFrom, regular.RunID)
+	if err != nil {
+		t.Fatalf("runs.Finalize: %v", err)
+	}
+	if kind != runs.KindRegular {
+		t.Errorf("runs.Finalize closed a %q, want a %q", kind, runs.KindRegular)
+	}
+	status, finalized := periodRow(t, dbs)
+	if status != "finalized" {
+		t.Errorf("the billing period is %q, want finalized", status)
+	}
+	if finalized != regular.RunID {
+		t.Errorf("the period was closed by %s, want the regular run %s", finalized, regular.RunID)
+	}
+
+	// The power cycle, arriving after the month was closed. Its events are
+	// dated inside the period and reach the reporting database at an instant
+	// past the one the finalized run read it at.
+	seedLate(t, dbs, c)
+
+	late, err := runs.DetectLate(ctx, dbs.engine, dbs.source, periodFrom, periodTo)
+	if err != nil {
+		t.Fatalf("runs.DetectLate: %v", err)
+	}
+	if late.RunID != regular.RunID {
+		t.Errorf("the late events are held against %s, want the finalized run %s", late.RunID, regular.RunID)
+	}
+	if late.Kind != runs.KindRegular {
+		t.Errorf("the run the late events are held against is a %q, want a %q", late.Kind, runs.KindRegular)
+	}
+	if late.Truncated != 0 {
+		t.Errorf("Truncated = %d, want none: the case has one resource", late.Truncated)
+	}
+	if len(late.Resources) != 1 {
+		t.Fatalf("late resources = %v, want the one instance the power cycle reached", late.Resources)
+	}
+	wantResource := source.Resource{
+		Cloud: cloud, Platform: "openstack", ResourceType: "instance", ResourceID: "i-reseller",
+	}
+	if late.Resources[0].Resource != wantResource {
+		t.Errorf("the late resource = %+v, want %+v", late.Resources[0].Resource, wantResource)
+	}
+	if late.Resources[0].Events != 2 {
+		t.Errorf("the late resource carries %d events, want the two of the power cycle",
+			late.Resources[0].Events)
+	}
+
+	first, err := runs.Correct(ctx, dbs.engine, dbs.source, c.correctOptions(t))
+	if err != nil {
+		t.Fatalf("runs.Correct: %v", err)
+	}
+	if first.CorrectsRunID != regular.RunID {
+		t.Errorf("CorrectsRunID = %s, want the finalized run %s", first.CorrectsRunID, regular.RunID)
+	}
+	if first.PricingVersion != pricingVersion {
+		t.Errorf("PricingVersion = %q, want the %q the corrected run rated with",
+			first.PricingVersion, pricingVersion)
+	}
+	assertNoWarnings(t, first.Stats.Stats)
+	for _, count := range []struct {
+		name      string
+		got, want int
+	}{
+		{"deltas", first.Stats.Deltas, 3},
+		{"adjustment_deltas", first.Stats.AdjustmentDeltas, 2},
+		{"adjustment_records", first.Stats.AdjustmentRecords, 2},
+		{"usage_records", first.Stats.UsageRecords, 3},
+		{"rated_records", first.Stats.RatedRecords, 12},
+		{"statements", first.Stats.Statements, 1},
+	} {
+		if count.got != count.want {
+			t.Errorf("correction stats %s = %d, want %d", count.name, count.got, count.want)
+		}
+	}
+
+	credit, err := export.Load(ctx, dbs.engine, first.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	// The instance ran 600 hours from 2026-03-07. The power cycle puts the 120
+	// hours from 2026-03-17 to 2026-03-22 into shutoff, which the model rates at
+	// the modifier 0.5, so the correction rates 540 effective hours: vcpus
+	// 50 x 540 x 0.02 = 540.00, ram_gb 100 x 540 x 0.005 = 270.00, disk_gb
+	// 500 x 540 x 0.001 = 270.00. They come in the order the diff sorts its
+	// keys. The egress both passes rated at zero is no difference, so the
+	// correction writes no delta for it.
+	wantDeltas := []struct{ dimension, old, new, delta string }{
+		{"disk_gb", "300.00", "270.00", "-30.00"},
+		{"ram_gb", "300.00", "270.00", "-30.00"},
+		{"vcpus", "600.00", "540.00", "-60.00"},
+	}
+	if len(credit.Deltas) != len(wantDeltas) {
+		t.Fatalf("deltas = %d, want %d", len(credit.Deltas), len(wantDeltas))
+	}
+	for i, w := range wantDeltas {
+		got := credit.Deltas[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"dimension", got.Dimension, w.dimension},
+			{"cloud", got.Cloud, cloud},
+			{"resource_id", got.ResourceID, "i-reseller"},
+			{"project_id", got.ProjectID, "customer-proj-1"},
+			{"currency", got.Currency, currency},
+		} {
+			if field.got != field.want {
+				t.Errorf("delta %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		for _, amount := range []struct {
+			name string
+			got  decimal.Decimal
+			want string
+		}{
+			{"old", got.Old, w.old},
+			{"new", got.New, w.new},
+			// The embedded corrections.Delta carries a field of its own name,
+			// so the difference is one level down from the export record.
+			{"delta", got.Delta.Delta, w.delta},
+		} {
+			if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+				t.Errorf("delta %d: the %s amount of %s = %s, want %s",
+					i, amount.name, w.dimension, amount.got, want)
+			}
+		}
+	}
+
+	if len(credit.Statements) != 1 {
+		t.Fatalf("credit notes = %d, want the one project of the case", len(credit.Statements))
+	}
+	note := credit.Statements[0]
+	if note.Key != key {
+		t.Errorf("credit note key = %q, want %q", note.Key, key)
+	}
+	// The note settles the net delta, which is what the customer is credited.
+	if want := decimal.RequireFromString("-102.00"); !note.Total.Equal(want) {
+		t.Errorf("the total of the credit note of %s = %s, want %s", key, note.Total, want)
+	}
+	if note.Currency != currency {
+		t.Errorf("the currency of the credit note of %s = %q, want %q", key, note.Currency, currency)
+	}
+	var document corrections.CreditNote
+	if err := json.Unmarshal(note.Document, &document); err != nil {
+		t.Fatalf("decoding the credit note of %s: %v", key, err)
+	}
+	if document.CorrectsRunID != regular.RunID.String() {
+		t.Errorf("the credit note corrects run %s, want the finalized run %s",
+			document.CorrectsRunID, regular.RunID)
+	}
+	assertBillingPeriod(t, "the credit note of "+key, document.BillingPeriod,
+		expectedBillingPeriod{From: "2026-03-01T00:00:00Z", To: "2026-04-01T00:00:00Z"})
+	for _, field := range []struct{ name, got, want string }{
+		{"project", document.ProjectID, "customer-proj-1"},
+		{"platform", document.Platform, "openstack"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the %s of the credit note of %s = %q, want %q",
+				field.name, key, field.got, field.want)
+		}
+	}
+	if len(document.RelatedCosts) != 0 {
+		t.Errorf("the credit note of %s carries the related costs %+v, want none: "+
+			"the case registers the partner beside the customer and relates them, "+
+			"which is not an attributing edge", key, document.RelatedCosts)
+	}
+
+	if len(document.LineItems) != 1 {
+		t.Fatalf("the credit note of %s carries %d line items, want the one instance the power cycle reached",
+			key, len(document.LineItems))
+	}
+	line := document.LineItems[0]
+	for _, field := range []struct{ name, got, want string }{
+		{"resource_type", line.ResourceType, "instance"},
+		{"resource_id", line.ResourceID, "i-reseller"},
+		{"platform", line.Platform, "openstack"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the line of the credit note of %s: %s = %q, want %q",
+				key, field.name, field.got, field.want)
+		}
+	}
+	// The line credits the usage, so its total is the base delta and not the
+	// net one the note settles.
+	if want := decimal.RequireFromString("-120.00"); !line.Total.Equal(want) {
+		t.Errorf("the total of the line of the credit note of %s = %s, want %s", key, line.Total, want)
+	}
+	if len(line.Dimensions) != len(wantDeltas) {
+		t.Errorf("the line of the credit note of %s credits %d dimensions, want %d",
+			key, len(line.Dimensions), len(wantDeltas))
+	}
+	for _, w := range wantDeltas {
+		change, credited := line.Dimensions[w.dimension]
+		if !credited {
+			t.Errorf("the line of the credit note of %s credits no %s", key, w.dimension)
+			continue
+		}
+		for _, amount := range []struct {
+			name string
+			got  decimal.Decimal
+			want string
+		}{
+			{"old", change.Old.Decimal, w.old},
+			{"new", change.New.Decimal, w.new},
+			{"delta", change.Delta.Decimal, w.delta},
+		} {
+			if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+				t.Errorf("the %s of the %s on the credit note of %s = %s, want %s",
+					amount.name, w.dimension, key, amount.got, want)
+			}
+		}
+	}
+
+	// The commercial part of the note, which a correction of an unadjusted month
+	// leaves off. The base falls from 1200.00 to 1080.00, so the discount off it
+	// goes from -180.00 to 0.15 x 1080.00 = -162.00, the net cost from 1020.00 to
+	// 918.00, and the partner's commission from 102.00 to 0.10 x 918.00 = 91.80.
+	for _, member := range []struct {
+		name    string
+		missing bool
+	}{
+		{"base_delta", document.BaseDelta == nil},
+		{"net_delta", document.NetDelta == nil},
+		{"kickback_delta", document.KickbackDelta == nil},
+	} {
+		if member.missing {
+			t.Fatalf("the credit note of %s carries no %s, want the one the adjustments moved",
+				key, member.name)
+		}
+	}
+	for _, amount := range []struct {
+		name string
+		got  decimal.Decimal
+		want string
+	}{
+		{"base delta", document.BaseDelta.Decimal, "-120.00"},
+		{"net delta", document.NetDelta.Decimal, "-102.00"},
+		{"kickback delta", document.KickbackDelta.Decimal, "-10.20"},
+	} {
+		if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+			t.Errorf("the %s of the credit note of %s = %s, want %s", amount.name, key, amount.got, want)
+		}
+	}
+
+	if len(document.Adjustments) != 2 {
+		t.Fatalf("the credit note of %s carries %d adjustments, want the discount and the kickback",
+			key, len(document.Adjustments))
+	}
+	for i, w := range []struct {
+		typ, rate, old, new, delta string
+	}{
+		{adjustment.TypeDiscount, "0.15", "-180.00", "-162.00", "18.00"},
+		{adjustment.TypeKickback, "0.10", "102.00", "91.80", "-10.20"},
+	} {
+		got := document.Adjustments[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"type", got.Type, w.typ},
+			{"relation_type", got.RelationType, "managed_by"},
+			{"relation_target", got.RelationTarget, "partner-corp"},
+			{"relation_id", got.RelationID, seeded.relations[0].String()},
+			{"scope", got.Scope, "all"},
+		} {
+			if field.got != field.want {
+				t.Errorf("adjustment %d of the credit note of %s: %s = %q, want %q",
+					i, key, field.name, field.got, field.want)
+			}
+		}
+		for _, amount := range []struct {
+			name string
+			got  decimal.Decimal
+			want string
+		}{
+			{"rate", got.Rate.Decimal, w.rate},
+			{"old", got.Old.Decimal, w.old},
+			{"new", got.New.Decimal, w.new},
+			{"delta", got.Delta.Decimal, w.delta},
+		} {
+			if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+				t.Errorf("adjustment %d of the credit note of %s: %s = %s, want %s",
+					i, key, amount.name, amount.got, want)
+			}
+		}
+	}
+
+	// What the partner is settled for the correction. A correction's kickbacks
+	// are the differences to the run it corrects, so the base and the amount are
+	// the new ones minus the old.
+	if len(credit.Kickbacks) != 1 {
+		t.Fatalf("kickbacks = %+v, want the one the correction moved", credit.Kickbacks)
+	}
+	paid := credit.Kickbacks[0]
+	for _, field := range []struct{ name, got, want string }{
+		{"beneficiary", paid.Beneficiary, "partner-corp"},
+		{"currency", paid.Currency, currency},
+		{"statement_key", paid.StatementKey, key},
+		{"cloud", paid.Cloud, cloud},
+		{"project_id", paid.ProjectID, "customer-proj-1"},
+		{"scope", paid.Scope, "all"},
+	} {
+		if field.got != field.want {
+			t.Errorf("the settled kickback: %s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+	if paid.RelationID != seeded.relations[0] {
+		t.Errorf("the settled kickback came off relation %s, want the one of the case %s",
+			paid.RelationID, seeded.relations[0])
+	}
+	for _, amount := range []struct {
+		name string
+		got  decimal.Decimal
+		want string
+	}{
+		{"rate", paid.Rate, "0.10"},
+		{"base", paid.Base, "-102.00"},
+		{"amount", paid.Amount, "-10.20"},
+	} {
+		if want := decimal.RequireFromString(amount.want); !amount.got.Equal(want) {
+			t.Errorf("the settled kickback: %s = %s, want %s", amount.name, amount.got, want)
+		}
+	}
+
+	// The rows behind that settlement. They carry what the correction applied
+	// rather than the differences: the discount off the 1080.00 the month now
+	// costs, and the commission on the 918.00 it leaves. type sorts discount
+	// before kickback under one project and relation, which is the order the
+	// query reads them in.
+	records := readAdjustmentRecords(t, dbs, first.RunID)
+	if len(records) != 2 {
+		t.Fatalf("adjustment records = %+v, want the discount and the kickback of the correction", records)
+	}
+	for i, w := range []struct {
+		typ, base, amount, beneficiary string
+		hasBeneficiary                 bool
+	}{
+		{typ: adjustment.TypeDiscount, base: "1080.00", amount: "-162.00"},
+		{
+			typ: adjustment.TypeKickback, base: "918.00", amount: "91.80",
+			beneficiary: "partner-corp", hasBeneficiary: true,
+		},
+	} {
+		got := records[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"type", got.typ, w.typ},
+			{"project_id", got.projectID, key},
+			{"relation_id", got.relationID, seeded.relations[0].String()},
+			{"beneficiary", got.beneficiary, w.beneficiary},
+		} {
+			if field.got != field.want {
+				t.Errorf("adjustment record %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		if got.hasBeneficiary != w.hasBeneficiary {
+			t.Errorf("adjustment record %d carries a beneficiary = %t, want %t",
+				i, got.hasBeneficiary, w.hasBeneficiary)
+		}
+		for _, amount := range []struct{ name, got, want string }{
+			{"base", got.base, w.base},
+			{"amount", got.amount, w.amount},
+		} {
+			stored, err := decimal.NewFromString(amount.got)
+			if err != nil {
+				t.Errorf("the stored %s of adjustment record %d: %v", amount.name, i, err)
+				continue
+			}
+			if want := decimal.RequireFromString(amount.want); !stored.Equal(want) {
+				t.Errorf("adjustment record %d: %s = %s, want %s", i, amount.name, stored, want)
+			}
+		}
+	}
+
+	if kind, err = runs.Finalize(ctx, dbs.engine, periodFrom, first.RunID); err != nil {
+		t.Fatalf("runs.Finalize: %v", err)
+	} else if kind != runs.KindCorrection {
+		t.Errorf("runs.Finalize closed a %q, want a %q", kind, runs.KindCorrection)
+	}
+
+	// The finalized correction is the period's truth now, and the power cycle is
+	// in it, so correcting again finds nothing to credit and nothing to settle.
+	second, err := runs.Correct(ctx, dbs.engine, dbs.source, c.correctOptions(t))
+	if err != nil {
+		t.Fatalf("runs.Correct: %v", err)
+	}
+	assertNoWarnings(t, second.Stats.Stats)
+	if second.CorrectsRunID != first.RunID {
+		t.Errorf("CorrectsRunID = %s, want the finalized correction %s", second.CorrectsRunID, first.RunID)
+	}
+	if second.Stats.Deltas != 0 {
+		t.Errorf("Stats.Deltas = %d, want none: the power cycle has been settled", second.Stats.Deltas)
+	}
+	if second.Stats.AdjustmentDeltas != 0 {
+		t.Errorf("Stats.AdjustmentDeltas = %d, want none: the adjustments come out as they were credited",
+			second.Stats.AdjustmentDeltas)
+	}
+	if second.Stats.Statements != 0 {
+		t.Errorf("Stats.Statements = %d, want none: there is nothing to credit", second.Stats.Statements)
+	}
+	// A correction applies the relation's adjustments to what it rated, whatever
+	// the run before it applied, so it stores its own rows where nothing moved.
+	if second.Stats.AdjustmentRecords != 2 {
+		t.Errorf("Stats.AdjustmentRecords = %d, want the two the correction applied",
+			second.Stats.AdjustmentRecords)
+	}
+	settled, err := export.Load(ctx, dbs.engine, second.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if len(settled.Deltas) != 0 {
+		t.Errorf("deltas = %+v, want none", settled.Deltas)
+	}
+	if len(settled.Statements) != 0 {
+		t.Errorf("credit notes = %d, want none", len(settled.Statements))
+	}
+	if len(settled.Kickbacks) != 0 {
+		t.Errorf("kickbacks = %+v, want none: the partner was settled by the first correction",
+			settled.Kickbacks)
+	}
+	if got := runStatus(t, dbs, second.RunID); got != "completed" {
+		t.Errorf("status = %q, want completed: a correction that found nothing is a correction", got)
 	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -273,6 +273,16 @@ func TestGolden(t *testing.T) {
 		"e2e_power_cycle",
 		"related_costs",
 		"virtual_relations",
+		"reseller",
+		"scoped_discount",
+		"inherited_member_discount",
+		// registry.json lists the three adjustments of this case kickback
+		// first, against the surcharge → discount → kickback order
+		// expected.json chains the bases in. The reversed input is what proves
+		// the engine applies its canonical order rather than the order of the
+		// document, so tidying the fixture to match expected.json would leave
+		// the case passing without testing what it is named after.
+		"order_and_stacking",
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := loadCase(t, name)

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -35,6 +37,8 @@ import (
 	"github.com/b42labs/tally/internal/engine/runs"
 	"github.com/b42labs/tally/internal/engine/scheduler"
 	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
 )
 
 // TestGoldenStubQuerier pins the stub the metricsql sources of the suite are
@@ -318,6 +322,7 @@ func TestGolden(t *testing.T) {
 	t.Run("temporal", func(t *testing.T) { goldenTemporal(t, f) })
 	t.Run("phase3_regression", func(t *testing.T) { goldenPhase3Regression(t, f) })
 	t.Run("adjusted_reproducibility", func(t *testing.T) { goldenAdjustedReproducibility(t, f) })
+	t.Run("auditability_drill", func(t *testing.T) { goldenAuditabilityDrill(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -1627,6 +1632,147 @@ func goldenAdjustedReproducibility(t *testing.T, f goldenFixture) {
 		if entry.Projects != 2 {
 			t.Errorf("the kickback total of %s came off %d projects, want the two of the group",
 				document.name, entry.Projects)
+		}
+	}
+}
+
+// goldenAuditabilityDrill answers the question an operator is asked about an
+// invoice, "why does this project get 15 % off?", out of stored data alone. It
+// is the phase's third exit criterion. Every adjustment_records row names the
+// relation it came from by id, so the walk starts at a row of an adjusted
+// statement, resolves that statement's project through
+// GET /api/v1/projects?cloud=&external_id=, and finds the relation by that id in
+// GET /api/v1/projects/{id}/relations?direction=outgoing&at=<period start>.
+//
+// The contract defines no GET on a single relation: api/reporting/openapi.yaml
+// carries a patch and a delete under that path and nothing else, so the drill
+// walks the two list endpoints instead (author's decision of 2026-08-31, named
+// here per guardrail 10 of roadmap/00-conventions.md).
+//
+// The at is the start of the period the row was billed in, because a relation
+// closed inside the month is no longer valid at now. The relation of the reseller
+// case is open, so the drill also reads it without at and holds that walk to the
+// same relation.
+//
+// The answer then stands on what the served relation carries: a managed_by edge
+// to partner-corp whose metadata spells the "Reseller end-customer discount" the
+// row was computed from.
+func goldenAuditabilityDrill(t *testing.T, f goldenFixture) {
+	c := loadCase(t, "reseller")
+	want := loadExpected(t, "reseller")
+	dbs := f.caseDatabases(t, "auditability_drill")
+	ctx := t.Context()
+
+	seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	result, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, result)
+
+	api := newRegistryAPI(t, dbs)
+
+	// The rows the invoice's adjustment lines were stored as: the discount off
+	// the base cost, and the kickback the partner is paid on what it leaves.
+	rows := readAdjustmentRecords(t, dbs, result.RunID)
+	if len(rows) != 2 {
+		t.Fatalf("adjustment records = %+v, want the discount and the kickback of the case", rows)
+	}
+
+	// The partner both relations reach, resolved once by the pair that keys the
+	// registry.
+	var partners httpapi.ProjectList
+	api.get(t, "/api/v1/projects?cloud=partner&external_id=partner-corp", &partners)
+	if len(partners.Items) != 1 {
+		t.Fatalf("the registry serves %d projects for partner/partner-corp, want the one the case registers",
+			len(partners.Items))
+	}
+
+	// The metadata the case seeded, re-encoded the way the served one is. The
+	// served Relation.Metadata is a map[string]interface{}, so marshalling both
+	// sides yields objects with their keys sorted, and every value of this
+	// fixture's metadata is a string, so no number passes through a float.
+	var seededMetadata any
+	if err := json.Unmarshal(c.Registry.Relations[0].Metadata, &seededMetadata); err != nil {
+		t.Fatalf("decoding the metadata of the relation of the case: %v", err)
+	}
+	wantMetadata, err := json.Marshal(seededMetadata)
+	if err != nil {
+		t.Fatalf("encoding the metadata of the relation of the case: %v", err)
+	}
+
+	for _, row := range rows {
+		cloud, externalID, err := statements.ParseKey(row.projectID)
+		if err != nil {
+			t.Fatalf("the project of the %s record: %v", row.typ, err)
+		}
+		var projects httpapi.ProjectList
+		api.get(t, "/api/v1/projects?cloud="+url.QueryEscape(cloud)+
+			"&external_id="+url.QueryEscape(externalID), &projects)
+		if len(projects.Items) != 1 {
+			t.Fatalf("the registry serves %d projects for %s, want the one the record names",
+				len(projects.Items), row.projectID)
+		}
+		project := projects.Items[0]
+
+		for _, walk := range []struct{ target, when string }{
+			{
+				target: fmt.Sprintf("/api/v1/projects/%s/relations?direction=outgoing&at=%s",
+					project.Id, url.QueryEscape("2026-03-01T00:00:00Z")),
+				when: "at the period start",
+			},
+			{
+				target: fmt.Sprintf("/api/v1/projects/%s/relations?direction=outgoing", project.Id),
+				when:   "at now",
+			},
+		} {
+			var relations httpapi.RelationList
+			api.get(t, walk.target, &relations)
+			at := slices.IndexFunc(relations.Items, func(r httpapi.Relation) bool {
+				return r.Id.String() == row.relationID
+			})
+			if at < 0 {
+				t.Fatalf("the registry serves no relation %s for %s %s",
+					row.relationID, row.projectID, walk.when)
+			}
+			relation := relations.Items[at]
+
+			if relation.RelationType != row.relationType {
+				t.Errorf("the served relation %s is a %q, want the %q the record names",
+					row.relationID, relation.RelationType, row.relationType)
+			}
+			if relation.TargetId != partners.Items[0].Id {
+				t.Errorf("the served relation %s reaches the project %s, want the partner %s",
+					row.relationID, relation.TargetId, partners.Items[0].Id)
+			}
+			served, err := json.Marshal(relation.Metadata)
+			if err != nil {
+				t.Fatalf("encoding the metadata of the served relation %s: %v", row.relationID, err)
+			}
+			if !bytes.Equal(served, wantMetadata) {
+				t.Errorf("the metadata of the served relation %s = %s, want %s",
+					row.relationID, served, wantMetadata)
+			}
+
+			// The element of that metadata the row was computed from, read by the
+			// schema the rating engine reads it by.
+			member, err := json.Marshal(relation.Metadata[adjustment.MetadataKey])
+			if err != nil {
+				t.Fatalf("encoding the adjustments of the served relation %s: %v", row.relationID, err)
+			}
+			parsed, err := adjustment.Parse(member)
+			if err != nil {
+				t.Fatalf("reading the adjustments of the served relation %s: %v", row.relationID, err)
+			}
+			if !slices.ContainsFunc(parsed, func(a adjustment.Adjustment) bool {
+				return a.Type == row.typ && a.Scope == row.scope &&
+					a.Rate.Equal(decimal.RequireFromString(row.rate))
+			}) {
+				t.Errorf("the served relation %s carries no %s adjustment of scope %s at the rate %s",
+					row.relationID, row.typ, row.scope, row.rate)
+			}
 		}
 	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -317,6 +317,7 @@ func TestGolden(t *testing.T) {
 	t.Run("scheduler_drill", func(t *testing.T) { goldenSchedulerDrill(t, f) })
 	t.Run("temporal", func(t *testing.T) { goldenTemporal(t, f) })
 	t.Run("phase3_regression", func(t *testing.T) { goldenPhase3Regression(t, f) })
+	t.Run("adjusted_reproducibility", func(t *testing.T) { goldenAdjustedReproducibility(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -716,25 +717,7 @@ func goldenReproducibility(t *testing.T, f goldenFixture) {
 		t.Fatalf("JSONFiles.Export: %v", err)
 	}
 
-	if len(b.Statements) != len(a.Statements) {
-		t.Fatalf("the second run billed %d statements, want the %d of the first",
-			len(b.Statements), len(a.Statements))
-	}
-	for i, want := range a.Statements {
-		got := b.Statements[i]
-		if got.Key != want.Key {
-			t.Errorf("statement %d: key = %q, want %q", i, got.Key, want.Key)
-		}
-		if !bytes.Equal(got.Document, want.Document) {
-			t.Errorf("the document of %s = %s, want %s", want.Key, got.Document, want.Document)
-		}
-		if !got.Total.Equal(want.Total) {
-			t.Errorf("the total of %s = %s, want %s", want.Key, got.Total, want.Total)
-		}
-		if got.Currency != want.Currency {
-			t.Errorf("the currency of %s = %q, want %q", want.Key, got.Currency, want.Currency)
-		}
-	}
+	assertSameStatements(t, b.Statements, a.Statements, "the second run")
 
 	if len(b.Rated) != len(a.Rated) {
 		t.Fatalf("the second run rated %d records, want the %d of the first", len(b.Rated), len(a.Rated))
@@ -820,6 +803,33 @@ func goldenReproducibility(t *testing.T, f goldenFixture) {
 	}
 }
 
+// assertSameStatements checks that two runs of one period billed the same
+// statements: the same keys, the same documents byte for byte, the same totals
+// and the same currency. what names the run the statements in got came from, so
+// a failure says which of the two runs of a drill differs.
+func assertSameStatements(t *testing.T, got, want []statements.Statement, what string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s billed %d statements, want %d", what, len(got), len(want))
+	}
+	for i, w := range want {
+		g := got[i]
+		if g.Key != w.Key {
+			t.Errorf("statement %d: key = %q, want %q", i, g.Key, w.Key)
+		}
+		if !bytes.Equal(g.Document, w.Document) {
+			t.Errorf("the document of %s = %s, want %s", w.Key, g.Document, w.Document)
+		}
+		if !g.Total.Equal(w.Total) {
+			t.Errorf("the total of %s = %s, want %s", w.Key, g.Total, w.Total)
+		}
+		if g.Currency != w.Currency {
+			t.Errorf("the currency of %s = %q, want %q", w.Key, g.Currency, w.Currency)
+		}
+	}
+}
+
 // exportedRun is the part of an exported run.json two runs of one period have
 // to agree on: the version they rated with, and the documents they wrote beside
 // the projects those bill.
@@ -835,6 +845,16 @@ type exportedDocument struct {
 	ProjectID string          `json:"project_id"`
 	Total     decimal.Decimal `json:"total"`
 	Currency  string          `json:"currency"`
+}
+
+// settlement is the part of a kickbacks.json a drill reads: what each partner
+// is owed for the month, and over how many projects that total was summed.
+type settlement struct {
+	Beneficiaries []struct {
+		Beneficiary   string          `json:"beneficiary"`
+		KickbackTotal decimal.Decimal `json:"kickback_total"`
+		Projects      int             `json:"projects"`
+	} `json:"beneficiaries"`
 }
 
 // readRunIndex reads the run.json one export wrote.
@@ -1398,25 +1418,7 @@ func goldenPhase3Regression(t *testing.T, f goldenFixture) {
 		t.Fatalf("JSONFiles.Export: %v", err)
 	}
 
-	if len(b.Statements) != len(a.Statements) {
-		t.Fatalf("the run without the walk billed %d statements, want the %d of the walking one",
-			len(b.Statements), len(a.Statements))
-	}
-	for i, want := range a.Statements {
-		got := b.Statements[i]
-		if got.Key != want.Key {
-			t.Errorf("statement %d: key = %q, want %q", i, got.Key, want.Key)
-		}
-		if !bytes.Equal(got.Document, want.Document) {
-			t.Errorf("the document of %s = %s, want %s", want.Key, got.Document, want.Document)
-		}
-		if !got.Total.Equal(want.Total) {
-			t.Errorf("the total of %s = %s, want %s", want.Key, got.Total, want.Total)
-		}
-		if got.Currency != want.Currency {
-			t.Errorf("the currency of %s = %q, want %q", want.Key, got.Currency, want.Currency)
-		}
-	}
+	assertSameStatements(t, b.Statements, a.Statements, "the run without the walk")
 
 	// The document a customer receives, on disk. kickbacks.json names the run it
 	// was settled from, so it is not the file the two exports are compared on.
@@ -1435,5 +1437,196 @@ func goldenPhase3Regression(t *testing.T, f goldenFixture) {
 	}
 	if records := readAdjustmentRecords(t, dbs, second.RunID); len(records) != 0 {
 		t.Errorf("the run without the walk stored the adjustment records %+v, want none", records)
+	}
+}
+
+// goldenAdjustedReproducibility meters one adjusted period twice from the same
+// events and checks that the two runs bill and settle the same thing. It is the
+// phase's second exit criterion: a rerun of a month is what an operator does
+// after a failed pass, and with adjustments in play a rerun that settled a
+// partner differently would pay that partner twice or at another amount. So the
+// drill compares the invoice, the rows a payout is summed from and the
+// settlement documents.
+//
+// The case it meters is the inherited member discount of the loop above, in
+// databases of its own. Two runs that agree with each other and with nothing
+// else would be reproducibly wrong, so the first of them is held against that
+// case's expectations whole rather than against a total written out again here.
+func goldenAdjustedReproducibility(t *testing.T, f goldenFixture) {
+	c := loadCase(t, "inherited_member_discount")
+	want := loadExpected(t, "inherited_member_discount")
+	dbs := f.caseDatabases(t, "adjusted_reproducibility")
+	ctx := t.Context()
+
+	seeded := seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+	dir := t.TempDir()
+
+	first, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, first)
+	assertStats(t, first.Stats, want.Stats)
+	assertUsage(t, dbs, first.RunID, want.Usage)
+
+	a, err := export.Load(ctx, dbs.engine, first.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	assertRated(t, a.Rated, want.Rated)
+	assertStatements(t, a.Statements, want.Statements, want.AbsentStatements, seeded)
+	assertAdjustmentRecords(t, dbs, first.RunID, want.Statements, seeded)
+	assertKickbacks(t, a.Kickbacks, want.Statements, seeded)
+	// The second run supersedes the first, and export.Load refuses a superseded
+	// run, so the first run is read and written out before the second opens.
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "a")}).Export(ctx, a); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	second, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, second)
+	if !slices.Equal(second.Superseded, []uuid.UUID{first.RunID}) {
+		t.Errorf("Superseded = %v, want the first run %s", second.Superseded, first.RunID)
+	}
+
+	b, err := export.Load(ctx, dbs.engine, second.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "b")}).Export(ctx, b); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	assertSameStatements(t, b.Statements, a.Statements, "the second run")
+
+	// The rows a payout is summed from, compared whole. DeepEqual is sound over
+	// these two slices: the query orders both, it reads back every column but id
+	// and run_id, and the relation ids are the registry's, which both runs read
+	// the same. So the two slices are equal exactly where the two runs adjusted
+	// the same.
+	recordsA := readAdjustmentRecords(t, dbs, first.RunID)
+	recordsB := readAdjustmentRecords(t, dbs, second.RunID)
+	if !reflect.DeepEqual(recordsA, recordsB) {
+		t.Errorf("the second run stored the adjustment records %+v, want the %+v of the first",
+			recordsB, recordsA)
+	}
+
+	if len(b.Kickbacks) != len(a.Kickbacks) {
+		t.Fatalf("the second run settles %d kickbacks, want the %d of the first",
+			len(b.Kickbacks), len(a.Kickbacks))
+	}
+	for i, want := range a.Kickbacks {
+		got := b.Kickbacks[i]
+		for _, field := range []struct{ name, got, want string }{
+			{"beneficiary", got.Beneficiary, want.Beneficiary},
+			{"currency", got.Currency, want.Currency},
+			{"statement_key", got.StatementKey, want.StatementKey},
+			{"cloud", got.Cloud, want.Cloud},
+			{"project_id", got.ProjectID, want.ProjectID},
+			{"scope", got.Scope, want.Scope},
+		} {
+			if field.got != field.want {
+				t.Errorf("kickback %d: %s = %q, want %q", i, field.name, field.got, field.want)
+			}
+		}
+		if got.RelationID != want.RelationID {
+			t.Errorf("kickback %d: relation_id = %s, want %s", i, got.RelationID, want.RelationID)
+		}
+		for _, amount := range []struct {
+			name      string
+			got, want decimal.Decimal
+		}{
+			{"rate", got.Rate, want.Rate},
+			{"base", got.Base, want.Base},
+			{"amount", got.Amount, want.Amount},
+		} {
+			if !amount.got.Equal(amount.want) {
+				t.Errorf("kickback %d: %s = %s, want %s", i, amount.name, amount.got, amount.want)
+			}
+		}
+	}
+
+	// The three documents the customers receive, on disk.
+	for _, statement := range []struct{ key, file string }{
+		{"os-golden-member/proj-alpha-1", "statement-os-golden-member%2Fproj-alpha-1.json"},
+		{"os-golden-member/proj-alpha-2", "statement-os-golden-member%2Fproj-alpha-2.json"},
+		{"os-golden-member/proj-beta", "statement-os-golden-member%2Fproj-beta.json"},
+	} {
+		document := export.DocumentFileName(runs.KindRegular, statement.key)
+		if document != statement.file {
+			t.Fatalf("export.DocumentFileName = %q, want %q", document, statement.file)
+		}
+		documentA := readExported(t, filepath.Join(dir, "a", document))
+		documentB := readExported(t, filepath.Join(dir, "b", document))
+		if !bytes.Equal(documentA, documentB) {
+			t.Errorf("the two exports of %s differ:\n%s\n%s", document, documentA, documentB)
+		}
+	}
+
+	// The documents the partner is paid from. Both name the run they belong to,
+	// and nothing else in them differs between two runs of one period, so each
+	// is compared with its own run id replaced by one placeholder.
+	jsonA, err := export.KickbacksJSON(a)
+	if err != nil {
+		t.Fatalf("export.KickbacksJSON: %v", err)
+	}
+	jsonB, err := export.KickbacksJSON(b)
+	if err != nil {
+		t.Fatalf("export.KickbacksJSON: %v", err)
+	}
+	csvA, err := export.KickbacksCSV(a)
+	if err != nil {
+		t.Fatalf("export.KickbacksCSV: %v", err)
+	}
+	csvB, err := export.KickbacksCSV(b)
+	if err != nil {
+		t.Fatalf("export.KickbacksCSV: %v", err)
+	}
+	anonymize := func(document []byte, run export.Run) []byte {
+		return bytes.ReplaceAll(document, []byte(run.ID.String()), []byte("<run>"))
+	}
+	for _, settled := range []struct {
+		name string
+		a, b []byte
+	}{
+		{"kickbacks.json", anonymize(jsonA, a), anonymize(jsonB, b)},
+		{"kickbacks.csv", anonymize(csvA, a), anonymize(csvB, b)},
+	} {
+		if !bytes.Equal(settled.a, settled.b) {
+			t.Errorf("the two settlements in %s differ:\n%s\n%s", settled.name, settled.a, settled.b)
+		}
+	}
+
+	// What the partner is owed for the month, read off both settlements: one
+	// beneficiary, the 14.14 of proj-alpha-1 and the 7.07 of proj-alpha-2, over
+	// the two projects those came off.
+	for _, document := range []struct {
+		name string
+		data []byte
+	}{
+		{"kickbacks.json of a", jsonA},
+		{"kickbacks.json of b", jsonB},
+	} {
+		var got settlement
+		decodeJSON(t, document.name, document.data, &got)
+		if len(got.Beneficiaries) != 1 {
+			t.Fatalf("the %s settles %d beneficiaries, want the one partner of the case",
+				document.name, len(got.Beneficiaries))
+		}
+		entry := got.Beneficiaries[0]
+		if entry.Beneficiary != "partner-corp" {
+			t.Errorf("the %s settles %q, want %q", document.name, entry.Beneficiary, "partner-corp")
+		}
+		if want := decimal.RequireFromString("21.21"); !entry.KickbackTotal.Equal(want) {
+			t.Errorf("the kickback total of %s = %s, want %s", document.name, entry.KickbackTotal, want)
+		}
+		if entry.Projects != 2 {
+			t.Errorf("the kickback total of %s came off %d projects, want the two of the group",
+				document.name, entry.Projects)
+		}
 	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -186,7 +186,7 @@ func TestGolden(t *testing.T) {
 			want := loadExpected(t, name)
 			dbs := f.caseDatabases(t, name)
 
-			seedRegistry(t, dbs, c.Registry)
+			seeded := seedRegistry(t, dbs, c.Registry)
 			seedEvents(t, dbs, c.Events)
 
 			result, err := runs.Execute(t.Context(), dbs.engine, dbs.source, c.options(t, want.Clouds))
@@ -202,7 +202,7 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("export.Load: %v", err)
 			}
 			assertRated(t, run.Rated, want.Rated)
-			assertStatements(t, run.Statements, want.Statements, want.AbsentStatements)
+			assertStatements(t, run.Statements, want.Statements, want.AbsentStatements, seeded)
 		})
 	}
 
@@ -568,7 +568,7 @@ func goldenReproducibility(t *testing.T, f goldenFixture) {
 	dbs := f.caseDatabases(t, "reproducibility")
 	ctx := t.Context()
 
-	seedRegistry(t, dbs, c.Registry)
+	seeded := seedRegistry(t, dbs, c.Registry)
 	seedEvents(t, dbs, c.Events)
 	dir := t.TempDir()
 
@@ -587,7 +587,7 @@ func goldenReproducibility(t *testing.T, f goldenFixture) {
 		t.Fatalf("export.Load: %v", err)
 	}
 	assertRated(t, a.Rated, want.Rated)
-	assertStatements(t, a.Statements, want.Statements, want.AbsentStatements)
+	assertStatements(t, a.Statements, want.Statements, want.AbsentStatements, seeded)
 	if err := (export.JSONFiles{Dir: filepath.Join(dir, "a")}).Export(ctx, a); err != nil {
 		t.Fatalf("JSONFiles.Export: %v", err)
 	}

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/b42labs/tally/internal/core/adjustment"
 	"github.com/b42labs/tally/internal/engine/corrections"
 	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/invariants"
@@ -161,6 +162,98 @@ func TestGoldenExpandBulk(t *testing.T) {
 	})
 }
 
+// TestGoldenAdjustmentExpectations pins the two derivations a commercial case
+// rests on: the adjustment records the statements of an expected.json describe,
+// and the kickbacks a run of it has to settle. Both are read out of the fixture
+// rather than out of the run, so they are what a case holds the engine to. Like
+// the two tests above they need no database.
+func TestGoldenAdjustmentExpectations(t *testing.T) {
+	const (
+		key          = "os-golden-x/proj-x"
+		plainKey     = "os-golden-x/proj-plain"
+		beneficiary  = "partner-corp"
+		relationType = "managed_by"
+	)
+	relation := uuid.New()
+	seeded := seededRegistry{relations: []uuid.UUID{relation}}
+
+	// The pair of adjustments the concept spells for a reseller relation: a
+	// discount off the base cost, and a commission on the net cost it leaves.
+	adjusted := expectedStatement{
+		Key: key,
+		Adjustments: []expectedAdjustment{
+			{
+				Type: adjustment.TypeDiscount, Relation: 0,
+				RelationType: relationType, RelationTarget: beneficiary,
+				Scope: "all", Description: "Reseller end-customer discount",
+				Rate:   decimal.RequireFromString("0.15"),
+				Base:   decimal.RequireFromString("1200.00"),
+				Amount: decimal.RequireFromString("-180.00"),
+			},
+			{
+				Type: adjustment.TypeKickback, Relation: 0,
+				RelationType: relationType, RelationTarget: beneficiary,
+				Scope: "all", Description: "Reseller commission on net revenue",
+				Rate:   decimal.RequireFromString("0.10"),
+				Base:   decimal.RequireFromString("1020.00"),
+				Amount: decimal.RequireFromString("102.00"),
+			},
+		},
+	}
+	plain := expectedStatement{Key: plainKey}
+
+	t.Run("derives one record per adjustment line", func(t *testing.T) {
+		got := expectedRecords([]expectedStatement{adjusted}, seeded)
+		if len(got) != 2 {
+			t.Fatalf("records = %+v, want the two lines of the statement", got)
+		}
+		for i, want := range []storedAdjustment{
+			{
+				projectID: key, relationID: relation.String(),
+				relationType: relationType, relationTarget: beneficiary,
+				typ: adjustment.TypeDiscount, scope: "all",
+				rate: "0.150000", base: "1200.00", amount: "-180.00", currency: currency,
+			},
+			{
+				projectID: key, relationID: relation.String(),
+				relationType: relationType, relationTarget: beneficiary,
+				beneficiary: beneficiary, hasBeneficiary: true,
+				typ: adjustment.TypeKickback, scope: "all",
+				rate: "0.100000", base: "1020.00", amount: "102.00", currency: currency,
+			},
+		} {
+			if got[i] != want {
+				t.Errorf("record %d = %+v, want %+v", i, got[i], want)
+			}
+		}
+	})
+
+	t.Run("derives no record for a statement without lines", func(t *testing.T) {
+		if got := expectedRecords([]expectedStatement{plain}, seeded); len(got) != 0 {
+			t.Errorf("records = %+v, want none", got)
+		}
+	})
+
+	t.Run("accepts the kickback the statement describes", func(t *testing.T) {
+		assertKickbacks(t, []export.Kickback{{
+			Beneficiary:  beneficiary,
+			Currency:     currency,
+			StatementKey: key,
+			Cloud:        "os-golden-x",
+			ProjectID:    "proj-x",
+			RelationID:   relation,
+			Scope:        "all",
+			Rate:         decimal.RequireFromString("0.10"),
+			Base:         decimal.RequireFromString("1020.00"),
+			Amount:       decimal.RequireFromString("102.00"),
+		}}, []expectedStatement{adjusted}, seeded)
+	})
+
+	t.Run("accepts an empty settlement for a statement without lines", func(t *testing.T) {
+		assertKickbacks(t, nil, []expectedStatement{plain}, seeded)
+	})
+}
+
 // TestGolden runs the golden suite. Every case gets its own pair of databases
 // inside the one pair of containers the fixture starts, so the cases share the
 // containers without sharing anything they bill, and the image and the
@@ -203,6 +296,8 @@ func TestGolden(t *testing.T) {
 			}
 			assertRated(t, run.Rated, want.Rated)
 			assertStatements(t, run.Statements, want.Statements, want.AbsentStatements, seeded)
+			assertAdjustmentRecords(t, dbs, result.RunID, want.Statements, seeded)
+			assertKickbacks(t, run.Kickbacks, want.Statements, seeded)
 		})
 	}
 

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -315,6 +315,7 @@ func TestGolden(t *testing.T) {
 	t.Run("reproducibility", func(t *testing.T) { goldenReproducibility(t, f) })
 	t.Run("invariant_violation", func(t *testing.T) { goldenInvariantViolation(t, f) })
 	t.Run("scheduler_drill", func(t *testing.T) { goldenSchedulerDrill(t, f) })
+	t.Run("temporal", func(t *testing.T) { goldenTemporal(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -1248,5 +1249,73 @@ func goldenSchedulerDrill(t *testing.T, f goldenFixture) {
 	}
 	if status, _ := periodRow(t, dbs); status != "finalized" {
 		t.Errorf("the billing period is %q, want finalized", status)
+	}
+}
+
+// goldenTemporal bills one instance over two months across a relation that
+// closes inside the first of them. Decision D4 of
+// roadmap/03-phase-3-metering-rating.md holds a relation to a period iff
+// valid_from < period_to AND (valid_to IS NULL OR valid_to > period_from), so
+// the edge that ends on 2026-03-15 applies to March whole and to April not at
+// all: the day it closed on does not prorate the month it lies in.
+//
+// It is a case of its own because the loop above meters the March the period
+// constants name, and this one bills April on top of it in the same databases.
+// Both months rate with the model the suite imports: PricingModelForPeriod
+// (internal/engine/store/queries.sql) takes the latest model whose valid_from
+// is at or before the start of the period, so the April run reports the 2026-03
+// that assertClean holds every run of the suite to. The two are regular runs of
+// different periods, so the second supersedes nothing the first billed.
+func goldenTemporal(t *testing.T, f goldenFixture) {
+	c := loadCase(t, "temporal")
+	march := loadExpectedFile(t, "temporal", "expected.json")
+	april := loadExpectedFile(t, "temporal", "expected_april.json")
+	dbs := f.caseDatabases(t, "temporal")
+	ctx := t.Context()
+
+	seeded := seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+
+	// One month billed and held to the file that carries its numbers.
+	check := func(opts runs.Options, want expectedFile) (runs.Result, export.Run) {
+		result, err := runs.Execute(ctx, dbs.engine, dbs.source, opts)
+		if err != nil {
+			t.Fatalf("runs.Execute: %v", err)
+		}
+		assertClean(t, result)
+		assertStats(t, result.Stats, want.Stats)
+		assertUsage(t, dbs, result.RunID, want.Usage)
+
+		run, err := export.Load(ctx, dbs.engine, result.RunID)
+		if err != nil {
+			t.Fatalf("export.Load: %v", err)
+		}
+		assertRated(t, run.Rated, want.Rated)
+		assertStatements(t, run.Statements, want.Statements, want.AbsentStatements, seeded)
+		assertAdjustmentRecords(t, dbs, result.RunID, want.Statements, seeded)
+		assertKickbacks(t, run.Kickbacks, want.Statements, seeded)
+		return result, run
+	}
+
+	// March, the month the relation's last day lies in: the discount is applied
+	// to the whole of it, and the invoice is the net cost it leaves.
+	check(c.options(t, march.Clouds), march)
+
+	// April, the month after the relation closed. The same events, the same
+	// model, and a statement at the base cost.
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	opts := c.options(t, april.Clouds)
+	opts.PeriodFrom, opts.PeriodTo = from, to
+	result, run := check(opts, april)
+	if result.Stats.AdjustmentRecords != 0 {
+		t.Errorf("Stats.AdjustmentRecords = %d, want none: the relation closed before April",
+			result.Stats.AdjustmentRecords)
+	}
+	if records := readAdjustmentRecords(t, dbs, result.RunID); len(records) != 0 {
+		t.Errorf("the April run stored the adjustment records %+v, want none", records)
+	}
+	if len(run.Kickbacks) != 0 {
+		t.Errorf("the April run settles the kickbacks %+v, want none", run.Kickbacks)
 	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -316,6 +316,7 @@ func TestGolden(t *testing.T) {
 	t.Run("invariant_violation", func(t *testing.T) { goldenInvariantViolation(t, f) })
 	t.Run("scheduler_drill", func(t *testing.T) { goldenSchedulerDrill(t, f) })
 	t.Run("temporal", func(t *testing.T) { goldenTemporal(t, f) })
+	t.Run("phase3_regression", func(t *testing.T) { goldenPhase3Regression(t, f) })
 }
 
 // goldenCorrectionCredit runs the correction chain of the concept over the
@@ -1317,5 +1318,122 @@ func goldenTemporal(t *testing.T, f goldenFixture) {
 	}
 	if len(run.Kickbacks) != 0 {
 		t.Errorf("the April run settles the kickbacks %+v, want none", run.Kickbacks)
+	}
+}
+
+// goldenPhase3Regression is the sixth row of the phase's exit criteria: a graph
+// whose relations carry no adjustment leaves every statement at the bytes Phase
+// 3 rendered. "Byte-identical to the Phase 3 goldens" is proven here as byte
+// equality between two runs over the virtual_relations case, whose managed_by
+// and member_of edges hold no pricing_adjustments: one run with the adjustment
+// walk on, the defaults every case of the loop runs with, and one with it off,
+// which is the render path Phase 3 shipped. Without a relation type to walk,
+// runs.produce builds no adjuster and statements.Build renders the document
+// without one.
+//
+// Two runs that agree with each other and with nothing else would agree on the
+// wrong document, so both are also held to that case's expected.json, which
+// carries the Phase 3 numbers.
+func goldenPhase3Regression(t *testing.T, f goldenFixture) {
+	c := loadCase(t, "virtual_relations")
+	want := loadExpected(t, "virtual_relations")
+	dbs := f.caseDatabases(t, "phase3_regression")
+	ctx := t.Context()
+
+	seeded := seedRegistry(t, dbs, c.Registry)
+	seedEvents(t, dbs, c.Events)
+	dir := t.TempDir()
+
+	first, err := runs.Execute(ctx, dbs.engine, dbs.source, c.options(t, want.Clouds))
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, first)
+	assertStats(t, first.Stats, want.Stats)
+	assertUsage(t, dbs, first.RunID, want.Usage)
+
+	a, err := export.Load(ctx, dbs.engine, first.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	assertRated(t, a.Rated, want.Rated)
+	// No statement of the file lists base_cost, so this is what says the walk
+	// left the four commercial members off the document it reached.
+	assertStatements(t, a.Statements, want.Statements, want.AbsentStatements, seeded)
+	assertAdjustmentRecords(t, dbs, first.RunID, want.Statements, seeded)
+	assertKickbacks(t, a.Kickbacks, want.Statements, seeded)
+	if first.Stats.AdjustmentRecords != 0 {
+		t.Errorf("Stats.AdjustmentRecords = %d, want none: the edges of the case adjust nothing",
+			first.Stats.AdjustmentRecords)
+	}
+	if records := readAdjustmentRecords(t, dbs, first.RunID); len(records) != 0 {
+		t.Errorf("the walking run stored the adjustment records %+v, want none", records)
+	}
+	if len(a.Kickbacks) != 0 {
+		t.Errorf("the walking run settles the kickbacks %+v, want none", a.Kickbacks)
+	}
+	// The second run supersedes the first, and export.Load refuses a superseded
+	// run, so the first run is read and written out before the second opens.
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "a")}).Export(ctx, a); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	// The same period without a relation type to walk: adjustments are off.
+	opts := c.options(t, want.Clouds)
+	opts.AdjustmentRelationTypes = nil
+	second, err := runs.Execute(ctx, dbs.engine, dbs.source, opts)
+	if err != nil {
+		t.Fatalf("runs.Execute: %v", err)
+	}
+	assertClean(t, second)
+	if !slices.Equal(second.Superseded, []uuid.UUID{first.RunID}) {
+		t.Errorf("Superseded = %v, want the first run %s", second.Superseded, first.RunID)
+	}
+
+	b, err := export.Load(ctx, dbs.engine, second.RunID)
+	if err != nil {
+		t.Fatalf("export.Load: %v", err)
+	}
+	if err := (export.JSONFiles{Dir: filepath.Join(dir, "b")}).Export(ctx, b); err != nil {
+		t.Fatalf("JSONFiles.Export: %v", err)
+	}
+
+	if len(b.Statements) != len(a.Statements) {
+		t.Fatalf("the run without the walk billed %d statements, want the %d of the walking one",
+			len(b.Statements), len(a.Statements))
+	}
+	for i, want := range a.Statements {
+		got := b.Statements[i]
+		if got.Key != want.Key {
+			t.Errorf("statement %d: key = %q, want %q", i, got.Key, want.Key)
+		}
+		if !bytes.Equal(got.Document, want.Document) {
+			t.Errorf("the document of %s = %s, want %s", want.Key, got.Document, want.Document)
+		}
+		if !got.Total.Equal(want.Total) {
+			t.Errorf("the total of %s = %s, want %s", want.Key, got.Total, want.Total)
+		}
+		if got.Currency != want.Currency {
+			t.Errorf("the currency of %s = %q, want %q", want.Key, got.Currency, want.Currency)
+		}
+	}
+
+	// The document a customer receives, on disk. kickbacks.json names the run it
+	// was settled from, so it is not the file the two exports are compared on.
+	document := export.DocumentFileName(runs.KindRegular, "gd-golden-virtual/team-alpha")
+	if want := "statement-gd-golden-virtual%2Fteam-alpha.json"; document != want {
+		t.Fatalf("export.DocumentFileName = %q, want %q", document, want)
+	}
+	documentA := readExported(t, filepath.Join(dir, "a", document))
+	documentB := readExported(t, filepath.Join(dir, "b", document))
+	if !bytes.Equal(documentA, documentB) {
+		t.Errorf("the two exports of %s differ:\n%s\n%s", document, documentA, documentB)
+	}
+
+	if len(b.Kickbacks) != 0 {
+		t.Errorf("the run without the walk settles the kickbacks %+v, want none", b.Kickbacks)
+	}
+	if records := readAdjustmentRecords(t, dbs, second.RunID); len(records) != 0 {
+		t.Errorf("the run without the walk stored the adjustment records %+v, want none", records)
 	}
 }

--- a/internal/engine/golden_integration_test.go
+++ b/internal/engine/golden_integration_test.go
@@ -5,11 +5,13 @@
 // down by hand.
 //
 // Every case bills March 2026, [2026-03-01T00:00:00Z, 2026-04-01T00:00:00Z),
-// which is the period README section 3.4 computes its examples over. The
-// expectations come from that section and from pricing/2026-03.yaml, never from
-// a previous run: a failure here is a report about the engine, so the answer to
-// one is to find what changed in the engine, not to write the engine's new
-// number into expected.json.
+// which is the period README section 3.4 computes its examples over, and the
+// temporal case bills the April after it as well. The expectations come from
+// that section, from WP 5.6 of roadmap/05-phase-5-commercial-pricing.md (the
+// commercial cases) and from pricing/2026-03.yaml, never from a previous run:
+// a failure here is a report about the engine, so the answer to one is to find
+// what changed in the engine, not to write the engine's new number into
+// expected.json.
 package engine_test
 
 import (
@@ -1347,15 +1349,15 @@ func goldenTemporal(t *testing.T, f goldenFixture) {
 	}
 }
 
-// goldenPhase3Regression is the sixth row of the phase's exit criteria: a graph
-// whose relations carry no adjustment leaves every statement at the bytes Phase
-// 3 rendered. "Byte-identical to the Phase 3 goldens" is proven here as byte
-// equality between two runs over the virtual_relations case, whose managed_by
-// and member_of edges hold no pricing_adjustments: one run with the adjustment
-// walk on, the defaults every case of the loop runs with, and one with it off,
-// which is the render path Phase 3 shipped. Without a relation type to walk,
-// runs.produce builds no adjuster and statements.Build renders the document
-// without one.
+// goldenPhase3Regression is the sixth row of WP 5.6, the phase's golden suite
+// table: a graph whose relations carry no adjustment leaves every statement at
+// the bytes Phase 3 rendered. "Byte-identical to the Phase 3 goldens" is proven
+// here as byte equality between two runs over the virtual_relations case, whose
+// managed_by and member_of edges hold no pricing_adjustments: one run with the
+// adjustment walk on, the defaults every case of the loop runs with, and one
+// with it off, which is the render path Phase 3 shipped. Without a relation
+// type to walk, runs.produce builds no adjuster and statements.Build renders
+// the document without one.
 //
 // Two runs that agree with each other and with nothing else would agree on the
 // wrong document, so both are also held to that case's expected.json, which

--- a/internal/engine/golden_registry_test.go
+++ b/internal/engine/golden_registry_test.go
@@ -1,0 +1,98 @@
+// The Reporting API the auditability drill walks. It is built in process over
+// the case's reporting database, through the real router, in enforced auth mode
+// with a seeded read_all token. No socket is opened: the requests go through
+// handler.ServeHTTP on a recorder, so what the drill reads has passed the
+// contract validator, the auth guard and the handlers, and the answer is the
+// one an operator asking the same question would get.
+package engine_test
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/b42labs/tally/internal/reporting/auth"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+	"github.com/b42labs/tally/internal/reporting/ingest"
+	"github.com/b42labs/tally/internal/reporting/reconciliation"
+	"github.com/b42labs/tally/internal/reporting/registry"
+	reportingsqlcgen "github.com/b42labs/tally/internal/reporting/store/sqlcgen"
+)
+
+// registryAPI is the API one drill reads the registry through: the router it
+// serves with, and the token it presents.
+type registryAPI struct {
+	handler http.Handler
+	token   string
+}
+
+// newRegistryAPI assembles the router over the case's reporting database and
+// issues the query token the drill reads with.
+func newRegistryAPI(t *testing.T, dbs caseDBs) registryAPI {
+	t.Helper()
+
+	q := reportingsqlcgen.New(dbs.reporting)
+
+	handler, err := httpapi.NewRouter(httpapi.Options{
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DB:                       dbs.reportingStore,
+		UnhealthyThreshold:       time.Minute,
+		Queries:                  q,
+		Store:                    dbs.reportingStore,
+		AuthMode:                 auth.ModeEnforced,
+		InternalToken:            "golden-internal-token",
+		Authenticator:            auth.NewStaticTokenAuthenticator(q),
+		Pipeline:                 ingest.New(registry.New(), false, nil, nil),
+		AttributingRelationTypes: attributingRelationTypes,
+		Syncer: reconciliation.New(dbs.reportingStore, ingest.New(registry.New(), false, nil, nil),
+			reconciliation.Config{}, map[string]reconciliation.Adapter{}, time.Now, nil),
+	})
+	if err != nil {
+		t.Fatalf("httpapi.NewRouter: %v", err)
+	}
+
+	token, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("generating the api token: %v", err)
+	}
+	// project_ids is NOT NULL, so a token that names no project carries an empty
+	// array rather than a nil slice, which pgx would send as NULL.
+	if _, err := q.CreateAPIToken(t.Context(), reportingsqlcgen.CreateAPITokenParams{
+		TokenHash:   auth.HashToken(token),
+		Role:        string(auth.RoleReadAll),
+		ProjectIds:  []uuid.UUID{},
+		Description: pgtype.Text{String: "golden auditability drill", Valid: true},
+	}); err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	return registryAPI{handler: handler, token: token}
+}
+
+// get reads one endpoint into v. A path-only target routes because the contract
+// declares no servers, so the drill names the paths the way the contract does.
+// A status other than 200 is a finding about the walk rather than a decoding
+// problem, so it fails naming the target, the status and the body the API
+// answered with.
+func (api registryAPI) get(t *testing.T, target string, into any) {
+	t.Helper()
+
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	r.Header.Set("Authorization", "Bearer "+api.token)
+	rec := httptest.NewRecorder()
+	api.handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", target, rec.Code, rec.Body)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), into); err != nil {
+		t.Fatalf("decoding the answer of GET %s: %v", target, err)
+	}
+}

--- a/internal/engine/testdata/golden/inherited_member_discount/events.json
+++ b/internal/engine/testdata/golden/inherited_member_discount/events.json
@@ -1,0 +1,47 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-alpha-1",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-member",
+      "resource_type": "instance",
+      "resource_id": "i-alpha-1",
+      "project_id": "proj-alpha-1",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    },
+    {
+      "event_id": "ev-create-i-alpha-2",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-member",
+      "resource_type": "instance",
+      "resource_id": "i-alpha-2",
+      "project_id": "proj-alpha-2",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 2, "ram_gb": 4, "disk_gb": 40, "flavor": "m1.medium"}
+      }
+    },
+    {
+      "event_id": "ev-create-i-beta",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-member",
+      "resource_type": "instance",
+      "resource_id": "i-beta",
+      "project_id": "proj-beta",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 1, "ram_gb": 2, "disk_gb": 20, "flavor": "m1.small"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/inherited_member_discount/expected.json
+++ b/internal/engine/testdata/golden/inherited_member_discount/expected.json
@@ -1,0 +1,206 @@
+{
+  "clouds": ["os-golden-member"],
+  "stats": {"candidates": 3, "usage_records": 3, "rated_records": 12, "statements": 3, "adjustment_records": 4},
+  "usage": [
+    {
+      "cloud": "os-golden-member",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-alpha-1",
+      "project_id": "proj-alpha-1",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {
+        "minutes": "44640",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large"
+      }
+    },
+    {
+      "cloud": "os-golden-member",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-alpha-2",
+      "project_id": "proj-alpha-2",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {
+        "minutes": "44640",
+        "count": "1",
+        "vcpus": "2",
+        "ram_gb": "4",
+        "disk_gb": "40",
+        "flavor": "m1.medium"
+      }
+    },
+    {
+      "cloud": "os-golden-member",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-beta",
+      "project_id": "proj-beta",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {
+        "minutes": "44640",
+        "count": "1",
+        "vcpus": "1",
+        "ram_gb": "2",
+        "disk_gb": "20",
+        "flavor": "m1.small"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-1", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "59.52"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-1", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "29.76"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-1", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "59.52"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-1", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-2", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "2", "amount": "29.76"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-2", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "4", "amount": "14.88"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-2", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "40", "amount": "29.76"},
+    {"cloud": "os-golden-member", "resource_id": "i-alpha-2", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"},
+    {"cloud": "os-golden-member", "resource_id": "i-beta", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "1", "amount": "14.88"},
+    {"cloud": "os-golden-member", "resource_id": "i-beta", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "2", "amount": "7.44"},
+    {"cloud": "os-golden-member", "resource_id": "i-beta", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "20", "amount": "14.88"},
+    {"cloud": "os-golden-member", "resource_id": "i-beta", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-member/proj-alpha-1",
+      "total": "141.36",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-alpha-1",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-alpha-1",
+          "total": "148.80",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "744.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "0"},
+              "cost": {"vcpus": "59.52", "ram_gb": "29.76", "disk_gb": "59.52", "egress_gb": "0.00", "total": "148.80"}
+            }
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "148.80",
+      "adjustments": [
+        {
+          "type": "project_discount",
+          "relation": 0,
+          "relation_type": "member_of",
+          "relation_target": "customer-alpha",
+          "scope": "all",
+          "description": "Customer Alpha group discount",
+          "rate": "0.05",
+          "base": "148.80",
+          "amount": "-7.44"
+        },
+        {
+          "type": "kickback",
+          "relation": 2,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "description": "Partner commission on the Customer Alpha group",
+          "rate": "0.10",
+          "base": "141.36",
+          "amount": "14.14"
+        }
+      ],
+      "net_cost": "141.36",
+      "kickback_total": "14.14"
+    },
+    {
+      "key": "os-golden-member/proj-alpha-2",
+      "total": "70.68",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-alpha-2",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-alpha-2",
+          "total": "74.40",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "744.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "2", "ram_gb": "4", "disk_gb": "40", "egress_gb": "0"},
+              "cost": {"vcpus": "29.76", "ram_gb": "14.88", "disk_gb": "29.76", "egress_gb": "0.00", "total": "74.40"}
+            }
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "74.40",
+      "adjustments": [
+        {
+          "type": "project_discount",
+          "relation": 1,
+          "relation_type": "member_of",
+          "relation_target": "customer-alpha",
+          "scope": "all",
+          "description": "Customer Alpha group discount",
+          "rate": "0.05",
+          "base": "74.40",
+          "amount": "-3.72"
+        },
+        {
+          "type": "kickback",
+          "relation": 2,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "description": "Partner commission on the Customer Alpha group",
+          "rate": "0.10",
+          "base": "70.68",
+          "amount": "7.07"
+        }
+      ],
+      "net_cost": "70.68",
+      "kickback_total": "7.07"
+    },
+    {
+      "key": "os-golden-member/proj-beta",
+      "total": "37.20",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-beta",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-beta",
+          "total": "37.20",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "744.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "1", "ram_gb": "2", "disk_gb": "20", "egress_gb": "0"},
+              "cost": {"vcpus": "14.88", "ram_gb": "7.44", "disk_gb": "14.88", "egress_gb": "0.00", "total": "37.20"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": ["meta/customer-alpha", "partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/inherited_member_discount/registry.json
+++ b/internal/engine/testdata/golden/inherited_member_discount/registry.json
@@ -1,0 +1,47 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-member", "external_id": "proj-alpha-1"},
+    {"platform": "openstack", "cloud": "os-golden-member", "external_id": "proj-alpha-2"},
+    {"platform": "openstack", "cloud": "os-golden-member", "external_id": "proj-beta"},
+    {"platform": "meta", "cloud": "meta", "external_id": "customer-alpha"},
+    {"platform": "partner", "cloud": "partner", "external_id": "partner-corp"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "os-golden-member", "external_id": "proj-alpha-1"},
+      "target": {"cloud": "meta", "external_id": "customer-alpha"},
+      "relation_type": "member_of",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "project_discount", "rate": "0.05", "scope": "all", "description": "Customer Alpha group discount"}
+        ]
+      }
+    },
+    {
+      "source": {"cloud": "os-golden-member", "external_id": "proj-alpha-2"},
+      "target": {"cloud": "meta", "external_id": "customer-alpha"},
+      "relation_type": "member_of",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "project_discount", "rate": "0.05", "scope": "all", "description": "Customer Alpha group discount"}
+        ]
+      }
+    },
+    {
+      "source": {"cloud": "meta", "external_id": "customer-alpha"},
+      "target": {"cloud": "partner", "external_id": "partner-corp"},
+      "relation_type": "managed_by",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "kickback", "rate": "0.10", "scope": "all", "description": "Partner commission on the Customer Alpha group"}
+        ]
+      }
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/order_and_stacking/events.json
+++ b/internal/engine/testdata/golden/order_and_stacking/events.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-stacking",
+      "timestamp": "2026-03-11T04:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-stacking",
+      "resource_type": "instance",
+      "resource_id": "i-stacking",
+      "project_id": "proj-stacking",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 50, "ram_gb": 100, "disk_gb": 500, "flavor": "m1.golden"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/order_and_stacking/expected.json
+++ b/internal/engine/testdata/golden/order_and_stacking/expected.json
@@ -1,0 +1,94 @@
+{
+  "clouds": ["os-golden-stacking"],
+  "stats": {"candidates": 1, "usage_records": 1, "rated_records": 4, "statements": 1, "adjustment_records": 3},
+  "usage": [
+    {
+      "cloud": "os-golden-stacking",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-stacking",
+      "project_id": "proj-stacking",
+      "state": "active",
+      "from": "2026-03-11T04:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1800000,
+      "usage": {
+        "minutes": "30000",
+        "count": "1",
+        "vcpus": "50",
+        "ram_gb": "100",
+        "disk_gb": "500",
+        "flavor": "m1.golden"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-stacking", "resource_id": "i-stacking", "from": "2026-03-11T04:00:00Z", "dimension": "vcpus", "quantity": "50", "amount": "500.00"},
+    {"cloud": "os-golden-stacking", "resource_id": "i-stacking", "from": "2026-03-11T04:00:00Z", "dimension": "ram_gb", "quantity": "100", "amount": "250.00"},
+    {"cloud": "os-golden-stacking", "resource_id": "i-stacking", "from": "2026-03-11T04:00:00Z", "dimension": "disk_gb", "quantity": "500", "amount": "250.00"},
+    {"cloud": "os-golden-stacking", "resource_id": "i-stacking", "from": "2026-03-11T04:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-stacking/proj-stacking",
+      "total": "935.00",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-stacking",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-stacking",
+          "total": "1000.00",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "500.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "50", "ram_gb": "100", "disk_gb": "500", "egress_gb": "0"},
+              "cost": {"vcpus": "500.00", "ram_gb": "250.00", "disk_gb": "250.00", "egress_gb": "0.00", "total": "1000.00"}
+            }
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "1000.00",
+      "adjustments": [
+        {
+          "type": "surcharge",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "description": "Managed-service markup",
+          "rate": "0.10",
+          "base": "1000.00",
+          "amount": "100.00"
+        },
+        {
+          "type": "discount",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "rate": "0.15",
+          "base": "1100.00",
+          "amount": "-165.00"
+        },
+        {
+          "type": "kickback",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "rate": "0.10",
+          "base": "935.00",
+          "amount": "93.50"
+        }
+      ],
+      "net_cost": "935.00",
+      "kickback_total": "93.50"
+    }
+  ],
+  "absent_statements": ["partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/order_and_stacking/registry.json
+++ b/internal/engine/testdata/golden/order_and_stacking/registry.json
@@ -1,0 +1,22 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-stacking", "external_id": "proj-stacking"},
+    {"platform": "partner", "cloud": "partner", "external_id": "partner-corp"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "os-golden-stacking", "external_id": "proj-stacking"},
+      "target": {"cloud": "partner", "external_id": "partner-corp"},
+      "relation_type": "managed_by",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "kickback", "rate": "0.10", "scope": "all"},
+          {"type": "discount", "rate": "0.15", "scope": "all"},
+          {"type": "surcharge", "rate": "0.10", "scope": "all", "description": "Managed-service markup"}
+        ]
+      }
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/reseller/events.json
+++ b/internal/engine/testdata/golden/reseller/events.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-reseller",
+      "timestamp": "2026-03-07T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-reseller",
+      "resource_type": "instance",
+      "resource_id": "i-reseller",
+      "project_id": "customer-proj-1",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 50, "ram_gb": 100, "disk_gb": 500, "flavor": "m1.golden"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/reseller/expected.json
+++ b/internal/engine/testdata/golden/reseller/expected.json
@@ -1,0 +1,85 @@
+{
+  "clouds": ["os-golden-reseller"],
+  "stats": {"candidates": 1, "usage_records": 1, "rated_records": 4, "statements": 1, "adjustment_records": 2},
+  "usage": [
+    {
+      "cloud": "os-golden-reseller",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-reseller",
+      "project_id": "customer-proj-1",
+      "state": "active",
+      "from": "2026-03-07T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2160000,
+      "usage": {
+        "minutes": "36000",
+        "count": "1",
+        "vcpus": "50",
+        "ram_gb": "100",
+        "disk_gb": "500",
+        "flavor": "m1.golden"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-reseller", "resource_id": "i-reseller", "from": "2026-03-07T00:00:00Z", "dimension": "vcpus", "quantity": "50", "amount": "600.00"},
+    {"cloud": "os-golden-reseller", "resource_id": "i-reseller", "from": "2026-03-07T00:00:00Z", "dimension": "ram_gb", "quantity": "100", "amount": "300.00"},
+    {"cloud": "os-golden-reseller", "resource_id": "i-reseller", "from": "2026-03-07T00:00:00Z", "dimension": "disk_gb", "quantity": "500", "amount": "300.00"},
+    {"cloud": "os-golden-reseller", "resource_id": "i-reseller", "from": "2026-03-07T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-reseller/customer-proj-1",
+      "total": "1020.00",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "customer-proj-1",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-reseller",
+          "total": "1200.00",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "600.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "50", "ram_gb": "100", "disk_gb": "500", "egress_gb": "0"},
+              "cost": {"vcpus": "600.00", "ram_gb": "300.00", "disk_gb": "300.00", "egress_gb": "0.00", "total": "1200.00"}
+            }
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "1200.00",
+      "adjustments": [
+        {
+          "type": "discount",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "description": "Reseller end-customer discount",
+          "rate": "0.15",
+          "base": "1200.00",
+          "amount": "-180.00"
+        },
+        {
+          "type": "kickback",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "description": "Reseller commission on net revenue",
+          "rate": "0.10",
+          "base": "1020.00",
+          "amount": "102.00"
+        }
+      ],
+      "net_cost": "1020.00",
+      "kickback_total": "102.00"
+    }
+  ],
+  "absent_statements": ["partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/reseller/late.json
+++ b/internal/engine/testdata/golden/reseller/late.json
@@ -1,0 +1,27 @@
+{
+  "events": [
+    {
+      "event_id": "ev-late-off-i-reseller",
+      "timestamp": "2026-03-17T00:00:00Z",
+      "event_type": "compute.instance.power_off.end",
+      "platform": "openstack",
+      "cloud": "os-golden-reseller",
+      "resource_type": "instance",
+      "resource_id": "i-reseller",
+      "project_id": "customer-proj-1",
+      "payload": {"state": "shutoff"}
+    },
+    {
+      "event_id": "ev-late-on-i-reseller",
+      "timestamp": "2026-03-22T00:00:00Z",
+      "event_type": "compute.instance.power_on.end",
+      "platform": "openstack",
+      "cloud": "os-golden-reseller",
+      "resource_type": "instance",
+      "resource_id": "i-reseller",
+      "project_id": "customer-proj-1",
+      "payload": {"state": "active"}
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/reseller/registry.json
+++ b/internal/engine/testdata/golden/reseller/registry.json
@@ -1,0 +1,21 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-reseller", "external_id": "customer-proj-1"},
+    {"platform": "partner", "cloud": "partner", "external_id": "partner-corp"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "os-golden-reseller", "external_id": "customer-proj-1"},
+      "target": {"cloud": "partner", "external_id": "partner-corp"},
+      "relation_type": "managed_by",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "discount", "description": "Reseller end-customer discount", "rate": "0.15", "scope": "all"},
+          {"type": "kickback", "description": "Reseller commission on net revenue", "rate": "0.10", "scope": "all"}
+        ]
+      }
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/scoped_discount/events.json
+++ b/internal/engine/testdata/golden/scoped_discount/events.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-scoped",
+      "timestamp": "2026-03-11T04:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-scoped",
+      "resource_type": "instance",
+      "resource_id": "i-scoped",
+      "project_id": "proj-scoped",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    },
+    {
+      "event_id": "ev-create-vol-scoped",
+      "timestamp": "2026-03-11T04:00:00Z",
+      "event_type": "volume.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-scoped",
+      "resource_type": "volume",
+      "resource_id": "vol-scoped",
+      "project_id": "proj-scoped",
+      "payload": {
+        "state": "in-use",
+        "size": {"size_gb": 1000, "type": "ssd"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/scoped_discount/expected.json
+++ b/internal/engine/testdata/golden/scoped_discount/expected.json
@@ -1,0 +1,93 @@
+{
+  "clouds": ["os-golden-scoped"],
+  "stats": {"candidates": 2, "usage_records": 2, "rated_records": 5, "statements": 1, "adjustment_records": 1},
+  "usage": [
+    {
+      "cloud": "os-golden-scoped",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-scoped",
+      "project_id": "proj-scoped",
+      "state": "active",
+      "from": "2026-03-11T04:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1800000,
+      "usage": {
+        "minutes": "30000",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large"
+      }
+    },
+    {
+      "cloud": "os-golden-scoped",
+      "platform": "openstack",
+      "resource_type": "volume",
+      "resource_id": "vol-scoped",
+      "project_id": "proj-scoped",
+      "state": "in-use",
+      "from": "2026-03-11T04:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 1800000,
+      "usage": {"minutes": "30000", "count": "1", "size_gb": "1000", "type": "ssd"}
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-scoped", "resource_id": "i-scoped", "from": "2026-03-11T04:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "40.00"},
+    {"cloud": "os-golden-scoped", "resource_id": "i-scoped", "from": "2026-03-11T04:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "20.00"},
+    {"cloud": "os-golden-scoped", "resource_id": "i-scoped", "from": "2026-03-11T04:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "40.00"},
+    {"cloud": "os-golden-scoped", "resource_id": "i-scoped", "from": "2026-03-11T04:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"},
+    {"cloud": "os-golden-scoped", "resource_id": "vol-scoped", "from": "2026-03-11T04:00:00Z", "dimension": "size_gb", "quantity": "1000", "amount": "50.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-scoped/proj-scoped",
+      "total": "130.00",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-scoped",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-scoped",
+          "total": "100.00",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "500.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "0"},
+              "cost": {"vcpus": "40.00", "ram_gb": "20.00", "disk_gb": "40.00", "egress_gb": "0.00", "total": "100.00"}
+            }
+          ]
+        },
+        {
+          "resource_id": "vol-scoped",
+          "total": "50.00",
+          "periods": [
+            {"state": "in-use", "hours": "500.00", "state_modifier": "1", "usage": {"size_gb": "1000"}, "cost": {"size_gb": "50.00", "total": "50.00"}}
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "150.00",
+      "adjustments": [
+        {
+          "type": "discount",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "openstack.instance",
+          "rate": "0.20",
+          "base": "100.00",
+          "amount": "-20.00"
+        }
+      ],
+      "net_cost": "130.00",
+      "kickback_total": "0.00"
+    }
+  ],
+  "absent_statements": ["partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/scoped_discount/registry.json
+++ b/internal/engine/testdata/golden/scoped_discount/registry.json
@@ -1,0 +1,20 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-scoped", "external_id": "proj-scoped"},
+    {"platform": "partner", "cloud": "partner", "external_id": "partner-corp"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "os-golden-scoped", "external_id": "proj-scoped"},
+      "target": {"cloud": "partner", "external_id": "partner-corp"},
+      "relation_type": "managed_by",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": null,
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "discount", "rate": "0.20", "scope": "openstack.instance"}
+        ]
+      }
+    }
+  ]
+}

--- a/internal/engine/testdata/golden/temporal/events.json
+++ b/internal/engine/testdata/golden/temporal/events.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "event_id": "ev-create-i-temporal",
+      "timestamp": "2026-02-10T00:00:00Z",
+      "event_type": "compute.instance.create.end",
+      "platform": "openstack",
+      "cloud": "os-golden-temporal",
+      "resource_type": "instance",
+      "resource_id": "i-temporal",
+      "project_id": "proj-temporal",
+      "payload": {
+        "state": "active",
+        "size": {"vcpus": 4, "ram_gb": 8, "disk_gb": 80, "flavor": "m1.large"}
+      }
+    }
+  ],
+  "bulk": []
+}

--- a/internal/engine/testdata/golden/temporal/expected.json
+++ b/internal/engine/testdata/golden/temporal/expected.json
@@ -1,0 +1,73 @@
+{
+  "clouds": ["os-golden-temporal"],
+  "stats": {"candidates": 1, "usage_records": 1, "rated_records": 4, "statements": 1, "adjustment_records": 1},
+  "usage": [
+    {
+      "cloud": "os-golden-temporal",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-temporal",
+      "project_id": "proj-temporal",
+      "state": "active",
+      "from": "2026-03-01T00:00:00Z",
+      "to": "2026-04-01T00:00:00Z",
+      "seconds": 2678400,
+      "usage": {
+        "minutes": "44640",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-03-01T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "59.52"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-03-01T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "29.76"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-03-01T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "59.52"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-03-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-temporal/proj-temporal",
+      "total": "126.48",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+      "project_id": "proj-temporal",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-temporal",
+          "total": "148.80",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "744.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "0"},
+              "cost": {"vcpus": "59.52", "ram_gb": "29.76", "disk_gb": "59.52", "egress_gb": "0.00", "total": "148.80"}
+            }
+          ]
+        }
+      ],
+      "related_costs": [],
+      "base_cost": "148.80",
+      "adjustments": [
+        {
+          "type": "discount",
+          "relation": 0,
+          "relation_type": "managed_by",
+          "relation_target": "partner-corp",
+          "scope": "all",
+          "rate": "0.15",
+          "base": "148.80",
+          "amount": "-22.32"
+        }
+      ],
+      "net_cost": "126.48",
+      "kickback_total": "0.00"
+    }
+  ],
+  "absent_statements": ["partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/temporal/expected_april.json
+++ b/internal/engine/testdata/golden/temporal/expected_april.json
@@ -1,0 +1,58 @@
+{
+  "clouds": ["os-golden-temporal"],
+  "stats": {"candidates": 1, "usage_records": 1, "rated_records": 4, "statements": 1, "adjustment_records": 0},
+  "usage": [
+    {
+      "cloud": "os-golden-temporal",
+      "platform": "openstack",
+      "resource_type": "instance",
+      "resource_id": "i-temporal",
+      "project_id": "proj-temporal",
+      "state": "active",
+      "from": "2026-04-01T00:00:00Z",
+      "to": "2026-05-01T00:00:00Z",
+      "seconds": 2592000,
+      "usage": {
+        "minutes": "43200",
+        "count": "1",
+        "vcpus": "4",
+        "ram_gb": "8",
+        "disk_gb": "80",
+        "flavor": "m1.large"
+      }
+    }
+  ],
+  "rated": [
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-04-01T00:00:00Z", "dimension": "vcpus", "quantity": "4", "amount": "57.60"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-04-01T00:00:00Z", "dimension": "ram_gb", "quantity": "8", "amount": "28.80"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-04-01T00:00:00Z", "dimension": "disk_gb", "quantity": "80", "amount": "57.60"},
+    {"cloud": "os-golden-temporal", "resource_id": "i-temporal", "from": "2026-04-01T00:00:00Z", "dimension": "egress_gb", "quantity": "0", "amount": "0.00"}
+  ],
+  "statements": [
+    {
+      "key": "os-golden-temporal/proj-temporal",
+      "total": "144.00",
+      "currency": "EUR",
+      "billing_period": {"from": "2026-04-01T00:00:00Z", "to": "2026-05-01T00:00:00Z"},
+      "project_id": "proj-temporal",
+      "platform": "openstack",
+      "line_items": [
+        {
+          "resource_id": "i-temporal",
+          "total": "144.00",
+          "periods": [
+            {
+              "state": "active",
+              "hours": "720.00",
+              "state_modifier": "1",
+              "usage": {"vcpus": "4", "ram_gb": "8", "disk_gb": "80", "egress_gb": "0"},
+              "cost": {"vcpus": "57.60", "ram_gb": "28.80", "disk_gb": "57.60", "egress_gb": "0.00", "total": "144.00"}
+            }
+          ]
+        }
+      ],
+      "related_costs": []
+    }
+  ],
+  "absent_statements": ["partner/partner-corp"]
+}

--- a/internal/engine/testdata/golden/temporal/registry.json
+++ b/internal/engine/testdata/golden/temporal/registry.json
@@ -1,0 +1,20 @@
+{
+  "projects": [
+    {"platform": "openstack", "cloud": "os-golden-temporal", "external_id": "proj-temporal"},
+    {"platform": "partner", "cloud": "partner", "external_id": "partner-corp"}
+  ],
+  "relations": [
+    {
+      "source": {"cloud": "os-golden-temporal", "external_id": "proj-temporal"},
+      "target": {"cloud": "partner", "external_id": "partner-corp"},
+      "relation_type": "managed_by",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_to": "2026-03-15T00:00:00Z",
+      "metadata": {
+        "pricing_adjustments": [
+          {"type": "discount", "rate": "0.15", "scope": "all"}
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #59

The Phase 5 gate: WP 5.6 of `roadmap/05-phase-5-commercial-pricing.md` and the phase's four exit criteria, added to the engine's golden suite. Test code and JSON fixtures only — `git diff --name-status` touches `internal/engine/golden_fixture_test.go`, `internal/engine/golden_integration_test.go`, the new `internal/engine/golden_registry_test.go` and five new directories under `internal/engine/testdata/golden/`. No engine package, no Reporting API, no `api/`, `roadmap/` or `docs/` file changes, and no fixture that existed before this branch is modified.

## The change set, in commit order

**`98ac5f1` Seed relation metadata and return the registry ids in the golden suite**
`registryRelation` gains a `metadata` document, seeded verbatim where a fixture holds one and as `{}` otherwise. A non-empty document is held to the adjustments schema with `adjustment.ValidateMetadata` before the insert, the way the Reporting API holds one it is posted — a fixture that goes around the API by raw SQL cannot seed adjustments the API would refuse. `seedRegistry` now returns `seededRegistry{projects, relations}`, the relation ids read back with `RETURNING id` in the order of `registry.json`, because an `expected.json` can only name a relation by that index: the id does not exist until the seeding assigns it.

**`bc505fb` Read adjustment members and records from a golden expected.json**
`expectedStats` gains `adjustment_records`, `expectedStatement` gains `base_cost`, `adjustments`, `net_cost` and `kickback_total`, and the new `expectedAdjustment` describes one line. `assertAdjustments` holds a document to them: a statement without `base_cost` must carry none of the four members (what the Phase 3 cases assert), and one with it is checked line by line, its `total` against its `net_cost`, and both totals against the lines they are the sum of (decision D7). `loadExpectedFile` reads an expectations file by name so a case that runs two passes can hold each in a file of its own; `loadExpected` keeps reading `expected.json`. The twelve existing `expected.json` files are unchanged — a nil `base_cost` and an absent `adjustment_records` are the Phase 3 shape.

**`47c7045` Check the adjustment records and kickbacks of a golden run**
A statement document shows what a customer pays; what a partner is paid is a sum over the `adjustment_records` rows. `readAdjustmentRecords` reads a run's rows back with the numbers as text, `expectedRecords` derives the rows the expected statements describe, and `assertAdjustmentRecords` compares in both directions — a stored row no expectation names is a finding the way a missing one is. `assertKickbacks` does the same for the settlement the export carries. `TestGoldenAdjustmentExpectations` pins both derivations without a database.

**`c390fe9` Add the four Phase 5 golden cases of the loop**
`reseller` is the example of README section 3.4 (discount 0.15, commission 0.10 on one `managed_by` edge, base 1200.00). `scoped_discount` holds a discount scoped to `openstack.instance` against a project that also runs a volume, so the volume is billed at its full 50.00. `inherited_member_discount` is the pattern of `docs/group-discounts.md`: two members inherit the meta-project's `project_discount` over `member_of`, the partner managing the meta-project earns a commission on each member's net cost, and a third project outside the group is billed unadjusted — the two commissions (14.136 → 14.14, 7.068 → 7.07) are what pin the half-up rounding. `order_and_stacking` lists its adjustments as kickback, discount, surcharge and expects them applied as surcharge, discount, kickback (decision D3).

**`e063983` Add the temporal golden case over March and April**
One instance billed over two months across a relation closing on 2026-03-15. Per decision D4 the edge applies to March whole and to April not at all; the day it closed on does not prorate the month. It is a subtest of its own rather than a row of the loop, whose period constants are March.

**`bd07e8e` Add the phase3_regression golden case**
Byte equality between two runs over the existing `virtual_relations` case, whose edges carry no `pricing_adjustments`: one with the adjustment walk on and one with it off, the second being the render path Phase 3 shipped. Both runs are also held to that case's `expected.json` — two runs that agree with each other and with nothing else would agree on the wrong document.

**`d4bbb45` Add the adjusted reproducibility drill** (exit criterion 2)
Meters `inherited_member_discount` twice in databases of its own and compares the invoice down to the bytes of the three exported statement documents, the `adjustment_records` rows a payout is summed from, and `kickbacks.json` / `kickbacks.csv` with each run's id replaced by a placeholder. It reads the settlement back as well: one beneficiary, 21.21 over two projects. The commit's deletions are the extraction of `assertSameStatements`, now shared with `goldenReproducibility`; the first run is held to the case's `expected.json` whole, so the drill cannot be reproducibly wrong.

**`aa32311` Add the registry API helper and the auditability drill** (exit criterion 3)
Walks `adjustment_records.relation_id` back to the relation and its metadata through the registry API, so "why does this project get 15 % off?" is answerable from data alone. The new `golden_registry_test.go` builds the real router over the case's reporting store in `auth.ModeEnforced` with a seeded `read_all` token, served through `handler.ServeHTTP` on a recorder rather than over a socket. The drill resolves each statement's project by cloud and external id, then finds the relation among that project's outgoing relations, once at the start of the billed period and once without `at`, and holds what comes back to the record: relation type, partner reached, seeded metadata, and the element the row's rate and scope were computed from.

**`67cbc2c` Add the adjusted correction drill** (exit criterion 4)
The reseller case is billed, finalized, reached by a power cycle arriving after the invoice, and corrected. The late events move the base, so the credit note and the partner's settlement follow the corrected usage rather than crediting the usage and leaving the commercial lines where the invoice put them: base 1080.00, discount -162.00, net 918.00, kickback 91.80, and as deltas -120.00 base, +18.00 discount, -102.00 net, -10.20 kickback. A second correction after the first is finalized finds nothing left to credit.

**`f7ab645` Name WP 5.6 in the golden suite's header comments**
Comment-only: the suite's headers name README section 3.4 and the WP 5.6 table as the sources of the commercial cases.

## Readings recorded per guardrail 10

Five readings of the roadmap were fixed when the issue was elaborated and the branch implements them as written:

1. The round bases the WP 5.6 table fixes (1200.00, 1000.00, 100.00, 50.00) cannot be rated over a whole March — a full-month `time_gauge` amount carries the factor 31 — so those cases create their resources inside March (at `2026-03-07T00:00:00Z` for 600 hours, `2026-03-11T04:00:00Z` for 500 hours). The cases whose bases the table leaves open (`inherited_member_discount`, `temporal`) bill the whole month.
2. "Depth 2" of the `inherited_member_discount` row is read as the two-level graph of `docs/group-discounts.md`: the `project_discount` on `member_of` at depth 1, the `kickback` on the meta-project's `managed_by` at depth 2. The kickback is what proves the walk crossed the meta-project.
3. "Byte-identical to the Phase 3 goldens" is proven as byte equality between the walk-on and walk-off runs over `virtual_relations`, per `bd07e8e` above.
4. The auditability drill walks the two list endpoints (`GET /api/v1/projects?cloud=&external_id=`, then `GET /api/v1/projects/{id}/relations?direction=outgoing&at=`) — the author's decision of 2026-08-31. The contract defines `patch` and `delete` but no `get` under `/api/v1/projects/{id}/relations/{relation_id}`, and no endpoint is added here.
5. `order_and_stacking` puts its three adjustments on one relation with the array in reverse application order, so the order the document shows is decided by D3 and not by the array. The loop carries a comment saying so, because tidying the fixture to match `expected.json` would leave the case passing without testing what it is named after.

Nothing else in the diff diverges from the issue: the six WP 5.6 cases, the three drills, the four helper boundaries and the registry helper are all present, and the non-goals (no new endpoint, no `roadmap/` or `docs/` edits, no CLI-driven cases, no rollup check) are respected.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 7ea363b with Claude:claude-opus-5_
