### PR TITLE
Emit traffic series and inventory metrics from the simulated cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMAGES := $(SERVICES) tally-openstack-collector tally-openstack-simulator
 SIM_IMAGES := tally-openstack-collector tally-openstack-simulator
 
 # The simulator stack, deploy/compose/compose.yaml: a broker, the collector, and
-# the simulator, run beside the dev cluster rather than in it. The seven SIM_
+# the simulator, run beside the dev cluster rather than in it. The ten SIM_
 # values below are what `simulator-up` writes into the .env file compose reads.
 # A factor of 744 puts a 31-day month on the bus in an hour.
 SIM_CLOUD ?= os-sim
@@ -60,6 +60,14 @@ SIM_REGISTER_PROJECTS ?= false
 # The cloud the two Gardener projects are registered under. It differs from
 # SIM_CLOUD because a cloud is one installation of one platform.
 SIM_GARDEN_CLOUD ?= garden-sim
+# The credential the OTLP endpoint of the dev Gateway asks for. The default
+# password is the literal the dev overlay generates into the tally-otlp-auth
+# secret (deploy/kubernetes/overlays/dev/kustomization.yaml).
+SIM_OTLP_USER ?= tally
+SIM_OTLP_PASSWORD ?= tally-dev-otlp-password
+# The grid the pushed traffic and inventory series lie on, which is the interval
+# Ceilometer polls at.
+SIM_METRICS_INTERVAL ?= 300s
 COMPOSE := docker compose -f deploy/compose/compose.yaml
 
 # Every kubectl call names the cluster explicitly. Creating a kind cluster
@@ -182,9 +190,10 @@ dev:
 # and written again under umask 077, because that api token writes the whole
 # registry and the default umask of a shell would leave it readable by every
 # other user of the machine, as would the mode of a file an earlier run left
-# behind. `tally-reporting-admin revoke-api-token <id>` is what ends it; the id
-# is the one the issuing line above prints, and `simulator-down` revokes
-# nothing.
+# behind. The OTLP password is a third credential the same file carries, and the
+# same umask covers it. `tally-reporting-admin revoke-api-token <id>` is what
+# ends it; the id is the one the issuing line above prints, and
+# `simulator-down` revokes nothing.
 ## simulator-up: run the simulator, the collector, and a broker against the dev cluster
 simulator-up:
 	@[ -n '$(SIM_PERIOD)' ] || { echo 'ERROR: set SIM_PERIOD to the past month to simulate, e.g. make simulator-up SIM_PERIOD=2026-07' >&2; exit 1; }
@@ -201,15 +210,18 @@ simulator-up:
 	fi; \
 	rm -f deploy/compose/.env; \
 	umask 077; \
-	printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_SIM_FAULTS=%s\nTALLY_SIM_REGISTER_PROJECTS=%s\nTALLY_SIM_GARDEN_CLOUD=%s\nTALLY_OSC_TOKEN=%s\nTALLY_SIM_API_TOKEN=%s\n' \
-		'$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' '$(SIM_FAULTS)' '$(SIM_REGISTER_PROJECTS)' '$(SIM_GARDEN_CLOUD)' "$$token" "$$api_token" > deploy/compose/.env
+	printf 'TALLY_SIM_CLOUD=%s\nTALLY_SIM_PERIOD=%s\nTALLY_SIM_SEED=%s\nTALLY_SIM_FACTOR=%s\nTALLY_SIM_FAULTS=%s\nTALLY_SIM_REGISTER_PROJECTS=%s\nTALLY_SIM_GARDEN_CLOUD=%s\nTALLY_OSC_TOKEN=%s\nTALLY_SIM_API_TOKEN=%s\nTALLY_SIM_OTLP_USER=%s\nTALLY_SIM_OTLP_PASSWORD=%s\nTALLY_SIM_METRICS_INTERVAL=%s\n' \
+		'$(SIM_CLOUD)' '$(SIM_PERIOD)' '$(SIM_SEED)' '$(SIM_FACTOR)' '$(SIM_FAULTS)' '$(SIM_REGISTER_PROJECTS)' '$(SIM_GARDEN_CLOUD)' "$$token" "$$api_token" '$(SIM_OTLP_USER)' '$(SIM_OTLP_PASSWORD)' '$(SIM_METRICS_INTERVAL)' > deploy/compose/.env
 	$(COMPOSE) up -d
 	@echo
 	@echo 'Simulator stack is up:'
-	@echo '  http://127.0.0.1:15672                          broker UI, guest/guest'
-	@echo '  http://127.0.0.1:8090/metrics                   collector'
-	@echo '  http://127.0.0.1:8091/clock                     simulator control'
-	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1  Reporting API'
+	@echo '  http://127.0.0.1:15672                               broker UI, guest/guest'
+	@echo '  http://127.0.0.1:8090/metrics                        collector'
+	@echo '  http://127.0.0.1:8091/clock                          simulator control'
+	@echo '  http://127.0.0.1:8091/metrics                        simulator inventory, the database exporter stand-in'
+	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1       Reporting API'
+	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics  OTLP endpoint the series are pushed to'
+	@echo '  https://vm.tally.127-0-0-1.nip.io:8443/targets       scrape targets'
 	@echo
 	@echo "Finish the month at once with:"
 	@echo "  curl -X PUT -d '{\"factor\": 0}' http://127.0.0.1:8091/clock"

--- a/cmd/tally-openstack-simulator/.env.example
+++ b/cmd/tally-openstack-simulator/.env.example
@@ -6,6 +6,7 @@
 # without the value appearing in a pod spec:
 # TALLY_SIM_AMQP_URL_FILE=/run/secrets/tally/amqp-url
 # TALLY_SIM_API_TOKEN_FILE=/run/secrets/tally/api-token
+# TALLY_SIM_OTLP_PASSWORD_FILE=/run/secrets/tally/otlp-password
 # Setting a secret and its *_FILE companion at the same time is an error.
 #
 # The simulator has three subcommands. run generates a month from a seed and
@@ -72,3 +73,39 @@ TALLY_SIM_API_TOKEN=
 # Gardener projects are not rows of the OpenStack installation their shoots run
 # on. Read with --register-projects alone.
 TALLY_SIM_GARDEN_CLOUD=
+
+# OTLP/HTTP endpoint the metrics of a month are pushed to. Empty by default,
+# which is a run without a push. When it is set, the traffic counters and the
+# inventory gauges go there as OTLP/HTTP JSON, each point stamped with the
+# virtual instant it belongs to; the compose stack sets the development
+# Gateway's https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics. It has to be
+# absolute and carry a host, and https unless TALLY_SIM_OTLP_INSECURE says
+# otherwise, because the Basic password below travels on it. It carries no
+# userinfo, no query and no fragment: the credential of a push belongs in the
+# two variables below, and one carried in the URL is handed to every error the
+# push writes. Read by run alone, and not by a run in file mode or by replay.
+TALLY_SIM_OTLP_URL=
+
+# Basic user the push authenticates with. Required as soon as the URL above is
+# set: the Gateway in front of the collector answers an unauthenticated push
+# with a 401.
+TALLY_SIM_OTLP_USER=
+
+# Basic password the push authenticates with. It is a secret, so it supports
+# TALLY_SIM_OTLP_PASSWORD_FILE, and setting both is an error. The development
+# overlay generates tally:tally-dev-otlp-password into the Secret
+# tally-otlp-auth.
+TALLY_SIM_OTLP_PASSWORD=
+
+# Allow a plaintext OTLP endpoint. The password above travels on every request,
+# so an http endpoint hands it to whoever reads the wire. Set this to true only
+# for a simulator and a collector on the same machine, such as the ones a
+# development stack runs.
+TALLY_SIM_OTLP_INSECURE=false
+
+# Serve the inventory on GET /metrics of the control port, where it stands in
+# for the OpenStack database exporter a real deployment scrapes. false registers
+# no route, and the path is then left to the fake OpenStack API, which answers
+# it with the 404 it answers any unknown path with. run serves the endpoint for
+# the length of the publishing, the way it serves the control routes.
+TALLY_METRICS_ENABLED=true

--- a/cmd/tally-openstack-simulator/commands.go
+++ b/cmd/tally-openstack-simulator/commands.go
@@ -18,6 +18,12 @@ import (
 // through.
 const defaultFactor = 744
 
+// defaultMetricsInterval is the grid a run samples its traffic counters and its
+// inventory on. It is the polling interval Ceilometer runs at out of the box,
+// which README section 4.1 names, so a simulated month carries as many points
+// per series as a real one.
+const defaultMetricsInterval = 300 * time.Second
+
 // defaultWaitForCollector is how long a run waits for the collector to appear
 // on its queue before it publishes. A topic exchange drops what no queue is
 // bound to, so a month published into an empty broker is a month lost; two
@@ -63,6 +69,11 @@ func newRunCmd() *cobra.Command {
 			if _, _, err := opts.Validate(); err != nil {
 				return err
 			}
+			// The push is checked before the broker is dialled too, the way the
+			// flags are: a whole month is posted to that endpoint.
+			if err := cfg.ValidateMetrics(); err != nil {
+				return fmt.Errorf("checking the configuration: %w", err)
+			}
 			// The switch is checked here too, so a missing token is reported before
 			// a broker is dialled, the way a mistyped period is.
 			if opts.RegisterProjects {
@@ -99,6 +110,9 @@ func newRunCmd() *cobra.Command {
 			"and held-back.jsonl when a switch holds notifications back")
 	cmd.Flags().DurationVar(&opts.WaitForCollector, "wait-for-collector", defaultWaitForCollector,
 		"how long to wait for a consumer on the collector's queue before publishing; 0 disables the wait")
+	cmd.Flags().DurationVar(&opts.MetricsInterval, "metrics-interval", defaultMetricsInterval,
+		"grid the traffic and inventory samples lie on, counted from the period start; "+
+			"whole seconds, at least 30s and at most 24h; 300s is the interval Ceilometer polls at")
 	cmd.Flags().StringSliceVar(&opts.Faults, "faults", nil,
 		"fault switches to turn on, comma-separated: "+strings.Join(simulator.FaultNames, ", ")+
 			"; every switch is off by default")

--- a/cmd/tally-openstack-simulator/main.go
+++ b/cmd/tally-openstack-simulator/main.go
@@ -18,6 +18,13 @@
 // whose metered intervals or quantities differ from the oracle; it exits 1 when
 // anything differs.
 //
+// A run pushes the month's traffic counters and inventory gauges to the
+// OTLP/HTTP endpoint TALLY_SIM_OTLP_URL names when it is set, on the same clock
+// the notifications go out under and on the --metrics-interval grid, and it
+// serves the inventory on GET /metrics of the control listener unless
+// TALLY_METRICS_ENABLED is false. A replay does neither: a recorded file holds
+// notifications and no oracle to read a metric off.
+//
 // The control endpoint on TALLY_SIM_HTTP_PORT changes the factor while a run
 // publishes, so a month that is going out too slowly is sped up without being
 // started over. POST /release on it publishes the notifications a run with the

--- a/cmd/tally-openstack-simulator/main_test.go
+++ b/cmd/tally-openstack-simulator/main_test.go
@@ -58,6 +58,11 @@ const closedRegistry = "https://127.0.0.1:1"
 // into.
 const testAPIToken = "tly_a_test"
 
+// testOTLPPassword is the Basic password of the push. The cases about the OTLP
+// configuration search their failure for it, for the reason the api token's
+// cases give: a message an operator pastes into a ticket carries no credential.
+const testOTLPPassword = "s3cret-of-the-test"
+
 // gardenCloud is the cloud the two Gardener projects are registered under. It
 // differs from simulatedCloud because a cloud is one installation of one
 // platform, and the registry keys a row by its cloud.
@@ -231,6 +236,33 @@ func TestRunWritesTheMonthInFileMode(t *testing.T) {
 		t.Errorf("oracle.json covers [%s, %s), want the [%s, %s) the run was given",
 			oracle.PeriodFrom.Format(time.RFC3339), oracle.PeriodTo.Format(time.RFC3339),
 			from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+
+	// The traffic a file-mode run records although it pushes nothing: one row
+	// per interval of every instance, ordered by resource id and then by from,
+	// which is the order the oracle states its rows in.
+	if len(oracle.Traffic) == 0 {
+		t.Error("oracle.json states no traffic row, want one per interval of every instance")
+	}
+	if !slices.IsSortedFunc(oracle.Traffic, func(a, b simulator.OracleTraffic) int {
+		if c := strings.Compare(a.ResourceID, b.ResourceID); c != 0 {
+			return c
+		}
+		return a.From.Compare(b.From)
+	}) {
+		t.Error("oracle.json states its traffic rows out of order, want them by resource id and then by from")
+	}
+	instances := make(map[string]bool)
+	for _, resource := range oracle.Resources {
+		if resource.ResourceType == "instance" {
+			instances[resource.ResourceID] = true
+		}
+	}
+	for _, row := range oracle.Traffic {
+		if !instances[row.ResourceID] {
+			t.Errorf("oracle.json states traffic for %q, want every row to name an instance it holds",
+				row.ResourceID)
+		}
 	}
 
 	skipped := nonBillableNotifications(t, 1, endedMonth, simulatedCloud)
@@ -542,6 +574,8 @@ func TestRunRefusesBadInput(t *testing.T) {
 	emptyURLFile := writeFile(t, t.TempDir(), "empty-amqp-url", "")
 	tokenFile := writeFile(t, t.TempDir(), "api-token", "tly_a_x\n")
 	emptyTokenFile := writeFile(t, t.TempDir(), "empty-api-token", "")
+	passwordFile := writeFile(t, t.TempDir(), "otlp-password", "pw\n")
+	emptyPasswordFile := writeFile(t, t.TempDir(), "empty-otlp-password", "")
 	// The output directory of the case about an unknown fault switch. It is held
 	// outside the case so the body can read it back: a refused switch has to end
 	// the run before the month is written.
@@ -549,6 +583,11 @@ func TestRunRefusesBadInput(t *testing.T) {
 	// The same for the case about a registry nothing listens on: a registration
 	// that fails ends the run before the month is written.
 	registerOut := t.TempDir()
+	// And for the two the metrics are refused by: the grid is checked with the
+	// other flags and the endpoint before the broker is dialled, so neither
+	// reaches the month either.
+	intervalOut := t.TempDir()
+	pushOut := t.TempDir()
 
 	for _, tc := range []struct {
 		name string
@@ -664,6 +703,83 @@ func TestRunRefusesBadInput(t *testing.T) {
 				"--out", t.TempDir(),
 			},
 			want: "--faults: pre-existing and missing-create exclude each other",
+		},
+		{
+			name: "a metrics interval of zero",
+			// The value is attached with =, for the reason the negative factor's
+			// case gives.
+			args:     []string{"--period", endedMonth, "--metrics-interval=0", "--out", intervalOut},
+			want:     "--metrics-interval: 0s must be a whole number of seconds between 30s and 24h0m0s",
+			emptyDir: intervalOut,
+		},
+		{
+			name: "a negative metrics interval",
+			args: []string{"--period", endedMonth, "--metrics-interval=-5m", "--out", t.TempDir()},
+			want: "--metrics-interval: -5m0s must be a whole number of seconds between 30s and 24h0m0s",
+		},
+		{
+			name: "a metrics interval that is not whole seconds",
+			args: []string{"--period", endedMonth, "--metrics-interval=1500ms", "--out", t.TempDir()},
+			want: "--metrics-interval: 1.5s must be a whole number of seconds between 30s and 24h0m0s",
+		},
+		{
+			// A month is placed whole before it is published, and a grid an order
+			// of magnitude below Ceilometer's is where that stops fitting into
+			// memory, so it is refused rather than started and killed.
+			name: "a metrics interval finer than the grid a month is placed on",
+			args: []string{"--period", endedMonth, "--metrics-interval=1s", "--out", t.TempDir()},
+			want: "--metrics-interval: 1s must be a whole number of seconds between 30s and 24h0m0s",
+		},
+		{
+			name: "a metrics interval longer than a day",
+			args: []string{"--period", endedMonth, "--metrics-interval=25h", "--out", t.TempDir()},
+			want: "--metrics-interval: 25h0m0s must be a whole number of seconds between 30s and 24h0m0s",
+		},
+		{
+			name: "a push without a user",
+			env:  map[string]string{"TALLY_SIM_OTLP_URL": "https://127.0.0.1:1/v1/metrics"},
+			args: []string{"--period", endedMonth, "--out", pushOut},
+			want: "checking the configuration: TALLY_SIM_OTLP_USER: " +
+				"must be set when TALLY_SIM_OTLP_URL is set",
+			emptyDir: pushOut,
+		},
+		{
+			name: "a push without a password",
+			env: map[string]string{
+				"TALLY_SIM_OTLP_URL":  "https://127.0.0.1:1/v1/metrics",
+				"TALLY_SIM_OTLP_USER": "tally",
+			},
+			args: []string{"--period", endedMonth, "--out", t.TempDir()},
+			want: "checking the configuration: TALLY_SIM_OTLP_PASSWORD: " +
+				"must be set when TALLY_SIM_OTLP_URL is set",
+		},
+		{
+			name: "a plaintext push nobody allowed",
+			env: map[string]string{
+				"TALLY_SIM_OTLP_URL":      "http://127.0.0.1:1/v1/metrics",
+				"TALLY_SIM_OTLP_USER":     "tally",
+				"TALLY_SIM_OTLP_PASSWORD": testOTLPPassword,
+			},
+			args:     []string{"--period", endedMonth, "--out", t.TempDir()},
+			contains: "TALLY_SIM_OTLP_INSECURE",
+			absent:   testOTLPPassword,
+		},
+		{
+			name: "an OTLP password given twice",
+			env: map[string]string{
+				"TALLY_SIM_OTLP_PASSWORD":      testOTLPPassword,
+				"TALLY_SIM_OTLP_PASSWORD_FILE": passwordFile,
+			},
+			args: []string{"--period", endedMonth, "--out", t.TempDir()},
+			want: "loading the configuration: set TALLY_SIM_OTLP_PASSWORD or " +
+				"TALLY_SIM_OTLP_PASSWORD_FILE, not both",
+			absent: testOTLPPassword,
+		},
+		{
+			name:     "an OTLP password file nobody filled",
+			env:      map[string]string{"TALLY_SIM_OTLP_PASSWORD_FILE": emptyPasswordFile},
+			args:     []string{"--period", endedMonth, "--out", t.TempDir()},
+			contains: fmt.Sprintf("TALLY_SIM_OTLP_PASSWORD_FILE: file %s is empty", emptyPasswordFile),
 		},
 		{
 			name: "a registration without a Reporting API",
@@ -792,6 +908,24 @@ func TestRunHelpListsTheFaultSwitches(t *testing.T) {
 		if !strings.Contains(stdout, name) {
 			t.Errorf("run --help does not name the fault switch %q, want all of %v listed",
 				name, simulator.FaultNames)
+		}
+	}
+}
+
+// TestRunHelpListsTheMetricsInterval holds the help of run to the grid the
+// metrics lie on and to the interval it takes when nobody names one. How many
+// points a month is pushed as follows from that grid, so an operator who has to
+// change it has to find it.
+func TestRunHelpListsTheMetricsInterval(t *testing.T) {
+	blankEnvironment(t)
+
+	stdout, stderr, err := runCLI(t, "run", "--help")
+	if err != nil {
+		t.Fatalf("run --help error = %v, want nil (stderr %q)", err, stderr)
+	}
+	for _, want := range []string{"--metrics-interval", "300s"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("run --help does not name %q, want it in the help of the flag", want)
 		}
 	}
 }

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -15,10 +15,11 @@
 #
 # The values interpolated below come from deploy/compose/.env, which
 # `make simulator-up` writes and git ignores. It carries the cloud, the period,
-# the seed, the factor, the fault switches, and the ingest token issued for that
-# cloud. It also carries the registry switch, the cloud the simulated Gardener
-# projects are registered under, and the admin api token that registers them,
-# which is the empty string unless the switch is on.
+# the seed, the factor, the fault switches, the OTLP user and password, the
+# metrics interval, and the ingest token issued for that cloud. It also carries
+# the registry switch, the cloud the simulated Gardener projects are registered
+# under, and the admin api token that registers them, which is the empty string
+# unless the switch is on.
 #
 # A named volume of one of these images belongs under /home/nonroot; the
 # collector's outbox below says why.
@@ -109,12 +110,28 @@ services:
       TALLY_SIM_API_TOKEN: ${TALLY_SIM_API_TOKEN}
       TALLY_SIM_GARDEN_CLOUD: ${TALLY_SIM_GARDEN_CLOUD}
       SSL_CERT_FILE: /etc/tally/tally-ca.crt
+      # The OTLP/HTTP route the dev Gateway publishes in front of the cluster's
+      # OpenTelemetry collector. The traffic counters and the inventory gauges
+      # of the month go there. The CA mounted below and SSL_CERT_FILE are what
+      # make the Gateway's certificate verify on this path too, and
+      # TALLY_SIM_OTLP_INSECURE stays unset because the endpoint is https.
+      TALLY_SIM_OTLP_URL: https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics
+      # The credential the dev overlay generates into tally-otlp-auth, written
+      # into .env by `make simulator-up`.
+      TALLY_SIM_OTLP_USER: ${TALLY_SIM_OTLP_USER}
+      TALLY_SIM_OTLP_PASSWORD: ${TALLY_SIM_OTLP_PASSWORD}
     # Both mirror the collector's above and are there for the reasons given
-    # with them.
+    # with them. The second name is the OTLP route on the same Gateway, mapped
+    # to the host the same way.
     extra_hosts:
       - "api.tally.127-0-0-1.nip.io:host-gateway"
+      - "otlp.tally.127-0-0-1.nip.io:host-gateway"
     volumes:
       - "../../tally-ca.crt:/etc/tally/tally-ca.crt:ro"
+    # --metrics-interval reaches the binary as a flag the way --factor does. It
+    # is the grid the traffic counters and the inventory gauges of the month lie
+    # on.
+    #
     # --faults is empty unless SIM_FAULTS names a switch. An empty value reaches
     # the binary as --faults "", which is an empty list of switch names, and an
     # empty list is the run with every switch off.
@@ -128,9 +145,11 @@ services:
     # --register-projects carries its value in the same argument because that is
     # where pflag reads a boolean flag's value from. A separate `false` would
     # reach the binary as a positional argument, and cobra.NoArgs refuses those.
-    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--faults", "${TALLY_SIM_FAULTS}", "--register-projects=${TALLY_SIM_REGISTER_PROJECTS}", "--allow-remote-broker"]
+    command: ["run", "--period", "${TALLY_SIM_PERIOD}", "--seed", "${TALLY_SIM_SEED}", "--factor", "${TALLY_SIM_FACTOR}", "--metrics-interval", "${TALLY_SIM_METRICS_INTERVAL}", "--faults", "${TALLY_SIM_FAULTS}", "--register-projects=${TALLY_SIM_REGISTER_PROJECTS}", "--allow-remote-broker"]
     ports:
       # the control endpoint: GET /clock, PUT /clock, POST /release, GET /healthz,
+      # GET /metrics, which is the inventory the dev cluster's
+      # openstack-db-exporter scrape job reads off host.docker.internal:8091,
       # and the fake OpenStack API a run serves on the same listener
       - "127.0.0.1:8091:8080"
 

--- a/deploy/compose/compose_test.go
+++ b/deploy/compose/compose_test.go
@@ -41,6 +41,11 @@ const (
 	gatewayHost  = "api.tally.127-0-0-1.nip.io"
 	reportingURL = "https://" + gatewayHost + ":8443"
 
+	// The OTLP endpoint of the same Gateway, as the simulator reaches it: a second
+	// extra_hosts entry maps this name, and the month's samples are pushed there.
+	otlpHost = "otlp.tally.127-0-0-1.nip.io"
+	otlpURL  = "https://" + otlpHost + ":8443"
+
 	// Every variable Tally itself reads carries this prefix. The environment maps
 	// below also hold variables of the base image, which no EnvNames list knows.
 	tallyPrefix = "TALLY_"
@@ -195,13 +200,24 @@ func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 		t.Errorf("the %s mount carries the options %q, want %q; the simulator has no reason to write the CA", caSource, ca.options, "ro")
 	}
 
-	if hosts := []string{gatewayHost + ":host-gateway"}; !slices.Equal(svc.ExtraHosts, hosts) {
-		t.Errorf("extra_hosts = %v, want %v; the name is otherwise resolved in the container's network, where the dev cluster is not",
+	if hosts := []string{gatewayHost + ":host-gateway", otlpHost + ":host-gateway"}; !slices.Equal(svc.ExtraHosts, hosts) {
+		t.Errorf("extra_hosts = %v, want %v; the names are otherwise resolved in the container's network, where the dev cluster is not",
 			svc.ExtraHosts, hosts)
 	}
 	if url := svc.Environment["TALLY_SIM_REPORTING_URL"]; !strings.HasPrefix(url, reportingURL) {
 		t.Errorf("TALLY_SIM_REPORTING_URL = %q, want it to start with %q, which is the name extra_hosts maps and the port kind publishes on the host",
 			url, reportingURL)
+	}
+	if url := svc.Environment["TALLY_SIM_OTLP_URL"]; !strings.HasPrefix(url, otlpURL) {
+		t.Errorf("TALLY_SIM_OTLP_URL = %q, want it to start with %q, which is the name extra_hosts maps and the port kind publishes on the host",
+			url, otlpURL)
+	}
+	// A push without the two is refused by the binary before it dials the broker,
+	// which is a stack that starts and publishes nothing.
+	for _, name := range []string{"TALLY_SIM_OTLP_USER", "TALLY_SIM_OTLP_PASSWORD"} {
+		if _, ok := svc.Environment[name]; !ok {
+			t.Errorf("environment = %v, want %s among it", svc.Environment, name)
+		}
 	}
 
 	if len(svc.Command) == 0 || svc.Command[0] != "run" {
@@ -212,11 +228,13 @@ func TestSimulatorEnvironmentIsWhatTheSimulatorReads(t *testing.T) {
 	// dropping either leaves a month that is not the one asked for, published at
 	// a pace nobody chose. A dropped --faults leaves SIM_FAULTS with nowhere to
 	// arrive, so a stack asked for a fault switch publishes the month without it.
+	// A dropped --metrics-interval leaves SIM_METRICS_INTERVAL with nowhere to
+	// arrive, so the month is pushed on a grid nobody chose.
 	// Without --allow-remote-broker the container refuses the broker beside it,
 	// which is a stack that starts and publishes nothing. A dropped
 	// --register-projects costs SIM_REGISTER_PROJECTS the same way, and it is
 	// checked below rather than in this loop.
-	for _, flag := range []string{"--period", "--seed", "--factor", "--faults", "--allow-remote-broker"} {
+	for _, flag := range []string{"--period", "--seed", "--factor", "--metrics-interval", "--faults", "--allow-remote-broker"} {
 		if !slices.Contains(svc.Command, flag) {
 			t.Errorf("command = %v, want %s among the arguments", svc.Command, flag)
 		}

--- a/deploy/kubernetes/overlays/dev/counter-sources.yaml
+++ b/deploy/kubernetes/overlays/dev/counter-sources.yaml
@@ -1,0 +1,28 @@
+# Counter sources of the dev cluster's metering engine, mounted into the
+# scheduler CronJob at /etc/tally/counter-sources.yaml by the patch at the end
+# of kustomization.yaml. The base manifest keeps TALLY_ENGINE_COUNTER_SOURCES
+# empty, which is the zero configuration a cluster that mounts no file needs;
+# this overlay is what points the variable at a file.
+#
+# The series is the one the simulator pushes over OTLP while it runs a month
+# (internal/providers/openstack/simulator/metrics.go), labelled with the cloud
+# and the resource id the query selects on.
+#
+# required: false because a dev cluster where no month was ever simulated holds
+# none of that series, and a required source that fails takes the whole tick
+# down with it, every scheduled hour. A failed query yields a
+# counter_source_failed warning instead, which the drill triages on a run that
+# finished.
+#
+# The divisor is 2^30, which is what bytesPerGibibyte in
+# internal/providers/openstack/simulator/oracle.go converts a reported size
+# with, so the export's quantity and the oracle's bytes are in one unit.
+sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    required: false
+    query: >
+      sum(increase(ceilometer_network_outgoing_bytes_total{cloud="{cloud}",
+          resource_id="{resource_id}"}[{window}])) / (1024 * 1024 * 1024)

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -72,6 +72,23 @@ configMapGenerator:
   - name: tally-reconciliation
     files:
       - reconciliation/clouds-config.yaml
+  # The scrape config of this cluster, in place of the base's. A generator for
+  # the same name marked behavior: replace overrides a generated ConfigMap,
+  # which is the mechanism docs/openstack-metrics.md documents under "Replacing
+  # the placeholders"; the generated name still carries a hash of the content,
+  # so editing the file re-rolls the VictoriaMetrics pod. What the overlay's
+  # file changes against the base is written in its own header.
+  - name: victoriametrics-scrape
+    behavior: replace
+    files:
+      - victoriametrics/scrape.yaml
+  # What the scheduler measures beyond the drafts metering folds: the egress of
+  # a simulated instance, out of the counter the simulator pushes. Generated
+  # from the file for the same reason as the reconciliation config above, and
+  # mounted by the last patch in this file.
+  - name: tally-counter-sources
+    files:
+      - counter-sources.yaml
 
 patches:
   # Route every service to its nip.io hostname.
@@ -197,7 +214,7 @@ patches:
         path: /spec/jobTemplate/spec/template/spec/containers/0/imagePullPolicy
         value: Never
 
-  # The four strategic merge patches in this file. They merge env entries by
+  # The five strategic merge patches in this file. They merge env entries by
   # name, so each names only the variables it sets instead of indexing into the
   # base env list, where a reorder in the base would move the values onto the
   # wrong variables.
@@ -298,3 +315,35 @@ patches:
                         name: tally-reconciliation
                     - secret:
                         name: tally-reconciliation-auth
+
+  # What the dev engine measures counters from. The base keeps
+  # TALLY_ENGINE_COUNTER_SOURCES empty, which is the zero configuration that
+  # works without a mounted file (see TestCounterSourcesIsSetToTheEmptyPath in
+  # deploy/kubernetes/base/tally-engine); this overlay mounts the ConfigMap the
+  # generator above builds and points the variable at the file inside it, so the
+  # tick measures the egress counter the simulator pushes. The volume names the
+  # generator by its unsuffixed name and the name reference transformer rewrites
+  # it to the hashed one, the same as the two sources of the clouds volume.
+  - patch: |
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: tally-engine
+      spec:
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tally-engine
+                    env:
+                      - name: TALLY_ENGINE_COUNTER_SOURCES
+                        value: /etc/tally/counter-sources.yaml
+                    volumeMounts:
+                      - name: counter-sources
+                        mountPath: /etc/tally
+                        readOnly: true
+                volumes:
+                  - name: counter-sources
+                    configMap:
+                      name: tally-counter-sources

--- a/deploy/kubernetes/overlays/dev/manifest_test.go
+++ b/deploy/kubernetes/overlays/dev/manifest_test.go
@@ -1,0 +1,448 @@
+// This file pins the two files this overlay adds to the metrics pipeline, and
+// the wiring that carries them into the cluster. Every mismatch it looks for
+// fails quietly. A scrape config that dropped or renamed a job of the base
+// leaves TallyScrapeTargetDown, TallyScrapeJobMissing and
+// TallyExporterServiceSilent selecting jobs this cluster no longer scrapes, and
+// neither the scrape nor the rules fail on their own. An exporter job on
+// another address or under another cloud label scrapes nothing while the
+// inventory of the simulated month sits unread. A counter sources file the
+// engine refuses to load fails every hourly tick before it opens a database,
+// and a patch whose variable and mount path disagree does the same on a file
+// the pod never carried. The tests read the YAML from disk and need neither a
+// cluster nor kustomize.
+package dev_test
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/b42labs/tally/internal/engine/counters"
+)
+
+const (
+	scrapeFile        = "victoriametrics/scrape.yaml"
+	baseScrapeFile    = "../../base/victoriametrics/scrape.yaml"
+	sourcesFile       = "counter-sources.yaml"
+	kustomizationFile = "kustomization.yaml"
+
+	// The two OpenStack jobs: the one this overlay repoints and the one it
+	// copies over untouched.
+	exporterJob   = "openstack-db-exporter"
+	ceilometerJob = "ceilometer"
+
+	// Where the compose stack publishes the simulator, as a pod in the kind
+	// node reaches it, and the cloud the simulated month is booked under.
+	simulatorTarget = "host.docker.internal:8091"
+	simulatedCloud  = "os-sim"
+
+	// The generated ConfigMaps, by their unsuffixed names, and the CronJob the
+	// second one is mounted into, which carries a container of the same name.
+	scrapeConfigMap  = "victoriametrics-scrape"
+	sourcesConfigMap = "tally-counter-sources"
+	cronJob          = "tally-engine"
+
+	// What points the engine at the mounted sources file.
+	sourcesVariable = "TALLY_ENGINE_COUNTER_SOURCES"
+)
+
+// scrapeConfig is the part of a scrape file these tests assert over. yaml.v3
+// ignores every field not named here, so the discovered jobs decode to their
+// names alone.
+type scrapeConfig struct {
+	ScrapeConfigs []scrapeJob `yaml:"scrape_configs"`
+}
+
+type scrapeJob struct {
+	JobName        string         `yaml:"job_name"`
+	ScrapeInterval string         `yaml:"scrape_interval"`
+	ScrapeTimeout  string         `yaml:"scrape_timeout"`
+	StaticConfigs  []staticConfig `yaml:"static_configs"`
+}
+
+type staticConfig struct {
+	Targets []string          `yaml:"targets"`
+	Labels  map[string]string `yaml:"labels"`
+}
+
+// kustomization is the part of the overlay these tests assert over: what it
+// generates and what it patches.
+type kustomization struct {
+	ConfigMapGenerator []generator `yaml:"configMapGenerator"`
+	Patches            []struct {
+		Patch string `yaml:"patch"`
+	} `yaml:"patches"`
+}
+
+type generator struct {
+	Name     string   `yaml:"name"`
+	Behavior string   `yaml:"behavior"`
+	Files    []string `yaml:"files"`
+}
+
+// cronJobPatch is one strategic merge patch against the scheduler CronJob.
+type cronJobPatch struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		JobTemplate struct {
+			Spec struct {
+				Template struct {
+					Spec struct {
+						Containers []container `yaml:"containers"`
+						Volumes    []volume    `yaml:"volumes"`
+					} `yaml:"spec"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		} `yaml:"jobTemplate"`
+	} `yaml:"spec"`
+}
+
+type container struct {
+	Name         string        `yaml:"name"`
+	Env          []envVar      `yaml:"env"`
+	VolumeMounts []volumeMount `yaml:"volumeMounts"`
+}
+
+type envVar struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type volumeMount struct {
+	Name      string `yaml:"name"`
+	MountPath string `yaml:"mountPath"`
+	ReadOnly  bool   `yaml:"readOnly"`
+}
+
+type volume struct {
+	Name      string `yaml:"name"`
+	ConfigMap struct {
+		Name string `yaml:"name"`
+	} `yaml:"configMap"`
+}
+
+func TestScrapeConfigKeepsTheBaseJobs(t *testing.T) {
+	// Three alerting rules name the scrape jobs rather than a metric, and
+	// deploy/kubernetes/base/vmalert/rules_test.go holds them to the base file.
+	// This overlay replaces that file wholesale, so a job it drops or renames
+	// takes itself out of all three selectors while both files stay legal YAML
+	// and the cluster keeps scraping the rest.
+	overlay := jobNames(scrapeConfigOf(t, scrapeFile))
+	base := jobNames(scrapeConfigOf(t, baseScrapeFile))
+
+	if !slices.Equal(overlay, base) {
+		t.Fatalf("%s declares jobs %v, want %v, the jobs of %s that TallyScrapeTargetDown, TallyScrapeJobMissing and TallyExporterServiceSilent select",
+			scrapeFile, overlay, base, baseScrapeFile)
+	}
+}
+
+func TestExporterJobScrapesTheSimulator(t *testing.T) {
+	// The one change this file makes against the base. The target is where a
+	// pod in the kind node reaches the simulator the compose stack publishes on
+	// the host, and the cloud label is what the simulated month's events are
+	// booked under: another value leaves the inventory series under a cloud no
+	// metering row meets. A scrape of a port nothing listens on is a job that
+	// TallyScrapeTargetDown reports, which is also what it does between two
+	// drill runs, so neither mistake shows up as anything else.
+	overlay := scrapeConfigOf(t, scrapeFile)
+	base := scrapeConfigOf(t, baseScrapeFile)
+
+	exporter := jobNamed(t, overlay, scrapeFile, exporterJob)
+	want := []staticConfig{{
+		Targets: []string{simulatorTarget},
+		Labels:  map[string]string{"platform": "openstack", "cloud": simulatedCloud},
+	}}
+	if !sameStaticConfigs(exporter.StaticConfigs, want) {
+		t.Errorf("job %s scrapes %+v, want %+v, which is the simulator the compose stack publishes on the host",
+			exporterJob, exporter.StaticConfigs, want)
+	}
+
+	// One scrape of this exporter runs a whole query set against the service
+	// databases of a real cloud, which is what the base's interval and timeout
+	// are cut for. Shortening them here would leave the dev cluster testing a
+	// pacing no deployment runs.
+	baseExporter := jobNamed(t, base, baseScrapeFile, exporterJob)
+	if exporter.ScrapeInterval != baseExporter.ScrapeInterval || exporter.ScrapeTimeout != baseExporter.ScrapeTimeout {
+		t.Errorf("job %s is scraped every %q with a %q timeout, want the base's %q and %q",
+			exporterJob, exporter.ScrapeInterval, exporter.ScrapeTimeout,
+			baseExporter.ScrapeInterval, baseExporter.ScrapeTimeout)
+	}
+
+	// The traffic of a simulated month reaches the store over OTLP, so this job
+	// has nothing to point at here and keeps the base's placeholder. Pointed at
+	// the simulator too, it would scrape the inventory a second time under a
+	// second job name.
+	ceilometer := jobNamed(t, overlay, scrapeFile, ceilometerJob)
+	baseCeilometer := jobNamed(t, base, baseScrapeFile, ceilometerJob)
+	if !sameStaticConfigs(ceilometer.StaticConfigs, baseCeilometer.StaticConfigs) {
+		t.Errorf("job %s scrapes %+v, want the base's %+v: the simulator's traffic counters are pushed over OTLP, not scraped",
+			ceilometerJob, ceilometer.StaticConfigs, baseCeilometer.StaticConfigs)
+	}
+}
+
+func TestCounterSourcesMeasureTheSimulatedEgress(t *testing.T) {
+	// The engine reads this file the way Load reads a deployment's, so a source
+	// it refuses is an hourly tick that fails before it opens a database. What
+	// the query has to carry beyond that is the series the simulator pushes,
+	// the three placeholders that narrow it to one resource and one interval,
+	// and the divisor that leaves the billed quantity in the unit the oracle
+	// states its bytes in.
+	cfg, err := counters.Load(sourcesFile)
+	if err != nil {
+		t.Fatalf("loading %s, which every tick of this cluster does: %v", sourcesFile, err)
+	}
+	if len(cfg.Sources) != 1 {
+		t.Fatalf("%s holds %d sources, want the one that measures the simulated egress", sourcesFile, len(cfg.Sources))
+	}
+
+	s := cfg.Sources[0]
+	if s.Platform != "openstack" || s.ResourceType != "instance" || s.Metric != "egress_gb" {
+		t.Errorf("the source measures %s of %s/%s, want egress_gb of openstack/instance, which is the usage key the export prices",
+			s.Metric, s.Platform, s.ResourceType)
+	}
+	if s.Kind != counters.KindMetricsQL {
+		t.Errorf("the source is a %q source, want %q: the egress is a series in the store, not an event in the reporting database",
+			s.Kind, counters.KindMetricsQL)
+	}
+	// A dev cluster where no month was ever simulated holds none of this
+	// series. Required, the source would fail every scheduled tick with it;
+	// optional, it yields a counter_source_failed warning on a run that
+	// finished.
+	if s.Required {
+		t.Error("the source is required, so a cluster that has never run a drill fails every hourly tick on a series nothing wrote")
+	}
+
+	for _, want := range []string{
+		"ceilometer_network_outgoing_bytes_total",
+		"{cloud}", "{resource_id}", "{window}",
+		"1024 * 1024 * 1024",
+	} {
+		if !strings.Contains(s.Query, want) {
+			t.Errorf("the query does not carry %q:\n%s", want, s.Query)
+		}
+	}
+	// An identity read as a pattern selects the series of the resources beside
+	// the one it names, and an aggregate over them bills this resource for
+	// theirs. Load refuses it, which the case below pins; the query itself may
+	// not get there in the first place.
+	if strings.Contains(s.Query, "=~") {
+		t.Errorf("the query matches with =~, which reads a substituted identity as a pattern:\n%s", s.Query)
+	}
+}
+
+func TestARegexMatchedIdentityIsRefused(t *testing.T) {
+	// What keeps the assertion above worth making: the loader, not this file,
+	// is what stops a query from reading a resource id as a pattern. A copy of
+	// the file with the one matcher loosened has to fail to load, or an edit
+	// that loosens the real one would reach a tick.
+	raw, err := os.ReadFile(sourcesFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", sourcesFile, err)
+	}
+	const matcher = `resource_id="{resource_id}"`
+	if n := strings.Count(string(raw), matcher); n != 1 {
+		t.Fatalf("%s carries %d occurrences of %s, so this case would loosen something else", sourcesFile, n, matcher)
+	}
+	loosened := strings.Replace(string(raw), matcher, `resource_id=~"{resource_id}"`, 1)
+
+	path := filepath.Join(t.TempDir(), sourcesFile)
+	if err := os.WriteFile(path, []byte(loosened), 0o600); err != nil {
+		t.Fatalf("writing the loosened copy: %v", err)
+	}
+	if _, err := counters.Load(path); err == nil {
+		t.Fatal("counters.Load accepted a query matching {resource_id} with =~, so nothing but review stops an aggregate over the series of the resources beside the one it names")
+	}
+}
+
+func TestKustomizationWiresTheTwoConfigMaps(t *testing.T) {
+	// Neither file reaches the cluster on its own. Without the replacing
+	// generator VictoriaMetrics keeps serving the base's placeholders, and
+	// without the patch the engine keeps the empty path the base sets, which is
+	// a tick that measures no counter and reports nothing about it.
+	var k kustomization
+	raw, err := os.ReadFile(kustomizationFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", kustomizationFile, err)
+	}
+	if err := yaml.Unmarshal(raw, &k); err != nil {
+		t.Fatalf("parsing %s, which kustomize refuses to build: %v", kustomizationFile, err)
+	}
+
+	scrape := generatorNamed(t, k, scrapeConfigMap)
+	if scrape.Behavior != "replace" {
+		t.Errorf("the %s generator has behavior %q, want \"replace\": that is what overrides the base's generated ConfigMap rather than adding a second one under the same name",
+			scrapeConfigMap, scrape.Behavior)
+	}
+	if !slices.Contains(scrape.Files, scrapeFile) {
+		t.Errorf("the %s generator carries %v rather than %s, so the base's placeholder targets stay in the store's scrape config",
+			scrapeConfigMap, scrape.Files, scrapeFile)
+	}
+	if sources := generatorNamed(t, k, sourcesConfigMap); !slices.Contains(sources.Files, sourcesFile) {
+		t.Errorf("the %s generator carries %v rather than %s, so the mount below projects a ConfigMap without the sources file",
+			sourcesConfigMap, sources.Files, sourcesFile)
+	}
+
+	// Three things have to agree: the volume names the generated ConfigMap, the
+	// mount puts it at a path, and the variable names the file inside that
+	// path. A mismatch in any of them leaves the tick failing on a file it
+	// cannot read, once an hour, in a Job history nobody reads.
+	patch := cronJobPatchOf(t, k)
+	c := containerNamed(t, patch, cronJob)
+
+	var name string
+	for _, v := range patch.Spec.JobTemplate.Spec.Template.Spec.Volumes {
+		if v.ConfigMap.Name == sourcesConfigMap {
+			name = v.Name
+			break
+		}
+	}
+	if name == "" {
+		t.Fatalf("the patch declares no volume backed by ConfigMap %s, so the sources file reaches no container", sourcesConfigMap)
+	}
+
+	i := slices.IndexFunc(c.VolumeMounts, func(m volumeMount) bool { return m.Name == name })
+	if i < 0 {
+		t.Fatalf("container %s carries %v rather than a mount of volume %q, so %s points at nothing",
+			cronJob, c.VolumeMounts, name, sourcesVariable)
+	}
+	mount := c.VolumeMounts[i]
+	if !mount.ReadOnly {
+		t.Errorf("the %s mount is writable, although the tick only reads it", name)
+	}
+
+	value, set := envValue(c, sourcesVariable)
+	if !set {
+		t.Fatalf("the patch sets no %s, so the engine keeps the empty path the base carries and measures no counter", sourcesVariable)
+	}
+	if want := mount.MountPath + "/" + sourcesFile; value != want {
+		t.Errorf("%s = %q, want %q, which is where volume %q mounts the generated ConfigMap", sourcesVariable, value, want, name)
+	}
+}
+
+// scrapeConfigOf decodes one scrape file.
+func scrapeConfigOf(t *testing.T, path string) scrapeConfig {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var cfg scrapeConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if len(cfg.ScrapeConfigs) == 0 {
+		t.Fatalf("%s declares no scrape jobs, so this test would assert over nothing", path)
+	}
+	return cfg
+}
+
+// jobNames is the jobs of a scrape file in the order it declares them. The
+// order is asserted rather than the set alone, so a job moved out of the block
+// its comment explains is noticed.
+func jobNames(cfg scrapeConfig) []string {
+	names := make([]string, 0, len(cfg.ScrapeConfigs))
+	for _, job := range cfg.ScrapeConfigs {
+		names = append(names, job.JobName)
+	}
+	return names
+}
+
+// jobNamed returns one job, failing if it is missing rather than asserting over
+// a zero value.
+func jobNamed(t *testing.T, cfg scrapeConfig, path, name string) scrapeJob {
+	t.Helper()
+
+	for _, job := range cfg.ScrapeConfigs {
+		if job.JobName == name {
+			return job
+		}
+	}
+	t.Fatalf("%s declares no job %q", path, name)
+	return scrapeJob{}
+}
+
+// sameStaticConfigs reports whether two job's static targets and labels match.
+func sameStaticConfigs(a, b []staticConfig) bool {
+	return slices.EqualFunc(a, b, func(x, y staticConfig) bool {
+		return slices.Equal(x.Targets, y.Targets) && maps.Equal(x.Labels, y.Labels)
+	})
+}
+
+// generatorNamed returns one ConfigMap generator of the overlay.
+func generatorNamed(t *testing.T, k kustomization, name string) generator {
+	t.Helper()
+
+	for _, g := range k.ConfigMapGenerator {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("%s generates no ConfigMap %q", kustomizationFile, name)
+	return generator{}
+}
+
+// cronJobPatchOf returns the one strategic merge patch against the scheduler.
+// The other entries of patches are JSON patches, which are sequences rather
+// than documents and are skipped by their shape.
+func cronJobPatchOf(t *testing.T, k kustomization) cronJobPatch {
+	t.Helper()
+
+	var found []cronJobPatch
+	for i, p := range k.Patches {
+		var shape any
+		if err := yaml.Unmarshal([]byte(p.Patch), &shape); err != nil {
+			t.Fatalf("parsing patches[%d]: %v", i, err)
+		}
+		if _, isDocument := shape.(map[string]any); !isDocument {
+			continue
+		}
+		var doc cronJobPatch
+		if err := yaml.Unmarshal([]byte(p.Patch), &doc); err != nil {
+			t.Fatalf("parsing patches[%d]: %v", i, err)
+		}
+		if doc.Kind == "CronJob" && doc.Metadata.Name == cronJob {
+			found = append(found, doc)
+		}
+	}
+
+	if len(found) != 1 {
+		t.Fatalf("%s holds %d strategic merge patches against CronJob %s, want one: two of them would leave which env list is merged to the order of the file",
+			kustomizationFile, len(found), cronJob)
+	}
+	return found[0]
+}
+
+// containerNamed returns one container of a patched pod. The name is what
+// strategic merge matches on, so a patch naming a container the base does not
+// have adds a second one instead of setting anything.
+func containerNamed(t *testing.T, patch cronJobPatch, name string) container {
+	t.Helper()
+
+	for _, c := range patch.Spec.JobTemplate.Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("the patch against CronJob %s carries no container %q", patch.Metadata.Name, name)
+	return container{}
+}
+
+// envValue reports what one variable of a container is set to, and whether the
+// patch names it at all.
+func envValue(c container, name string) (string, bool) {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}

--- a/deploy/kubernetes/overlays/dev/victoriametrics/scrape.yaml
+++ b/deploy/kubernetes/overlays/dev/victoriametrics/scrape.yaml
@@ -1,0 +1,101 @@
+# VictoriaMetrics scrape configuration of the dev cluster.
+#
+# This file replaces the generated victoriametrics-scrape ConfigMap through the
+# behavior: replace generator in the overlay's kustomization.yaml, which is the
+# mechanism docs/openstack-metrics.md documents under "Replacing the
+# placeholders". Everything below is the base file; the one change is the
+# openstack-db-exporter job.
+#
+# That job scrapes the simulated cloud the compose stack publishes on the host
+# at 127.0.0.1:8091. A pod in the kind node reaches the host as
+# host.docker.internal, the same address reconciliation/clouds.yaml already
+# relies on. The cloud is os-sim, the SIM_CLOUD default; a drill under another
+# cloud name edits this file, the rule the reconciliation directory carries too.
+#
+# Between two runs nothing listens on that port, so the job is down and
+# TallyScrapeTargetDown fires for it after five minutes, which is what it does
+# against the base's placeholder as well. The job goes green while a drill runs.
+#
+# The ceilometer job is copied over unchanged, on its placeholder target: the
+# recorded Ceilometer default is the Pushgateway path, where that job carries
+# metering data on a real deployment, and the traffic of a simulated month
+# reaches the store over OTLP instead.
+#
+# The jobs, their intervals, how the in-cluster jobs find their targets, the
+# static labels on the two OpenStack jobs, the placeholder targets, and how a
+# real deployment replaces this file are documented in
+# docs/openstack-metrics.md.
+scrape_configs:
+  # The in-cluster jobs discover endpoints instead of naming a Service address.
+  # A Service address is one ClusterIP that kube-proxy resolves to an arbitrary
+  # backend per connection, so a second replica would leave every scrape landing
+  # on a different pod while every sample carries the same instance label, and
+  # one series would interleave two independent counters. rate() reads each of
+  # those decreases as a counter reset, the targets stay up, nothing is logged,
+  # and the numbers billing reconciles against are quietly wrong. Discovery
+  # gives every pod a target and an instance label of its own.
+  #
+  # own_namespace keeps the discovery inside the namespace the pod runs in,
+  # which is what the Role in victoriametrics.yaml grants.
+  #
+  # instance comes from the pod name rather than the default, which is
+  # __address__ and therefore the pod IP and port. A pod IP is handed back to
+  # the pool on deletion and reused, so the next pod to take it would continue
+  # the series its predecessor wrote — two independent counters in one series,
+  # which is what discovery is here to prevent. A pod name carries a random
+  # suffix and is not reused.
+  #
+  # What discovery cannot express is a job that resolves to nothing. up is a
+  # per-target series, so zero targets produce no up series at all rather than
+  # up == 0: a Deployment scaled to zero, a renamed Service, a renamed port, a
+  # removed RoleBinding, or an unreachable API server all take the job off
+  # /targets instead of turning it red. An alert on these two jobs therefore
+  # pairs up == 0 with absent(up{job="..."})
+  # (roadmap/02-phase-2-reporting-dashboards.md).
+  - job_name: reporting-api
+    scrape_interval: 30s
+    kubernetes_sd_configs:
+      - role: endpointslice
+        namespaces:
+          own_namespace: true
+    relabel_configs:
+      - source_labels:
+          - __meta_kubernetes_service_name
+          - __meta_kubernetes_endpointslice_port_name
+        regex: reporting-api;http
+        action: keep
+      - source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: instance
+  # One scrape of this exporter runs its whole query set against the live
+  # OpenStack service databases. The default 10s timeout gives up long before
+  # those queries finish on a cloud of any size, while the queries themselves
+  # keep running to completion, so a short interval piles a second set on top of
+  # the first until the control plane's database is saturated. The timeout is
+  # what one scrape may cost; the interval leaves it room to finish.
+  - job_name: openstack-db-exporter
+    scrape_interval: 300s
+    scrape_timeout: 60s
+    static_configs:
+      - targets: ["host.docker.internal:8091"]
+        labels: { platform: "openstack", cloud: "os-sim" }
+  - job_name: ceilometer
+    scrape_interval: 60s
+    static_configs:
+      - targets: ["ceilometer-exporter:9101"]
+        labels: { platform: "openstack", cloud: "os-prod-eu1" }
+  - job_name: otel-collector
+    scrape_interval: 15s
+    kubernetes_sd_configs:
+      - role: endpointslice
+        namespaces:
+          own_namespace: true
+    relabel_configs:
+      - source_labels:
+          - __meta_kubernetes_service_name
+          - __meta_kubernetes_endpointslice_port_name
+        regex: otel-collector;metrics
+        action: keep
+      - source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: instance

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -136,9 +136,10 @@ from breaking a panel is its "All" value `.*`: a selector `cloud=~".*"` matches
 whatever the store holds, including nothing.
 
 The scrape-health stat on Tally / Ingestion Health reports `up == 0` for
-`openstack-db-exporter` and `ceilometer`. Both are static targets for exporters
-that run beside an OpenStack control plane rather than in this cluster. That is
-the designed dev state, described under
+`ceilometer`, a static target for an exporter that runs beside an OpenStack
+control plane rather than in this cluster, and for `openstack-db-exporter`
+until a simulator run publishes a month, when that job scrapes the simulator's
+inventory. That is the designed dev state, described under
 [Replacing the placeholders](openstack-metrics.md#replacing-the-placeholders),
 and not a fault to chase.
 
@@ -412,9 +413,20 @@ dashboards then carries a value. The panels built on `rate()` and `increase()`
 show the drill as one spike over their window rather than a level, because the
 drill pushed each series once.
 
-On the scrape-health stat, `openstack-db-exporter` and `ceilometer` report
-`up == 0` while `reporting-api` and `otel-collector` report `up == 1`. Those two
-jobs stay down for the reason above: the designed dev state, not a failure.
+A simulated month fills the same `openstack_*` panels without Part 2.
+`make simulator-up SIM_PERIOD=2026-07` pushes the traffic counters and the
+inventory gauges of a generated cloud and serves that inventory to the
+`openstack-db-exporter` job, which
+[`openstack-simulator.md`](openstack-simulator.md#the-metric-series) describes.
+Those series carry `cloud="os-sim"` and lie on the simulated period, so the
+panels and the Project variable fill with the Cloud variable on `os-sim` and the
+time range set to that month rather than to the hour the run took. Part 2 stays
+the way to fill the panels without a run.
+
+On the scrape-health stat, `ceilometer` reports `up == 0` while `reporting-api`
+and `otel-collector` report `up == 1`. `openstack-db-exporter` reports `up == 0`
+as well between simulator runs, and `up == 1` while one publishes. Both are the
+designed dev state for the reason above, not a failure.
 
 The same OTLP push without `--user` answers `401` and
 `{"code":16,"message":"no basic auth provided"}`, and writes nothing. That is

--- a/docs/openstack-metrics.md
+++ b/docs/openstack-metrics.md
@@ -137,7 +137,8 @@ in the tree.
 
 `os-db-exporter:9180`, `ceilometer-exporter:9101`, and the cloud name
 `os-prod-eu1` are placeholders. Those exporters run beside an OpenStack control
-plane and not in this cluster, so on dev both jobs stay down.
+plane and not in this cluster. On dev the `ceilometer` job stays down, and
+`openstack-db-exporter` is pointed at the OpenStack simulator instead.
 
 A real deployment does not patch the file. Its overlay declares a
 `configMapGenerator` of its own for the same generated name and marks it
@@ -154,6 +155,16 @@ configMapGenerator:
 
 The overlay's own `scrape.yaml` then names that deployment's exporter addresses
 and its cloud.
+
+[`victoriametrics/scrape.yaml`](../deploy/kubernetes/overlays/dev/victoriametrics/scrape.yaml)
+of the dev overlay is such a file. It points `openstack-db-exporter` at the
+simulator the compose stack publishes, `host.docker.internal:8091` under
+`cloud: os-sim`, which is where a pod in the kind node reaches the inventory
+endpoint [`openstack-simulator.md`](openstack-simulator.md#the-metric-series)
+describes. The job is up while a run publishes a month and down between runs,
+where nothing listens on that port. The `ceilometer` job is copied over on its
+placeholder target, because the traffic of a simulated month reaches the store
+over OTLP rather than through a Pushgateway.
 
 ### What is exposed and what is not
 
@@ -659,19 +670,22 @@ Target health is a separate page, `/targets`, and the same CA file reaches it:
 curl --cacert tally-ca.crt 'https://vm.tally.127-0-0-1.nip.io:8443/targets'
 ```
 
-Four jobs are listed. `reporting-api` and `otel-collector` are up.
-`openstack-db-exporter` and `ceilometer` are down with an unresolved-host error,
-because neither target exists in this cluster. That is the designed dev state
-and not a fault to chase.
+Four jobs are listed. `reporting-api` and `otel-collector` are up. `ceilometer`
+is down with an unresolved-host error, because its target exists in no dev
+cluster. `openstack-db-exporter` is down between simulator runs, when nothing
+listens on `host.docker.internal:8091`, and up while `make simulator-up`
+publishes a month. Neither is a fault to chase: both are the dev state as it is
+designed.
 
-It is the designed state in dev alone. Both of those jobs are metering sources
+That state is acceptable in dev alone. Both of those jobs are metering sources
 for everything Tally bills, so a deployment where they are down produces the
-same `/targets` page as a healthy dev cluster while the meter runs empty, and
-the first symptom is an invoice that comes up short. A deployment that replaces
-this file therefore alerts on `up == 0` for both jobs — they are static targets,
-so their `up` series exists whatever the exporter is doing. The two discovered
-jobs need the second rule as well, on `absent(up{job="..."})`, for the reason
-above. `TallyScrapeTargetDown` and `TallyScrapeJobMissing` in
+same `/targets` page as a dev cluster between simulator runs while the meter
+runs empty, and the first symptom is an invoice that comes up short. A
+deployment that replaces this file therefore alerts on `up == 0` for both jobs
+— they are static targets, so their `up` series exists whatever the exporter is
+doing. The two discovered jobs need the second rule as well, on
+`absent(up{job="..."})`, for the reason above. `TallyScrapeTargetDown` and
+`TallyScrapeJobMissing` in
 [`deploy/kubernetes/base/vmalert/rules.yaml`](../deploy/kubernetes/base/vmalert/rules.yaml)
 are those two rules; [`alerting.md`](alerting.md) describes them and the eight
 others the tree ships.

--- a/docs/openstack-simulator.md
+++ b/docs/openstack-simulator.md
@@ -11,15 +11,16 @@ paced by a virtual clock, so a 31-day month goes out in the wall time the
 factor compresses it into.
 
 A `run` serves the month it publishes as a fake OpenStack API on the control
-listener, which "The fake OpenStack API" below describes. The simulator has no
-metrics endpoint of its own. #65 is the meta issue the simulated workloads
-belong to, and this document describes its first stage. The noise, the
+listener, which "The fake OpenStack API" below describes. It pushes the month's
+network traffic counters and inventory gauges to an OTLP endpoint on the same
+virtual clock, and serves the inventory on `GET /metrics` of that listener,
+which "The metric series" below describes. #65 is the meta issue the simulated
+workloads belong to, and this document describes its first stage. The noise, the
 notifications the collector does not bill, is rendered and described under "The
 noise" below. The oracle of a month and the comparison against an engine export
 are described under "The oracle" below, the six fault switches under "The fault
 switches", and the registration of the month's tenants and Gardener projects
-with the project registry under "The project registry". #67 owns the traffic
-series and `/metrics`.
+with the project registry under "The project registry".
 The drill #51 cites this simulator as the way a month reaches the Reporting API.
 The workload renders octavia's three load balancer types from the shoots' load
 balancers.
@@ -507,6 +508,16 @@ of them draws from the stream the month's shape comes from, so a run with every
 switch off consumes the three streams above the way a run without the switches
 consumes them.
 
+The traffic jitter is drawn from a fourth stream, seeded by the seed together
+with a salt of its own, `metrics\x00traffic`. It never touches the shape stream,
+the identifier stream, or the noise stream, so a month whose traffic was placed
+consumes those three exactly as one whose traffic was not, and the notifications
+of a month are the same bytes whatever its metrics say. The metrics interval
+joins the seed, the period, and the cloud among the inputs the oracle depends
+on: a coarser grid rounds each step's integer division differently, so two runs
+of one seed under two intervals state traffic figures that differ by a few bytes
+per interval.
+
 The same seed, period, and cloud therefore publish byte-identical
 notifications, and a rerun of the same build costs nothing at the far end: the
 collector books the oslo message id as the event's `event_id`, and the
@@ -569,7 +580,11 @@ The target builds the collector and the simulator image, writes the dev CA to
 `tally-reporting-admin create-api-token --role admin`. It writes the cloud, the
 period, the seed, the factor, the fault switches as `TALLY_SIM_FAULTS`, the
 switch as `TALLY_SIM_REGISTER_PROJECTS`, the garden cloud as
-`TALLY_SIM_GARDEN_CLOUD`, and the two tokens as `TALLY_OSC_TOKEN` and
+`TALLY_SIM_GARDEN_CLOUD`, the OTLP credential of `SIM_OTLP_USER` (`tally`) and
+`SIM_OTLP_PASSWORD` (`tally-dev-otlp-password`, the literal the dev overlay
+generates into the `tally-otlp-auth` Secret) as `TALLY_SIM_OTLP_USER` and
+`TALLY_SIM_OTLP_PASSWORD`, the grid of `SIM_METRICS_INTERVAL` (`300s`) as
+`TALLY_SIM_METRICS_INTERVAL`, and the two tokens as `TALLY_OSC_TOKEN` and
 `TALLY_SIM_API_TOKEN` into `deploy/compose/.env`, where the api token is the
 empty string with the switch off. The file is removed and written again under
 `umask 077`, because an admin api token in a world-readable file is one every
@@ -587,20 +602,29 @@ The period has to lie in the past. `run` refuses a month that has not ended,
 because the engine warns about a period that has not ended, and a simulated
 month reaching into the future would carry that warning into every run over it.
 
-Four URLs come out of the stack:
+Seven URLs come out of the stack:
 
 - `http://127.0.0.1:15672`, the broker's management UI, guest/guest
 - `http://127.0.0.1:8090/metrics`, the collector
 - `http://127.0.0.1:8091/clock`, the simulator's control endpoint
+- `http://127.0.0.1:8091/metrics`, the simulator's inventory, the database
+  exporter stand-in of "The metric series"
 - `https://api.tally.127-0-0-1.nip.io:8443/api/v1`, the Reporting API
+- `https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics`, the OTLP endpoint the
+  series are pushed to
+- `https://vm.tally.127-0-0-1.nip.io:8443/targets`, the scrape targets of the
+  dev cluster, where the `openstack-db-exporter` job goes green while the run
+  publishes
 
 Every host port is bound to `127.0.0.1` and lies above 1024;
 `deploy/kind/kind.yaml` states why. The collector's container reaches the
 cluster through `extra_hosts`, which maps `api.tally.127-0-0-1.nip.io` to
 `host-gateway`, and `tally-ca.crt` is mounted read-only at the path
 `SSL_CERT_FILE` names, which is what makes the Gateway's certificate verify. The
-simulator's container carries the same three: a registration posts to the
-Gateway over the same kind of client the collector delivers with.
+simulator's container carries the same three, and a second `extra_hosts` entry
+beside them, `otlp.tally.127-0-0-1.nip.io`: a registration posts to the Gateway
+over the same kind of client the collector delivers with, and the push takes
+that second name to the same Gateway.
 
 The collector service of the stack lists all eight exchanges in
 `TALLY_OSC_EXCHANGES`:
@@ -843,8 +867,9 @@ of the month is paced by the lead the switch drew.
 
 `oracle.json` states the month the generator built. It holds the `format` of the
 document, the `cloud` and the `seed` it was rendered from, the month as
-`period_from` and `period_to`, the `resources` the month bills, and the `counts`
-of the events the collector has to record. A resource names its type, its id, and its workload (`classic`,
+`period_from` and `period_to`, the `resources` the month bills, the `counts`
+of the events the collector has to record, and the `traffic` its instances
+moved. A resource names its type, its id, and its workload (`classic`,
 `gardener`, or `ci`), and lists the intervals of constant state, size, and
 project it was billed over. The spare volume of a
 classic project has two of them, meeting at the transfer that hands it to the
@@ -926,6 +951,31 @@ as `compute.instance.power_off`, and the transfer of a spare volume counts under
 the accepting project. They are what `GET /api/v1/stats/events` of the Reporting
 API holds for the month.
 
+The traffic is one row per instance and per interval of that instance: the
+`resource_id`, the interval's `from` and `to`, and the `egress_bytes` and
+`ingress_bytes` the instance moved over it. The rows are ordered by resource id
+and then by `from`.
+
+```json
+{
+  "resource_id": "079faae9-9d39-426f-a963-769cb12aa629",
+  "from": "2026-07-01T03:17:02Z",
+  "to": "2026-07-02T05:36:15Z",
+  "egress_bytes": 39956080648,
+  "ingress_bytes": 9989019968
+}
+```
+
+A row states the exact sum of the grid steps of "The metric series" that fall
+inside its interval, so an interval the instance spent `shutoff`, `shelved`, or
+`resized` carries 0, and an interval shorter than the grid, which holds no step
+at all, carries 0 as well rather than being left out: a comparison reads a row
+of every interval the oracle holds. The rows stand beside the resources rather
+than inside their intervals because of the fold: two adjacent facts that repeat
+the state, the size, and the project are kept in one interval, and a traffic
+figure inside an interval would make two such facts compare unequal and split
+that fold.
+
 The oracle is folded by the simulator's own code out of what the generator knows
 while it emits a billable transition, not out of the rendered notification and
 not out of what the engine made of it. A payload that lost a member renders a
@@ -951,7 +1001,9 @@ not read, and one that leaves a member it does read unstated. The last of the
 three is the one nothing else would catch, because JSON leaves an absent member
 at its zero value: an oracle without its sizes would be compared, and every
 `time_gauge` dimension of every priced resource would come out as a difference
-the engine did not cause.
+the engine did not cause. This build is at format 3, the number the `traffic`
+rows were added in, so a file an earlier build wrote at format 2 is refused
+rather than compared.
 
 ### Comparing an export
 
@@ -976,10 +1028,12 @@ against each other by index rather than by their bounds, so an interval one fold
 split in two is reported at the place the two folds part ways rather than on
 every interval behind it.
 
-The `counter` dimensions are left out, `egress_gb` among them: the counters pass
-measures one from the events table or from a metrics store, and the oracle
-models neither. Left out as well are the amounts, the state modifiers, the
-statement totals, and the resource types the model does not price. Under
+The `counter` dimensions are left out, `egress_gb` among them: `increase()`
+extrapolates a counter over the edges of the window it is asked about, so the
+quantity an export carries differs from the exact integral the generator placed
+in the interval, and the `traffic` rows of the oracle are what a drill reads
+that figure off instead. Left out as well are the amounts, the state modifiers,
+the statement totals, and the resource types the model does not price. Under
 `pricing/2026-03.yaml` an `image` and a `loadbalancer` are unpriced, so the
 rating pass writes no record of one, and the report names each such type on a
 line of its own instead of calling its resources missing:
@@ -1614,6 +1668,248 @@ run, and the instants told to the runs of one cloud must not go backwards.
 Nothing schedules it here and no target starts it; the drill of #51 folds it
 into its procedure.
 
+## The metric series
+
+A `run` states the month a second time, as the series a monitoring stack would
+have recorded while it went by: the two network counters Ceilometer polls off
+every instance, and the inventory gauges the OpenStack database exporter reads
+off the service databases of a real cloud. Both are placed by
+[`metrics.go`](../internal/providers/openstack/simulator/metrics.go) out of the
+month the notifications describe, so the pushed series, the scraped endpoint,
+and the oracle state one world instead of three descriptions of it. A `replay`
+places neither of the two: a recorded file holds notifications and no month to
+fold them out of.
+
+### The grid
+
+Every series of a month lies on one grid, the whole steps of
+`--metrics-interval` counted from the period start. The flag defaults to `300s`,
+the interval Ceilometer polls at out of the box, and it takes a whole number of
+seconds between 30s and 24h. Whole seconds because a step's bytes are counted in
+seconds, and a grid of half seconds would drop that half out of every step it
+places; 24h because the byte arithmetic below is a product of int64 factors, and
+a longer step is where it stops fitting into one; 30s because the traffic of the
+whole period is placed before the first notification goes out, and a July of
+seed 1 that carries about 320,000 samples on the 300s grid carries ten times
+that at 30s and about a hundred million at 1s, which is where the run is killed
+for its memory instead of publishing anything.
+
+The grid is counted from the period start rather than from each instance's own
+first interval, so two instances sampled around one instant carry the very same
+timestamp and one query reads a step as one point per series.
+
+### The traffic
+
+Every instance carries two cumulative counters,
+`ceilometer_network_outgoing_bytes_total` and
+`ceilometer_network_incoming_bytes_total`, under the names Ceilometer's
+Prometheus exporter publishes them with, so a dashboard written for a real cloud
+reads a simulated one.
+
+What an instance moves is stated per office hour and per workload: a classic
+tenant's server sends 2 GiB, a shoot's worker 8 GiB, and a CI runner 256 MiB.
+The ingress is the egress times 1/4 for a classic tenant, times 1/2 for a shoot,
+and times 2/1 for a runner, which pulls its image and its dependencies and sends
+little back; each of the three quotients is exact.
+
+Every other hour of the month is that level weighed by the working-week profile
+of "The profile" above. A step carries `hourWeight(step)/officeWeight` of the
+level and the step's share of an hour, so a night step accrues a tenth of an
+office step of the same length. The weight is read off the step's start, so a
+step that straddles the boundary between two hours carries the weight of the
+hour it began in. A jitter drawn once per instance, a numerator in [50, 150]
+over a denominator of 100, keeps two instances of one workload from reporting
+the same byte count without taking either of them out of its level:
+
+```text
+bytes = level * hourWeight(step) * step_seconds * jitter
+        / (officeWeight * 3600 * 100)
+```
+
+`hourWeight` is 10 in an office hour, 3 in the fringe around it, and 1 at night
+and on a weekend; `officeWeight` is 10. Every factor is an int64 and the one
+division comes last. A byte count is a usage quantity that reaches an invoice,
+and a quotient that went through a float64 would arrive carrying digits nobody
+placed.
+
+A step accrues bytes only while the interval its start falls in is `active`. A
+`shutoff`, a `shelved`, and a `resized` instance move nothing, so their steps
+carry zero and the counter behind them stays flat, which is what the counter of
+a stopped machine does. A step that falls into a gap between two intervals
+belongs to no state and accrues nothing either.
+
+A series begins at 0 on the first grid step at or after the instance's first
+interval start and ends before the end of its last interval, which is where
+Ceilometer starts polling an instance and where it stops. The value at an
+instant is what accrued before it, the way a cumulative counter reports: the
+increment of the last step therefore lands in the oracle's last traffic row of
+that instance and in no sample at all, the way Ceilometer's last poll precedes a
+delete.
+
+Five labels identify a point: `platform`, `cloud`, `resource_type="instance"`,
+`resource_id`, and `project_id`, the project the instance ran in over the
+interval the step lies in.
+
+### The inventory
+
+The inventory is the world of the month as it stands at one instant: one gauge
+per live resource, the limits of every project, and the counts the cloud reports
+about itself.
+
+| Series | Labels | Value |
+| --- | --- | --- |
+| `openstack_nova_server_status` | `id`, `uuid`, `name`, `tenant_id`, `status`, `flavor_id` | 1 |
+| `openstack_cinder_volume_status` | `id`, `name`, `tenant_id`, `status`, `volume_type` | 1 |
+| `openstack_cinder_volume_gb` | `id`, `name`, `tenant_id`, `volume_type` | the volume's `size_gb` |
+| `openstack_glance_image_bytes` | `id`, `name`, `tenant_id` | the image's size in bytes |
+| `openstack_neutron_floating_ip` | `id`, `project_id`, `status` | 1 |
+| `openstack_neutron_router` | `id`, `project_id`, `status` | 1 |
+| `openstack_loadbalancer_loadbalancer_status` | `id`, `name`, `project_id`, `provisioning_status`, `operating_status` | 1 |
+| `openstack_nova_limits_instances_used` and `_max` | `tenant_id` | the project's live instances, and 100 |
+| `openstack_nova_limits_vcpus_used` and `_max` | `tenant_id` | their summed vcpus, and 400 |
+| `openstack_nova_limits_memory_used` and `_max` | `tenant_id` | their summed memory in MB, and 819200 |
+| `openstack_identity_projects` | none | the count of tenants |
+| `openstack_identity_project_info` | `id`, `name`, `domain_id="default"`, `enabled="true"` | 1 |
+| `openstack_nova_total_vms` | none | the live instances of the cloud |
+| `openstack_cinder_volumes` | none | its live volumes |
+| `openstack_neutron_floating_ips` | none | its live floating addresses |
+| `openstack_glance_images` | none | its live images |
+| `openstack_loadbalancer_total_loadbalancers` | none | its live load balancers |
+
+The names and the label spellings are the exporter's own. A name this endpoint
+spelled its own way is a panel that stays empty against a simulated cloud and
+fills against a real one. The `id`, the `uuid`, and the `name` of a resource are
+all its generated id, because the oracle these gauges are folded out of holds no
+display name; the fake OpenStack API answers a listing the same way.
+
+The `status` of a server is nova's own word, read through the same table the
+fake OpenStack API answers a listing with, so it is `active`, `stopped`,
+`shelved_offloaded`, or `resized` where the oracle states the state the
+collector books. The memory is `ram_gb` times 1024, because nova's limits report
+megabytes where a size states gibibytes. The three maxima are constants: the
+simulated world has no quota, and the drilldown's gauge panels divide a used
+series by a maximum one, so a panel without the divisor would show a division by
+an absent series rather than a ratio. A size member an interval does not carry
+reads as zero, so one malformed interval costs its own series a value instead of
+failing a whole scrape.
+
+The routers are the one family the oracle does not hold, because nothing bills a
+router and the generator books none. They are folded out of the schedule's
+`router.create.end` and `router.delete.end` instead, which are transitions of
+the noise catalogue. The classic tenants' networks pre-exist the month and
+neutron announces nothing about them, so those projects report no router at all,
+which is what the simulated world holds.
+
+The samples carry neither `platform` nor `cloud`. A real exporter carries
+neither: both come from the static labels of the scrape job, and an endpoint
+that stated them as well would push the job's own under `exported_cloud`. A
+pushed point carries both, because a push has no scrape job to take them from.
+
+### The push
+
+`TALLY_SIM_OTLP_URL` is the OTLP/HTTP endpoint a run posts to, and an empty one
+is a run without a push. The document is OTLP/HTTP JSON, written by
+[`otlp.go`](../internal/providers/openstack/simulator/otlp.go) rather than by
+the OpenTelemetry SDK: the SDK stamps a point with the instant it collected it,
+and every point of a month belongs to a virtual instant months away from the
+wall clock; `timeUnixNano` is where a point carries that instant. A value
+travels as an `asInt` string, which keeps a byte count exact where a float64
+stops being exact above 2^53. The two counters go out as a monotonic cumulative
+`sum` and the inventory as a `gauge`. No metric declares a unit and the counter
+names already end in `_total`, so the OpenTelemetry collector's
+`prometheusremotewrite` exporter appends nothing and the store keeps the name
+that was sent.
+
+One request carries at most 5000 data points, and when a batch goes out is the
+clock's decision. At the default factor of 744 the run has not reached the next
+grid instant by the time it has folded this one, so the batch of a grid step
+leaves as the clock passes that step, about one request per 0.4 wall seconds on
+a 300s grid. At factor 0 virtual time stands still, no step ever waits, and the
+batch fills to the cap instead, which is what keeps a month at factor 0 from
+being one request per step.
+
+A request is retried under the policy the engine's counter client queries
+VictoriaMetrics with: a connection error, a 429, which is what the Gateway's
+`BackendTrafficPolicy` answers a run that pushes faster than the rate it allows,
+and a 5xx except 501, four retries at most; a 4xx such as the 401 of a wrong
+password comes back at once. A batch that still fails ends the push with
+`pushing metrics to <url>: ...` and exit status 1, reported once the last
+notification is on the bus: the month is what the operator asked for, and the
+exit status is what says the metric half of it failed. SIGINT and SIGTERM stop
+the push the way they stop the publishing, with exit status 0.
+
+A `replay` pushes nothing and serves no `/metrics`. A `run` in file mode pushes
+nothing either, and it writes the traffic rows of the month into its oracle all
+the same. The compose stack pushes to the dev Gateway's
+`https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics` under the credential the
+dev overlay generates into the `tally-otlp-auth` Secret.
+
+The points lie on the simulated period rather than on the wall clock of the run
+that sent them. A dashboard therefore reads the month by setting its time range
+to the period, not to the hour the run took.
+
+### The endpoint
+
+`GET /metrics` on the control listener serves the inventory in the Prometheus
+exposition format while a run publishes, out of the same `InventoryAt` the push
+reads and clamped to the end of the month the way a listing of the fake
+OpenStack API is. The registry behind it is private and holds that one
+collector: no Go metrics and no process metrics, because an endpoint that stands
+in for an exporter of the cloud has no business reporting the heap and the file
+descriptors of the process that runs the drill.
+
+`TALLY_METRICS_ENABLED=false` registers no route, and the path is then left to
+the fake OpenStack API, which answers it with the 404 it answers any unknown
+path with.
+
+The dev overlay's `openstack-db-exporter` scrape job reads that endpoint at
+`host.docker.internal:8091` under `cloud: os-sim`, which is where a pod in the
+kind node reaches the port the compose stack publishes on the host
+([`scrape.yaml`](../deploy/kubernetes/overlays/dev/victoriametrics/scrape.yaml)).
+The job is up while a run publishes and down between runs, where
+`TallyScrapeTargetDown` fires for it after five minutes, the way it does against
+the base's placeholder target. The `ceilometer` job keeps its placeholder: the
+recorded Ceilometer default is the Pushgateway path, and the traffic of a
+simulated month reaches the store over OTLP.
+
+### The counter
+
+[`counter-sources.yaml`](../deploy/kubernetes/overlays/dev/counter-sources.yaml)
+of the dev overlay measures `egress_gb` of an OpenStack instance from the
+counter a push writes:
+
+```yaml
+sources:
+  - platform: openstack
+    resource_type: instance
+    metric: egress_gb
+    kind: metricsql
+    required: false
+    query: >
+      sum(increase(ceilometer_network_outgoing_bytes_total{cloud="{cloud}",
+          resource_id="{resource_id}"}[{window}])) / (1024 * 1024 * 1024)
+```
+
+`required: false` because a dev cluster where no month was ever simulated holds
+none of that series, and a required source whose query fails takes the whole
+tick down with it, every scheduled hour; a failed query of an optional source
+yields a `counter_source_failed` warning on a run that finished. The divisor is
+2^30, which is what `bytesPerGibibyte` converts a reported size with, so the
+export's quantity and the oracle's bytes are in one unit. The overlay mounts the
+generated ConfigMap into the `tally-engine` CronJob at
+`/etc/tally/counter-sources.yaml` and points `TALLY_ENGINE_COUNTER_SOURCES` at
+that path. A metricsql source is queried at the end of every usage draft, which
+for a simulated month is an instant inside the period the points lie on, so
+`rated.csv` of a run over that month carries a non-zero `egress_gb` quantity for
+every instance that was active.
+
+`compare` leaves the `counter` dimensions out all the same. `increase()`
+extrapolates a counter over the edges of the window it is asked about, so the
+quantity an export carries differs from the exact integral the generator placed
+in the interval, and a comparison that held the two equal would report the
+extrapolation as an engine difference. The oracle's `traffic` rows are what a
+drill reads the intended figure off.
+
 ## Configuration
 
 [`../cmd/tally-openstack-simulator/.env.example`](../cmd/tally-openstack-simulator/.env.example)
@@ -1630,6 +1926,11 @@ lists every variable with its default and its meaning.
 | `TALLY_SIM_REPORTING_INSECURE` | `false` | `run` with `--register-projects` | allow a plaintext Reporting API. The api token travels in a header on every request and is of role `admin`, so it is not scoped to one cloud the way an ingest token is. |
 | `TALLY_SIM_API_TOKEN` | none | `run` with `--register-projects` | credential of the registration, an api token of role `admin`, which `POST /api/v1/projects` and `POST /api/v1/projects/{id}/relations` demand. It also accepts `TALLY_SIM_API_TOKEN_FILE`; setting both is an error. |
 | `TALLY_SIM_GARDEN_CLOUD` | none | `run` with `--register-projects` | cloud the two Gardener rows are registered under. It has to differ from `TALLY_SIM_CLOUD`: a cloud is one installation of one platform. |
+| `TALLY_SIM_OTLP_URL` | none | `run` | OTLP/HTTP endpoint the traffic counters and the inventory gauges are pushed to. Empty is a run without a push. It has to be absolute and carry a host, to carry no userinfo, query or fragment, because the credential of a push belongs in `TALLY_SIM_OTLP_USER` and `TALLY_SIM_OTLP_PASSWORD` and a URL that carries one hands it to every error the push writes, and to be `https` unless `TALLY_SIM_OTLP_INSECURE` says otherwise, because the Basic password travels on it. |
+| `TALLY_SIM_OTLP_USER` | none | `run` with `TALLY_SIM_OTLP_URL` | Basic user of the push. The endpoint in front of the collector answers an unauthenticated push with a 401. |
+| `TALLY_SIM_OTLP_PASSWORD` | none | `run` with `TALLY_SIM_OTLP_URL` | Basic password of the push. It also accepts `TALLY_SIM_OTLP_PASSWORD_FILE`; setting both is an error. |
+| `TALLY_SIM_OTLP_INSECURE` | `false` | `run` | allow a plaintext OTLP endpoint. The password travels on every request, so an `http` endpoint hands it to whoever reads the wire. |
+| `TALLY_METRICS_ENABLED` | `true` | `run`, while publishing | serve the inventory on `GET /metrics` of the control listener, which "The metric series" describes. `false` registers no route, and the fake OpenStack API answers that path with its own 404. |
 
 An empty `TALLY_SIM_AMQP_URL` puts `run` in file mode, where `--out` is what it
 writes to instead, and `replay` refuses to start without one.
@@ -1647,14 +1948,17 @@ reason, and `--allow-remote-broker` is the confirmation that lets one through.
 The compose stack passes it, because its broker is the container next door.
 
 `run` takes `--period` (required, `YYYY-MM`), `--seed` (1), `--factor` (744),
-`--out` (empty), `--wait-for-collector` (two minutes), `--faults` (empty),
-`--register-projects` (off), and `--allow-remote-broker` (off). `--faults` takes
+`--out` (empty), `--wait-for-collector` (two minutes), `--metrics-interval`
+(`300s`), `--faults` (empty), `--register-projects` (off), and
+`--allow-remote-broker` (off). `--faults` takes
 the six switch names `pre-existing`, `missing-create`, `duplicates`,
 `reordering`, `refused-shapes`, and `held-back`, comma-separated; empty is every
 switch off, and "The fault switches" describes what each of them does.
 `--register-projects` registers the month's tenants, the two Gardener projects,
 and their `infrastructure_tenant` relations before anything is written or
-published, which "The project registry" describes. `replay` takes `--in`
+published, which "The project registry" describes. `--metrics-interval` is the
+grid the traffic and the inventory samples lie on, which "The metric series"
+describes. `replay` takes `--in`
 (required),
 `--factor` (744), `--wait-for-collector` (two minutes), and
 `--allow-remote-broker` (off). `compare` takes `--oracle`, `--export`, and
@@ -1662,5 +1966,5 @@ published, which "The project registry" describes. `replay` takes `--in`
 holds three files against each other and touches neither a broker nor the
 Reporting API.
 
-`TALLY_METRICS_ENABLED` is not read: the simulator exports no metrics, and #67
-owns the endpoint that would serve them.
+`TALLY_METRICS_ENABLED` switches the inventory endpoint of "The metric series"
+above.

--- a/internal/providers/openstack/simulator/compare.go
+++ b/internal/providers/openstack/simulator/compare.go
@@ -31,8 +31,11 @@ import (
 // not compared is what the pricing model decides. An amount is what the model
 // charges for a quantity, so a comparison that recomputed one would hold the
 // model against itself. A counter dimension is left out for a reason of its
-// own: no transition of a simulated month meters egress, so the quantity an
-// export carries for one is read from nothing the oracle states.
+// own: increase() extrapolates a counter over the edges of the window it is
+// asked about, so the quantity an export carries differs from the exact
+// integral the generator placed in the interval, and a comparison that held the
+// two equal would report the extrapolation as an engine difference. The
+// oracle's traffic rows are what a drill reads the intended figure off.
 //
 // A resource type the model does not price reaches no rated record at all,
 // because rating.Rate skips it, so its resources are counted per type instead

--- a/internal/providers/openstack/simulator/config.go
+++ b/internal/providers/openstack/simulator/config.go
@@ -30,7 +30,7 @@ import (
 // fileSuffix names the companion variable of a secret: the value of
 // TALLY_SIM_AMQP_URL is read from the file at TALLY_SIM_AMQP_URL_FILE when that
 // variable holds a path, and TALLY_SIM_API_TOKEN from TALLY_SIM_API_TOKEN_FILE
-// the same way.
+// and TALLY_SIM_OTLP_PASSWORD from TALLY_SIM_OTLP_PASSWORD_FILE the same way.
 const fileSuffix = "_FILE"
 
 // The variables this package reads. They are named here because the errors
@@ -46,6 +46,12 @@ const (
 	envReportingInsecure = "TALLY_SIM_REPORTING_INSECURE"
 	envAPIToken          = "TALLY_SIM_API_TOKEN"
 	envGardenCloud       = "TALLY_SIM_GARDEN_CLOUD"
+
+	envOTLPURL        = "TALLY_SIM_OTLP_URL"
+	envOTLPUser       = "TALLY_SIM_OTLP_USER"
+	envOTLPPassword   = "TALLY_SIM_OTLP_PASSWORD"
+	envOTLPInsecure   = "TALLY_SIM_OTLP_INSECURE"
+	envMetricsEnabled = "TALLY_METRICS_ENABLED"
 )
 
 // EnvNames is every variable this package reads, including the *_FILE
@@ -63,6 +69,12 @@ var EnvNames = []string{
 	envAPIToken,
 	envAPIToken + fileSuffix,
 	envGardenCloud,
+	envOTLPURL,
+	envOTLPUser,
+	envOTLPPassword,
+	envOTLPPassword + fileSuffix,
+	envOTLPInsecure,
+	envMetricsEnabled,
 }
 
 // loopback is the address the control endpoint binds unless a deployment names
@@ -121,12 +133,36 @@ type Config struct {
 	// GardenCloud is the cloud the two Gardener projects are registered under.
 	// It has no default, for the reason Cloud has none.
 	GardenCloud string `env:"TALLY_SIM_GARDEN_CLOUD"`
+	// OTLPURL is the OTLP/HTTP endpoint the traffic and inventory series of a run
+	// are pushed to. Empty is a run without a push. It has to be absolute and
+	// carry a host, and to be https unless OTLPInsecure allows a plaintext one,
+	// because the Basic password travels on it. run reads it alone.
+	OTLPURL string `env:"TALLY_SIM_OTLP_URL"`
+	// OTLPUser is the Basic user of the push. The endpoint in front of the
+	// collector takes Basic auth, so a URL without a user reaches nothing.
+	OTLPUser string `env:"TALLY_SIM_OTLP_USER"`
+	// OTLPPassword is the Basic password of the push. It supports the *_FILE
+	// convention.
+	OTLPPassword string `env:"TALLY_SIM_OTLP_PASSWORD"`
+	// OTLPInsecure allows an http endpoint. It exists for a simulator and a
+	// collector on the same machine, and for development; anywhere else it puts
+	// the Basic password on the wire in cleartext.
+	OTLPInsecure bool `env:"TALLY_SIM_OTLP_INSECURE" envDefault:"false"`
+	// MetricsEnabled serves the inventory on GET /metrics of the control listener
+	// while a run publishes, where it stands in for the OpenStack database
+	// exporter a deployment scrapes. False registers no route, and the fake
+	// OpenStack API then answers that path with its own 404. A Config that never
+	// went through Load carries false, which is why a test that needs the
+	// endpoint sets it. The variable has no SIM infix because roadmap section 8
+	// lists it among the common variables every service reads.
+	MetricsEnabled bool `env:"TALLY_METRICS_ENABLED" envDefault:"true"`
 }
 
 // Load reads the environment, resolves the file-backed secrets, and checks the
 // log level. It does not check whether the required values are present: which
 // ones are required depends on the subcommand and on its switches, which is
-// what ValidateRun, ValidateReplay, and ValidateRegistration decide.
+// what ValidateRun, ValidateReplay, ValidateRegistration, and ValidateMetrics
+// decide.
 func Load() (Config, error) {
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
@@ -137,6 +173,9 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	if cfg.APIToken, err = resolveFileSecret(envAPIToken, cfg.APIToken); err != nil {
+		return Config{}, err
+	}
+	if cfg.OTLPPassword, err = resolveFileSecret(envOTLPPassword, cfg.OTLPPassword); err != nil {
 		return Config{}, err
 	}
 
@@ -250,6 +289,47 @@ func (c Config) validateReportingURL() error {
 	if parsed.Scheme != "https" && !c.ReportingInsecure {
 		return fmt.Errorf("%s: %q must use https, because the admin api token travels on it; "+
 			"set %s=true to allow plaintext", envReportingURL, c.ReportingURL, envReportingInsecure)
+	}
+	return nil
+}
+
+// ValidateMetrics is the gate of the push side of the metrics, checked before a
+// run dials the broker. An empty TALLY_SIM_OTLP_URL is a run without a push and
+// passes: the month is generated and published, and the samples it places stay
+// in the process.
+//
+// A URL that is set is one a whole month is posted to, so what it needs is
+// asked for now rather than at the first flush, an hour into a paced run.
+func (c Config) ValidateMetrics() error {
+	if c.OTLPURL == "" {
+		return nil
+	}
+	if c.OTLPUser == "" {
+		return fmt.Errorf("%s: must be set when %s is set", envOTLPUser, envOTLPURL)
+	}
+	if c.OTLPPassword == "" {
+		return fmt.Errorf("%s: must be set when %s is set", envOTLPPassword, envOTLPURL)
+	}
+	// The value is named and not quoted, unlike the Reporting API's: a mistyped
+	// endpoint may carry userinfo, and an error an operator pastes into a ticket
+	// must not carry a credential.
+	parsed, err := url.Parse(c.OTLPURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return fmt.Errorf("%s: must be an absolute http(s) URL with a host", envOTLPURL)
+	}
+	// The credential of a push is the Basic one, and the URL is where it must
+	// not be. A token carried as the userinfo or as a query parameter is one no
+	// message can be trusted to keep out: an http client redacts the password
+	// half of a userinfo before it wraps a transport error and leaves the user
+	// and the query standing, and that error is logged as JSON and shipped from
+	// there. So the shape is refused rather than redacted afterwards.
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("%s: must carry no userinfo, query or fragment; the credential of a push "+
+			"belongs in %s and %s", envOTLPURL, envOTLPUser, envOTLPPassword)
+	}
+	if parsed.Scheme != "https" && !c.OTLPInsecure {
+		return fmt.Errorf("%s: must use https, because the Basic password travels on it; "+
+			"set %s=true to allow plaintext", envOTLPURL, envOTLPInsecure)
 	}
 	return nil
 }

--- a/internal/providers/openstack/simulator/config_test.go
+++ b/internal/providers/openstack/simulator/config_test.go
@@ -1,6 +1,9 @@
 package simulator
 
 import (
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -180,4 +183,229 @@ func TestValidateRegistrationChecksTheReportingURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateMetricsAsksForWhatAPushNeeds covers the gate of the metrics push.
+// Each refusal names the variable an operator sets, and the Basic password is
+// the value no message quotes, for the reason the api token is never quoted.
+func TestValidateMetricsAsksForWhatAPushNeeds(t *testing.T) {
+	const password = "s3cret-of-the-test"
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "no user",
+			cfg:  Config{OTLPURL: "https://otlp.example/v1/metrics", OTLPPassword: password},
+			want: "TALLY_SIM_OTLP_USER: must be set when TALLY_SIM_OTLP_URL is set",
+		},
+		{
+			name: "no password",
+			cfg:  Config{OTLPURL: "https://otlp.example/v1/metrics", OTLPUser: "tally"},
+			want: "TALLY_SIM_OTLP_PASSWORD: must be set when TALLY_SIM_OTLP_URL is set",
+		},
+		{
+			name: "an endpoint that is not a URL",
+			cfg:  Config{OTLPURL: "not a url", OTLPUser: "tally", OTLPPassword: password},
+			want: "TALLY_SIM_OTLP_URL: must be an absolute http(s) URL with a host",
+		},
+		{
+			name: "an endpoint without a host",
+			cfg:  Config{OTLPURL: "https://", OTLPUser: "tally", OTLPPassword: password},
+			want: "TALLY_SIM_OTLP_URL: must be an absolute http(s) URL with a host",
+		},
+		{
+			name: "an endpoint that is not HTTP",
+			cfg: Config{
+				OTLPURL: "ftp://otlp.example/v1/metrics", OTLPUser: "tally", OTLPPassword: password,
+			},
+			want: "TALLY_SIM_OTLP_URL: must be an absolute http(s) URL with a host",
+		},
+		{
+			name: "an endpoint that carries a token as its user",
+			cfg: Config{
+				OTLPURL:  "https://" + password + "@otlp.example/v1/metrics",
+				OTLPUser: "tally", OTLPPassword: password,
+			},
+			want: "TALLY_SIM_OTLP_URL: must carry no userinfo, query or fragment; " +
+				"the credential of a push belongs in TALLY_SIM_OTLP_USER and TALLY_SIM_OTLP_PASSWORD",
+		},
+		{
+			name: "an endpoint that carries an api key in its query",
+			cfg: Config{
+				OTLPURL:  "https://otlp.example/v1/metrics?api-key=" + password,
+				OTLPUser: "tally", OTLPPassword: password,
+			},
+			want: "TALLY_SIM_OTLP_URL: must carry no userinfo, query or fragment; " +
+				"the credential of a push belongs in TALLY_SIM_OTLP_USER and TALLY_SIM_OTLP_PASSWORD",
+		},
+		{
+			name: "an endpoint that carries a fragment",
+			cfg: Config{
+				OTLPURL:  "https://otlp.example/v1/metrics#" + password,
+				OTLPUser: "tally", OTLPPassword: password,
+			},
+			want: "TALLY_SIM_OTLP_URL: must carry no userinfo, query or fragment; " +
+				"the credential of a push belongs in TALLY_SIM_OTLP_USER and TALLY_SIM_OTLP_PASSWORD",
+		},
+		{
+			name: "a plaintext endpoint that was not allowed",
+			cfg: Config{
+				OTLPURL: "http://otlp.example/v1/metrics", OTLPUser: "tally", OTLPPassword: password,
+			},
+			want: "TALLY_SIM_OTLP_URL: must use https, because the Basic password travels on it; " +
+				"set TALLY_SIM_OTLP_INSECURE=true to allow plaintext",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.ValidateMetrics()
+			if err == nil {
+				t.Fatalf("ValidateMetrics() error = nil, want %q", tc.want)
+			}
+			if err.Error() != tc.want {
+				t.Errorf("ValidateMetrics() error = %q, want %q", err, tc.want)
+			}
+			if got := err.Error(); strings.Contains(got, password) {
+				t.Errorf("ValidateMetrics() error = %q, want it to keep the password out", got)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "a run without a push",
+			cfg:  Config{},
+		},
+		{
+			name: "an https endpoint with its credentials",
+			cfg: Config{
+				OTLPURL: "https://otlp.example/v1/metrics", OTLPUser: "tally", OTLPPassword: password,
+			},
+		},
+		{
+			name: "a plaintext endpoint that was allowed",
+			cfg: Config{
+				OTLPURL: "http://127.0.0.1:4318/v1/metrics", OTLPUser: "tally",
+				OTLPPassword: password, OTLPInsecure: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.ValidateMetrics(); err != nil {
+				t.Errorf("ValidateMetrics() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestLoadResolvesTheOTLPPasswordFile holds the Basic password to the *_FILE
+// convention the other two secrets follow: the file's content becomes the
+// value, both sources at once are a mistake, and an empty file is one too,
+// because it usually means the Secret was never populated.
+func TestLoadResolvesTheOTLPPasswordFile(t *testing.T) {
+	t.Run("the file holds the password", func(t *testing.T) {
+		blankEnvironment(t)
+		t.Setenv(envOTLPPassword+fileSuffix, secretFile(t, "pw\n"))
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if cfg.OTLPPassword != "pw" {
+			t.Errorf("OTLPPassword = %q, want %q", cfg.OTLPPassword, "pw")
+		}
+	})
+
+	t.Run("both sources at once", func(t *testing.T) {
+		blankEnvironment(t)
+		t.Setenv(envOTLPPassword, "pw")
+		t.Setenv(envOTLPPassword+fileSuffix, secretFile(t, "pw\n"))
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want the two sources refused")
+		}
+		want := "set TALLY_SIM_OTLP_PASSWORD or TALLY_SIM_OTLP_PASSWORD_FILE, not both"
+		if err.Error() != want {
+			t.Errorf("Load() error = %q, want %q", err, want)
+		}
+	})
+
+	t.Run("an empty file", func(t *testing.T) {
+		blankEnvironment(t)
+		path := secretFile(t, "")
+		t.Setenv(envOTLPPassword+fileSuffix, path)
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want the empty file refused")
+		}
+		want := "TALLY_SIM_OTLP_PASSWORD_FILE: file " + path + " is empty"
+		if err.Error() != want {
+			t.Errorf("Load() error = %q, want %q", err, want)
+		}
+	})
+
+	t.Run("the defaults of a run that sets neither", func(t *testing.T) {
+		blankEnvironment(t)
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		if !cfg.MetricsEnabled {
+			t.Errorf("MetricsEnabled = false, want true: the endpoint is served unless it is turned off")
+		}
+		if cfg.OTLPInsecure {
+			t.Errorf("OTLPInsecure = true, want false: plaintext is typed for, not fallen into")
+		}
+	})
+}
+
+// TestEnvNamesListTheMetricsVariables keeps the metrics variables in the list
+// the tests blank and the example file is held against: one that is missing
+// from it reaches the code under test out of the developer's shell, and nobody
+// documents it.
+func TestEnvNamesListTheMetricsVariables(t *testing.T) {
+	for _, name := range []string{
+		envOTLPURL,
+		envOTLPUser,
+		envOTLPPassword,
+		envOTLPPassword + fileSuffix,
+		envOTLPInsecure,
+		envMetricsEnabled,
+	} {
+		if !slices.Contains(EnvNames, name) {
+			t.Errorf("EnvNames does not list %s, want it among %v", name, EnvNames)
+		}
+	}
+}
+
+// blankEnvironment blanks every variable this package reads, so a value in the
+// developer's shell never reaches Load. A variable set to the empty string
+// falls back to its default exactly as an unset one does, which is what the
+// blanked TALLY_LOG_LEVEL relies on.
+func blankEnvironment(t *testing.T) {
+	t.Helper()
+
+	for _, name := range EnvNames {
+		t.Setenv(name, "")
+	}
+}
+
+// secretFile writes content to a file in a temporary directory and returns its
+// path, which is what a *_FILE companion points at.
+func secretFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
 }

--- a/internal/providers/openstack/simulator/control_test.go
+++ b/internal/providers/openstack/simulator/control_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -516,5 +517,134 @@ func TestControlAddrBindsLoopbackUnlessAskedOtherwise(t *testing.T) {
 				t.Errorf("ControlAddr() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// runMux is the mux a run serves: the control routes, the inventory endpoint,
+// and the fake OpenStack API beneath the two. The wall clock is frozen, so
+// every document the endpoint answers with is the one the test picked however
+// long the test takes. A nil exporter is a run with metrics turned off.
+func runMux(t *testing.T, month Month, withExporter bool) *httptest.Server {
+	t.Helper()
+
+	wall := time.Unix(0, 0)
+	clock := NewClock(cloudDay(10), 744, func() time.Time { return wall })
+	api, err := NewCloudAPI(clock, month.Oracle)
+	if err != nil {
+		t.Fatalf("NewCloudAPI() error = %v, want nil", err)
+	}
+
+	var exporter http.Handler
+	if withExporter {
+		exporter = NewExporter(month, clock)
+	}
+	mux := NewControlMux(clock, func() Progress { return controlProgress }, func() error { return nil })
+	mountRun(mux, api, exporter)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// servedMonth is one month a run serves: one tenant, and one instance of it
+// that outlives the month, so both the scrape and the listing hold something.
+func servedMonth() Month {
+	return Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle:  testOracle(oneInstance("web-01", cloudDay(2), cloudTo)),
+	}
+}
+
+func TestMetricsRouteIsMatchedAheadOfTheFakeAPI(t *testing.T) {
+	server := runMux(t, servedMonth(), true)
+
+	status, contentType, body := request(t, server, http.MethodGet, "/metrics", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if !strings.HasPrefix(contentType, "text/plain") {
+		t.Errorf("GET /metrics Content-Type = %q, want it to start with text/plain", contentType)
+	}
+	if !strings.Contains(body, seriesNovaTotalVMs) {
+		t.Errorf("GET /metrics states no %s, want the scrape and not the fake API's 404",
+			seriesNovaTotalVMs)
+	}
+
+	status, _, body = request(t, server, http.MethodGet, "/healthz", "")
+	if status != http.StatusOK || body != "ok" {
+		t.Errorf("GET /healthz = %d with body %q, want %d and %q", status, body, http.StatusOK, "ok")
+	}
+
+	status, _, body = request(t, server, http.MethodGet, "/clock", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	want := clockDocument{
+		VirtualNow: cloudDay(10).Format(time.RFC3339),
+		Factor:     744,
+		Published:  controlProgress.Published,
+		Total:      controlProgress.Total,
+		Held:       controlProgress.Held,
+		Holding:    controlProgress.Holding,
+		PeriodFrom: cloudFrom.Format(time.RFC3339),
+		PeriodTo:   cloudTo.Format(time.RFC3339),
+	}
+	if doc := decodeDocument(t, body); doc != want {
+		t.Errorf("GET /clock document = %+v, want %+v", doc, want)
+	}
+
+	status, _, body = request(t, server, http.MethodPut, "/clock", `{"factor": 0}`)
+	if status != http.StatusOK {
+		t.Fatalf("PUT /clock = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if got := decodeDocument(t, body).Factor; got != 0 {
+		t.Errorf("PUT /clock document factor = %g, want 0", got)
+	}
+
+	status, contentType, body = request(t, server, http.MethodPost, "/release", "")
+	if status != http.StatusOK {
+		t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Errorf("POST /release Content-Type = %q, want it to start with application/json", contentType)
+	}
+
+	// Everything the two patterns above leave is still the fake API's, so a sync
+	// reads the month off the very listener a scrape reads the inventory off.
+	status, body = askCloud(t, server, tokenOf(t, server), serversPath)
+	if status != http.StatusOK {
+		t.Fatalf("GET %s = %d, want %d (body %q)", serversPath, status, http.StatusOK, body)
+	}
+	if got := servedIDs(t, body, "servers"); !slices.Equal(got, []string{"web-01"}) {
+		t.Errorf("the live listing answered with %v, want the instance the month holds at day 10", got)
+	}
+}
+
+func TestMetricsRouteIsAbsentWhenMetricsAreOff(t *testing.T) {
+	server := runMux(t, servedMonth(), false)
+
+	status, _, body := request(t, server, http.MethodGet, "/metrics", "")
+	if status != http.StatusNotFound {
+		t.Errorf("GET /metrics with metrics off = %d, want %d from the fake API's catch-all (body %q)",
+			status, http.StatusNotFound, body)
+	}
+	status, _, body = request(t, server, http.MethodGet, "/healthz", "")
+	if status != http.StatusOK || body != "ok" {
+		t.Errorf("GET /healthz with metrics off = %d with body %q, want %d and %q",
+			status, body, http.StatusOK, "ok")
+	}
+
+	// A replay mounts neither: it holds the notifications of a month and no
+	// oracle, so there is nothing to scrape and nothing to list.
+	replayMux := NewControlMux(NewClock(cloudDay(10), 0, time.Now),
+		func() Progress { return controlProgress }, nil)
+	mountRun(replayMux, nil, nil)
+	replay := httptest.NewServer(replayMux)
+	t.Cleanup(replay.Close)
+
+	status, _, body = request(t, replay, http.MethodGet, "/metrics", "")
+	if status != http.StatusNotFound {
+		t.Errorf("GET /metrics on the mux of a replay = %d, want %d (body %q)",
+			status, http.StatusNotFound, body)
 	}
 }

--- a/internal/providers/openstack/simulator/exporter.go
+++ b/internal/providers/openstack/simulator/exporter.go
@@ -1,0 +1,99 @@
+package simulator
+
+import (
+	"maps"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// The endpoint the inventory of a month is scraped off. It stands in for the
+// OpenStack database exporter a real cloud runs beside its services: the same
+// series under the same names, read off the month instead of off the databases
+// of nova, cinder, neutron, glance and octavia. A dashboard written against a
+// real cloud therefore fills against a simulated one, and the drill compares
+// what the panels show with what the oracle states.
+//
+// What a scrape reports is decided by InventoryAt alone. This file turns those
+// samples into the exposition format and serves them; which series a month
+// holds, and what a value is, is stated there.
+
+// exporterHelp is the help every family of this endpoint carries. The exporter
+// it stands in for writes one line per family out of its own table, and one
+// line for all of them says the thing somebody reading a scrape by hand needs
+// to know: where the numbers come from and which instant they belong to.
+const exporterHelp = "The simulated cloud's inventory at the run's virtual instant, " +
+	"under the OpenStack database exporter's names."
+
+// The bounds one scrape is served under. They are the collector's, stated in
+// internal/providers/openstack/metrics.go together with the reasons: a gather
+// walks and serializes the whole registry, and this route carries no credential
+// either. The two constants there are unexported, so the values are repeated
+// here rather than shared.
+const (
+	maxScrapesInFlight = 3
+	scrapeBudget       = 10 * time.Second
+)
+
+// inventoryCollector renders the inventory of one month on every scrape. It
+// holds the month and the clock rather than a rendered set of samples, because
+// what a scrape reports is the world at the instant it arrives: a drill that
+// stops the clock reads one document twice, and one that lets it run watches
+// the month go by.
+type inventoryCollector struct {
+	month Month
+	clock *Clock
+}
+
+// Describe sends no descriptor, which registers this as an unchecked collector.
+// The families a scrape carries follow the world at that instant: a month holds
+// no load balancer before the first one is built, and states none until it is.
+// A descriptor set fixed at registration would either promise families that are
+// absent or forbid the ones that appear.
+func (c inventoryCollector) Describe(chan<- *prometheus.Desc) {}
+
+// Collect states every sample the inventory places at the clock's instant, each
+// as a gauge under the labels the sample carries. An instant past the end of
+// the month is answered at that end, which is where a listing of the fake API
+// is held too, so a clock that outran the month keeps reporting what it held.
+//
+// A scrape carries no timestamp of its own: Prometheus stamps a sample with the
+// instant it read it, and the virtual instant the value belongs to is the one
+// the whole run is paced by.
+//
+// The exposition format is float by definition. Every value here is a count, a
+// gibibyte figure or the byte size of an image, all far below 2^53, so the
+// conversion states them exactly.
+func (c inventoryCollector) Collect(out chan<- prometheus.Metric) {
+	for _, sample := range InventoryAt(c.month, c.clock.Now()) {
+		keys := slices.Sorted(maps.Keys(sample.Labels))
+		values := make([]string, 0, len(keys))
+		for _, key := range keys {
+			values = append(values, sample.Labels[key])
+		}
+		out <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(sample.Name, exporterHelp, keys, nil),
+			prometheus.GaugeValue, float64(sample.Value), values...)
+	}
+}
+
+// NewExporter serves the inventory of one month in the Prometheus exposition
+// format, over the clock the run is paced by. It is what GET /metrics is
+// mounted on for as long as the run publishes.
+//
+// The registry is private and holds this one collector: no Go collector and no
+// process collector. The endpoint stands in for an exporter of the simulated
+// cloud, and a scrape that also carried the simulator's heap and its file
+// descriptors would state series about the process running the drill under an
+// endpoint that is supposed to speak for a cloud.
+func NewExporter(month Month, clock *Clock) http.Handler {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(inventoryCollector{month: month, clock: clock})
+	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		MaxRequestsInFlight: maxScrapesInFlight,
+		Timeout:             scrapeBudget,
+	})
+}

--- a/internal/providers/openstack/simulator/exporter_test.go
+++ b/internal/providers/openstack/simulator/exporter_test.go
@@ -1,0 +1,243 @@
+package simulator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// aggregateSeries is the five the alert TallyExporterServiceSilent reads off a
+// database exporter, in deploy/kubernetes/base/vmalert/rules.yaml. A scrape of
+// the stand-in that states one of them under another name is an exporter the
+// rule calls silent.
+var aggregateSeries = []string{
+	seriesNovaTotalVMs, seriesCinderVolumes, seriesNeutronFloatingIPs,
+	seriesGlanceImages, seriesLoadBalancerTotal,
+}
+
+// scrapeOf is the body of one scrape of a month at a virtual instant. The clock
+// runs at factor 0, so the instant the endpoint answers at is the one the test
+// picked however long the test takes.
+func scrapeOf(t *testing.T, month Month, at time.Time) string {
+	t.Helper()
+
+	server := httptest.NewServer(NewExporter(month, NewClock(at, 0, time.Now)))
+	t.Cleanup(server.Close)
+
+	status, contentType, body := request(t, server, http.MethodGet, "/metrics", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET /metrics at %s = %d, want %d (body %q)",
+			at.Format(time.RFC3339), status, http.StatusOK, body)
+	}
+	if !strings.HasPrefix(contentType, "text/plain") {
+		t.Errorf("GET /metrics Content-Type = %q, want it to start with text/plain", contentType)
+	}
+	return body
+}
+
+// scrapedGauge is the one sample a family of the exposition holds: its value
+// and its labels. A scrape of this endpoint is a short document of gauges
+// without a timestamp, so it is read line by line rather than through a parser
+// this module would have to depend on for the tests alone.
+//
+// A family stated twice, stated not at all, or typed as anything but a gauge
+// fails here: those are the three ways a collector states an inventory a
+// dashboard cannot read.
+func scrapedGauge(t *testing.T, body, name string) (float64, map[string]string) {
+	t.Helper()
+
+	if !strings.Contains(body, "# TYPE "+name+" gauge\n") {
+		t.Errorf("%s is not typed as a gauge, which is what an inventory is read as", name)
+	}
+
+	// The name is matched whole, against the line's own name and not against a
+	// prefix of it, so openstack_cinder_volumes is no line of
+	// openstack_cinder_volume_gb.
+	held := make([]string, 0, 1)
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, name+"{") || strings.HasPrefix(line, name+" ") {
+			held = append(held, line)
+		}
+	}
+	if len(held) != 1 {
+		t.Fatalf("%s is stated %d times, want once", name, len(held))
+	}
+
+	labels := make(map[string]string)
+	rest, labeled := strings.CutPrefix(held[0], name+"{")
+	if labeled {
+		block, tail, closed := strings.Cut(rest, "}")
+		if !closed {
+			t.Fatalf("the line %q closes no label block", held[0])
+		}
+		for _, pair := range strings.Split(block, ",") {
+			key, value, ok := strings.Cut(pair, "=")
+			if !ok {
+				t.Fatalf("the label %q of %s is no key=\"value\" pair", pair, name)
+			}
+			// No label of this endpoint carries a quote or a comma of its own, so
+			// the quotes around a value are the only ones on the line.
+			labels[key] = strings.Trim(value, `"`)
+		}
+		rest = tail
+	} else {
+		rest = strings.TrimPrefix(held[0], name)
+	}
+
+	value, err := strconv.ParseFloat(strings.TrimSpace(rest), 64)
+	if err != nil {
+		t.Fatalf("the value of %s in %q: %v", name, held[0], err)
+	}
+	return value, labels
+}
+
+func TestExporterServesTheInventoryOfTheInstant(t *testing.T) {
+	at := cloudDay(10)
+	month := faultyMonth(t, 1, Faults{})
+	body := scrapeOf(t, month, at)
+
+	samples := InventoryAt(month, at)
+	for _, name := range aggregateSeries {
+		held := namedSamples(samples, name)
+		if len(held) != 1 {
+			t.Fatalf("the inventory states %s %d times, want once", name, len(held))
+		}
+		value, labels := scrapedGauge(t, body, name)
+		if value != float64(held[0].Value) {
+			t.Errorf("the scrape states %s = %g, want the %d the inventory holds at %s",
+				name, value, held[0].Value, at.Format(time.RFC3339))
+		}
+		if len(labels) != 0 {
+			t.Errorf("%s carries the labels %v, want an aggregate of the cloud to carry none", name, labels)
+		}
+	}
+
+	served := false
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, seriesNovaServerStatus+"{") && strings.Contains(line, `tenant_id="`) {
+			served = true
+			break
+		}
+	}
+	if !served {
+		t.Errorf("no %s line names a tenant_id, want one per server the month runs at %s",
+			seriesNovaServerStatus, at.Format(time.RFC3339))
+	}
+
+	// The two labels a scrape job puts on every series it collects. An endpoint
+	// that stated them itself would push the job's own under exported_cloud.
+	for _, forbidden := range []string{"platform=", "cloud="} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("the scrape carries a %s label, want it from the scrape job alone",
+				strings.TrimSuffix(forbidden, "="))
+		}
+	}
+}
+
+func TestExporterGathersConsistently(t *testing.T) {
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle: testOracle(
+			oneInstance("srv-1", cloudDay(2), cloudDay(4)),
+			oneResource(typeVolume, "vol-1", cloudDay(2), cloudDay(4), stateInUse,
+				volumeSizeOf(&volume{sizeGB: 100, volumeType: "ssd"})),
+		),
+	}
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(inventoryCollector{month: month, clock: NewClock(cloudDay(3), 0, time.Now)})
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v, want nil: a registry refuses a family whose members "+
+			"disagree about their labels", err)
+	}
+
+	names := make([]string, 0, len(families))
+	metrics := 0
+	for _, family := range families {
+		names = append(names, family.GetName())
+		metrics += len(family.GetMetric())
+	}
+	if !slices.IsSorted(names) {
+		t.Errorf("the families come back as %v, want them by name, which is the order a scrape reads",
+			names)
+	}
+	// The instance states its status, the volume its status and its size, the
+	// tenant its six limits and its project info, and the cloud its count of
+	// projects together with the five aggregates.
+	const want = 1 + 2 + 6 + 1 + 1 + 5
+	if metrics != want {
+		t.Errorf("the gather holds %d samples, want %d", metrics, want)
+	}
+	if len(families) != want {
+		t.Errorf("the gather holds %d families, want %d, because this month states every series once",
+			len(families), want)
+	}
+}
+
+func TestExporterClampsPastTheMonth(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	end := scrapeOf(t, month, month.Oracle.PeriodTo)
+	past := scrapeOf(t, month, month.Oracle.PeriodTo.AddDate(0, 0, 1))
+
+	if end == "" {
+		t.Fatal("the last instant of the month scrapes empty, want the resources that outlived it")
+	}
+	if past != end {
+		t.Error("a day past the month scrapes another document than its last instant, want the end held")
+	}
+}
+
+func TestExporterAnswersBeforeTheMonth(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	body := scrapeOf(t, month, month.Oracle.PeriodFrom.Add(-time.Hour))
+
+	for _, name := range aggregateSeries {
+		value, _ := scrapedGauge(t, body, name)
+		if value != 0 {
+			t.Errorf("%s = %g an hour before the month began, want 0", name, value)
+		}
+	}
+	if strings.Contains(body, seriesNovaServerStatus) {
+		t.Error("the scrape states a server before the month began, want none")
+	}
+}
+
+func TestExporterAnswersOverAMalformedSize(t *testing.T) {
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle: testOracle(
+			oneResource(typeInstance, "srv-1", cloudDay(2), cloudDay(4), stateActive,
+				map[string]any{}),
+			oneResource(typeVolume, "vol-1", cloudDay(2), cloudDay(4), stateInUse,
+				map[string]any{"type": "ssd"}),
+		),
+	}
+	body := scrapeOf(t, month, cloudDay(3))
+
+	// A size member nobody stated costs its own series a value and nothing else:
+	// the volume is still stated, at zero gibibytes.
+	size, labels := scrapedGauge(t, body, seriesCinderVolumeGB)
+	if size != 0 {
+		t.Errorf("%s = %g for a volume whose size states no size_gb, want 0", seriesCinderVolumeGB, size)
+	}
+	if labels["id"] != "vol-1" {
+		t.Errorf("%s names the volume %q, want %q", seriesCinderVolumeGB, labels["id"], "vol-1")
+	}
+
+	status, _ := scrapedGauge(t, body, seriesNovaServerStatus)
+	if status != 1 {
+		t.Errorf("%s = %g for a server whose size names no flavor, want the server stated all the same",
+			seriesNovaServerStatus, status)
+	}
+}

--- a/internal/providers/openstack/simulator/metrics.go
+++ b/internal/providers/openstack/simulator/metrics.go
@@ -1,0 +1,575 @@
+package simulator
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"time"
+)
+
+// The metrics of a month are the second face of the simulated cloud. The
+// notifications say what the cloud did, and these say what a monitoring stack
+// would have seen while it did it: the network counters Ceilometer polls off
+// every instance, and the inventory gauges the OpenStack exporter scrapes off
+// the services.
+//
+// Both faces are placed here rather than inside the pusher and the endpoint
+// that carry them. One function per face means a pushed month and a scraped
+// live view state one world instead of two descriptions of it, and neither of
+// them reads a code path of the other.
+
+// SampleKind tells a gauge from a counter.
+type SampleKind int
+
+const (
+	// KindGauge is a value read at an instant, encoded as an OTLP gauge.
+	KindGauge SampleKind = iota
+	// KindCounter is a cumulative monotonic sum, encoded as an OTLP sum.
+	KindCounter
+)
+
+// Sample is one point of one series: the metric name, the labels beyond the
+// ones a scrape job or the pusher adds, the value, and the virtual instant it
+// belongs to. Kind is KindGauge or KindCounter, which decides whether the push
+// encodes it as an OTLP gauge or as a cumulative monotonic sum.
+//
+// The samples of one series over one interval share one Labels map, and nothing
+// mutates it. A caller that has to carry a label of its own builds a map of its
+// own.
+type Sample struct {
+	Name   string
+	Labels map[string]string
+	Value  int64
+	At     time.Time
+	Kind   SampleKind
+}
+
+// The two counters Ceilometer polls per instance. The names are the ones its
+// Prometheus exporter publishes them under, so a dashboard written for a real
+// cloud reads a simulated one.
+const (
+	egressSeries  = "ceilometer_network_outgoing_bytes_total"
+	ingressSeries = "ceilometer_network_incoming_bytes_total"
+)
+
+// trafficLevel is what one instance of a workload sends and receives over an
+// office hour. Every other hour of the month is this level weighed by the
+// working-week profile of profile.go.
+type trafficLevel struct {
+	egress  int64
+	ingress int64
+}
+
+// trafficLevels is the level of each of the three workloads: a classic tenant's
+// server is a machine a person works on, a shoot's worker carries what runs on
+// it, and a CI runner is small.
+//
+// The ingress is the egress times 1/4 for a classic tenant, times 1/2 for a
+// shoot and times 2/1 for a runner, and each of the three quotients is exact. A
+// runner pulls its image and its dependencies and sends little back, which is
+// the one of the three that receives more than it sends.
+var trafficLevels = map[string]trafficLevel{
+	workloadClassic:  {egress: 2147483648, ingress: 536870912},
+	workloadGardener: {egress: 8589934592, ingress: 4294967296},
+	workloadCI:       {egress: 268435456, ingress: 536870912},
+}
+
+// The per-instance jitter: a numerator drawn once per instance over a fixed
+// denominator, so two instances of one workload do not report the same byte
+// count while neither of them leaves its workload's level behind.
+const (
+	jitterMin = 50
+	jitterMax = 150
+	jitterDen = 100
+)
+
+// secondsPerHour is what a level stated per office hour is converted to the
+// seconds of one grid step with.
+const secondsPerHour = 3600
+
+// maxMetricsInterval is the longest grid step the byte arithmetic holds for.
+// The numerator of stepBytes is a level times the office weight times the
+// step's seconds times the jitter, and the largest of those products is
+// 8589934592 * 10 * 86400 * 150, about 1.11e18, which an int64 carries with
+// room to spare. A run refuses a longer interval before it generates a month.
+const maxMetricsInterval = 24 * time.Hour
+
+// minMetricsInterval is the finest grid a month is placed on. TrafficOf places
+// the samples of the whole period before the first notification goes out and
+// holds them for the length of the run, and their count grows as the grid
+// shrinks: a July of seed 1 carries about 320,000 samples on Ceilometer's 300s
+// grid, ten times that at 30s, and about a hundred million at 1s, which is
+// where the process is killed for its memory before it publishes anything. A
+// run refuses a shorter interval before it generates a month, the way it
+// refuses a longer one.
+const minMetricsInterval = 30 * time.Second
+
+// metricsSalt mixes the metrics into the state of their stream, the way
+// faultSalt mixes a switch's name into the state of its own.
+func metricsSalt() uint64 {
+	digest := fnv.New64a()
+	// A hash.Hash never fails a write, which is why the error is not examined.
+	_, _ = digest.Write([]byte("metrics\x00traffic"))
+	return digest.Sum64()
+}
+
+// metricsStream is the generator the traffic jitter is drawn from: the seed of
+// the run together with a salt of its own.
+//
+// It is never the shape stream, the identifier stream or the noise stream. A
+// month whose traffic was placed therefore consumes those three exactly as one
+// whose traffic was not, and the two render byte-identical notifications.
+func metricsStream(seed uint64) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, metricsSalt()))
+}
+
+// stepBytes is what one grid step of one series accrues: the level, which is
+// stated per office hour, weighed by the hour the step lies in and by the
+// step's share of an hour, and moved by the instance's jitter. A night step
+// therefore carries a tenth of an office step of the same level.
+//
+// Every factor is an int64 and the one division comes last. A byte count is a
+// usage quantity that reaches an invoice, and a quotient that went through a
+// float64 would arrive carrying digits nobody placed.
+//
+// The weight is read off the step's start alone, so a step that straddles the
+// boundary between two hours carries the weight of the hour it began in.
+func stepBytes(perOfficeHour int64, at time.Time, stepSeconds, jitter int64) int64 {
+	return perOfficeHour * int64(hourWeight(at)) * stepSeconds * jitter /
+		(officeWeight * secondsPerHour * jitterDen)
+}
+
+// gridStepAtOrAfter is the first instant of the grid from, from+interval,
+// from+2*interval and so on that is at or after at. Every series of a month is
+// placed on the one grid counted from the period's start, so two instances
+// sampled around one instant carry the very same timestamp.
+func gridStepAtOrAfter(from, at time.Time, interval time.Duration) time.Time {
+	if !at.After(from) {
+		return from
+	}
+	steps := (at.Sub(from) + interval - 1) / interval
+	return from.Add(steps * interval)
+}
+
+// trafficStep is one grid step of one instance: the instant it was polled at,
+// the project it ran in then, and the bytes the step accrued in each direction.
+type trafficStep struct {
+	at        time.Time
+	projectID string
+	egress    int64
+	ingress   int64
+}
+
+// instanceSteps places the grid steps of one instance. It walks every grid
+// instant from the start of the instance's first interval to the end of its
+// last one, which is where Ceilometer starts polling an instance and where it
+// stops.
+//
+// A step accrues bytes only while the interval it starts in is active. A
+// stopped, a shelved and a resized instance move nothing, so their steps carry
+// zero and the counter behind them stays flat, which is what a real counter of
+// a stopped instance does.
+//
+// A step that falls into a gap between two intervals belongs to no state, so it
+// accrues nothing. It is booked under the project of the interval before it,
+// which is the last project the instance is known to have run in.
+func instanceSteps(resource OracleResource, from time.Time, interval time.Duration,
+	level trafficLevel, jitter int64,
+) []trafficStep {
+	if len(resource.Intervals) == 0 {
+		return nil
+	}
+	intervals := resource.Intervals
+	end := intervals[len(intervals)-1].To
+	stepSeconds := int64(interval / time.Second)
+
+	// The grid instants between the instance's first one and its end, which is
+	// exactly what the loop below places: an instance live for a whole month
+	// carries thousands of them, and a slice grown from nothing copies them over
+	// and over on its way there.
+	first := gridStepAtOrAfter(from, intervals[0].From, interval)
+	steps := make([]trafficStep, 0, max(0, int(end.Sub(first)/interval)+1))
+	projectID := intervals[0].ProjectID
+	cursor := 0
+	for s := first; s.Before(end); s = s.Add(interval) {
+		for cursor < len(intervals) && !s.Before(intervals[cursor].To) {
+			cursor++
+		}
+		step := trafficStep{at: s}
+		if cursor < len(intervals) && !s.Before(intervals[cursor].From) {
+			projectID = intervals[cursor].ProjectID
+			if intervals[cursor].State == stateActive {
+				step.egress = stepBytes(level.egress, s, stepSeconds, jitter)
+				step.ingress = stepBytes(level.ingress, s, stepSeconds, jitter)
+			}
+		}
+		step.projectID = projectID
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+// TrafficOf places the network traffic of a month: the samples every instance
+// is pushed under, and the rows the oracle records them by.
+//
+// The samples come back ordered by their instant and then by name and resource
+// id, so a pusher walks them with one cursor instead of indexing them. Their
+// value is the running sum of the steps before them, which is what a cumulative
+// counter reports: the first sample of every series is 0, and the sample at one
+// instant states the bytes accrued before it.
+//
+// The rows come back ordered by resource id and then by From, because the
+// oracle's instances are sorted by their id and the intervals of one instance
+// by their start. A row states the exact sum of the steps placed inside its
+// interval, so the increment of an instance's last step lands in its last row
+// and in no sample, the way Ceilometer's last poll precedes a delete.
+//
+// The one refusal is an instance whose workload is none of the three: that is
+// an oracle another build wrote, and a level this one would have to guess at.
+// A byte count nobody stated is worse than no month at all.
+func TrafficOf(oracle Oracle, seed uint64, interval time.Duration) ([]Sample, []OracleTraffic, error) {
+	samples := make([]Sample, 0)
+	rows := make([]OracleTraffic, 0)
+	jitter := metricsStream(seed)
+
+	for _, resource := range oracle.Resources {
+		if resource.ResourceType != typeInstance {
+			continue
+		}
+		level, ok := trafficLevels[resource.Workload]
+		if !ok {
+			return nil, nil, fmt.Errorf(
+				"instance %s runs the workload %q, which no traffic level is stated for; "+
+					"the levels are %s, %s and %s",
+				resource.ResourceID, resource.Workload, workloadClassic, workloadGardener, workloadCI)
+		}
+		// One draw per instance, in oracle order, so the stream is consumed the
+		// same way whatever a month holds beside its instances.
+		drawn := jitterMin + jitter.Int64N(jitterMax-jitterMin+1)
+		steps := instanceSteps(resource, oracle.PeriodFrom, interval, level, drawn)
+
+		// Two samples per step, the egress and the ingress of it.
+		samples = slices.Grow(samples, 2*len(steps))
+		samples = appendTraffic(samples, oracle.Cloud, resource.ResourceID, steps)
+		rows = appendRows(rows, resource, steps)
+	}
+
+	slices.SortFunc(samples, func(a, b Sample) int {
+		if c := a.At.Compare(b.At); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Labels["resource_id"], b.Labels["resource_id"])
+	})
+	return samples, rows, nil
+}
+
+// appendTraffic states the two counters of one instance over its steps. The
+// labels change only where the instance changed project, so the samples of one
+// interval share the map their project was written into.
+func appendTraffic(samples []Sample, cloud, resourceID string, steps []trafficStep) []Sample {
+	var (
+		labels          map[string]string
+		projectID       string
+		egress, ingress int64
+	)
+	for _, step := range steps {
+		if labels == nil || step.projectID != projectID {
+			projectID = step.projectID
+			labels = map[string]string{
+				"platform":      platformOpenStack,
+				"cloud":         cloud,
+				"resource_type": typeInstance,
+				"resource_id":   resourceID,
+				"project_id":    projectID,
+			}
+		}
+		samples = append(samples,
+			Sample{Name: egressSeries, Labels: labels, Value: egress, At: step.at, Kind: KindCounter},
+			Sample{Name: ingressSeries, Labels: labels, Value: ingress, At: step.at, Kind: KindCounter})
+		egress += step.egress
+		ingress += step.ingress
+	}
+	return samples
+}
+
+// appendRows records one row per interval of the instance, whether a step fell
+// inside it or not: an interval shorter than the grid holds no step and is
+// stated with no bytes rather than left out, so a comparison reads the row of
+// every interval the oracle holds.
+//
+// The steps and the intervals are both in order, so one cursor walks them
+// together. A step that fell into a gap between two intervals is summed into
+// the row that follows it, which adds nothing: it is the same step
+// instanceSteps accrued no bytes for.
+func appendRows(rows []OracleTraffic, resource OracleResource, steps []trafficStep) []OracleTraffic {
+	cursor := 0
+	for _, interval := range resource.Intervals {
+		row := OracleTraffic{ResourceID: resource.ResourceID, From: interval.From, To: interval.To}
+		for ; cursor < len(steps) && steps[cursor].at.Before(interval.To); cursor++ {
+			row.EgressBytes += steps[cursor].egress
+			row.IngressBytes += steps[cursor].ingress
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// The series the four dashboards read and the drill requires, under the names
+// and the label spellings the OpenStack exporter publishes them with. A name
+// this endpoint spelled its own way is a panel that stays empty against a
+// simulated cloud and fills against a real one.
+const (
+	seriesNovaServerStatus    = "openstack_nova_server_status"
+	seriesCinderVolumeStatus  = "openstack_cinder_volume_status"
+	seriesCinderVolumeGB      = "openstack_cinder_volume_gb"
+	seriesGlanceImageBytes    = "openstack_glance_image_bytes"
+	seriesNeutronFloatingIP   = "openstack_neutron_floating_ip"
+	seriesNeutronRouter       = "openstack_neutron_router"
+	seriesLoadBalancerStatus  = "openstack_loadbalancer_loadbalancer_status"
+	seriesLimitsInstancesUsed = "openstack_nova_limits_instances_used"
+	seriesLimitsInstancesMax  = "openstack_nova_limits_instances_max"
+	seriesLimitsVCPUsUsed     = "openstack_nova_limits_vcpus_used"
+	seriesLimitsVCPUsMax      = "openstack_nova_limits_vcpus_max"
+	seriesLimitsMemoryUsed    = "openstack_nova_limits_memory_used"
+	seriesLimitsMemoryMax     = "openstack_nova_limits_memory_max"
+	seriesIdentityProjects    = "openstack_identity_projects"
+	seriesIdentityProjectInfo = "openstack_identity_project_info"
+	seriesNovaTotalVMs        = "openstack_nova_total_vms"
+	seriesCinderVolumes       = "openstack_cinder_volumes"
+	seriesNeutronFloatingIPs  = "openstack_neutron_floating_ips"
+	seriesGlanceImages        = "openstack_glance_images"
+	seriesLoadBalancerTotal   = "openstack_loadbalancer_total_loadbalancers"
+)
+
+// The quota a project is reported against. The simulated world has no quota, so
+// the three are constants: they exist because the drilldown's gauge panels
+// divide a used series by a maximum one, and a panel without the divisor shows
+// a division by an absent series rather than a ratio.
+const (
+	limitInstancesMax = 100
+	limitVCPUsMax     = 400
+	limitMemoryMaxMB  = 819200
+)
+
+// The two transitions of the noise catalogue the routers of a month are folded
+// out of.
+const (
+	routerCreateType = "router.create.end"
+	routerDeleteType = "router.delete.end"
+)
+
+// router is one neutron router of the month: the id it was announced under and
+// the project it was created in.
+type router struct {
+	id        string
+	projectID string
+}
+
+// routerFold folds the routers of a schedule out of it, in the order they were
+// created in.
+//
+// Routers are the one family of the inventory the oracle does not hold: nothing
+// bills a router, so the generator books none, and the noise catalogue is where
+// neutron announces them. The classic tenants' networks pre-exist the month and
+// neutron announces nothing about a resource that was there before the first
+// transition, so those projects report no router at all, which is what the
+// simulated world holds.
+//
+// The cursor is what a run pushes a month through: it never moves back, so the
+// grid of a whole month costs one pass over the schedule rather than a pass per
+// grid step, which is a schedule of fifteen thousand transitions walked from
+// its head nine thousand times.
+type routerFold struct {
+	schedule Schedule
+	cursor   int
+	live     []router
+}
+
+// at is the routers that stand at the instant at.
+//
+// The instants it is asked about only ever move forward, because the fold
+// carries what the ones before them left behind. A caller that reads an earlier
+// instant builds a fold of its own, which is what every single reading does.
+func (f *routerFold) at(at time.Time) []router {
+	for ; f.cursor < len(f.schedule); f.cursor++ {
+		transition := f.schedule[f.cursor]
+		// The schedule is in instant order, so the first transition past at is
+		// where the fold stops.
+		if transition.At.After(at) {
+			break
+		}
+		switch transition.EventType {
+		case routerCreateType:
+			f.live = append(f.live, router{id: transition.ResourceID, projectID: transition.ProjectID})
+		case routerDeleteType:
+			f.live = slices.DeleteFunc(f.live, func(held router) bool {
+				return held.id == transition.ResourceID
+			})
+		}
+	}
+	return f.live
+}
+
+// projectUsage is what one project holds at an instant, in the units nova's
+// limits report: a count of servers, their vcpus, and their memory in
+// megabytes.
+type projectUsage struct {
+	instances int64
+	vcpus     int64
+	memoryMB  int64
+}
+
+// InventoryAt is the world of the month as it stands at the virtual instant at:
+// one gauge per live resource of the six families the oracle holds, the routers
+// the schedule left standing, the limits of every project, and the counts the
+// cloud reports about itself.
+//
+// An instant past the end of the month is answered at that end, the way the
+// fake API answers a listing from a clock that has run past it: every interval
+// of the oracle ends inside the month, and a later instant would report a cloud
+// that lost everything at once.
+//
+// A size member an interval does not carry reads as zero, which is what
+// sizeDecimal answers with, so one malformed interval costs its own series a
+// value instead of failing a whole scrape. The status of a server is the word
+// nova reports rather than the one the collector books it under.
+//
+// The samples carry neither a platform nor a cloud label. A real exporter
+// carries neither: both come from the scrape job's static labels, and an
+// endpoint that stated them as well would push the job's own under
+// exported_cloud. A series the table gives no labels of its own carries no map.
+func InventoryAt(month Month, at time.Time) []Sample {
+	return inventoryAt(month, at, &routerFold{schedule: month.Schedule})
+}
+
+// inventoryAt is InventoryAt over a fold the caller keeps. A run reads one
+// inventory per grid step and hands the same fold to every one of them, so a
+// month folds its routers once instead of once per step.
+func inventoryAt(month Month, at time.Time, routers *routerFold) []Sample {
+	at = at.UTC()
+	if at.After(month.Oracle.PeriodTo) {
+		at = month.Oracle.PeriodTo.UTC()
+	}
+
+	samples := make([]Sample, 0)
+	usage := make(map[string]projectUsage)
+	var instances, volumes, addresses, images, balancers int64
+
+	for _, resource := range month.Oracle.Resources {
+		interval, ok := liveAt(resource, at, month.Oracle.PeriodTo)
+		if !ok {
+			continue
+		}
+		id := resource.ResourceID
+		switch resource.ResourceType {
+		case typeInstance:
+			held, _ := flavorByName(sizeString(interval.Size, "flavor"))
+			samples = append(samples, gauge(seriesNovaServerStatus, map[string]string{
+				"id":        id,
+				"uuid":      id,
+				"name":      id,
+				"tenant_id": interval.ProjectID,
+				"status":    novaVMStates[interval.State],
+				"flavor_id": held.flavorID,
+			}, 1, at))
+
+			used := usage[interval.ProjectID]
+			used.instances++
+			used.vcpus += int64(sizeInt(interval.Size, "vcpus"))
+			// Nova's limits report megabytes where the size states gibibytes.
+			used.memoryMB += sizeDecimal(interval.Size, "ram_gb").Mul(mebibytesPerGibibyte).IntPart()
+			usage[interval.ProjectID] = used
+			instances++
+
+		case typeVolume:
+			volumeType := sizeString(interval.Size, "type")
+			samples = append(samples,
+				gauge(seriesCinderVolumeStatus, map[string]string{
+					"id":          id,
+					"name":        id,
+					"tenant_id":   interval.ProjectID,
+					"status":      interval.State,
+					"volume_type": volumeType,
+				}, 1, at),
+				gauge(seriesCinderVolumeGB, map[string]string{
+					"id":          id,
+					"name":        id,
+					"tenant_id":   interval.ProjectID,
+					"volume_type": volumeType,
+				}, int64(sizeInt(interval.Size, "size_gb")), at))
+			volumes++
+
+		case typeImage:
+			samples = append(samples, gauge(seriesGlanceImageBytes, map[string]string{
+				"id":        id,
+				"name":      id,
+				"tenant_id": interval.ProjectID,
+			}, sizeDecimal(interval.Size, "size_gb").Mul(bytesPerGibibyte).IntPart(), at))
+			images++
+
+		case typeFloatingIP:
+			samples = append(samples, gauge(seriesNeutronFloatingIP, map[string]string{
+				"id":         id,
+				"project_id": interval.ProjectID,
+				"status":     "ACTIVE",
+			}, 1, at))
+			addresses++
+
+		case typeLoadBalancer:
+			samples = append(samples, gauge(seriesLoadBalancerStatus, map[string]string{
+				"id":                  id,
+				"name":                id,
+				"project_id":          interval.ProjectID,
+				"provisioning_status": "ACTIVE",
+				"operating_status":    "ONLINE",
+			}, 1, at))
+			balancers++
+		}
+	}
+
+	for _, held := range routers.at(at) {
+		samples = append(samples, gauge(seriesNeutronRouter, map[string]string{
+			"id":         held.id,
+			"project_id": held.projectID,
+			"status":     "ACTIVE",
+		}, 1, at))
+	}
+
+	for _, tenant := range month.Tenants {
+		used := usage[tenant.ID]
+		// The six limits of one project share the one label the table gives them.
+		limits := map[string]string{"tenant_id": tenant.ID}
+		samples = append(samples,
+			gauge(seriesLimitsInstancesUsed, limits, used.instances, at),
+			gauge(seriesLimitsInstancesMax, limits, limitInstancesMax, at),
+			gauge(seriesLimitsVCPUsUsed, limits, used.vcpus, at),
+			gauge(seriesLimitsVCPUsMax, limits, limitVCPUsMax, at),
+			gauge(seriesLimitsMemoryUsed, limits, used.memoryMB, at),
+			gauge(seriesLimitsMemoryMax, limits, limitMemoryMaxMB, at),
+			gauge(seriesIdentityProjectInfo, map[string]string{
+				"id":        tenant.ID,
+				"name":      tenant.Name,
+				"domain_id": "default",
+				"enabled":   "true",
+			}, 1, at))
+	}
+
+	return append(samples,
+		gauge(seriesIdentityProjects, nil, int64(len(month.Tenants)), at),
+		gauge(seriesNovaTotalVMs, nil, instances, at),
+		gauge(seriesCinderVolumes, nil, volumes, at),
+		gauge(seriesNeutronFloatingIPs, nil, addresses, at),
+		gauge(seriesGlanceImages, nil, images, at),
+		gauge(seriesLoadBalancerTotal, nil, balancers, at))
+}
+
+// gauge is one inventory sample. Every one of them states the world at the
+// instant it was read, which is what a gauge is.
+func gauge(name string, labels map[string]string, value int64, at time.Time) Sample {
+	return Sample{Name: name, Labels: labels, Value: value, At: at, Kind: KindGauge}
+}

--- a/internal/providers/openstack/simulator/metrics_test.go
+++ b/internal/providers/openstack/simulator/metrics_test.go
@@ -1,0 +1,909 @@
+package simulator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testMetricsInterval is the grid the tests place their samples on. It is
+// Ceilometer's own polling interval, which is what a month is pushed under.
+const testMetricsInterval = 300 * time.Second
+
+// The instants the profile is read at. July 1st 2026 is a Wednesday, so 10:00
+// is an office hour, 06:00 a fringe hour and 02:00 a quiet one.
+var (
+	officeInstant = time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	fringeInstant = time.Date(2026, 7, 1, 6, 0, 0, 0, time.UTC)
+	quietInstant  = time.Date(2026, 7, 1, 2, 0, 0, 0, time.UTC)
+)
+
+// testOracle is one hand-built oracle over the month of the api tests.
+func testOracle(resources ...OracleResource) Oracle {
+	return Oracle{
+		Cloud:      testCloud,
+		PeriodFrom: cloudFrom,
+		PeriodTo:   cloudTo,
+		Resources:  resources,
+	}
+}
+
+// withWorkload names the workload of a hand-built resource. The fixtures of
+// api_test.go leave it unset, because nothing a listing answers is decided by
+// it, and the traffic level of an instance is read off it.
+func withWorkload(resource OracleResource, workload string) OracleResource {
+	resource.Workload = workload
+	return resource
+}
+
+// spanInstance is one instance that ran through the states it is given, each of
+// them four hours long from the first instant.
+func spanInstance(id, workload string, from time.Time, states ...string) OracleResource {
+	intervals := make([]OracleInterval, 0, len(states))
+	for _, state := range states {
+		to := from.Add(4 * time.Hour)
+		intervals = append(intervals, OracleInterval{
+			From: from, To: to, State: state, ProjectID: cloudTenant, Size: instanceSizeOf(largeFlavor),
+		})
+		from = to
+	}
+	return OracleResource{
+		ResourceType: typeInstance, ResourceID: id, Workload: workload, Intervals: intervals,
+	}
+}
+
+// trafficOf places the traffic of an oracle or fails the test.
+func trafficOf(t *testing.T, oracle Oracle, seed uint64, interval time.Duration,
+) ([]Sample, []OracleTraffic) {
+	t.Helper()
+
+	samples, rows, err := TrafficOf(oracle, seed, interval)
+	if err != nil {
+		t.Fatalf("TrafficOf(oracle, %d, %s) error = %v, want nil", seed, interval, err)
+	}
+	return samples, rows
+}
+
+// sampleOrder is the order TrafficOf states its samples in: by instant, then by
+// name, then by the resource the sample is about.
+func sampleOrder(a, b Sample) int {
+	if c := a.At.Compare(b.At); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.Name, b.Name); c != 0 {
+		return c
+	}
+	return strings.Compare(a.Labels["resource_id"], b.Labels["resource_id"])
+}
+
+// seriesOf picks the samples of one series about one resource, in the order
+// they were stated in.
+func seriesOf(samples []Sample, name, resourceID string) []Sample {
+	picked := make([]Sample, 0)
+	for _, sample := range samples {
+		if sample.Name == name && sample.Labels["resource_id"] == resourceID {
+			picked = append(picked, sample)
+		}
+	}
+	return picked
+}
+
+// namedSamples picks every sample of one series.
+func namedSamples(samples []Sample, name string) []Sample {
+	picked := make([]Sample, 0)
+	for _, sample := range samples {
+		if sample.Name == name {
+			picked = append(picked, sample)
+		}
+	}
+	return picked
+}
+
+// instancesOf is every instance the oracle holds.
+func instancesOf(oracle Oracle) []OracleResource {
+	held := make([]OracleResource, 0)
+	for _, resource := range oracle.Resources {
+		if resource.ResourceType == typeInstance {
+			held = append(held, resource)
+		}
+	}
+	return held
+}
+
+// labelKeys is the sorted list of the labels a sample carries, which is what a
+// series is held against the exporter's own spelling by.
+func labelKeys(sample Sample) []string {
+	keys := make([]string, 0, len(sample.Labels))
+	for key := range sample.Labels {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func TestTrafficLiesOnTheGrid(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	samples, _, err := TrafficOf(month.Oracle, 1, testMetricsInterval)
+	if err != nil {
+		t.Fatalf("TrafficOf() error = %v, want nil", err)
+	}
+	if len(samples) == 0 {
+		t.Fatal("TrafficOf() placed no sample, want the counters of a month of instances")
+	}
+
+	for _, sample := range samples {
+		if offset := sample.At.Sub(month.Oracle.PeriodFrom); offset%testMetricsInterval != 0 {
+			t.Fatalf("%s of %s lies %s past the start of the month, which is no whole step of %s",
+				sample.Name, sample.Labels["resource_id"], offset, testMetricsInterval)
+		}
+	}
+
+	for _, instance := range instancesOf(month.Oracle) {
+		egress := len(seriesOf(samples, egressSeries, instance.ResourceID))
+		ingress := len(seriesOf(samples, ingressSeries, instance.ResourceID))
+		if egress != ingress {
+			t.Errorf("instance %s carries %d outgoing and %d incoming samples, want one of each per step",
+				instance.ResourceID, egress, ingress)
+		}
+		// An instance that lived and died between two grid instants is polled at
+		// none of them, the way Ceilometer never sees a runner that was gone
+		// before its next poll.
+		first := gridStepAtOrAfter(month.Oracle.PeriodFrom, instance.Intervals[0].From, testMetricsInterval)
+		polled := first.Before(instance.Intervals[len(instance.Intervals)-1].To)
+		if polled != (egress > 0) {
+			t.Errorf("instance %s over %s..%s carries %d samples, want polled = %v",
+				instance.ResourceID, instance.Intervals[0].From,
+				instance.Intervals[len(instance.Intervals)-1].To, egress, polled)
+		}
+	}
+
+	for i := 1; i < len(samples); i++ {
+		if sampleOrder(samples[i-1], samples[i]) >= 0 {
+			t.Fatalf("sample %d (%s of %s at %s) does not follow sample %d (%s of %s at %s)",
+				i, samples[i].Name, samples[i].Labels["resource_id"], samples[i].At,
+				i-1, samples[i-1].Name, samples[i-1].Labels["resource_id"], samples[i-1].At)
+		}
+	}
+}
+
+func TestTrafficCountersNeverDecreaseAndStartAtZero(t *testing.T) {
+	month := faultyMonth(t, 2, Faults{})
+	samples, _ := trafficOf(t, month.Oracle, 2, testMetricsInterval)
+
+	for _, instance := range instancesOf(month.Oracle) {
+		for _, name := range []string{egressSeries, ingressSeries} {
+			series := seriesOf(samples, name, instance.ResourceID)
+			if len(series) == 0 {
+				continue
+			}
+			want := gridStepAtOrAfter(month.Oracle.PeriodFrom, instance.Intervals[0].From, testMetricsInterval)
+			if !series[0].At.Equal(want) {
+				t.Errorf("%s of %s begins at %s, want the first grid step at or after %s, which is %s",
+					name, instance.ResourceID, series[0].At, instance.Intervals[0].From, want)
+			}
+			if series[0].Value != 0 {
+				t.Errorf("%s of %s begins at %d bytes, want a counter that starts at 0",
+					name, instance.ResourceID, series[0].Value)
+			}
+			for i := 1; i < len(series); i++ {
+				if series[i].Value < series[i-1].Value {
+					t.Fatalf("%s of %s falls from %d to %d at %s, want a counter that never decreases",
+						name, instance.ResourceID, series[i-1].Value, series[i].Value, series[i].At)
+				}
+			}
+		}
+	}
+}
+
+func TestTrafficAccruesOnlyWhileActive(t *testing.T) {
+	instance := spanInstance("srv-states", workloadClassic, cloudDay(1).Add(8*time.Hour),
+		stateActive, stateShutoff, stateShelved, stateResized, stateActive)
+	samples, _ := trafficOf(t, testOracle(instance), 7, testMetricsInterval)
+
+	series := seriesOf(samples, egressSeries, instance.ResourceID)
+	if len(series) < len(instance.Intervals) {
+		t.Fatalf("the instance carries %d samples over %d intervals, want at least one per interval",
+			len(series), len(instance.Intervals))
+	}
+
+	// The value of a sample is what the steps before it accrued, so the step
+	// that begins at one sample is the increment to the next.
+	for i := 1; i < len(series); i++ {
+		increment := series[i].Value - series[i-1].Value
+		state := ""
+		for _, interval := range instance.Intervals {
+			if !series[i-1].At.Before(interval.From) && series[i-1].At.Before(interval.To) {
+				state = interval.State
+			}
+		}
+		switch state {
+		case stateActive:
+			if increment <= 0 {
+				t.Errorf("the step at %s ran active and accrued %d bytes, want a positive count",
+					series[i-1].At, increment)
+			}
+		case "":
+			t.Fatalf("the step at %s lies in no interval of the instance", series[i-1].At)
+		default:
+			if increment != 0 {
+				t.Errorf("the step at %s was %s and accrued %d bytes, want nothing while the instance moves nothing",
+					series[i-1].At, state, increment)
+			}
+		}
+	}
+}
+
+func TestTrafficLevelsFollowTheWorkloadAndTheProfile(t *testing.T) {
+	// 75 over 100 divides every level of the table exactly, so the office steps
+	// below are the quotients they state rather than rounded ones.
+	const jitter = 75
+	stepSeconds := int64(testMetricsInterval / time.Second)
+
+	classic := trafficLevels[workloadClassic]
+	gardener := trafficLevels[workloadGardener]
+
+	classicOffice := stepBytes(classic.egress, officeInstant, stepSeconds, jitter)
+	gardenerOffice := stepBytes(gardener.egress, officeInstant, stepSeconds, jitter)
+	if classicOffice <= 0 {
+		t.Fatalf("stepBytes(%d, office) = %d, want a positive count", classic.egress, classicOffice)
+	}
+	if gardenerOffice != 4*classicOffice {
+		t.Errorf("the gardener office step is %d and the classic one %d, want four times as much",
+			gardenerOffice, classicOffice)
+	}
+
+	profile := []struct {
+		name string
+		at   time.Time
+		want int64
+	}{
+		{"an office hour of a working day", officeInstant, classicOffice},
+		// The hours weigh 10, 3 and 1 against each other and the one division
+		// comes last, so a quiet step is a tenth of the office step and a fringe
+		// step three tenths of it.
+		{"a quiet hour", quietInstant, classicOffice / 10},
+		{"a fringe hour", fringeInstant, 3 * classicOffice / 10},
+	}
+	for _, want := range profile {
+		t.Run(want.name, func(t *testing.T) {
+			got := stepBytes(classic.egress, want.at, stepSeconds, jitter)
+			if got != want.want {
+				t.Errorf("stepBytes(classic, %s) = %d, want %d", want.at, got, want.want)
+			}
+		})
+	}
+
+	fringe := stepBytes(classic.egress, fringeInstant, stepSeconds, jitter)
+	quiet := stepBytes(classic.egress, quietInstant, stepSeconds, jitter)
+	if fringe <= quiet || fringe >= classicOffice {
+		t.Errorf("the fringe step is %d, want it between the quiet step %d and the office step %d",
+			fringe, quiet, classicOffice)
+	}
+
+	levels := []struct {
+		workload string
+		times    int64
+		divided  int64
+	}{
+		{workloadClassic, 1, 4},
+		{workloadGardener, 1, 2},
+		{workloadCI, 2, 1},
+	}
+	for _, level := range levels {
+		t.Run(level.workload+" ingress", func(t *testing.T) {
+			held := trafficLevels[level.workload]
+			if held.ingress*level.divided != held.egress*level.times {
+				t.Errorf("the %s level receives %d and sends %d, want %d/%d of the egress",
+					level.workload, held.ingress, held.egress, level.times, level.divided)
+			}
+		})
+	}
+}
+
+func TestTrafficHoldsTheLongestInterval(t *testing.T) {
+	// A whole day of office seconds at the highest level and the largest jitter
+	// is the biggest product the arithmetic has to carry. Its numerator is about
+	// 1.11e18, and one that had overflowed an int64 would come back negative.
+	stepSeconds := int64(maxMetricsInterval / time.Second)
+	level := trafficLevels[workloadGardener]
+
+	numerator := level.egress * officeWeight * stepSeconds * jitterMax
+	if numerator <= 0 {
+		t.Fatalf("the numerator of a step of %s is %d, want it inside an int64",
+			maxMetricsInterval, numerator)
+	}
+
+	// 8589934592 bytes an office hour over 86400 seconds at 150 over 100.
+	const want = 309237645312
+	if got := stepBytes(level.egress, officeInstant, stepSeconds, jitterMax); got != want {
+		t.Errorf("stepBytes over a step of %s = %d, want %d", maxMetricsInterval, got, want)
+	}
+}
+
+func TestTrafficStopsAtTheInstancesEnd(t *testing.T) {
+	month := faultyMonth(t, 3, Faults{})
+	samples, _ := trafficOf(t, month.Oracle, 3, testMetricsInterval)
+	steps := int(month.Oracle.PeriodTo.Sub(month.Oracle.PeriodFrom) / testMetricsInterval)
+
+	deleted := 0
+	for _, instance := range instancesOf(month.Oracle) {
+		end := instance.Intervals[len(instance.Intervals)-1].To
+		series := seriesOf(samples, egressSeries, instance.ResourceID)
+		for _, sample := range series {
+			if !sample.At.Before(end) {
+				t.Fatalf("instance %s ended at %s and is still sampled at %s, want no sample past its end",
+					instance.ResourceID, end, sample.At)
+			}
+		}
+		if !end.Before(month.Oracle.PeriodTo) {
+			continue
+		}
+		deleted++
+		if len(series) >= steps {
+			t.Errorf("instance %s was deleted at %s and carries %d samples, want fewer than the %d of the month",
+				instance.ResourceID, end, len(series), steps)
+		}
+	}
+	if deleted == 0 {
+		t.Fatal("the month deleted no instance, so nothing states that a deleted one stops being polled")
+	}
+}
+
+func TestTrafficIsDeterministic(t *testing.T) {
+	month := faultyMonth(t, 4, Faults{})
+
+	before := renderedStream(t, "before.jsonl", month.Stream)
+	samples, rows := trafficOf(t, month.Oracle, 4, testMetricsInterval)
+	again, rowsAgain := trafficOf(t, month.Oracle, 4, testMetricsInterval)
+	after := renderedStream(t, "after.jsonl", month.Stream)
+
+	if !reflect.DeepEqual(samples, again) {
+		t.Error("two runs of TrafficOf over one oracle placed two different sets of samples")
+	}
+	if !reflect.DeepEqual(rows, rowsAgain) {
+		t.Error("two runs of TrafficOf over one oracle recorded two different sets of rows")
+	}
+
+	// The jitter is drawn from a stream of its own, so the notifications of the
+	// month read the same whether the traffic was placed or not.
+	if !reflect.DeepEqual(before, after) {
+		t.Error("the notifications of the month changed while the traffic was placed")
+	}
+	plain := faultyMonth(t, 4, Faults{})
+	if !reflect.DeepEqual(before, renderedStream(t, "plain.jsonl", plain.Stream)) {
+		t.Error("a second month of the same seed renders other notifications than the one the traffic was placed for")
+	}
+
+	moved, _ := trafficOf(t, month.Oracle, 5, testMetricsInterval)
+	if len(moved) != len(samples) {
+		t.Fatalf("the seed changed the sample count from %d to %d, want the grid to hold",
+			len(samples), len(moved))
+	}
+	if reflect.DeepEqual(samples, moved) {
+		t.Error("another seed placed the very same bytes, want the jitter to move with it")
+	}
+}
+
+// renderedStream writes one stream to a file of the test's own directory and
+// reads it back, which is how a run states what it published.
+func renderedStream(t *testing.T, name string, schedule Schedule) []byte {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := WriteStream(path, schedule); err != nil {
+		t.Fatalf("WriteStream(%s) error = %v, want nil", name, err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s error = %v, want nil", name, err)
+	}
+	return body
+}
+
+func TestTrafficOfAnEmptyOracle(t *testing.T) {
+	cases := []struct {
+		name   string
+		oracle Oracle
+	}{
+		{"an oracle with no resource at all", testOracle()},
+		{"an oracle that holds no instance", testOracle(oneResource(typeVolume, "vol-1",
+			cloudDay(2), cloudDay(3), stateAvailable, volumeSizeOf(&volume{sizeGB: 50, volumeType: "ssd"})))},
+	}
+	for _, held := range cases {
+		t.Run(held.name, func(t *testing.T) {
+			samples, rows, err := TrafficOf(held.oracle, 1, testMetricsInterval)
+			if err != nil {
+				t.Fatalf("TrafficOf() error = %v, want nil", err)
+			}
+			if samples == nil || len(samples) != 0 {
+				t.Errorf("TrafficOf() samples = %v, want an empty slice that is not nil", samples)
+			}
+			if rows == nil || len(rows) != 0 {
+				t.Errorf("TrafficOf() rows = %v, want an empty slice that is not nil", rows)
+			}
+		})
+	}
+}
+
+func TestTrafficRefusesAnUnknownWorkload(t *testing.T) {
+	instance := withWorkload(oneInstance("srv-batch", cloudDay(2), cloudDay(3)), "batch")
+
+	samples, rows, err := TrafficOf(testOracle(instance), 1, testMetricsInterval)
+	if err == nil {
+		t.Fatalf("TrafficOf() over an unknown workload error = nil, want a refusal; it placed %d samples",
+			len(samples))
+	}
+	if rows != nil {
+		t.Errorf("TrafficOf() recorded %d rows beside its error, want none", len(rows))
+	}
+	for _, want := range []string{"srv-batch", `"batch"`, workloadGardener} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("TrafficOf() error = %q, want it to name %s", err, want)
+		}
+	}
+}
+
+func TestTrafficRowsStateEveryInterval(t *testing.T) {
+	// The grid runs from midnight in whole steps of five minutes, so the middle
+	// interval below begins a minute past a step and ends before the next one:
+	// it holds no step at all.
+	day := cloudDay(2)
+	brief := OracleResource{
+		ResourceType: typeInstance, ResourceID: "srv-a", Workload: workloadClassic,
+		Intervals: []OracleInterval{
+			{
+				From: day.Add(8 * time.Hour), To: day.Add(10*time.Hour + time.Minute),
+				State: stateActive, ProjectID: cloudTenant, Size: instanceSizeOf(largeFlavor),
+			},
+			{
+				From: day.Add(10*time.Hour + time.Minute), To: day.Add(10*time.Hour + 2*time.Minute),
+				State: stateActive, ProjectID: cloudTenant, Size: instanceSizeOf(flavors[0]),
+			},
+			{
+				From: day.Add(10*time.Hour + 2*time.Minute), To: day.Add(14 * time.Hour),
+				State: stateActive, ProjectID: cloudTenant, Size: instanceSizeOf(largeFlavor),
+			},
+		},
+	}
+	resized := withWorkload(resizedInstance("srv-b", day.Add(9*time.Hour),
+		day.Add(11*time.Hour), day.Add(13*time.Hour)), workloadGardener)
+
+	oracle := testOracle(brief, resized)
+	samples, rows := trafficOf(t, oracle, 11, testMetricsInterval)
+
+	wantRows := 0
+	for _, instance := range instancesOf(oracle) {
+		wantRows += len(instance.Intervals)
+	}
+	if len(rows) != wantRows {
+		t.Fatalf("TrafficOf() recorded %d rows over %d intervals, want one row per interval",
+			len(rows), wantRows)
+	}
+	for i := 1; i < len(rows); i++ {
+		if c := strings.Compare(rows[i-1].ResourceID, rows[i].ResourceID); c > 0 ||
+			(c == 0 && !rows[i-1].From.Before(rows[i].From)) {
+			t.Fatalf("row %d (%s from %s) does not follow row %d (%s from %s), want them by id and then by start",
+				i, rows[i].ResourceID, rows[i].From, i-1, rows[i-1].ResourceID, rows[i-1].From)
+		}
+	}
+
+	if rows[1].EgressBytes != 0 || rows[1].IngressBytes != 0 {
+		t.Errorf("the interval of one minute between two steps carries %d and %d bytes, want none",
+			rows[1].EgressBytes, rows[1].IngressBytes)
+	}
+
+	// The jitter is drawn once per instance, in oracle order, so the first draw
+	// of a fresh stream belongs to the first instance.
+	stream := metricsStream(11)
+	for _, instance := range instancesOf(oracle) {
+		drawn := jitterMin + stream.Int64N(jitterMax-jitterMin+1)
+		level := trafficLevels[instance.Workload]
+		steps := instanceSteps(instance, oracle.PeriodFrom, testMetricsInterval, level, drawn)
+
+		var egress, ingress int64
+		for i, interval := range instance.Intervals {
+			var placed int64
+			for _, step := range steps {
+				if step.at.Before(interval.From) || !step.at.Before(interval.To) {
+					continue
+				}
+				placed += step.egress
+			}
+			row := rows[slices.IndexFunc(rows, func(held OracleTraffic) bool {
+				return held.ResourceID == instance.ResourceID && held.From.Equal(interval.From)
+			})]
+			if row.EgressBytes != placed {
+				t.Errorf("row %d of %s states %d bytes, want the %d its steps placed",
+					i, instance.ResourceID, row.EgressBytes, placed)
+			}
+			egress += row.EgressBytes
+			ingress += row.IngressBytes
+		}
+
+		// The last step of an instance is placed in its last row and observed by
+		// no sample, the way Ceilometer's last poll precedes a delete.
+		last := steps[len(steps)-1]
+		series := seriesOf(samples, egressSeries, instance.ResourceID)
+		if got := series[len(series)-1].Value + last.egress; got != egress {
+			t.Errorf("the rows of %s sum to %d, want the last sample %d plus its last step %d",
+				instance.ResourceID, egress, series[len(series)-1].Value, last.egress)
+		}
+		incoming := seriesOf(samples, ingressSeries, instance.ResourceID)
+		if got := incoming[len(incoming)-1].Value + last.ingress; got != ingress {
+			t.Errorf("the rows of %s sum to %d incoming bytes, want %d",
+				instance.ResourceID, ingress, got)
+		}
+	}
+}
+
+func TestTrafficFollowsTheInterval(t *testing.T) {
+	month := faultyMonth(t, 6, Faults{})
+	fine, _ := trafficOf(t, month.Oracle, 6, testMetricsInterval)
+	coarse, _ := trafficOf(t, month.Oracle, 6, 2*testMetricsInterval)
+
+	for _, sample := range coarse {
+		if offset := sample.At.Sub(month.Oracle.PeriodFrom); offset%(2*testMetricsInterval) != 0 {
+			t.Fatalf("%s of %s lies %s past the start of the month, which is no whole step of the coarser grid",
+				sample.Name, sample.Labels["resource_id"], offset)
+		}
+	}
+
+	for _, instance := range instancesOf(month.Oracle) {
+		dense := len(seriesOf(fine, egressSeries, instance.ResourceID))
+		sparse := len(seriesOf(coarse, egressSeries, instance.ResourceID))
+		// A span holds half as many steps of twice the length, give or take the
+		// one step its two ends fall inside.
+		if sparse < dense/2-1 || sparse > dense/2+1 {
+			t.Errorf("instance %s carries %d samples on the coarse grid and %d on the fine one, "+
+				"want about half as many", instance.ResourceID, sparse, dense)
+		}
+	}
+}
+
+func TestInventoryBeforeTheMonthHoldsNothing(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	samples := InventoryAt(month, month.Oracle.PeriodFrom.Add(-time.Hour))
+
+	empty := []string{
+		seriesNovaTotalVMs, seriesCinderVolumes, seriesNeutronFloatingIPs,
+		seriesGlanceImages, seriesLoadBalancerTotal,
+	}
+	for _, name := range empty {
+		held := namedSamples(samples, name)
+		if len(held) != 1 {
+			t.Fatalf("%s is stated %d times, want once", name, len(held))
+		}
+		if held[0].Value != 0 {
+			t.Errorf("%s = %d before the month began, want 0", name, held[0].Value)
+		}
+	}
+
+	silent := []string{
+		seriesNovaServerStatus, seriesCinderVolumeStatus, seriesCinderVolumeGB,
+		seriesGlanceImageBytes, seriesNeutronFloatingIP, seriesNeutronRouter,
+		seriesLoadBalancerStatus,
+	}
+	for _, name := range silent {
+		if held := namedSamples(samples, name); len(held) != 0 {
+			t.Errorf("%s is stated %d times before the month began, want no resource at all",
+				name, len(held))
+		}
+	}
+
+	limits := map[string]int64{
+		seriesLimitsInstancesUsed: 0, seriesLimitsInstancesMax: limitInstancesMax,
+		seriesLimitsVCPUsUsed: 0, seriesLimitsVCPUsMax: limitVCPUsMax,
+		seriesLimitsMemoryUsed: 0, seriesLimitsMemoryMax: limitMemoryMaxMB,
+	}
+	for name, want := range limits {
+		held := namedSamples(samples, name)
+		if len(held) != len(month.Tenants) {
+			t.Fatalf("%s is stated %d times, want one per tenant, of which there are %d",
+				name, len(held), len(month.Tenants))
+		}
+		for _, sample := range held {
+			if sample.Value != want {
+				t.Errorf("%s of %s = %d, want %d",
+					name, sample.Labels["tenant_id"], sample.Value, want)
+			}
+		}
+	}
+}
+
+func TestInventoryIsHeldAtTheEndOfTheMonth(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	end := InventoryAt(month, month.Oracle.PeriodTo)
+	past := InventoryAt(month, month.Oracle.PeriodTo.AddDate(0, 0, 1))
+
+	if !reflect.DeepEqual(end, past) {
+		t.Error("a day past the month reports another world than its last instant, want the end held")
+	}
+
+	outlived := make(map[string]bool)
+	for _, instance := range instancesOf(month.Oracle) {
+		if !instance.Intervals[len(instance.Intervals)-1].To.Before(month.Oracle.PeriodTo) {
+			outlived[instance.ResourceID] = true
+		}
+	}
+	if len(outlived) == 0 {
+		t.Fatal("no instance outlived the month, so nothing states what its last instant holds")
+	}
+
+	served := namedSamples(past, seriesNovaServerStatus)
+	if len(served) != len(outlived) {
+		t.Fatalf("the end of the month serves %d servers, want the %d that outlived it",
+			len(served), len(outlived))
+	}
+	for _, sample := range served {
+		if !outlived[sample.Labels["id"]] {
+			t.Errorf("server %s is served at the end of the month, want only the ones that outlived it",
+				sample.Labels["id"])
+		}
+	}
+}
+
+func TestInventoryFoldsTheRoutersOutOfTheSchedule(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+	workloads := make(map[string]string, len(month.Tenants))
+	for _, tenant := range month.Tenants {
+		workloads[tenant.ID] = tenant.Workload
+	}
+
+	counted := make(map[string]int)
+	for _, sample := range namedSamples(InventoryAt(month, july2026.AddDate(0, 0, 9)), seriesNeutronRouter) {
+		if sample.Value != 1 {
+			t.Errorf("router %s = %d, want 1", sample.Labels["id"], sample.Value)
+		}
+		counted[workloads[sample.Labels["project_id"]]]++
+	}
+
+	if counted[workloadCI] != 1 {
+		t.Errorf("the CI tenant holds %d routers, want the one its network was built with",
+			counted[workloadCI])
+	}
+	if counted[workloadGardener] == 0 {
+		t.Error("no shoot holds a router, want one per shoot alive on the tenth day")
+	}
+	// The classic tenants' networks pre-exist the month, so neutron announced no
+	// router of theirs and the fold finds none.
+	if counted[workloadClassic] != 0 {
+		t.Errorf("the classic tenants hold %d routers, want none", counted[workloadClassic])
+	}
+}
+
+func TestInventoryDropsADeletedRouter(t *testing.T) {
+	month := Month{
+		Schedule: Schedule{
+			{At: cloudDay(2), EventType: routerCreateType, ResourceID: "rtr-1", ProjectID: cloudTenant},
+			{At: cloudDay(3), EventType: routerCreateType, ResourceID: "rtr-2", ProjectID: cloudTenant},
+			{At: cloudDay(4), EventType: routerDeleteType, ResourceID: "rtr-1", ProjectID: cloudTenant},
+		},
+		Oracle: testOracle(),
+	}
+
+	standing := func(at time.Time) []string {
+		held := make([]string, 0)
+		for _, sample := range namedSamples(InventoryAt(month, at), seriesNeutronRouter) {
+			held = append(held, sample.Labels["id"])
+		}
+		return held
+	}
+	if got, want := standing(cloudDay(3)), []string{"rtr-1", "rtr-2"}; !slices.Equal(got, want) {
+		t.Errorf("the routers of the third day are %v, want %v", got, want)
+	}
+	// The gauge of a torn-down router is what a panel would otherwise hold at 1
+	// for the rest of the month.
+	if got, want := standing(cloudDay(5)), []string{"rtr-2"}; !slices.Equal(got, want) {
+		t.Errorf("the routers of the fifth day are %v, want %v: the deleted one is gone", got, want)
+	}
+}
+
+// TestTheRouterFoldWalksForwardLikeSingleReadings holds the fold a run carries
+// through a month against the one a single reading builds. The push hands one
+// fold to every grid step of the month and the scrape builds a fresh one per
+// request, so a cursor that walked past a transition would leave the pushed
+// world stating routers the scraped one never states.
+func TestTheRouterFoldWalksForwardLikeSingleReadings(t *testing.T) {
+	schedule := make(Schedule, 0)
+	for day := 1; day <= 12; day++ {
+		schedule = append(schedule,
+			Transition{
+				At: cloudDay(day), EventType: routerCreateType,
+				ResourceID: fmt.Sprintf("rtr-%d", day), ProjectID: cloudTenant,
+			},
+			// A transition of another family at the same instant: the fold walks
+			// over it and has to leave the cursor on the one behind it.
+			Transition{
+				At: cloudDay(day), EventType: imageCreateType,
+				ResourceID: fmt.Sprintf("img-%d", day), ProjectID: cloudTenant,
+			})
+		if day%3 == 0 {
+			schedule = append(schedule, Transition{
+				At: cloudDay(day), EventType: routerDeleteType,
+				ResourceID: fmt.Sprintf("rtr-%d", day-1), ProjectID: cloudTenant,
+			})
+		}
+	}
+
+	walked := &routerFold{schedule: schedule}
+	for day := 1; day <= 12; day++ {
+		at := cloudDay(day)
+		got, want := walked.at(at), (&routerFold{schedule: schedule}).at(at)
+		if !slices.Equal(got, want) {
+			t.Fatalf("the fold walked to day %d holds %v, want the %v a single reading holds",
+				day, got, want)
+		}
+		if len(got) == 0 {
+			t.Fatalf("day %d holds no router at all, want the ones created up to it", day)
+		}
+	}
+}
+
+func TestInventoryCarriesNoScrapeLabels(t *testing.T) {
+	month := faultyMonth(t, 1, Faults{})
+
+	for _, sample := range InventoryAt(month, cloudDay(10)) {
+		for _, forbidden := range []string{"platform", "cloud"} {
+			if _, held := sample.Labels[forbidden]; held {
+				t.Fatalf("%s carries a %s label, want it from the scrape job alone",
+					sample.Name, forbidden)
+			}
+		}
+	}
+}
+
+func TestInventoryReportsMemoryInMegabytes(t *testing.T) {
+	at := cloudDay(3)
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle: testOracle(
+			oneInstance("srv-1", cloudDay(2), cloudDay(4)),
+			oneInstance("srv-2", cloudDay(2), cloudDay(4)),
+		),
+	}
+	samples := InventoryAt(month, at)
+
+	want := map[string]int64{
+		seriesLimitsInstancesUsed: 2,
+		seriesLimitsInstancesMax:  limitInstancesMax,
+		seriesLimitsVCPUsUsed:     2 * int64(largeFlavor.vcpus),
+		seriesLimitsVCPUsMax:      limitVCPUsMax,
+		// Nova reports megabytes, and the size states the flavor's memory in
+		// gibibytes, so the limit is the summed ram_gb times 1024.
+		seriesLimitsMemoryUsed: 2 * int64(largeFlavor.memoryMB),
+		seriesLimitsMemoryMax:  limitMemoryMaxMB,
+	}
+	for name, value := range want {
+		held := namedSamples(samples, name)
+		if len(held) != 1 {
+			t.Fatalf("%s is stated %d times, want once for the one tenant", name, len(held))
+		}
+		if held[0].Value != value {
+			t.Errorf("%s = %d, want %d", name, held[0].Value, value)
+		}
+		if held[0].Labels["tenant_id"] != cloudTenant {
+			t.Errorf("%s names the tenant %q, want %q", name, held[0].Labels["tenant_id"], cloudTenant)
+		}
+	}
+}
+
+func TestInventoryToleratesAMalformedSize(t *testing.T) {
+	at := cloudDay(3)
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle: testOracle(
+			oneResource(typeInstance, "srv-1", cloudDay(2), cloudDay(4), stateActive, map[string]any{}),
+			oneResource(typeVolume, "vol-1", cloudDay(2), cloudDay(4), stateInUse,
+				map[string]any{"type": "ssd"}),
+		),
+	}
+	samples := InventoryAt(month, at)
+
+	servers := namedSamples(samples, seriesNovaServerStatus)
+	if len(servers) != 1 {
+		t.Fatalf("the server is stated %d times, want once even without a flavor", len(servers))
+	}
+	if servers[0].Labels["flavor_id"] != "" {
+		t.Errorf("the server names the flavor %q, want none for a size that states no flavor",
+			servers[0].Labels["flavor_id"])
+	}
+
+	zero := []string{seriesLimitsVCPUsUsed, seriesLimitsMemoryUsed, seriesCinderVolumeGB}
+	for _, name := range zero {
+		held := namedSamples(samples, name)
+		if len(held) != 1 {
+			t.Fatalf("%s is stated %d times, want once", name, len(held))
+		}
+		if held[0].Value != 0 {
+			t.Errorf("%s = %d, want a size member nobody stated to count as 0", name, held[0].Value)
+		}
+	}
+}
+
+func TestInventoryNamesTheExportersLabels(t *testing.T) {
+	at := cloudDay(3)
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Schedule: Schedule{{
+			At: cloudDay(2), EventType: routerCreateType, ResourceID: "rtr-1", ProjectID: cloudTenant,
+		}},
+		Oracle: testOracle(
+			oneResource(typeInstance, "srv-1", cloudDay(2), cloudDay(4), stateShutoff,
+				instanceSizeOf(largeFlavor)),
+			oneResource(typeVolume, "vol-1", cloudDay(2), cloudDay(4), stateInUse,
+				volumeSizeOf(&volume{sizeGB: 100, volumeType: "ssd"})),
+			oneResource(typeImage, "img-1", cloudDay(2), cloudDay(4), stateActive,
+				imageSizeOf(&image{size: quarterGiB})),
+			oneResource(typeFloatingIP, "fip-1", cloudDay(2), cloudDay(4), stateActive,
+				floatingIPSizeOf()),
+			oneResource(typeLoadBalancer, "lb-1", cloudDay(2), cloudDay(4), stateActive,
+				loadBalancerSizeOf(2, 1)),
+		),
+	}
+	samples := InventoryAt(month, at)
+
+	families := []struct {
+		name   string
+		labels []string
+	}{
+		{seriesNovaServerStatus, []string{"flavor_id", "id", "name", "status", "tenant_id", "uuid"}},
+		{seriesCinderVolumeStatus, []string{"id", "name", "status", "tenant_id", "volume_type"}},
+		{seriesCinderVolumeGB, []string{"id", "name", "tenant_id", "volume_type"}},
+		{seriesGlanceImageBytes, []string{"id", "name", "tenant_id"}},
+		{seriesNeutronFloatingIP, []string{"id", "project_id", "status"}},
+		{seriesNeutronRouter, []string{"id", "project_id", "status"}},
+		{
+			seriesLoadBalancerStatus,
+			[]string{"id", "name", "operating_status", "project_id", "provisioning_status"},
+		},
+		{seriesLimitsInstancesUsed, []string{"tenant_id"}},
+		{seriesIdentityProjectInfo, []string{"domain_id", "enabled", "id", "name"}},
+		{seriesIdentityProjects, nil},
+		{seriesNovaTotalVMs, nil},
+	}
+	for _, family := range families {
+		t.Run(family.name, func(t *testing.T) {
+			held := namedSamples(samples, family.name)
+			if len(held) != 1 {
+				t.Fatalf("%s is stated %d times, want once", family.name, len(held))
+			}
+			if got := labelKeys(held[0]); !slices.Equal(got, family.labels) {
+				t.Errorf("%s carries the labels %v, want %v", family.name, got, family.labels)
+			}
+		})
+	}
+
+	for _, sample := range samples {
+		if sample.Kind != KindGauge {
+			t.Errorf("%s is stated as kind %d, want every inventory series as a gauge",
+				sample.Name, sample.Kind)
+		}
+		if !sample.At.Equal(at) {
+			t.Errorf("%s is stated at %s, want the instant the world was read at, %s",
+				sample.Name, sample.At, at)
+		}
+	}
+
+	// The status is what nova reports, not what the collector books: the oracle
+	// says shutoff and nova says stopped.
+	if got := namedSamples(samples, seriesNovaServerStatus)[0].Labels["status"]; got != "stopped" {
+		t.Errorf("the server is served as %q, want nova's own word for a shutoff instance", got)
+	}
+	if got := namedSamples(samples, seriesGlanceImageBytes)[0].Value; got != quarterGiB {
+		t.Errorf("the image is stated as %d bytes, want %d", got, quarterGiB)
+	}
+	info := namedSamples(samples, seriesIdentityProjectInfo)[0]
+	if info.Labels["domain_id"] != "default" || info.Labels["enabled"] != "true" {
+		t.Errorf("the project is stated in domain %q and enabled %q, want default and true",
+			info.Labels["domain_id"], info.Labels["enabled"])
+	}
+	if got := namedSamples(samples, seriesIdentityProjects)[0].Value; got != int64(len(month.Tenants)) {
+		t.Errorf("%s = %d, want the %d tenants of the month",
+			seriesIdentityProjects, got, len(month.Tenants))
+	}
+}

--- a/internal/providers/openstack/simulator/oracle.go
+++ b/internal/providers/openstack/simulator/oracle.go
@@ -221,7 +221,8 @@ var billableTypes = map[string]billableType{
 // not read.
 //
 // Format 2 added the faults member on the document and on every resource.
-const oracleFormat = 2
+// Format 3 added the traffic member on the document.
+const oracleFormat = 3
 
 // Oracle is the generator's statement of what a month contained: for every
 // billable resource the intervals of constant state, size and project it
@@ -238,6 +239,15 @@ type Oracle struct {
 	// Faults holds the fault switches the month ran with, in FaultNames order.
 	// A month nobody passed --faults to states an empty list.
 	Faults []string `json:"faults"`
+	// Traffic holds one row per instance and per interval of that instance,
+	// ordered by resource id and then by From. Run fills it from the metric
+	// samples once the month is generated, so buildOracle states an empty list.
+	//
+	// The rows lie outside OracleInterval on purpose: foldFacts merges two
+	// adjacent facts that repeat the state, project and size, and a traffic
+	// figure inside the interval would make two mergeable intervals compare
+	// unequal and split that fold.
+	Traffic []OracleTraffic `json:"traffic"`
 }
 
 // OracleResource is one billable resource of the month and the intervals it
@@ -268,6 +278,16 @@ type OracleCount struct {
 	ProjectID string `json:"project_id"`
 	EventType string `json:"event_type"`
 	Count     int    `json:"count"`
+}
+
+// OracleTraffic is the network traffic one instance was given over one of its
+// intervals: the exact sum of the grid steps the generator placed inside it.
+type OracleTraffic struct {
+	ResourceID   string    `json:"resource_id"`
+	From         time.Time `json:"from"`
+	To           time.Time `json:"to"`
+	EgressBytes  int64     `json:"egress_bytes"`
+	IngressBytes int64     `json:"ingress_bytes"`
 }
 
 // resourceKey names one resource of the month. The id alone would not do: two
@@ -376,6 +396,7 @@ func buildOracle(facts []fact, seed uint64, cloud string, from, to time.Time,
 		Resources:  resources,
 		Counts:     sortedCounts(counts),
 		Faults:     faults.Names(),
+		Traffic:    []OracleTraffic{},
 	}, nil
 }
 
@@ -556,7 +577,9 @@ func ReadOracle(path string) (Oracle, error) {
 // writes, so a document without it is a trimmed or a truncated file rather than
 // a month that meant it: a missing size alone would turn every time gauge
 // dimension of every priced resource into a difference, because the comparison
-// bills an absent size member at zero the way the engine does.
+// bills an absent size member at zero the way the engine does. The traffic
+// rows are read the same way, and an empty list of them is a month nothing
+// pushed a counter for.
 func (o Oracle) validate() error {
 	switch {
 	case o.Cloud == "":
@@ -585,6 +608,14 @@ func (o Oracle) validate() error {
 			case interval.Size == nil:
 				return fmt.Errorf("states no size for %s from %s", named, at)
 			}
+		}
+	}
+	for _, row := range o.Traffic {
+		if row.ResourceID == "" {
+			return errors.New("states a traffic row without a resource")
+		}
+		if row.From.IsZero() || row.To.IsZero() {
+			return fmt.Errorf("states a traffic row of instance %s without bounds", row.ResourceID)
 		}
 	}
 	return nil

--- a/internal/providers/openstack/simulator/oracle_test.go
+++ b/internal/providers/openstack/simulator/oracle_test.go
@@ -806,7 +806,7 @@ func TestBuildOracleRefusesTwoFactsAtOneInstant(t *testing.T) {
 func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 	// surface is the format the lists below are stated for. A change to any of
 	// them raises this number and oracleFormat with it.
-	const surface = 2
+	const surface = 3
 
 	if oracleFormat != surface {
 		t.Fatalf("oracleFormat = %d and the surface below is stated for format %d, want the two "+
@@ -891,7 +891,7 @@ func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 				named: "Oracle", typ: reflect.TypeFor[Oracle](),
 				want: []string{
 					"format", "cloud", "seed", "period_from", "period_to", "resources", "counts",
-					"faults",
+					"faults", "traffic",
 				},
 			},
 			{
@@ -905,6 +905,10 @@ func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 			{
 				named: "OracleCount", typ: reflect.TypeFor[OracleCount](),
 				want: []string{"project_id", "event_type", "count"},
+			},
+			{
+				named: "OracleTraffic", typ: reflect.TypeFor[OracleTraffic](),
+				want: []string{"resource_id", "from", "to", "egress_bytes", "ingress_bytes"},
 			},
 		} {
 			t.Run(tc.named, func(t *testing.T) {
@@ -938,9 +942,9 @@ func TestOracleFormatCoversTheGeneratorsBookedSurface(t *testing.T) {
 // emptyOracleDocument is an oracle of a month that states no resource, written
 // out by hand because buildOracle only folds one from a ledger the generator
 // never produces.
-const emptyOracleDocument = `{"format":2,"cloud":"os-test","seed":1,` +
+const emptyOracleDocument = `{"format":3,"cloud":"os-test","seed":1,` +
 	`"period_from":"2026-07-01T00:00:00Z",` +
-	`"period_to":"2026-08-01T00:00:00Z","resources":[],"counts":[],"faults":[]}`
+	`"period_to":"2026-08-01T00:00:00Z","resources":[],"counts":[],"faults":[],"traffic":[]}`
 
 // completeOracleDocument is the smallest document ReadOracle accepts, and
 // oracleIntervalDocument the one interval it holds. The cases that hold the
@@ -949,10 +953,11 @@ const emptyOracleDocument = `{"format":2,"cloud":"os-test","seed":1,` +
 const oracleIntervalDocument = `{"from":"2026-07-01T00:00:00Z","to":"2026-07-02T00:00:00Z",` +
 	`"state":"available","project_id":"p1","size":{"size_gb":50}}`
 
-const completeOracleDocument = `{"format":2,"cloud":"os-test","seed":1,` +
+const completeOracleDocument = `{"format":3,"cloud":"os-test","seed":1,` +
 	`"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z",` +
 	`"resources":[{"resource_type":"volume","resource_id":"v","workload":"classic",` +
-	`"intervals":[` + oracleIntervalDocument + `],"faults":[]}],"counts":[],"faults":[]}`
+	`"intervals":[` + oracleIntervalDocument + `],"faults":[]}],"counts":[],"faults":[],` +
+	`"traffic":[]}`
 
 // generatedOracle is the oracle of one generated month, or a failed test.
 func generatedOracle(t *testing.T, seed uint64) Oracle {
@@ -985,6 +990,17 @@ func writeOracleFile(t *testing.T, document string) string {
 // the engine read from the same notification and lose them.
 func TestOracleRoundTrips(t *testing.T) {
 	oracle := generatedOracle(t, 1)
+	// The traffic rows are put on by hand, because Run fills them from the
+	// metric samples and a fold states the empty list. The second row was given
+	// no traffic at all, which has to come back as the zero it was written as
+	// rather than as a row the read dropped.
+	oracle.Traffic = []OracleTraffic{
+		{
+			ResourceID: "i1", From: july2026, To: july2026.AddDate(0, 0, 1),
+			EgressBytes: 12, IngressBytes: 3,
+		},
+		{ResourceID: "i1", From: july2026.AddDate(0, 0, 1), To: july2026.AddDate(0, 0, 2)},
+	}
 	path := filepath.Join(t.TempDir(), "oracle.json")
 
 	if err := WriteOracle(path, oracle); err != nil {
@@ -997,6 +1013,9 @@ func TestOracleRoundTrips(t *testing.T) {
 
 	if !reflect.DeepEqual(read, oracle) {
 		t.Errorf("ReadOracle() = %+v, want %+v", read, oracle)
+	}
+	if !reflect.DeepEqual(read.Traffic, oracle.Traffic) {
+		t.Errorf("ReadOracle().Traffic = %+v, want %+v", read.Traffic, oracle.Traffic)
 	}
 
 	content, err := os.ReadFile(path)
@@ -1011,6 +1030,26 @@ func TestOracleRoundTrips(t *testing.T) {
 	if !strings.HasSuffix(text, "\n") {
 		t.Errorf("%s ends with %q, want a trailing newline", path, text[max(len(text)-20, 0):])
 	}
+
+	t.Run("a month nothing pushed a counter for keeps its empty list", func(t *testing.T) {
+		quiet := generatedOracle(t, 1)
+		quiet.Traffic = []OracleTraffic{}
+		path := filepath.Join(t.TempDir(), "oracle.json")
+
+		if err := WriteOracle(path, quiet); err != nil {
+			t.Fatalf("WriteOracle() error = %v, want nil", err)
+		}
+		read, err := ReadOracle(path)
+		if err != nil {
+			t.Fatalf("ReadOracle() error = %v, want nil", err)
+		}
+
+		// A null would leave a comparison unable to tell a month without traffic
+		// from one whose rows the read dropped.
+		if read.Traffic == nil || len(read.Traffic) != 0 {
+			t.Errorf("ReadOracle().Traffic = %+v, want an empty list", read.Traffic)
+		}
+	})
 }
 
 // TestOracleRoundTripsTheFaultSwitches holds the two faults members through a
@@ -1123,11 +1162,11 @@ func TestReadOracleRefusesWhatIsNotAnOracle(t *testing.T) {
 	})
 
 	t.Run("an oracle written to another format", func(t *testing.T) {
-		path := writeOracleFile(t, strings.Replace(completeOracleDocument, `"format":2`, `"format":1`, 1))
+		path := writeOracleFile(t, strings.Replace(completeOracleDocument, `"format":3`, `"format":2`, 1))
 
 		_, err := ReadOracle(path)
 
-		want := fmt.Sprintf("%s states format 1 and this build writes format %d", path, oracleFormat)
+		want := fmt.Sprintf("%s states format 2 and this build writes format %d", path, oracleFormat)
 		if err == nil || err.Error() != want {
 			t.Fatalf("ReadOracle() error = %v, want %q", err, want)
 		}
@@ -1179,6 +1218,43 @@ func TestReadOracleRefusesWhatIsNotAnOracle(t *testing.T) {
 			document := strings.Replace(completeOracleDocument, tc.cut, "", 1)
 			if document == completeOracleDocument {
 				t.Fatalf("the document holds no %q to cut, want the case to name a member of it", tc.cut)
+			}
+			path := writeOracleFile(t, document)
+
+			_, err := ReadOracle(path)
+
+			want := path + " " + tc.want
+			if err == nil || err.Error() != want {
+				t.Fatalf("ReadOracle() error = %v, want %q", err, want)
+			}
+		})
+	}
+
+	// The traffic rows are written into the document rather than cut out of it:
+	// an accepted file states the empty list, and what the read has to refuse is
+	// a row that names no instance or no bounds for one.
+	for _, tc := range []struct {
+		name    string
+		traffic string
+		want    string
+	}{
+		{
+			name: "a traffic row without a resource",
+			traffic: `[{"from":"2026-07-01T00:00:00Z","to":"2026-07-02T00:00:00Z",` +
+				`"egress_bytes":1,"ingress_bytes":1}]`,
+			want: "states a traffic row without a resource",
+		},
+		{
+			name: "a traffic row without bounds",
+			traffic: `[{"resource_id":"i","to":"2026-07-02T00:00:00Z",` +
+				`"egress_bytes":1,"ingress_bytes":1}]`,
+			want: "states a traffic row of instance i without bounds",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			document := strings.Replace(completeOracleDocument, `"traffic":[]`, `"traffic":`+tc.traffic, 1)
+			if document == completeOracleDocument {
+				t.Fatalf("the document states no empty traffic list, want the one the case fills")
 			}
 			path := writeOracleFile(t, document)
 

--- a/internal/providers/openstack/simulator/otlp.go
+++ b/internal/providers/openstack/simulator/otlp.go
@@ -1,0 +1,317 @@
+package simulator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// The push side of the metrics: the samples a month places go to an OTLP/HTTP
+// endpoint as JSON, the route the Gateway publishes in front of the collector.
+//
+// The document is written here with encoding/json rather than handed to the
+// OpenTelemetry Go SDK. The SDK stamps a point with the instant it collected
+// it, and every point of a month belongs to a virtual instant that is months
+// away from the wall clock. There is no seam in an SDK exporter to hand that
+// instant to, and a hand-written document is the shorter way to a point that
+// carries the instant it belongs to.
+
+const (
+	// maxDataPoints is the cap one request carries. A run paced by a factor of 0
+	// renders a whole month at once, and the loop that pushes it flushes at this
+	// count rather than posting a million points in a single body.
+	maxDataPoints = 5000
+	// pushTimeout bounds one attempt. The retries happen below http.Client.Do,
+	// so the bound is per attempt rather than per batch.
+	pushTimeout = 30 * time.Second
+	// The waits between two attempts of one batch.
+	pushRetryWaitMin = 500 * time.Millisecond
+	pushRetryWaitMax = 5 * time.Second
+	// otlpCumulative is the AggregationTemporality enum value for cumulative,
+	// which is what the counters of a month report: the value of a sample is
+	// everything that accrued before it.
+	otlpCumulative = 2
+)
+
+// The OTLP/HTTP JSON document, as much of it as a push writes: one resource
+// carrying one scope, and one metric object per series name below it.
+//
+// No type here carries a unit member. The prometheusremotewrite exporter of the
+// collector appends _total to a monotonic cumulative sum whose name does not
+// already end in it, and a unit suffix to a metric that declares a unit. A name
+// that already ends in _total, on a metric with no unit, is therefore stored
+// under exactly the name that was sent, whichever way those two options are
+// set.
+type otlpExport struct {
+	ResourceMetrics []otlpResourceMetrics `json:"resourceMetrics"`
+}
+
+type otlpResourceMetrics struct {
+	ScopeMetrics []otlpScopeMetrics `json:"scopeMetrics"`
+}
+
+type otlpScopeMetrics struct {
+	Metrics []otlpMetric `json:"metrics"`
+}
+
+// otlpMetric is one series name with its points. Exactly one of the two members
+// stands: a gauge is a value read at an instant, a sum is a counter.
+type otlpMetric struct {
+	Name  string     `json:"name"`
+	Gauge *otlpGauge `json:"gauge,omitempty"`
+	Sum   *otlpSum   `json:"sum,omitempty"`
+}
+
+type otlpGauge struct {
+	DataPoints []otlpPoint `json:"dataPoints"`
+}
+
+type otlpSum struct {
+	AggregationTemporality int         `json:"aggregationTemporality"`
+	IsMonotonic            bool        `json:"isMonotonic"`
+	DataPoints             []otlpPoint `json:"dataPoints"`
+}
+
+// otlpPoint is one value of one series at one instant.
+//
+// The instant and the value are JSON strings, which is the proto3 JSON mapping
+// of a 64-bit integer and what the OTLP/HTTP receiver reads them as. The
+// recorded drill in docs/grafana-dashboards.md sends timeUnixNano as a string
+// too. An integer value also keeps a byte count exact, which a float64 stops
+// doing above 2^53.
+type otlpPoint struct {
+	Attributes   []otlpAttribute `json:"attributes"`
+	TimeUnixNano string          `json:"timeUnixNano"`
+	AsInt        string          `json:"asInt"`
+}
+
+type otlpAttribute struct {
+	Key   string    `json:"key"`
+	Value otlpValue `json:"value"`
+}
+
+type otlpValue struct {
+	StringValue string `json:"stringValue"`
+}
+
+// encodeBatch renders the samples as one OTLP/HTTP JSON document: one metric
+// object per series name, in the order the names were first seen, holding the
+// points of that name.
+//
+// The attributes of a point are the static labels overlaid by the sample's own,
+// so the sample wins a clash, sorted by key. A sample that carries no labels of
+// its own is one of an aggregate series and carries the static ones alone.
+//
+// Two samples of one name that disagree on their kind are refused. A series is
+// a gauge or a sum, and a document stating it as both stores it under whichever
+// of the two the collector read last.
+func encodeBatch(samples []Sample, static map[string]string) ([]byte, error) {
+	metrics := make([]otlpMetric, 0)
+	index := make(map[string]int, len(samples))
+
+	for _, sample := range samples {
+		at, ok := index[sample.Name]
+		if !ok {
+			metric := otlpMetric{Name: sample.Name}
+			if sample.Kind == KindCounter {
+				metric.Sum = &otlpSum{AggregationTemporality: otlpCumulative, IsMonotonic: true}
+			} else {
+				metric.Gauge = &otlpGauge{}
+			}
+			metrics = append(metrics, metric)
+			at = len(metrics) - 1
+			index[sample.Name] = at
+		}
+
+		point := otlpPoint{
+			Attributes:   attributesOf(sample.Labels, static),
+			TimeUnixNano: strconv.FormatInt(sample.At.UnixNano(), 10),
+			AsInt:        strconv.FormatInt(sample.Value, 10),
+		}
+		switch {
+		case sample.Kind == KindCounter && metrics[at].Sum != nil:
+			metrics[at].Sum.DataPoints = append(metrics[at].Sum.DataPoints, point)
+		case sample.Kind == KindGauge && metrics[at].Gauge != nil:
+			metrics[at].Gauge.DataPoints = append(metrics[at].Gauge.DataPoints, point)
+		default:
+			return nil, fmt.Errorf(
+				"the metric %s carries a gauge sample and a counter sample in one batch", sample.Name)
+		}
+	}
+
+	return json.Marshal(otlpExport{ResourceMetrics: []otlpResourceMetrics{{
+		ScopeMetrics: []otlpScopeMetrics{{Metrics: metrics}},
+	}}})
+}
+
+// attributesOf merges the labels of a sample over the static ones and states
+// them as OTLP attributes, sorted by key. Sorting them makes one batch of a
+// series byte-identical to the next one over the same samples, which a diff of
+// two runs reads.
+func attributesOf(labels, static map[string]string) []otlpAttribute {
+	merged := make(map[string]string, len(static)+len(labels))
+	maps.Copy(merged, static)
+	maps.Copy(merged, labels)
+
+	attributes := make([]otlpAttribute, 0, len(merged))
+	for _, key := range slices.Sorted(maps.Keys(merged)) {
+		attributes = append(attributes, otlpAttribute{Key: key, Value: otlpValue{StringValue: merged[key]}})
+	}
+	return attributes
+}
+
+// Pusher posts samples to an OTLP/HTTP metrics endpoint under a basic
+// credential.
+//
+// It never formats the password or the Authorization header into an error or a
+// log line. What a failure states is the url, the status, and the beginning of
+// the body the endpoint refused with, which is what an operator needs and where
+// the credential never is. The url an error carries is the redacted one: a
+// credential a caller put into the URL itself is a password as much as the
+// configured one is.
+type Pusher struct {
+	url      string
+	safeURL  string
+	user     string
+	password string
+	static   map[string]string
+	client   *http.Client
+}
+
+// NewPusher returns the pusher that posts to url under the credential user and
+// password. Every point it sends carries platform and cloud on top of the
+// labels of its sample: a push has no scrape job to take those two from, and
+// the dashboards filter on both.
+//
+// A nil httpClient selects the package default, which is the one
+// internal/engine/counters builds for its queries. The retrying transport sits
+// below http.Client.Do, so a push makes one call and sees one result however
+// many attempts it took. The default policy retries connection errors, a 429,
+// which is what the Gateway's BackendTrafficPolicy answers a run that pushes
+// faster than the rate it allows, and a 5xx except 501. A 4xx such as the 401
+// of a wrong password is returned at once. Tests pass their own client.
+func NewPusher(url, user, password, cloud string, httpClient *http.Client) *Pusher {
+	if httpClient == nil {
+		rc := retryablehttp.NewClient()
+		// The default logger writes every retry to stderr, past the run's handler.
+		rc.Logger = nil
+		// Without a passthrough handler an exhausted retry on a 5xx returns a bare
+		// "giving up after N attempt(s)" error and drops the response, and the
+		// status the endpoint refused with is what the message needs.
+		rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+		rc.RetryWaitMin = pushRetryWaitMin
+		rc.RetryWaitMax = pushRetryWaitMax
+		rc.HTTPClient.Timeout = pushTimeout
+		// RetryMax stays at its default of four.
+		httpClient = rc.StandardClient()
+	}
+	return &Pusher{
+		url:      url,
+		safeURL:  redactedURL(url),
+		user:     user,
+		password: password,
+		static:   map[string]string{"platform": platformOpenStack, "cloud": cloud},
+		client:   httpClient,
+	}
+}
+
+// redactedURL is the endpoint an error may name, and a URL that does not parse
+// is not named at all. Neither half of the userinfo survives: an endpoint may
+// carry a bearer token as its user, and url.URL.Redacted replaces the password
+// alone. The query goes whole, because an api key is as often a parameter as it
+// is a password, and the host and the path are what name the endpoint an
+// operator mistyped.
+//
+// ValidateMetrics refuses all three shapes, so a run never reaches here with
+// one. This is the second line, for a Pusher built straight from a URL: the
+// error it formats is logged as JSON to stdout and shipped from there.
+func redactedURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "the configured endpoint"
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("redacted")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+// Push posts the samples in chunks of at most maxDataPoints points and stops at
+// the first chunk that fails, because a batch the endpoint refused is one the
+// ones behind it will be refused with too. An empty batch is no request at all.
+//
+// A cancelled context comes back as the context's own error, so a caller's
+// errors.Is(err, context.Canceled) holds and the publishing loop reads it as
+// the clean stop a signal asked for rather than as a failed push.
+func (p *Pusher) Push(ctx context.Context, samples []Sample) error {
+	for chunk := range slices.Chunk(samples, maxDataPoints) {
+		if err := p.send(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// send posts one batch and reports what the endpoint answered.
+func (p *Pusher) send(ctx context.Context, samples []Sample) error {
+	body, err := encodeBatch(samples, p.static)
+	if err != nil {
+		return fmt.Errorf("pushing metrics to %s: %w", p.safeURL, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("pushing metrics to %s: %w", p.safeURL, err)
+	}
+	req.SetBasicAuth(p.user, p.password)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		// A run that was stopped did not fail its push. The context's error is
+		// returned as it is, rather than wrapped in what the transport made of it,
+		// so that the caller reads its own cancellation back out.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		// The endpoint is named once, redacted, and the cause is unwrapped out of
+		// what carried it. http.Client reports a transport failure inside a
+		// *url.Error holding the request's own URL, and the masking it does there
+		// covers the password half of a userinfo alone: a bare user and the whole
+		// query stand in the message it formats.
+		var wrapped *url.Error
+		if errors.As(err, &wrapped) {
+			err = wrapped.Err
+		}
+		return fmt.Errorf("pushing metrics to %s: %w", p.safeURL, err)
+	}
+	// Reading the rest of an accepted answer before closing it is what lets the
+	// connection carry the batch that follows, of which a month has many.
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode/100 != 2 {
+		// What the endpoint refused with is what an operator needs: the collector
+		// names the point it rejected there. A read that failed halfway still
+		// returns what it got, which is what the message quotes.
+		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, refusalBodyMax))
+		return fmt.Errorf("pushing metrics to %s: unexpected status %d: %s",
+			p.safeURL, resp.StatusCode, excerpt)
+	}
+	return nil
+}

--- a/internal/providers/openstack/simulator/otlp_test.go
+++ b/internal/providers/openstack/simulator/otlp_test.go
@@ -1,0 +1,575 @@
+package simulator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// The credential the cases push under. The password is a literal the refusal
+// case searches the error for: a message that carried it would put it into
+// whatever an operator pastes it into.
+const (
+	pushUser     = "tally"
+	pushPassword = "s3cret-of-the-test"
+)
+
+// pushInstant is the virtual instant the pushed points belong to.
+var pushInstant = time.Date(2026, 7, 1, 10, 5, 0, 0, time.UTC)
+
+// pushClient builds the client a case pushes through: the retry policy of the
+// package default, with the waits cut to a millisecond and the number of
+// retries set per case.
+func pushClient(retryMax int) *http.Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = nil
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	rc.RetryWaitMin = time.Millisecond
+	rc.RetryWaitMax = time.Millisecond
+	rc.RetryMax = retryMax
+	return rc.StandardClient()
+}
+
+// pushedRequest is what the stand-in endpoint saw of one request.
+type pushedRequest struct {
+	authorization string
+	contentType   string
+	raw           []byte
+	export        otlpExport
+}
+
+// otlpServer stands in for the OTLP/HTTP endpoint. It answers by the statuses
+// the case scripted, the last of them repeated for every request past their
+// number, so a case states a refusal or a retry ladder and holds the requests
+// it took against it afterwards.
+type otlpServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	statuses []int
+	requests []pushedRequest
+}
+
+func newOTLPServer(t *testing.T, statuses ...int) *otlpServer {
+	t.Helper()
+
+	server := &otlpServer{statuses: statuses}
+	server.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading the pushed body: %v", err)
+		}
+		var export otlpExport
+		if err := json.Unmarshal(raw, &export); err != nil {
+			t.Errorf("the pushed body %q is no OTLP document: %v", raw, err)
+		}
+
+		server.mu.Lock()
+		server.requests = append(server.requests, pushedRequest{
+			authorization: r.Header.Get("Authorization"),
+			contentType:   r.Header.Get("Content-Type"),
+			raw:           raw,
+			export:        export,
+		})
+		status := http.StatusOK
+		if len(server.statuses) > 0 {
+			status = server.statuses[min(len(server.requests)-1, len(server.statuses)-1)]
+		}
+		server.mu.Unlock()
+
+		if status/100 != 2 {
+			http.Error(w, "the collector refused the batch", status)
+			return
+		}
+		// An accepted push is answered with the empty export response.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "{}")
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// seen is the requests the endpoint took. A retried batch reaches the handler
+// from the client's goroutine and a case reads the slice from its own, so it is
+// guarded and handed out as a copy.
+func (s *otlpServer) seen() []pushedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.requests)
+}
+
+// pusherTo builds the pusher of a case.
+func pusherTo(server *otlpServer, retryMax int) *Pusher {
+	return NewPusher(server.URL, pushUser, pushPassword, testCloud, pushClient(retryMax))
+}
+
+// closedEndpoint is an address on the loopback nothing listens on: a port is
+// taken and handed back at once. A push to it fails in the transport, before
+// there is a status to read.
+func closedEndpoint(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("taking a port to close again: %v", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("closing the port %s again: %v", address, err)
+	}
+	return "http://" + address + "/v1/metrics"
+}
+
+// countSample is the batch the transport cases push. What they hold is the
+// client rather than the document, so one point of one series is enough.
+func countSample() []Sample {
+	return []Sample{{Name: seriesNovaTotalVMs, Value: 3, At: pushInstant, Kind: KindGauge}}
+}
+
+// decodeExport reads back a document encodeBatch wrote.
+func decodeExport(t *testing.T, body []byte) otlpExport {
+	t.Helper()
+
+	var export otlpExport
+	if err := json.Unmarshal(body, &export); err != nil {
+		t.Fatalf("decoding the document %s: %v", body, err)
+	}
+	return export
+}
+
+// metricsOf unwraps the one resource and the one scope of a document.
+func metricsOf(t *testing.T, export otlpExport) []otlpMetric {
+	t.Helper()
+
+	if len(export.ResourceMetrics) != 1 {
+		t.Fatalf("the document carries %d resourceMetrics, want 1", len(export.ResourceMetrics))
+	}
+	if len(export.ResourceMetrics[0].ScopeMetrics) != 1 {
+		t.Fatalf("the resource carries %d scopeMetrics, want 1",
+			len(export.ResourceMetrics[0].ScopeMetrics))
+	}
+	return export.ResourceMetrics[0].ScopeMetrics[0].Metrics
+}
+
+// pointsOf is the points of a metric, whichever of the two members carries
+// them.
+func pointsOf(metric otlpMetric) []otlpPoint {
+	switch {
+	case metric.Sum != nil:
+		return metric.Sum.DataPoints
+	case metric.Gauge != nil:
+		return metric.Gauge.DataPoints
+	default:
+		return nil
+	}
+}
+
+// onePointOf is the single point a metric of these cases carries.
+func onePointOf(t *testing.T, metric otlpMetric) otlpPoint {
+	t.Helper()
+
+	points := pointsOf(metric)
+	if len(points) != 1 {
+		t.Fatalf("%s carries %d points, want 1", metric.Name, len(points))
+	}
+	return points[0]
+}
+
+// attributeKeys is the keys of a point in the order they were sent.
+func attributeKeys(point otlpPoint) []string {
+	keys := make([]string, 0, len(point.Attributes))
+	for _, attribute := range point.Attributes {
+		keys = append(keys, attribute.Key)
+	}
+	return keys
+}
+
+// attributeValues is the attributes of a point by key.
+func attributeValues(point otlpPoint) map[string]string {
+	values := make(map[string]string, len(point.Attributes))
+	for _, attribute := range point.Attributes {
+		values[attribute.Key] = attribute.Value.StringValue
+	}
+	return values
+}
+
+// dataPointCount is how many points one request carried, which is what the cap
+// bounds.
+func dataPointCount(export otlpExport) int {
+	count := 0
+	for _, resource := range export.ResourceMetrics {
+		for _, scope := range resource.ScopeMetrics {
+			for _, metric := range scope.Metrics {
+				count += len(pointsOf(metric))
+			}
+		}
+	}
+	return count
+}
+
+func TestEncodeBatchFollowsTheOTLPShape(t *testing.T) {
+	body, err := encodeBatch([]Sample{
+		{
+			Name:   egressSeries,
+			Labels: map[string]string{"resource_id": "0f6d"},
+			Value:  4294967296,
+			At:     pushInstant,
+			Kind:   KindCounter,
+		},
+		{Name: seriesNovaTotalVMs, Value: 7, At: pushInstant, Kind: KindGauge},
+	}, map[string]string{"platform": platformOpenStack, "cloud": testCloud})
+	if err != nil {
+		t.Fatalf("encoding the batch: %v", err)
+	}
+
+	metrics := metricsOf(t, decodeExport(t, body))
+	if len(metrics) != 2 {
+		t.Fatalf("the document carries %d metrics, want one per series name", len(metrics))
+	}
+
+	traffic := metrics[0]
+	if traffic.Name != egressSeries || !strings.HasSuffix(traffic.Name, "_total") {
+		t.Errorf("the counter is named %q, want %s, which ends in _total", traffic.Name, egressSeries)
+	}
+	if traffic.Sum == nil || traffic.Gauge != nil {
+		t.Fatalf("%s is stated with sum %v and gauge %v, want a sum alone",
+			traffic.Name, traffic.Sum, traffic.Gauge)
+	}
+	if traffic.Sum.AggregationTemporality != otlpCumulative || !traffic.Sum.IsMonotonic {
+		t.Errorf("%s carries the temporality %d and isMonotonic %t, want %d and true",
+			traffic.Name, traffic.Sum.AggregationTemporality, traffic.Sum.IsMonotonic, otlpCumulative)
+	}
+	point := onePointOf(t, traffic)
+	if point.AsInt != "4294967296" {
+		t.Errorf("%s carries the value %q, want the decimal string 4294967296", traffic.Name, point.AsInt)
+	}
+	if want := strconv.FormatInt(pushInstant.UnixNano(), 10); point.TimeUnixNano != want {
+		t.Errorf("%s carries the instant %q, want %q", traffic.Name, point.TimeUnixNano, want)
+	}
+
+	inventory := metrics[1]
+	if inventory.Gauge == nil || inventory.Sum != nil {
+		t.Fatalf("%s is stated with gauge %v and sum %v, want a gauge alone",
+			inventory.Name, inventory.Gauge, inventory.Sum)
+	}
+	if value := onePointOf(t, inventory).AsInt; value != "7" {
+		t.Errorf("%s carries the value %q, want 7", inventory.Name, value)
+	}
+
+	// A metric that declared a unit is stored under a name with the unit
+	// appended to it, which is not the name the dashboards read.
+	if strings.Contains(string(body), `"unit"`) {
+		t.Errorf("the document %s carries a unit member, want none", body)
+	}
+}
+
+func TestEncodeBatchRefusesOneNameUnderTwoKinds(t *testing.T) {
+	_, err := encodeBatch([]Sample{
+		{Name: egressSeries, Value: 1, At: pushInstant, Kind: KindCounter},
+		{Name: egressSeries, Value: 2, At: pushInstant, Kind: KindGauge},
+	}, nil)
+	if err == nil {
+		t.Fatalf("encoding %s as a counter and as a gauge returned no error", egressSeries)
+	}
+	if !strings.Contains(err.Error(), egressSeries) {
+		t.Errorf("the error %v does not name the metric %s", err, egressSeries)
+	}
+}
+
+func TestEncodeBatchStatesAnEmptyBatchAsNoMetric(t *testing.T) {
+	body, err := encodeBatch(nil, map[string]string{"cloud": testCloud})
+	if err != nil {
+		t.Fatalf("encoding an empty batch: %v", err)
+	}
+	if metrics := metricsOf(t, decodeExport(t, body)); len(metrics) != 0 {
+		t.Errorf("an empty batch encodes to %s, want a document with no metric", body)
+	}
+}
+
+func TestEncodeBatchLetsTheSampleWinALabelClash(t *testing.T) {
+	body, err := encodeBatch([]Sample{{
+		Name:   egressSeries,
+		Labels: map[string]string{"cloud": "os-of-the-month"},
+		At:     pushInstant,
+		Kind:   KindCounter,
+	}}, map[string]string{"platform": platformOpenStack, "cloud": "os-of-the-pusher"})
+	if err != nil {
+		t.Fatalf("encoding the batch: %v", err)
+	}
+
+	metrics := metricsOf(t, decodeExport(t, body))
+	if len(metrics) != 1 {
+		t.Fatalf("the document carries %d metrics, want 1", len(metrics))
+	}
+	if cloud := attributeValues(onePointOf(t, metrics[0]))["cloud"]; cloud != "os-of-the-month" {
+		t.Errorf("the point carries the cloud %q, want the one its sample states", cloud)
+	}
+}
+
+func TestPushCarriesTheLabelsEachFaceNeeds(t *testing.T) {
+	server := newOTLPServer(t)
+	err := pusherTo(server, 0).Push(t.Context(), []Sample{
+		// The five labels TrafficOf places, which the concept makes mandatory for
+		// every provider.
+		{
+			Name: egressSeries,
+			Labels: map[string]string{
+				"platform":      platformOpenStack,
+				"cloud":         testCloud,
+				"resource_type": typeInstance,
+				"resource_id":   "0f6d",
+				"project_id":    cloudTenant,
+			},
+			Value: 4096,
+			At:    pushInstant,
+			Kind:  KindCounter,
+		},
+		// An inventory sample carries the exporter's own labels and neither a
+		// platform nor a cloud, because a scrape takes those from its job.
+		{
+			Name:   seriesNovaServerStatus,
+			Labels: map[string]string{"id": "0f6d", "tenant_id": cloudTenant},
+			Value:  1,
+			At:     pushInstant,
+			Kind:   KindGauge,
+		},
+		// An aggregate carries no labels of its own at all.
+		{Name: seriesNovaTotalVMs, Value: 3, At: pushInstant, Kind: KindGauge},
+	})
+	if err != nil {
+		t.Fatalf("pushing the three faces: %v", err)
+	}
+
+	seen := server.seen()
+	if len(seen) != 1 {
+		t.Fatalf("the endpoint saw %d requests, want 1", len(seen))
+	}
+	metrics := metricsOf(t, seen[0].export)
+	if len(metrics) != 3 {
+		t.Fatalf("the request carries %d metrics, want one per series name", len(metrics))
+	}
+
+	for _, tc := range []struct {
+		metric otlpMetric
+		want   []string
+	}{
+		{metrics[0], []string{"cloud", "platform", "project_id", "resource_id", "resource_type"}},
+		{metrics[1], []string{"cloud", "id", "platform", "tenant_id"}},
+		{metrics[2], []string{"cloud", "platform"}},
+	} {
+		if keys := attributeKeys(onePointOf(t, tc.metric)); !slices.Equal(keys, tc.want) {
+			t.Errorf("%s carries the attributes %v, want %v, sorted by key", tc.metric.Name, keys, tc.want)
+		}
+	}
+
+	values := attributeValues(onePointOf(t, metrics[1]))
+	if values["platform"] != platformOpenStack || values["cloud"] != testCloud {
+		t.Errorf("the inventory point is pushed under the platform %q and the cloud %q, want %s and %s",
+			values["platform"], values["cloud"], platformOpenStack, testCloud)
+	}
+}
+
+func TestPushSendsTheBasicCredential(t *testing.T) {
+	server := newOTLPServer(t)
+	if err := pusherTo(server, 0).Push(t.Context(), countSample()); err != nil {
+		t.Fatalf("pushing one sample: %v", err)
+	}
+
+	seen := server.seen()
+	if len(seen) != 1 {
+		t.Fatalf("the endpoint saw %d requests, want 1", len(seen))
+	}
+	if want := "Basic " + base64.StdEncoding.EncodeToString([]byte(pushUser+":"+pushPassword)); seen[0].authorization != want {
+		t.Errorf("the endpoint saw the authorization %q, want the basic credential of %s",
+			seen[0].authorization, pushUser)
+	}
+	if seen[0].contentType != "application/json" {
+		t.Errorf("the endpoint saw the content type %q, want application/json", seen[0].contentType)
+	}
+}
+
+func TestPushReportsARefusal(t *testing.T) {
+	server := newOTLPServer(t, http.StatusUnauthorized)
+	err := pusherTo(server, 2).Push(t.Context(), countSample())
+	if err == nil {
+		t.Fatalf("pushing to an endpoint that answers 401 returned no error")
+	}
+	for _, want := range []string{"pushing metrics to " + server.URL, "401"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error %v does not state %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), pushPassword) {
+		t.Errorf("the error states the password, want a message an operator can paste anywhere")
+	}
+	if n := len(server.seen()); n != 1 {
+		t.Errorf("the endpoint saw %d requests, want 1: a 4xx is not retried", n)
+	}
+}
+
+// TestPushRedactsACredentialInTheURL is the endpoint whose credential sits in
+// the URL itself. ValidateMetrics refuses all three shapes, so a run never
+// builds such a pusher, but a Pusher is built straight from a URL and the
+// failure it formats is logged as JSON and shipped from there: the endpoint the
+// message names carries neither half of a userinfo nor a parameter.
+//
+// Every shape is held against both faces of a failed push. One is a status the
+// endpoint answered with. The other is a transport that never reached it, which
+// http.Client reports inside a wrapper carrying the request's own URL, of which
+// it masks the password half of a userinfo alone.
+func TestPushRedactsACredentialInTheURL(t *testing.T) {
+	const embedded = "s3cret-in-the-url"
+
+	for _, endpoint := range []struct {
+		name string
+		of   func(*testing.T) string
+	}{
+		{
+			name: "refusing the batch",
+			of:   func(t *testing.T) string { return newOTLPServer(t, http.StatusUnauthorized).URL },
+		},
+		{
+			name: "refusing the connection",
+			of:   closedEndpoint,
+		},
+	} {
+		for _, tc := range []struct {
+			name  string
+			carry func(*url.URL)
+		}{
+			{
+				name:  "a password in the userinfo",
+				carry: func(u *url.URL) { u.User = url.UserPassword(pushUser, embedded) },
+			},
+			{
+				name:  "a token as the user",
+				carry: func(u *url.URL) { u.User = url.User(embedded) },
+			},
+			{
+				name:  "an api key in the query",
+				carry: func(u *url.URL) { u.RawQuery = url.Values{"api-key": {embedded}}.Encode() },
+			},
+		} {
+			t.Run(endpoint.name+" with "+tc.name, func(t *testing.T) {
+				raw := endpoint.of(t)
+				parsed, err := url.Parse(raw)
+				if err != nil {
+					t.Fatalf("parsing the stand-in endpoint %s: %v", raw, err)
+				}
+				tc.carry(parsed)
+
+				err = NewPusher(parsed.String(), pushUser, pushPassword, testCloud, pushClient(0)).
+					Push(t.Context(), countSample())
+				if err == nil {
+					t.Fatal("pushing to an endpoint that refuses the push returned no error")
+				}
+				if strings.Contains(err.Error(), embedded) {
+					t.Errorf("the error %v states the credential the URL carried, want it redacted", err)
+				}
+				if !strings.Contains(err.Error(), parsed.Host) {
+					t.Errorf("the error %v names no endpoint, want the host an operator mistyped", err)
+				}
+			})
+		}
+	}
+}
+
+func TestPushRetriesA429(t *testing.T) {
+	server := newOTLPServer(t, http.StatusTooManyRequests, http.StatusTooManyRequests, http.StatusOK)
+	if err := pusherTo(server, 2).Push(t.Context(), countSample()); err != nil {
+		t.Fatalf("pushing through two rate limits: %v", err)
+	}
+	if n := len(server.seen()); n != 3 {
+		t.Errorf("the endpoint saw %d requests, want the two refused ones and the accepted one", n)
+	}
+}
+
+func TestPushGivesUpOnA503(t *testing.T) {
+	server := newOTLPServer(t, http.StatusServiceUnavailable)
+	err := pusherTo(server, 2).Push(t.Context(), countSample())
+	if err == nil {
+		t.Fatalf("pushing to an endpoint that stays down returned no error")
+	}
+	for _, want := range []string{"pushing metrics to " + server.URL, "503"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error %v does not state %q", err, want)
+		}
+	}
+	if n := len(server.seen()); n != 3 {
+		t.Errorf("the endpoint saw %d requests, want the attempt and its two retries", n)
+	}
+}
+
+func TestPushSendsNothingForAnEmptyBatch(t *testing.T) {
+	server := newOTLPServer(t)
+	pusher := pusherTo(server, 0)
+	if err := pusher.Push(t.Context(), nil); err != nil {
+		t.Errorf("pushing no samples at all: %v", err)
+	}
+	if err := pusher.Push(t.Context(), []Sample{}); err != nil {
+		t.Errorf("pushing an empty batch: %v", err)
+	}
+	if n := len(server.seen()); n != 0 {
+		t.Errorf("the endpoint saw %d requests, want none for a batch with no point", n)
+	}
+}
+
+func TestPushSplitsAtTheCap(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		count int
+		want  []int
+	}{
+		{name: "one point past the cap", count: maxDataPoints + 1, want: []int{maxDataPoints, 1}},
+		{name: "exactly the cap", count: maxDataPoints, want: []int{maxDataPoints}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			samples := make([]Sample, 0, tc.count)
+			for i := range tc.count {
+				samples = append(samples, Sample{
+					Name: seriesNovaTotalVMs, Value: int64(i), At: pushInstant, Kind: KindGauge,
+				})
+			}
+
+			server := newOTLPServer(t)
+			if err := pusherTo(server, 0).Push(t.Context(), samples); err != nil {
+				t.Fatalf("pushing %d samples: %v", tc.count, err)
+			}
+
+			counts := make([]int, 0, len(tc.want))
+			for _, request := range server.seen() {
+				counts = append(counts, dataPointCount(request.export))
+			}
+			if !slices.Equal(counts, tc.want) {
+				t.Errorf("%d samples were pushed as the requests %v, want %v", tc.count, counts, tc.want)
+			}
+		})
+	}
+}
+
+func TestPushStopsOnACancelledContext(t *testing.T) {
+	server := newOTLPServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := pusherTo(server, 0).Push(ctx, countSample())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("pushing under a cancelled context returned %v, want a context.Canceled a loop reads as its stop", err)
+	}
+	if n := len(server.seen()); n != 0 {
+		t.Errorf("the endpoint saw %d requests, want none from a run that was already stopped", n)
+	}
+}

--- a/internal/providers/openstack/simulator/publish_integration_test.go
+++ b/internal/providers/openstack/simulator/publish_integration_test.go
@@ -11,11 +11,13 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -449,6 +451,7 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 		Factor:           0,
 		Out:              out,
 		WaitForCollector: pollDeadline,
+		MetricsInterval:  testMetricsInterval,
 	}, publisher, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
@@ -466,6 +469,16 @@ func TestRunPublishesWhatTheCollectorConsumes(t *testing.T) {
 	// so it is held against what the collector did produce rather than trusted.
 	if got := eventIDsOf(t, filepath.Join(out, "events.jsonl")); !slices.Equal(got, want) {
 		t.Errorf("the event ids in events.jsonl = %v, want %v", got, want)
+	}
+	// The oracle beside them is one this build reads back, and it carries the
+	// traffic of the month although this run pushed none of it: what a drill
+	// reads the intended figure off is the file, not the endpoint.
+	oracle, err := ReadOracle(filepath.Join(out, "oracle.json"))
+	if err != nil {
+		t.Fatalf("ReadOracle() error = %v, want nil", err)
+	}
+	if len(oracle.Traffic) == 0 {
+		t.Error("oracle.json states no traffic row, want the rows the run placed")
 	}
 
 	// What the rest of the month becomes in the collector: every notification the
@@ -537,6 +550,7 @@ func TestACollectorAtItsDefaultExchangesMissesTheOtherFourExchanges(t *testing.T
 		Factor:           0,
 		Out:              t.TempDir(),
 		WaitForCollector: pollDeadline,
+		MetricsInterval:  testMetricsInterval,
 	}, publisher, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
@@ -600,10 +614,11 @@ func TestACollectorAtItsDefaultExchangesMissesTheOtherFourExchanges(t *testing.T
 func TestReplayPublishesACapturedMonth(t *testing.T) {
 	out := t.TempDir()
 	err := Run(t.Context(), Config{Cloud: testCloud}, RunOptions{
-		Period: "2026-07",
-		Seed:   1,
-		Factor: 0,
-		Out:    out,
+		Period:          "2026-07",
+		Seed:            1,
+		Factor:          0,
+		Out:             out,
+		MetricsInterval: testMetricsInterval,
 	}, nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() in file mode error = %v, want nil", err)
@@ -663,6 +678,7 @@ func TestRunWaitsForTheCollector(t *testing.T) {
 				Period:           "2026-07",
 				Seed:             2,
 				WaitForCollector: 0,
+				MetricsInterval:  testMetricsInterval,
 			}, publisher, testLogger(t))
 		}()
 
@@ -683,6 +699,7 @@ func TestRunWaitsForTheCollector(t *testing.T) {
 			Period:           "2026-07",
 			Seed:             2,
 			WaitForCollector: wait,
+			MetricsInterval:  testMetricsInterval,
 		}, publisher, testLogger(t))
 
 		want := "no consumer on the queue tally-notifications appeared within 2s; " +
@@ -747,6 +764,7 @@ func TestRunHoldsBackUntilReleased(t *testing.T) {
 			Factor:           0,
 			Faults:           []string{FaultHeldBack},
 			WaitForCollector: pollDeadline,
+			MetricsInterval:  testMetricsInterval,
 		}, publisher, testLogger(t))
 	}()
 
@@ -870,6 +888,7 @@ func TestRunServesTheFakeAPIOnTheControlListener(t *testing.T) {
 			Factor:           0,
 			Faults:           []string{FaultPreExisting, FaultHeldBack},
 			WaitForCollector: pollDeadline,
+			MetricsInterval:  testMetricsInterval,
 		}, publisher, testLogger(t))
 	}()
 	waitForHold(t, port, held)
@@ -943,6 +962,7 @@ func TestRunStoppedWhileHoldingKeepsTheHeldNotificationsBack(t *testing.T) {
 			Factor:           0,
 			Faults:           []string{FaultHeldBack},
 			WaitForCollector: pollDeadline,
+			MetricsInterval:  testMetricsInterval,
 		}, publisher, logger)
 	}()
 
@@ -986,7 +1006,10 @@ func TestRunStoppedWhileRegisteringWritesNothing(t *testing.T) {
 		ReportingURL: "https://127.0.0.1:1",
 		APIToken:     "tly_a_secret-of-the-test",
 		GardenCloud:  gardenCloud,
-	}, RunOptions{Period: "2026-07", Seed: 1, Out: out, RegisterProjects: true}, nil, logger)
+	}, RunOptions{
+		Period: "2026-07", Seed: 1, Out: out, RegisterProjects: true,
+		MetricsInterval: testMetricsInterval,
+	}, nil, logger)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil: a stop while registering is a clean stop", err)
 	}
@@ -1030,6 +1053,7 @@ func TestReleaseFailsWhenTheBrokerIsGone(t *testing.T) {
 			Factor:           0,
 			Faults:           []string{FaultHeldBack},
 			WaitForCollector: 0,
+			MetricsInterval:  testMetricsInterval,
 		}, publisher, testLogger(t))
 	}()
 
@@ -1077,6 +1101,7 @@ func TestRunPublishesDuplicatesTheCollectorHandsOn(t *testing.T) {
 		Factor:           0,
 		Faults:           []string{FaultDuplicates},
 		WaitForCollector: pollDeadline,
+		MetricsInterval:  testMetricsInterval,
 	}, publisher, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
@@ -1135,6 +1160,7 @@ func TestRunPublishesRefusedShapesTheCollectorRefuses(t *testing.T) {
 		Factor:           0,
 		Faults:           []string{FaultRefusedShapes},
 		WaitForCollector: pollDeadline,
+		MetricsInterval:  testMetricsInterval,
 	}, publisher, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
@@ -1180,5 +1206,418 @@ func TestRunPublishesRefusedShapesTheCollectorRefuses(t *testing.T) {
 	})
 	if got := storedEventIDs(t, outbox, len(want)); !slices.Equal(got, want) {
 		t.Errorf("buffered event ids = %v, want %v", got, want)
+	}
+}
+
+// metricsStub stands in for the OTLP/HTTP endpoint a run pushes to. It records
+// what a request carried rather than the request itself: a month at factor 0
+// arrives as hundreds of batches of five thousand points, and a stub keeping
+// the bodies would hold the whole month a second time.
+//
+// The statuses are answered one per request, the last of them repeated, the way
+// the stand-in of otlp_test.go answers them. No status at all is 200 throughout.
+type metricsStub struct {
+	*httptest.Server
+	mu       sync.Mutex
+	statuses []int
+	requests []pushedBatch
+}
+
+// pushedBatch is what the stub saw of one request: how many points it carried,
+// whether it authenticated, and the series in it.
+type pushedBatch struct {
+	points int
+	basic  bool
+	series map[string]pushedSeries
+}
+
+// pushedSeries is one metric name inside one request: the points it carried and
+// the shape it arrived under. A counter has to reach the collector as a
+// monotonic cumulative sum, because that is what the remote write exporter
+// stores under the name the sample was pushed with.
+type pushedSeries struct {
+	points      int
+	sum         bool
+	monotonic   bool
+	temporality int
+}
+
+// startMetricsStub runs the stand-in endpoint for the test.
+func startMetricsStub(t *testing.T, statuses ...int) *metricsStub {
+	t.Helper()
+
+	stub := &metricsStub{statuses: statuses}
+	stub.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var export otlpExport
+		// A body that ends early is passed over rather than failed on: a stopped
+		// run drops the request it was sending, and half a document arriving is
+		// that stop working. What a whole document holds is held in otlp_test.go,
+		// and a build that wrote none at all would leave the counts below at zero.
+		if err := json.NewDecoder(r.Body).Decode(&export); err != nil {
+			return
+		}
+		_, _, ok := r.BasicAuth()
+		batch := pushedBatch{basic: ok, series: make(map[string]pushedSeries)}
+		for _, resource := range export.ResourceMetrics {
+			for _, scope := range resource.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					series := batch.series[metric.Name]
+					if metric.Sum != nil {
+						series.sum = true
+						series.monotonic = metric.Sum.IsMonotonic
+						series.temporality = metric.Sum.AggregationTemporality
+						series.points += len(metric.Sum.DataPoints)
+						batch.points += len(metric.Sum.DataPoints)
+					}
+					if metric.Gauge != nil {
+						series.points += len(metric.Gauge.DataPoints)
+						batch.points += len(metric.Gauge.DataPoints)
+					}
+					batch.series[metric.Name] = series
+				}
+			}
+		}
+
+		stub.mu.Lock()
+		stub.requests = append(stub.requests, batch)
+		status := http.StatusOK
+		if len(stub.statuses) > 0 {
+			status = stub.statuses[min(len(stub.requests)-1, len(stub.statuses)-1)]
+		}
+		stub.mu.Unlock()
+
+		if status/100 != 2 {
+			http.Error(w, "the collector refused the batch", status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "{}")
+	}))
+	t.Cleanup(stub.Close)
+	return stub
+}
+
+// taken is the batches the endpoint took. The pusher reaches the handler from
+// the run's goroutine and a case reads the slice from its own, so it is guarded
+// and handed out as a copy.
+func (s *metricsStub) taken() []pushedBatch {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return slices.Clone(s.requests)
+}
+
+// pushSettleWait is the window a case watches the stand-in endpoint for once a
+// run has returned, and it waits two of them. The first lets the batch the
+// endpoint was still handling when the run gave up on it arrive, and a count
+// that moves during the second is a pusher that outlived the run: one at factor
+// 0 walks the month batch after batch.
+const pushSettleWait = 500 * time.Millisecond
+
+// TestPushSamplesFlushesEveryStepOfAPacedRun is the branch a drill runs under.
+// At a factor above zero the clock has not reached the next grid instant by the
+// time the step has been folded, so the batch of a step leaves with that step
+// instead of filling to the cap; the cases around it run at factor 0, where
+// virtual time stands still and the cap is what flushes. A month whose metrics
+// all arrived in one lump at the end would leave the panels of a paced drill
+// empty for as long as it ran.
+func TestPushSamplesFlushesEveryStepOfAPacedRun(t *testing.T) {
+	stub := startMetricsStub(t)
+
+	// Twelve grid steps of a period of its own rather than a whole month: the
+	// factor puts each of them a twentieth of a second of wall time behind the
+	// one before, and a month at that pace would outlast the test by hours.
+	const steps = 12
+	from := july2026
+	month := Month{
+		Tenants: []Tenant{{ID: cloudTenant, Name: "tenant-a", Workload: workloadClassic}},
+		Oracle: Oracle{
+			Cloud:      testCloud,
+			PeriodFrom: from,
+			PeriodTo:   from.Add(steps * testMetricsInterval),
+		},
+	}
+	factor := 20 * testMetricsInterval.Seconds()
+
+	var pushed atomic.Int64
+	err := pushSamples(t.Context(), NewClock(from, factor, time.Now), &metricsRun{
+		pusher:   NewPusher(stub.URL, pushUser, pushPassword, testCloud, nil),
+		month:    month,
+		interval: testMetricsInterval,
+	}, testLogger(t), &pushed)
+	if err != nil {
+		t.Fatalf("pushSamples() error = %v, want nil", err)
+	}
+
+	if n := len(stub.taken()); n != steps {
+		t.Errorf("the endpoint took %d requests over %d grid steps, want one per step: "+
+			"the batch of a step leaves with that step on a paced run", n, steps)
+	}
+	if pushed.Load() == 0 {
+		t.Error("the run counted no pushed point, want the inventory of every step")
+	}
+}
+
+// TestRunPushesTheMetricsAndServesTheInventory is the second face of a month
+// end to end: while the notifications go out, the traffic counters and the
+// inventory are pushed to the endpoint the configuration names, and the
+// inventory of the instant the run stands at is served on the control
+// listener. What each of the two states is held in metrics_test.go and
+// exporter_test.go; what only a run puts together is that both go out beside
+// the month.
+func TestRunPushesTheMetricsAndServesTheInventory(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	startCollector(t, url, ServiceExchanges)
+	stub := startMetricsStub(t)
+
+	// A factor of 0 stops virtual time at the first instant of the month, and
+	// held-back is what keeps the run up long enough to scrape it: it waits in
+	// the hold, and the endpoint goes down with the run.
+	month := faultyMonth(t, 1, Faults{PreExisting: true, HeldBack: true})
+	held := len(month.Held)
+	if held == 0 {
+		t.Fatal("the month holds nothing back, want the switch to have picked notifications")
+	}
+	samples, _, err := TrafficOf(month.Oracle, 1, testMetricsInterval)
+	if err != nil {
+		t.Fatalf("TrafficOf() error = %v, want nil", err)
+	}
+
+	logger, log := capturedLogger(t)
+	port := reservePort(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(t.Context(), Config{
+			Cloud:          testCloud,
+			HTTPPort:       port,
+			MetricsEnabled: true,
+			OTLPURL:        stub.URL,
+			OTLPUser:       pushUser,
+			OTLPPassword:   pushPassword,
+			OTLPInsecure:   true,
+		}, RunOptions{
+			Period:           "2026-07",
+			Seed:             1,
+			Factor:           0,
+			Faults:           []string{FaultPreExisting, FaultHeldBack},
+			WaitForCollector: pollDeadline,
+			MetricsInterval:  testMetricsInterval,
+		}, publisher, logger)
+	}()
+	waitForHold(t, port, held)
+
+	status, body, answered := controlRequest(t, port, http.MethodGet, "/metrics")
+	if !answered {
+		t.Fatal("GET /metrics reached nothing, want the inventory on the run's listener")
+	}
+	if status != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	for _, want := range []string{
+		seriesNovaTotalVMs, seriesCinderVolumes, seriesNeutronFloatingIPs,
+		seriesGlanceImages, seriesLoadBalancerTotal,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the scrape carries no %s, want the aggregate the dashboards read", want)
+		}
+	}
+	// A scrape carries no static label of its own: platform and cloud come from
+	// the scrape job, and an endpoint stating them would push the job's own under
+	// exported_cloud.
+	if strings.Contains(body, "platform=") {
+		t.Error("the scrape carries a platform label, want the scrape job to state it")
+	}
+
+	status, body, answered = controlRequest(t, port, http.MethodPost, "/release")
+	if !answered {
+		t.Fatal("POST /release reached nothing, want the endpoint to serve the hold")
+	}
+	if status != http.StatusOK {
+		t.Fatalf("POST /release = %d, want %d (body %q)", status, http.StatusOK, body)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil", err)
+		}
+	case <-time.After(pollDeadline):
+		t.Fatalf("Run() did not finish within %v after the release", pollDeadline)
+	}
+
+	batches := stub.taken()
+	if len(batches) < 2 {
+		t.Fatalf("the endpoint took %d requests, want a month to arrive in several", len(batches))
+	}
+	traffic, inventory := 0, 0
+	pushedNames := make(map[string]bool)
+	for number, batch := range batches {
+		if batch.points > maxDataPoints {
+			t.Errorf("request %d carried %d points, want at most %d", number, batch.points, maxDataPoints)
+		}
+		if !batch.basic {
+			t.Errorf("request %d carried no Basic credential, want every push to authenticate", number)
+		}
+		for _, name := range []string{egressSeries, ingressSeries} {
+			series, ok := batch.series[name]
+			if !ok {
+				continue
+			}
+			traffic += series.points
+			if !series.sum || !series.monotonic || series.temporality != otlpCumulative {
+				t.Fatalf("request %d states %s as sum=%v monotonic=%v temporality=%d, "+
+					"want a monotonic cumulative sum", number, name, series.sum, series.monotonic,
+					series.temporality)
+			}
+		}
+		// Everything else in the batch is the inventory of the grid step, which
+		// the push carries beside the counters: the scrape above reads the same
+		// world through the exporter, and nothing but this states that it reaches
+		// the endpoint at all.
+		for name, series := range batch.series {
+			if name == egressSeries || name == ingressSeries {
+				continue
+			}
+			pushedNames[name] = true
+			inventory += series.points
+			if series.sum {
+				t.Errorf("request %d states the inventory series %s as a sum, "+
+					"want the gauge a world read at an instant is", number, name)
+			}
+		}
+	}
+	if inventory == 0 {
+		t.Error("the endpoint took no inventory point, want the gauges beside the counters")
+	}
+	for _, name := range []string{seriesNovaTotalVMs, seriesIdentityProjects, seriesNeutronRouter} {
+		if !pushedNames[name] {
+			t.Errorf("the endpoint took no %s point, want the pushed month to hold what the scraped one holds",
+				name)
+		}
+	}
+	// Every traffic sample the month placed reached the endpoint exactly once:
+	// the cursor hands each grid step to the step it belongs to, and no batch
+	// repeats one.
+	if traffic != len(samples) {
+		t.Errorf("the endpoint took %d traffic points, want the %d the month placed", traffic, len(samples))
+	}
+	if !strings.Contains(log.String(), "msg=completed") || strings.Contains(log.String(), "pushed=0") {
+		t.Errorf("the run logged %q, want a completed line with the points it pushed", log.String())
+	}
+}
+
+// TestRunReportsAFailedPushAfterTheMonth is the endpoint that refuses every
+// batch: the month goes out whole regardless, because that is what the operator
+// asked for, and the run ends with the failed push so the exit status says the
+// metric half of it never arrived.
+func TestRunReportsAFailedPushAfterTheMonth(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	outbox, _, _ := startCollector(t, url, ServiceExchanges)
+	stub := startMetricsStub(t, http.StatusServiceUnavailable)
+
+	want := billableMessageIDs(t, generateMonth(t, 1, july2026, testCloud))
+	logger, log := capturedLogger(t)
+	err := Run(t.Context(), Config{
+		Cloud:        testCloud,
+		HTTPPort:     0,
+		OTLPURL:      stub.URL,
+		OTLPUser:     pushUser,
+		OTLPPassword: pushPassword,
+		OTLPInsecure: true,
+	}, RunOptions{
+		Period:           "2026-07",
+		Seed:             1,
+		Factor:           0,
+		WaitForCollector: pollDeadline,
+		MetricsInterval:  testMetricsInterval,
+	}, publisher, logger)
+
+	if err == nil {
+		t.Fatal("Run() error = nil, want the refused push")
+	}
+	for _, fragment := range []string{"pushing metrics to " + stub.URL, "503"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("Run() error = %q, want it to contain %q", err, fragment)
+		}
+	}
+	// The message reaches whatever an operator pastes it into, and the credential
+	// is never in it.
+	if strings.Contains(err.Error(), pushPassword) {
+		t.Errorf("Run() error = %q, want it to keep the password out", err)
+	}
+	// The exit status waits for the month, and the log does not: a drill paced
+	// over an hour would otherwise publish for the rest of it with nothing but
+	// healthy progress in the log.
+	if !strings.Contains(log.String(), "msg=\"pushing stopped\"") {
+		t.Errorf("the run logged %q, want the push to be reported where it stopped", log.String())
+	}
+	// And the month is on the bus whole: the push is reported after the last
+	// notification, not instead of it.
+	waitFor(t, "every billable notification is buffered", func() bool {
+		return outbox.Depth() == int64(len(want))
+	})
+}
+
+// TestRunStoppedWhilePushingIsACleanStop is what SIGINT does to the pusher: the
+// cancellation reaches it as the context's own error, which is no failed push,
+// so the process ends with exit status 0 the way a stop during the publishing
+// does. The run waits for the pusher on its way out, so nothing pushes a month
+// the run has already left behind.
+func TestRunStoppedWhilePushingIsACleanStop(t *testing.T) {
+	url, _ := startBroker(t)
+	publisher := connect(t, url)
+	startCollector(t, url, ServiceExchanges)
+	stub := startMetricsStub(t)
+
+	month := faultyMonth(t, 1, Faults{HeldBack: true})
+	held := len(month.Held)
+	if held == 0 {
+		t.Fatal("the month holds nothing back, want the switch to have picked notifications")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	port := reservePort(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{
+			Cloud:        testCloud,
+			HTTPPort:     port,
+			OTLPURL:      stub.URL,
+			OTLPUser:     pushUser,
+			OTLPPassword: pushPassword,
+			OTLPInsecure: true,
+		}, RunOptions{
+			Period:           "2026-07",
+			Seed:             1,
+			Factor:           0,
+			Faults:           []string{FaultHeldBack},
+			WaitForCollector: pollDeadline,
+			MetricsInterval:  testMetricsInterval,
+		}, publisher, testLogger(t))
+	}()
+
+	waitForHold(t, port, held)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil: a stop during the push is a clean stop", err)
+		}
+	case <-time.After(pollDeadline):
+		t.Fatalf("Run() did not finish within %v after the stop", pollDeadline)
+	}
+
+	time.Sleep(pushSettleWait)
+	taken := len(stub.taken())
+	if taken == 0 {
+		t.Fatal("the endpoint took no request, want the run to have pushed while it published")
+	}
+	time.Sleep(pushSettleWait)
+	if again := len(stub.taken()); again != taken {
+		t.Errorf("the endpoint took %d requests after the run returned, want it to stay at %d: "+
+			"the pusher outlived the run", again, taken)
 	}
 }

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -72,6 +72,11 @@ type RunOptions struct {
 	// notification published. What it needs is the environment, which Config
 	// checks through ValidateRegistration.
 	RegisterProjects bool
+	// MetricsInterval is the grid the traffic counters and the inventory are
+	// sampled on, counted from the period's start. It is a whole number of
+	// seconds, at least 30s and at most 24h; the flag defaults to Ceilometer's
+	// polling interval of 300s.
+	MetricsInterval time.Duration
 }
 
 // Validate checks the options and returns the month Period names.
@@ -95,6 +100,20 @@ func (o RunOptions) Validate() (from, to time.Time, err error) {
 	}
 	if err := validatePacing(o.Factor, o.WaitForCollector); err != nil {
 		return time.Time{}, time.Time{}, err
+	}
+	// Both bounds are stated in metrics.go. The upper one is the byte
+	// arithmetic's: the numerator of stepBytes is an int64, and
+	// maxMetricsInterval is the longest step it holds. The lower one is the
+	// month's own size: the traffic of the whole period is placed before the
+	// first notification goes out, and a grid an order of magnitude below
+	// Ceilometer's is where that stops fitting into memory. Whole seconds
+	// because stepBytes counts a step in seconds, so a grid of half seconds
+	// would drop that half out of every step it places.
+	if o.MetricsInterval < minMetricsInterval || o.MetricsInterval > maxMetricsInterval ||
+		o.MetricsInterval%time.Second != 0 {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"--metrics-interval: %s must be a whole number of seconds between %s and %s",
+			o.MetricsInterval, minMetricsInterval, maxMetricsInterval)
 	}
 	if _, err := ParseFaults(o.Faults); err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("--faults: %w", err)
@@ -177,6 +196,14 @@ type queued struct {
 // while they are published. File mode serves neither of the two: nothing is in
 // flight there.
 //
+// The second face of the month goes out beside the notifications: the traffic
+// counters and the inventory gauges are pushed to the OTLP endpoint the
+// configuration names, on the clock the notifications are paced by, and the
+// inventory is served on GET /metrics of the same listener. A run without an
+// OTLP URL pushes nothing, and file mode pushes nothing either, but both write
+// the traffic rows into the oracle. A push that failed is reported once the
+// month has gone out whole, because the month is what the operator asked for.
+//
 // A cancelled context is a clean stop: what went out stays out, and Run returns
 // nil, so SIGINT and SIGTERM leave exit status 0 the way they do for the
 // collector. A failed publish is an error instead, and what an operator does
@@ -190,6 +217,11 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 	from, to, err := opts.Validate()
 	if err != nil {
 		return err
+	}
+	// Checked here as well as in the subcommand, for the reason the gate below
+	// gives.
+	if err := cfg.ValidateMetrics(); err != nil {
+		return fmt.Errorf("checking the configuration: %w", err)
 	}
 	// Checked here as well as in the subcommand, because an exported function
 	// cannot rely on its caller having checked.
@@ -213,6 +245,14 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 	if err != nil {
 		return err
 	}
+	// The traffic is placed before anything is written, and its rows go into the
+	// oracle: a run that pushes nothing still records what an instance moved, and
+	// the file it writes is what a drill reads the intended figure off.
+	traffic, rows, err := TrafficOf(month.Oracle, opts.Seed, opts.MetricsInterval)
+	if err != nil {
+		return fmt.Errorf("placing the traffic of the month: %w", err)
+	}
+	month.Oracle.Traffic = rows
 	schedule := month.Schedule
 
 	logger.Info("starting",
@@ -227,6 +267,11 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 		"stream", len(month.Stream),
 		"held", len(month.Held),
 		"resources", len(month.Oracle.Resources),
+		"metrics_interval", opts.MetricsInterval,
+		"traffic_samples", len(traffic),
+		// The bool and never the URL: a mistyped endpoint may carry userinfo, and
+		// a log line is read by whoever the log reaches.
+		"otlp", cfg.OTLPURL != "",
 		"broker", publisher != nil,
 		"out", opts.Out)
 
@@ -335,8 +380,24 @@ func Run(ctx context.Context, cfg Config, opts RunOptions, publisher *Publisher,
 	if err != nil {
 		return fmt.Errorf("building the fake OpenStack API: %w", err)
 	}
+	// The scraped face of the month and the pushed one, both off the month that
+	// is going out. A configuration without an OTLP URL is a run without a push,
+	// and the samples it placed stay in the process.
+	var exporter http.Handler
+	if cfg.MetricsEnabled {
+		exporter = NewExporter(month, clock)
+	}
+	var metrics *metricsRun
+	if cfg.OTLPURL != "" {
+		metrics = &metricsRun{
+			pusher:   NewPusher(cfg.OTLPURL, cfg.OTLPUser, cfg.OTLPPassword, cfg.Cloud, nil),
+			month:    month,
+			traffic:  traffic,
+			interval: opts.MetricsInterval,
+		}
+	}
 
-	return broadcast(ctx, cfg, publisher, logger, clock, from, to, lines, held, api)
+	return broadcast(ctx, cfg, publisher, logger, clock, from, to, lines, held, api, exporter, metrics)
 }
 
 // renderQueue turns a schedule into the notifications the bus carries. The
@@ -431,7 +492,18 @@ func Replay(ctx context.Context, cfg Config, opts ReplayOptions, publisher *Publ
 	}
 	clock := NewClock(from, opts.Factor, time.Now)
 
-	return broadcast(ctx, cfg, publisher, logger, clock, from, to, lines, nil, nil)
+	return broadcast(ctx, cfg, publisher, logger, clock, from, to, lines, nil, nil, nil, nil)
+}
+
+// metricsRun is what a run pushes: the pusher it posts through, the month the
+// samples are read off, the traffic samples the generator placed, and the grid
+// they lie on. The inventory is not held here, because it is folded per grid
+// step out of the month.
+type metricsRun struct {
+	pusher   *Pusher
+	month    Month
+	traffic  []Sample
+	interval time.Duration
 }
 
 // broadcast puts the lines on the bus in the order they stand in, paced by the
@@ -455,12 +527,19 @@ func Replay(ctx context.Context, cfg Config, opts ReplayOptions, publisher *Publ
 // notifications go out as fast as the broker confirms them, each under the
 // timestamp inside the month it always carried. A context that ends during the
 // hold is a clean stop with the held share never published.
+//
+// The pusher runs beside the publishing loop and on the same clock, so the
+// metrics of a grid step leave while the notifications of that step do. Its
+// failure is reported once the last notification is on the bus, the way the
+// endpoint's is. A nil metrics is a run without a push, which is what a replay
+// and a run with no OTLP URL pass.
 func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *slog.Logger,
-	clock *Clock, from, to time.Time, lines, held []queued, api http.Handler,
+	clock *Clock, from, to time.Time, lines, held []queued, api, exporter http.Handler,
+	metrics *metricsRun,
 ) error {
 	hb := newHoldback(len(held))
 	total := len(lines) + len(held)
-	var published atomic.Int64
+	var published, pushed atomic.Int64
 	// How every end of a run is answered: a cancelled context is a clean stop,
 	// reported as one and answered with nil, and anything else is the error it
 	// is. SIGINT and SIGTERM leave exit status 0 through this.
@@ -468,7 +547,8 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 		if ctx.Err() == nil {
 			return err
 		}
-		logger.Info("stopped", "published", published.Load(), "total", total, "held", hb.held())
+		logger.Info("stopped", "published", published.Load(), "total", total, "held", hb.held(),
+			"pushed", pushed.Load())
 		return nil
 	}
 
@@ -491,7 +571,7 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 		}
 	}
 	mux := NewControlMux(clock, progress, hb.release)
-	mountRun(mux, api, nil)
+	mountRun(mux, api, exporter)
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: readHeaderTimeout,
@@ -521,6 +601,33 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 	}
 	logger.Info("listening", "port", port)
 
+	pushCtx, cancelPush := context.WithCancel(ctx)
+	var pushErr error
+	pushDone := make(chan struct{})
+	if metrics != nil {
+		go func() {
+			defer close(pushDone)
+			pushErr = pushSamples(pushCtx, clock, metrics, logger, &pushed)
+			// Said here as well as at the end of the run: the exit status waits
+			// for the month, because the month is what the operator asked for,
+			// but a drill paced over an hour would otherwise publish for the rest
+			// of it with the dashboards empty and the log saying nothing.
+			if pushErr != nil && pushCtx.Err() == nil {
+				logger.Error("pushing stopped", "error", pushErr, "pushed", pushed.Load())
+			}
+		}()
+	} else {
+		close(pushDone)
+	}
+	// Every path out of here ends the pusher and waits for it, so a publish that
+	// failed leaves no goroutine pushing a month nobody publishes any more. On
+	// the path that ends well the pusher has already finished, and the wait
+	// returns at once.
+	defer func() {
+		cancelPush()
+		<-pushDone
+	}()
+
 	if err := publishLines(ctx, clock, publisher, logger, lines, &published); err != nil {
 		return stop(err)
 	}
@@ -541,6 +648,15 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 		}
 	}
 
+	// The push is reported here rather than while the month runs, the way the
+	// control endpoint is: the month is what the operator asked for, and the
+	// exit status is what says the metric half of it failed. stop turns a
+	// cancelled push into the clean stop it is.
+	<-pushDone
+	if pushErr != nil {
+		return stop(pushErr)
+	}
+
 	// A control endpoint that never came up is reported here rather than while
 	// the month runs: the month is what the operator asked for, and losing the
 	// endpoint is no reason to stop publishing it.
@@ -552,7 +668,7 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 	default:
 	}
 
-	logger.Info("completed", "published", published.Load(), "total", total)
+	logger.Info("completed", "published", published.Load(), "total", total, "pushed", pushed.Load())
 	return nil
 }
 
@@ -602,6 +718,61 @@ func publishLines(ctx context.Context, clock *Clock, publisher *Publisher, logge
 			"exchange", line.exchange,
 			"message_id", line.messageID,
 			"timestamp", line.at.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// pushSamples posts the metrics of the month, paced by the clock the
+// notifications are paced by: it waits for a grid instant, takes the traffic
+// samples that belong to it and the inventory that stands at it, and counts
+// every point the endpoint accepted.
+//
+// When a batch goes out is what the flush decides. A paced run has not reached
+// the next grid instant by the time it has folded this one, so the batch of a
+// step leaves with that step. At factor 0 the clock never reaches the next
+// instant and SleepUntil never waits, so the batch fills to maxDataPoints
+// instead of going out a step at a time, which is what keeps a month at factor
+// 0 from being one request per step.
+//
+// The error comes back as it is: the pusher already names the endpoint in it,
+// and a cancellation arrives as the context's own error, which is the clean
+// stop the publishing loop answers a signal with.
+func pushSamples(ctx context.Context, clock *Clock, metrics *metricsRun,
+	logger *slog.Logger, pushed *atomic.Int64,
+) error {
+	from, to := metrics.month.Oracle.PeriodFrom, metrics.month.Oracle.PeriodTo
+	pending := make([]Sample, 0, maxDataPoints)
+	cursor := 0
+	// The grid only moves forward, so the routers of the inventory are folded
+	// across it rather than per step: one fold walks the schedule once for the
+	// month, where a reading of its own would walk it from the head at every one
+	// of the month's thousands of steps.
+	routers := routerFold{schedule: metrics.month.Schedule}
+
+	for s := from; s.Before(to); s = s.Add(metrics.interval) {
+		if err := clock.SleepUntil(ctx, s); err != nil {
+			return err
+		}
+		// The samples are in instant order, so one cursor walks them: everything
+		// up to this instant belongs to this step.
+		for cursor < len(metrics.traffic) && !metrics.traffic[cursor].At.After(s) {
+			pending = append(pending, metrics.traffic[cursor])
+			cursor++
+		}
+		pending = append(pending, inventoryAt(metrics.month, s, &routers)...)
+
+		next := s.Add(metrics.interval)
+		flush := len(pending) >= maxDataPoints || !next.Before(to) ||
+			(clock.Factor() != 0 && clock.Now().Before(next))
+		if !flush {
+			continue
+		}
+		if err := metrics.pusher.Push(ctx, pending); err != nil {
+			return err
+		}
+		pushed.Add(int64(len(pending)))
+		logger.Debug("pushed", "at", s.Format(time.RFC3339), "points", len(pending))
+		pending = pending[:0]
 	}
 	return nil
 }

--- a/internal/providers/openstack/simulator/simulator.go
+++ b/internal/providers/openstack/simulator/simulator.go
@@ -446,7 +446,9 @@ func Replay(ctx context.Context, cfg Config, opts ReplayOptions, publisher *Publ
 // An api is mounted on the same listener, under every path the control routes
 // leave: those are method-qualified and beat the catch-all, so the fake
 // OpenStack API answers the rest and lives exactly as long as the endpoint. A
-// nil api mounts nothing, which is what a replay passes.
+// nil api mounts nothing, which is what a replay passes. Both mounts are
+// mountRun's, and the inventory endpoint it takes beside the api goes up the
+// same way: one method-qualified pattern ahead of that catch-all.
 //
 // A held share is published after the last regular line, once POST /release
 // asks for it. Every held instant lies before the clock by then, so the
@@ -489,9 +491,7 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 		}
 	}
 	mux := NewControlMux(clock, progress, hb.release)
-	if api != nil {
-		mux.Handle("/", api)
-	}
+	mountRun(mux, api, nil)
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: readHeaderTimeout,
@@ -554,6 +554,28 @@ func broadcast(ctx context.Context, cfg Config, publisher *Publisher, logger *sl
 
 	logger.Info("completed", "published", published.Load(), "total", total)
 	return nil
+}
+
+// mountRun puts what a run serves beside its control routes onto the one mux:
+// the inventory exporter under GET /metrics, and the fake OpenStack API under
+// every path left over.
+//
+// The order the two are registered in decides nothing; the patterns do: a
+// method-qualified pattern is more specific than the catch-all and is matched
+// ahead of it, which is how the control routes keep their paths as well. The
+// fake API therefore answers everything except the one path a scrape asks for.
+//
+// A nil exporter registers no route at all, which is a run with metrics turned
+// off: the fake API then answers a scrape with its own 404, the way it answers
+// any other path it holds no route for. A nil api mounts no catch-all, which is
+// what a replay passes, because a recorded file holds no oracle to serve.
+func mountRun(mux *http.ServeMux, api, exporter http.Handler) {
+	if exporter != nil {
+		mux.Handle("GET /metrics", exporter)
+	}
+	if api != nil {
+		mux.Handle("/", api)
+	}
 }
 
 // publishLines puts the lines on the bus in the order they stand in, paced by


### PR DESCRIPTION
Closes #67

The simulator put a month of notifications on a bus and served the same month as a fake OpenStack API, and produced no metric at all. This branch gives that world its second face: network traffic per instance and the cloud's inventory, both read off the same month, pushed over OTLP on the run's virtual clock and served live on a `/metrics` endpoint shaped like the OpenStack database exporter. The dev overlay is wired so the cluster scrapes that endpoint and the engine measures the pushed counter.

## The commits, in order

**`d7a993e` Raise the oracle to format 3 with the traffic rows** — `oracleFormat` goes to 3 and the document gains `traffic`: one `OracleTraffic` row per instance and per interval of that instance, holding the bytes the samples pushed over it. The rows sit outside `OracleInterval` on purpose — a traffic figure inside an interval would make two otherwise mergeable facts compare unequal and split `foldFacts`. `buildOracle` states an empty list; `Run` fills it. A format 2 file is refused with the format error rather than read as a month without traffic.

**`fc7277d` Place the traffic samples and the inventory of a month** — the new `metrics.go`. `TrafficOf` places `ceilometer_network_outgoing_bytes_total` and `ceilometer_network_incoming_bytes_total` for every instance on one grid of whole steps counted from the period start, so every series of a month falls on the same instants. A step accrues bytes only while the interval it starts in is active; the series runs from the instance's first grid instant to its last, the way Ceilometer starts and stops polling one. The level comes from the workload, weighed by the working-week profile and moved by a per-instance jitter. Every byte count is `int64` with a single division at the end — a quotient that went through a `float64` would reach an invoice carrying digits nobody placed — and `maxMetricsInterval` states the bound the products stay inside. The jitter is drawn from a stream of its own, salted the way a fault stream is, so a month whose traffic was placed renders byte-identical notifications to one whose traffic was not. `InventoryAt` answers the world at one virtual instant under the upstream exporter's own names and label spellings; routers come out of `Month.Schedule` rather than the oracle, because nothing bills a router and the generator books none.

**`7557132` Serve the inventory as the database exporter stand-in** — a `prometheus.Collector` renders `InventoryAt` at the clock's instant on every scrape, so the endpoint stands in for the database exporter a real cloud runs beside nova, cinder, neutron, glance and octavia. It describes nothing and is registered unchecked: the families a scrape carries follow the world at that instant, so a fixed descriptor set would promise families a month without load balancers does not hold. The registry is private and carries this collector alone — no Go or process collectors, since the endpoint speaks for a cloud and not for the simulator's own heap. `mountRun` puts `GET /metrics` on the one mux ahead of the fake API's catch-all, the method-qualified pattern winning the match.

**`c2f6fd3` Push samples over OTLP/HTTP JSON with retries** — the new `otlp.go` writes the document with `encoding/json` rather than handing it to the OpenTelemetry Go SDK: the SDK stamps a point with the instant it collected it, and every point here belongs to a virtual instant months away from the wall clock. Traffic is a cumulative monotonic sum whose name already ends in `_total`, and no metric declares a unit, so `prometheusremotewrite` stores each name as exactly itself whichever way its two suffix options are set. Inventory is a gauge. Retries are `hashicorp/go-retryablehttp`'s defaults — the dependency `internal/engine/counters` already queries through — covering the Gateway's 429 and a 5xx; a 4xx such as a wrong password comes back at once, and the password is formatted nowhere. One request carries at most 5000 points.

**`5d9ca85` Read the OTLP credentials and the metrics switch from the environment** — `TALLY_SIM_OTLP_URL`, `_USER`, `_PASSWORD` (with its `_FILE` companion through `resolveFileSecret`), `_INSECURE`, and `TALLY_METRICS_ENABLED`. `ValidateMetrics` is their gate, shaped like `ValidateRegistration`: an empty URL is a run without a push and passes; a set one demands both credentials, must be absolute with a host, and must be https unless the insecure switch allows plaintext. The refusals name the variable and never quote its value — a mistyped endpoint may carry userinfo, and an error an operator pastes into a ticket must not carry a credential.

**`feec211` Push the month beside the notifications and record its traffic** — the pusher runs beside the publishing loop on the same clock: it waits for a grid instant, takes the traffic of that instant and the inventory standing at it, and flushes at 5000 points. At factor 744 a step's batch leaves with that step; at factor 0 virtual time stands still and the batch fills to the cap instead. File mode pushes nothing but still records the traffic, so a drill reads the intended figure off disk either way. A batch that fails after the retries stops the push and is reported once the last notification is on the bus — the month goes out whole and the exit status says the metric half failed; a cancellation is answered with nil.

**`f6545a6` Push from the compose stack to the dev Gateway** — a second `extra_hosts` entry maps `otlp.tally.127-0-0-1.nip.io` to the host, and the CA the container already mounts makes the certificate verify on that path, so `TALLY_SIM_OTLP_INSECURE` stays unset. `make simulator-up` writes the user, the password and the interval into `deploy/compose/.env` under the same `umask 077` that already covers the ingest and api tokens.

**`46378b6` Scrape the simulator and measure its egress on the dev cluster** — the dev overlay declares a `victoriametrics-scrape` generator marked `behavior: replace`, the mechanism `docs/openstack-metrics.md` documents. Its `scrape.yaml` is the base file with `openstack-db-exporter` pointed at `host.docker.internal:8091` under the cloud `os-sim`; all four job names are kept so `TallyScrapeTargetDown`, `TallyScrapeJobMissing` and `TallyExporterServiceSilent` still select every job. `counter-sources.yaml` measures `egress_gb` from the pushed counter, `required: false` so a cluster where no month was ever simulated warns rather than failing every tick, with 2^30 as the divisor to match `bytesPerGibibyte`.

**`ed5443c` Document the metric series of a simulated month** — a new "The metric series" section in `docs/openstack-simulator.md`, plus the determinism stream, the oracle's format 3, the `.env` values and the configuration table. `docs/openstack-metrics.md` and `docs/grafana-dashboards.md` said both OpenStack scrape jobs stay down on dev; `openstack-db-exporter` is now up while a run publishes, and both files state that instead.

## Divergences from the issue

- **The OTLP URL is a literal in `compose.yaml`, not a `SIM_OTLP_URL` Make variable.** The issue's Affected Areas listed `SIM_OTLP_URL` among the values `make simulator-up` writes into `.env`, while its section 3 described exactly three values coming from there — the user, the password and the interval. The implementation follows section 3: the dev Gateway publishes that one route and nothing about it varies per run, so only what varies is a variable.
- **`--metrics-interval` carries bounds the issue did not state.** Beyond refusing 0 and a negative value, it demands a whole number of seconds between `minMetricsInterval` and `maxMetricsInterval`. The upper bound is the byte arithmetic's — `stepBytes`'s numerator is an `int64` — and the lower one is the month's, since the whole period's traffic is placed before the first notification goes out. Whole seconds because `stepBytes` counts a step in seconds.
- **The `ceilometer` scrape job keeps its placeholder target** and stays down, and `compare` still leaves counter dimensions out with the `increase()` extrapolation as its stated reason. Both are the author decisions the issue records under Non-Goals.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 7ea363b with Claude:claude-opus-5_
