### PR TITLE
Write the core tutorial track from an empty machine to a rated month

### DIFF
--- a/docs/.vitepress/proper-nouns.txt
+++ b/docs/.vitepress/proper-nouns.txt
@@ -6,3 +6,4 @@ Hetzner
 Ceilometer
 Grafana
 Pushgateway
+Tally

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -20,7 +20,8 @@
           "text": "Core track",
           "items": [
             { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" },
-            { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" }
+            { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" },
+            { "text": "Meter and rate your first month", "link": "/tutorials/meter-and-rate-your-first-month" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -19,7 +19,8 @@
         {
           "text": "Core track",
           "items": [
-            { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" }
+            { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" },
+            { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -22,7 +22,8 @@
             { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" },
             { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" },
             { "text": "Meter and rate your first month", "link": "/tutorials/meter-and-rate-your-first-month" },
-            { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" }
+            { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" },
+            { "text": "Tear down your local Tally", "link": "/tutorials/tear-down-your-local-tally" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -12,7 +12,18 @@
     }
   ],
   "/tutorials/": [
-    { "text": "Tutorials", "items": [{ "text": "Overview", "link": "/tutorials/" }] }
+    {
+      "text": "Tutorials",
+      "items": [
+        { "text": "Overview", "link": "/tutorials/" },
+        {
+          "text": "Core track",
+          "items": [
+            { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" }
+          ]
+        }
+      ]
+    }
   ],
   "/how-to/": [
     {

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -21,7 +21,8 @@
           "items": [
             { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" },
             { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" },
-            { "text": "Meter and rate your first month", "link": "/tutorials/meter-and-rate-your-first-month" }
+            { "text": "Meter and rate your first month", "link": "/tutorials/meter-and-rate-your-first-month" },
+            { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" }
           ]
         }
       ]

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials
-description: Lessons that take you by the hand from an empty machine to a rated month.
+description: Lessons that take you by the hand from an empty machine to a rated month, and the track that continues from there.
 quadrant: tutorial
 audience: all
 ---
@@ -19,11 +19,60 @@ the lesson is run from an empty machine before it is published.
 You do not have to decide anything. Where a real deployment has a choice, the
 lesson makes one for you and moves on. The trade-offs behind that choice belong
 in [Explanation](/explanation/), and the other options belong in
-[How-to guides](/how-to/).
+[How-to guides](/how-to/). Every lesson runs against the local dev stack with
+the simulator as its only data source, so the output a lesson shows is the
+output of a real run and matches yours.
 
 You end with a working mental model. After the last step you have a running
 system you built yourself, and a name for each part of it.
 
-The sidebar lists each lesson as it is published. The first track takes you
-from an empty machine to a rated month, and the billing track (finalization,
-corrections, commercial pricing and attribution) continues from there.
+## The learning path
+
+### Core track
+
+1. [Set up your local Tally](/tutorials/set-up-your-local-tally): clone the
+   repository, bring the kind cluster with the dev overlay up, trust its CA,
+   mint an API token and make a first call.
+2. [Simulate a month of OpenStack](/tutorials/simulate-a-month-of-openstack):
+   start the simulator stack for July 2026 with the held-back switch on, watch
+   the month arrive, finish it at once and read it back.
+3. [Meter and rate your first month](/tutorials/meter-and-rate-your-first-month):
+   import the pricing model, run the month, read the warnings, export the run
+   as JSON and read one project's statement.
+4. [Watch the month in Grafana](/tutorials/watch-the-month-in-grafana): read the
+   four dashboards against the simulated cloud and the simulated month, find
+   the one alert the dev stack fires by design, and take the state the next
+   track continues from.
+5. [Tear down your local Tally](/tutorials/tear-down-your-local-tally): stop the
+   stack, delete the cluster and remove what the lessons wrote.
+   Assumes Set up your local Tally, or any later lesson.
+
+The fifth lesson is where the track ends when you want a clean machine. A
+reader going on to the billing track does it after that track's last lesson,
+because the billing track continues from the state the fourth lesson leaves
+behind.
+
+### Billing track
+
+"The billing track: finalization, late events and corrections, commercial pricing and related-cost attribution"
+is the track written next. It continues from the state the fourth lesson of the
+core track leaves behind: the cluster up, the simulator holding its 84
+notifications, the month rated but not finalized, the registry empty.
+
+## The simulated cloud
+
+Every lesson works on the same generated month: seed 1, July 2026, the cloud
+`os-sim`, six tenants, of which three are classic projects, two are Gardener
+tenants and one is a CI tenant. That month renders 15727 notifications, 1812 of
+them billable, and 84 of those stay held back by the switch the second lesson
+turns on, so the counts a lesson shows are the counts every machine gets.
+
+What the month holds is in
+[the simulated OpenStack world](/explanation/the-simulated-openstack-world).
+
+## When to read this section
+
+- You are new to Tally and want a guided first hour that ends with a rated
+  month you built yourself.
+- You contribute to Tally and want a known-good baseline of the dev stack, with
+  every output pinned to one run, before you change it.

--- a/docs/tutorials/meter-and-rate-your-first-month.md
+++ b/docs/tutorials/meter-and-rate-your-first-month.md
@@ -1,0 +1,524 @@
+---
+title: Meter and rate your first month
+description: Point the metering engine at the month lesson 2 ingested, import a pricing model, run July 2026, and export and read the project statements it rates.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Meter and rate your first month
+
+In this lesson you point the metering engine at the reporting database lesson 2
+filled and at its own database, import a pricing model, run the month, read
+what the run recorded, export it, and read one project's statement.
+
+At the end you hold one completed, not finalized run of July 2026 in the engine
+database, its run id in a variable of your shell, and the JSON export with six
+project statements under `~/tally-tutorial/2026-07`.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state lesson 2 leaves: the kind cluster with the dev overlay, the
+  simulator stack holding its 84 notifications, the month of July 2026 in the
+  reporting database, `tally-ca.crt` at the repository root, and that shell at
+  the repository root.
+- `jq` 1.8.1 (`jq --version`), the one lesson 1 asks for.
+- The engine commands below run with `go run` from the repository root, the way
+  lesson 1 ran the admin CLI.
+
+If you closed that shell, the first step of this lesson exports everything a
+run needs. `TALLY_REPORTING_DB_URL` and `TALLY_API_TOKEN`, the two variables
+lesson 1 exported, are not read by the engine, so a new shell may be missing
+both. Lesson 4 needs neither.
+
+## Point the engine at both databases
+
+1. Export the four inputs of a run and open the path to the metrics store:
+
+   ```sh
+   export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+   export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+   export TALLY_ENGINE_COUNTER_SOURCES=deploy/kubernetes/overlays/dev/counter-sources.yaml
+   export TALLY_ENGINE_VM_URL=http://127.0.0.1:8428
+   kubectl --context kind-tally -n tally port-forward svc/victoriametrics 8428:8428 &
+   ```
+
+   ```text
+   Forwarding from 127.0.0.1:8428 -> 8428
+   Forwarding from [::1]:8428 -> 8428
+   ```
+
+   - `TALLY_ENGINE_DB_URL` is the engine's own database, `tally_engine`, on the
+     Gateway's TCP listener, where the run row and its records go.
+   - `TALLY_ENGINE_REPORTING_DB_URL` reads the reporting database lesson 2
+     filled, as the login role `tally_engine`, a reader the dev overlay
+     creates.
+   - `TALLY_ENGINE_COUNTER_SOURCES` names the dev cluster's counter sources
+     file, which declares where the egress counter of an instance comes from.
+   - `TALLY_ENGINE_VM_URL` is the metrics store the port-forward publishes on
+     `127.0.0.1:8428`, and that forward is what lets the run read the egress
+     counter from the store. The engine reaches the store over plain http, so
+     the Gateway's https hostname is not used here.
+
+   The two `Forwarding from` lines are what the background job prints. A
+   `Handling connection for 8428` line appears each time the run queries the
+   store, and both are your own.
+
+   The values are the ones the Phase 3 drill of this repository exports, and
+   [run a period](/how-to/engine/run-a-period) states what each variable
+   defaults to.
+
+2. Check that the store answers through the forward:
+
+   ```sh
+   curl -s http://127.0.0.1:8428/health
+   ```
+
+   ```text
+   OK
+   ```
+
+   `OK` has to match. A connection refused here means the port-forward is not
+   running, so start it again with the last line of the block above.
+
+## Import the pricing model
+
+1. Import the model:
+
+   ```sh
+   go run ./cmd/tally-engine pricing import pricing/2026-03.yaml
+   ```
+
+   ```text
+   imported pricing model 2026-03 valid from 2026-03-01T00:00:00Z
+   ```
+
+   The line has to match. `pricing/2026-03.yaml` is the model this repository
+   ships, and [import a pricing model](/how-to/engine/import-a-pricing-model)
+   covers writing another. It is valid from March 2026, so it prices July.
+
+   It prices an instance by `vcpus`, `ram_gb`, `disk_gb` and `egress_gb`, a
+   volume by `size_gb` and a floating IP by `count`. It prices neither `image`
+   nor `loadbalancer`, the two types the run below records as unpriced. What a
+   model file may declare is in the
+   [pricing model file](/reference/formats/pricing-model) reference.
+
+2. List what the engine database holds:
+
+   ```sh
+   go run ./cmd/tally-engine pricing list
+   ```
+
+   ```text
+   2026-03 valid_from=2026-03-01T00:00:00Z currency=EUR imported_at=2026-09-07T12:46:13Z
+   ```
+
+   The version, `valid_from` and `currency=EUR` have to match. `imported_at` is
+   your own.
+
+3. A second import of the same file changes nothing:
+
+   ```sh
+   go run ./cmd/tally-engine pricing import pricing/2026-03.yaml
+   ```
+
+   ```text
+   pricing model 2026-03 already imported
+   ```
+
+   The line has to match. Nothing is stored, and the version already in the
+   database stays the one a run rates against.
+
+## Run the month
+
+1. Meter and rate July 2026:
+
+   ```sh
+   go run ./cmd/tally-engine run --period 2026-07
+   ```
+
+   ```text
+   run 66a9c8b9-2e20-43ef-9f8e-7e421e1832f9 completed for 2026-07 with pricing model 2026-03
+   metered 867 candidates into 945 usage records, 3101 rated records and 6 project statements
+   warnings recorded in runs.stats: 38 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 6 unregistered projects
+   ```
+
+   The `metered` line and the warnings line have to match. The run id on the
+   first line is your own. `2026-07` is the period this track uses everywhere,
+   and the run took a second on the machine behind this page.
+
+   The run is completed, not finalized:
+   [the lifecycle](/explanation/billing-period-lifecycle-and-corrections#the-lifecycle)
+   sets the two states apart, and the billing track finalizes.
+
+2. Put the id from the first line of your own output in place of this one:
+
+   ```sh
+   export RUN_ID=66a9c8b9-2e20-43ef-9f8e-7e421e1832f9
+   ```
+
+   Every command below reads `RUN_ID`.
+
+3. Read what stands there instead if the run printed something else:
+
+   - `no pricing model is valid for this period` means the import above was
+     skipped. Import the model and run the month again.
+   - An error opening on `another run of this period is in progress` means the
+     hourly tick of the cluster's `tally-engine` scheduler holds the period.
+     Wait a minute and run the month again.
+   - A `superseded run <run id>` line between the second and the third line
+     means such a tick metered the month first. It changes nothing below.
+   - A non-zero `counter` count on the warnings line means the port-forward
+     died before the run read the store. Start it again and run the month
+     again; the new run supersedes this one.
+   - `reading the counter sources deploy/kubernetes/overlays/dev/counter-sources.yaml: open deploy/kubernetes/overlays/dev/counter-sources.yaml: no such file or directory`
+     means the shell is not at the repository root, or the export of
+     `TALLY_ENGINE_COUNTER_SOURCES` was skipped.
+
+## Read the warnings
+
+1. Read the last line of the run once more. Three of its seven classes are
+   non-zero:
+
+   ```text
+   warnings recorded in runs.stats: 38 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 6 unregistered projects
+   ```
+
+   Unpriced resource types, 2: `openstack/image` and `openstack/loadbalancer`,
+   the two types the model prices nothing for. The run met 9 images and 5 load
+   balancers, the counts `jq .stats` shows below, and each of them is left off
+   every statement.
+
+   Unregistered projects, 6: the six tenant ids of the month, because the
+   project registry is empty. Each is billed standalone under its id. The ids
+   stand with their resource counts in the `unregistered_projects` list below,
+   at 309, 16, 447, 15, 16 and 16 resources. The billing track's registration
+   lesson fills the registry, and
+   [register simulated projects](/how-to/simulator/register-simulated-projects)
+   is the how-to behind it.
+
+   Metering warnings, 38: every one of them is `history_starts_without_create`,
+   a resource whose stored history begins with a later transition because its
+   create is among the 84 notifications the simulator holds back. They are 28
+   instances, 9 volumes and 1 floating IP. 23 of the instances are CI runners
+   of the CI tenant `10e287d5788957a2a331cabd1b5dccdf`, 3 are workers of the
+   Gardener tenant `005be5adeef3d87e280d03d9d57c38b4`, 1 is a worker of the
+   Gardener tenant `e31f9083a7e5ee15071a3bd53cb2bac7` and 1 is an instance of
+   the classic project `d5a8024946ddf673277b9e2490643a2c`. The 9 volumes belong
+   to `005be5adeef3d87e280d03d9d57c38b4` and the floating IP to
+   `e31f9083a7e5ee15071a3bd53cb2bac7`. These counts and these ids are the
+   seed's and have to match. The billing track's correction lesson settles the
+   38 once the held share is released.
+
+   The other four classes read 0 on this run: no counter source failed, no
+   project was claimed twice, no kickback was dropped and no usage field was
+   unreadable. A non-zero `counter` count means the port-forward died before
+   the run read the store, the fourth mismatch above.
+
+## Export the statements
+
+1. Export the run as JSON:
+
+   ```sh
+   mkdir -p ~/tally-tutorial && go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07
+   ```
+
+   ```text
+   run 66a9c8b9-2e20-43ef-9f8e-7e421e1832f9 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 0 kickbacks
+   ```
+
+   The second and the third line have to match. The run id and the home
+   directory on the first line are your own. JSON is the format this track
+   exports in because a statement is readable no other way, and
+   [export a run](/how-to/engine/export-a-run) covers the CSV table.
+
+2. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07
+   ```
+
+   ```text
+   kickbacks.json
+   run.json
+   statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   statement-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json
+   statement-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json
+   statement-os-sim%2Fe31f9083a7e5ee15071a3bd53cb2bac7.json
+   ```
+
+   The eight names have to match. A statement file is named after the cloud and
+   the tenant id joined by a slash, escaped, which is where the `%2F` comes
+   from.
+
+3. Read the run's stats off the index, with the 38 metering warnings counted
+   by resource type:
+
+   ```sh
+   jq '.stats | .metering_warnings |= (group_by(.resource_type) | map({code: .[0].code, resource_type: .[0].resource_type, count: length}))' ~/tally-tutorial/2026-07/run.json
+   ```
+
+   ```json
+   {
+     "unpriced": [
+       {
+         "count": 9,
+         "platform": "openstack",
+         "resource_type": "image"
+       },
+       {
+         "count": 5,
+         "platform": "openstack",
+         "resource_type": "loadbalancer"
+       }
+     ],
+     "candidates": 867,
+     "statements": 6,
+     "snapshot_at": "2026-09-07T12:46:14.395319Z",
+     "rated_records": 3101,
+     "usage_records": 945,
+     "metering_warnings": [
+       {
+         "code": "history_starts_without_create",
+         "resource_type": "floating_ip",
+         "count": 1
+       },
+       {
+         "code": "history_starts_without_create",
+         "resource_type": "instance",
+         "count": 28
+       },
+       {
+         "code": "history_starts_without_create",
+         "resource_type": "volume",
+         "count": 9
+       }
+     ],
+     "unregistered_projects": [
+       {
+         "cloud": "os-sim",
+         "resources": 309,
+         "project_id": "005be5adeef3d87e280d03d9d57c38b4"
+       },
+       {
+         "cloud": "os-sim",
+         "resources": 16,
+         "project_id": "018504a6cc10019a40e3f9eef4dae529"
+       },
+       {
+         "cloud": "os-sim",
+         "resources": 447,
+         "project_id": "10e287d5788957a2a331cabd1b5dccdf"
+       },
+       {
+         "cloud": "os-sim",
+         "resources": 15,
+         "project_id": "34e991db9fc6466f8ca69b43f70fce65"
+       },
+       {
+         "cloud": "os-sim",
+         "resources": 16,
+         "project_id": "d5a8024946ddf673277b9e2490643a2c"
+       },
+       {
+         "cloud": "os-sim",
+         "resources": 16,
+         "project_id": "e31f9083a7e5ee15071a3bd53cb2bac7"
+       }
+     ]
+   }
+   ```
+
+   The three lists are the warnings line as lists: the 38 metering warnings
+   counted by resource type, the 2 unpriced resource types and the 6
+   unregistered projects. The four counts beside them are the `metered` line
+   of the run. `snapshot_at` is your own, the instant the run opened its
+   reporting snapshot.
+
+4. An export into a directory that already holds files is refused:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07
+   ```
+
+   ```text
+   Error: --out: /Users/berendt/tally-tutorial/2026-07 is not empty, and an export does not remove what an earlier one left there
+   exit status 1
+   ```
+
+   Nothing is written, and a second export needs a directory of its own. The
+   path in the line is your own.
+
+## Read a project statement
+
+1. Read the total of every statement:
+
+   ```sh
+   jq -r '"\(.project_id)\t\(.total)\t\(.currency)"' ~/tally-tutorial/2026-07/statement-*.json
+   ```
+
+   ```text
+   005be5adeef3d87e280d03d9d57c38b4	3661.32	EUR
+   018504a6cc10019a40e3f9eef4dae529	876.63	EUR
+   10e287d5788957a2a331cabd1b5dccdf	698.29	EUR
+   34e991db9fc6466f8ca69b43f70fce65	598.39	EUR
+   d5a8024946ddf673277b9e2490643a2c	905.10	EUR
+   e31f9083a7e5ee15071a3bd53cb2bac7	651.24	EUR
+   ```
+
+   The six totals have to match: they are the seed's usage rated at the model's
+   prices. The largest is `3661.32` for `005be5adeef3d87e280d03d9d57c38b4`, one
+   of the two Gardener tenants, and the reads below open that statement. `jq`
+   1.8.1 prints the amounts as the file carries them, while an older `jq`
+   re-renders `905.10` as `905.1`.
+
+2. Count its line items:
+
+   ```sh
+   jq '.line_items | length' ~/tally-tutorial/2026-07/statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   ```
+
+   ```text
+   309
+   ```
+
+   The count has to match. There is one line item per resource the project is
+   billed for: 169 instances, 137 volumes and 3 floating IPs on this statement.
+   Images and load balancers carry no line item at all, because the model
+   prices neither.
+
+3. Read the first line item:
+
+   ```sh
+   jq '.line_items[0]' ~/tally-tutorial/2026-07/statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   ```
+
+   ```json
+   {
+     "resource_type": "floating_ip",
+     "resource_id": "9aca6b44-4a7f-4c45-b4fc-074281931c58",
+     "platform": "openstack",
+     "description": "floating_ip 9aca6b44-4a7f-4c45-b4fc-074281931c58",
+     "periods": [
+       {
+         "state": "active",
+         "hours": 563.57,
+         "usage": {
+           "count": 1.0000
+         },
+         "cost": {
+           "count": 2.82,
+           "total": 2.82
+         },
+         "state_modifier": 1.0000
+       }
+     ],
+     "total": 2.82
+   }
+   ```
+
+   It is a floating IP with one period. A period is one state of one resource
+   for a span of hours: `usage` holds the quantity per dimension, `count` 1.0000
+   here at four decimal places, `cost` what each dimension cost and their
+   `total` at two places, and `state_modifier` the factor the state is billed
+   at, 1.0000 for `active`. `hours` 563.57 is how long the address existed
+   within the month. The whole document has to match.
+
+4. Read the first instance line item:
+
+   ```sh
+   jq '[.line_items[] | select(.resource_type == "instance")][0]' ~/tally-tutorial/2026-07/statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   ```
+
+   ```json
+   {
+     "resource_type": "instance",
+     "resource_id": "01775514-2a32-4ba5-8b1e-4e2aeac85b8c",
+     "platform": "openstack",
+     "description": "c1.large instance",
+     "periods": [
+       {
+         "state": "active",
+         "hours": 12.00,
+         "usage": {
+           "disk_gb": 0.0000,
+           "egress_gb": 72.4533,
+           "ram_gb": 8.0000,
+           "vcpus": 4.0000
+         },
+         "cost": {
+           "disk_gb": 0.00,
+           "egress_gb": 6.52,
+           "ram_gb": 0.48,
+           "total": 7.96,
+           "vcpus": 0.96
+         },
+         "state_modifier": 1.0000
+       }
+     ],
+     "total": 7.96
+   }
+   ```
+
+   An instance carries four dimensions, and the document has to match.
+   `egress_gb`, 72.4533 here, is in no notification: it is the counter the run
+   read from the metrics store through the port-forward, the
+   `ceilometer_network_outgoing_bytes_total` series lesson 2 pushed, summed over
+   the period and converted to gibibytes. `disk_gb` is 0 because `c1.large` has
+   no root disk, and the worker on it boots from a volume that is billed as a
+   volume line item instead.
+
+5. Read what the project owes:
+
+   ```sh
+   jq '{total, currency}' ~/tally-tutorial/2026-07/statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   ```
+
+   ```json
+   {
+     "total": 3661.32,
+     "currency": "EUR"
+   }
+   ```
+
+   The total is the sum of the line items, each dimension rounded once to two
+   places and then summed, in the one currency the model names. How the amounts
+   are held and rounded is in
+   [money and rounding](/explanation/money-and-rounding), and how they were
+   derived in
+   [metering separated from rating](/explanation/metering-separated-from-rating).
+   Every member of the document is in
+   [statements](/reference/formats/exports#statements).
+
+## What you learned
+
+- A run meters first, into usage records per state and resource, and rates
+  those records against the model afterwards:
+  [why two stages](/explanation/metering-separated-from-rating#why-two-stages).
+- `egress_gb` is a counter, read from the metrics store through the counter
+  sources file rather than from a notification:
+  [counters](/explanation/metering-separated-from-rating#counters).
+- The amounts on a statement are decimals, rounded once per dimension:
+  [why rounding happens once](/explanation/money-and-rounding#why-rounding-happens-once).
+- A project the registry does not hold is billed standalone under its id:
+  [projects as first-class entities](/explanation/project-registry-relations-and-attribution#projects-as-first-class-entities).
+- A completed run is not final. Another run of the period supersedes it, and
+  finalization is a step of its own that this track does not take:
+  [runs before finalization](/explanation/billing-period-lifecycle-and-corrections#runs-before-finalization).
+
+## Where to go next
+
+[Watch the month in Grafana](/tutorials/watch-the-month-in-grafana) reads the
+month you just rated off the dashboards.
+
+It starts from the state this lesson leaves behind: everything lesson 2 left,
+plus the pricing model `2026-03` and one completed, not finalized run of
+`2026-07` in the engine database, the four `TALLY_ENGINE_` variables and
+`RUN_ID` in the shell, the JSON export under `~/tally-tutorial/2026-07`, and
+the port-forward on `127.0.0.1:8428`, which stays running in that shell.

--- a/docs/tutorials/set-up-your-local-tally.md
+++ b/docs/tutorials/set-up-your-local-tally.md
@@ -1,0 +1,296 @@
+---
+title: Set up your local Tally
+description: Create a kind cluster with the Tally dev overlay, trust its certificate authority, mint an API token, and make a first call against the Reporting API.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Set up your local Tally
+
+In this lesson you clone the repository, create a kind cluster with the Tally
+dev overlay on it, trust the certificate authority that cluster issues its
+certificates from, mint an API token, and make your first call against the
+Reporting API.
+
+At the end you have a running Tally answering on
+`https://api.tally.127-0-0-1.nip.io:8443`, an admin token in a variable of your
+shell, and the CA certificate in `tally-ca.crt` at the repository root. That is
+the state the rest of this track starts from.
+
+This lesson takes about 60 minutes.
+
+## Before you start
+
+- macOS 15.7.4 with Docker Desktop 4.86.0 running, given 6 CPUs and 8 GB of
+  memory. `docker version` prints the Docker Desktop version on its `Server:`
+  line, and this prints what the engine was given:
+
+  ```sh
+  docker info --format '{{.NCPU}} CPUs, {{.MemTotal}} bytes'
+  ```
+
+  ```text
+  6 CPUs, 8322072576 bytes
+  ```
+
+  The lessons are written for macOS with Docker Desktop, the platform the
+  `Makefile` and `deploy/kind/kind.yaml` assume.
+- `git` 2.51.0 (`git --version`), `kind` v0.32.0 (`kind version`), `kubectl`
+  v1.36.1 (`kubectl version --client`) and Go 1.26 or newer (`go version`) on
+  the path. The run had `go1.26.1` installed, and the first `go run` inside the
+  repository downloads `go1.27.1`, the toolchain `go.mod` names.
+- `jq` 1.8.1 (`jq --version`) and `curl` 8.7.1 (`curl --version`), the one
+  macOS ships.
+- No kind cluster named `tally` on the machine. `kind get clusters` printed
+  `No kind clusters found.` on the run. If it prints `tally`, tear that cluster
+  down with the `make down` of lesson 5 first.
+- 10 GB of free disk for Docker Desktop. Its usage grew by 9.5 GB over this
+  lesson on the run, measured with `docker system df` before and after across
+  images, volumes and build cache.
+
+## Get the code
+
+1. Clone the repository and change into it:
+
+   ```sh
+   git clone https://github.com/B42Labs/tally.git
+   cd tally
+   ```
+
+   ```text
+   Cloning into 'tally'...
+   remote: Enumerating objects: 3555, done.        
+   remote: Counting objects: 100% (727/727), done.        
+   remote: Compressing objects: 100% (407/407), done.        
+   Receiving objects: 100% (3555/3555), 3.29 MiB | 119.00 KiB/s
+   Receiving objects: 100% (3555/3555), 3.30 MiB | 111.00 KiB/s, done.
+   Resolving deltas: 100% (1866/1866)
+   Resolving deltas: 100% (1866/1866), done.
+   ```
+
+   The object counts and the transfer speed are your own.
+
+2. Read the commit you are on:
+
+   ```sh
+   git rev-parse --short HEAD
+   ```
+
+   ```text
+   d0d5905
+   ```
+
+   A newer commit is fine. Every output this page shows comes from a run at
+   `d0d5905`. Every command from here on runs from this directory, the
+   repository root.
+
+## Create the cluster and bring the stack up
+
+1. Bring the stack up:
+
+   ```sh
+   make up
+   ```
+
+   The target creates the kind cluster `tally` and says so with
+   `==> creating kind cluster tally`, installs cert-manager v1.21.1 and Envoy
+   Gateway v1.8.3 and waits for their rollouts, applies the dev certificate
+   authority, builds the four images (`tally-reporting`, `tally-engine`,
+   `tally-openstack-collector` and `tally-openstack-simulator`), loads them into
+   the cluster, applies the dev overlay, and applies the two migration chains,
+   the reporting one and the engine one. Several hundred lines go by. These are
+   the last ones:
+
+   ```text
+   Stack is up:
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1        Reporting API
+     https://vm.tally.127-0-0-1.nip.io:8443                VictoriaMetrics
+     https://grafana.tally.127-0-0-1.nip.io:8443           Grafana
+     https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/  vmalert
+     https://alertmanager.tally.127-0-0-1.nip.io:8443      Alertmanager
+     https://otlp.tally.127-0-0-1.nip.io:8443              OTLP/HTTP
+     db.tally.127-0-0-1.nip.io:5432                        TimescaleDB
+
+   Trust the dev CA with: make -s ca > tally-ca.crt
+   ```
+
+   The seven URLs and the last line have to match exactly. Everything above
+   them differs in timing and in the ids Kubernetes hands out.
+
+2. Read the error if `make up` stopped on a rollout instead of printing that
+   block. The run behind this page needed four calls. The first ended after
+   eight minutes under
+   `kubectl --context kind-tally -n envoy-gateway-system rollout status
+   deployment/envoy-gateway --timeout=300s`:
+
+   ```text
+   Waiting for deployment "envoy-gateway" rollout to finish: 0 of 1 updated replicas are available...
+   error: timed out waiting for the condition
+   make: *** [up] Error 1
+   ```
+
+   The second ended on the same error under the `statefulset/timescaledb`
+   rollout, the third on `error: deployment "reporting-api" exceeded its
+   progress deadline`. Each time the node was still pulling an image: the
+   cluster pulls its images on the first `make up`, and a slow network outlasts
+   the five-minute rollout timeout.
+
+3. Wait until every pod of the stack is `Running` before the next call:
+
+   ```sh
+   kubectl --context kind-tally -n tally get pods
+   ```
+
+   ```text
+   NAME                             READY   STATUS    RESTARTS   AGE
+   alertmanager-0                   1/1     Running   0          33m
+   grafana-6c58589c8b-fjpjz         2/2     Running   0          33m
+   otel-collector-599c64db4-9m2hv   1/1     Running   0          33m
+   reporting-api-6b8ffd9598-bvxnn   1/1     Running   0          33m
+   tally-engine-29813040-6kd9c      0/1     Error     0          32m
+   timescaledb-0                    1/1     Running   0          33m
+   victoriametrics-0                1/1     Running   0          33m
+   vmalert-7699459f4-t89tm          1/1     Running   0          33m
+   ```
+
+   The names carry ids of their own and the ages are your machine's. The
+   `tally-engine-<id>` pod is a Job of the hourly scheduler, and it shows
+   `Error` until lesson 3 imports a pricing model, which is expected here.
+   Every other pod reads `Running`. Then run `make up` again: against a cluster
+   that already exists it reuses it, applies the overlay again and prints the
+   block above. The fourth call did that in 16 seconds.
+
+   `==> kind cluster tally already exists` as the first line of a first
+   `make up` means a cluster from an earlier run of this track is still on the
+   machine. Tear it down with the `make down` of lesson 5 and start over. On a
+   repeated call after a timeout that line is the expected one.
+
+## Trust the dev CA
+
+1. Write the cluster's CA certificate to a file:
+
+   ```sh
+   make -s ca > tally-ca.crt
+   ```
+
+   The target prints nothing. `tally-ca.crt` now holds the certificate of the
+   certificate authority cert-manager created for this cluster, 562 bytes on
+   the run. It is not installed into the operating system or into a browser:
+   cert-manager creates a new CA on every `make up`, so an installed one is
+   stale after the next tear-down. `curl` is handed the file per call with
+   `--cacert` instead.
+
+2. Call the Reporting API with the file and no credential:
+
+   ```sh
+   curl --cacert tally-ca.crt https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources
+   ```
+
+   ```json
+   {"type":"urn:tally:error:unauthorized","title":"Unauthorized","status":401,"detail":"the request carries no bearer token"}
+   ```
+
+   The API answered and refused, which is what a verified connection without a
+   credential looks like. `type` `urn:tally:error:unauthorized` and `status`
+   401 have to match. The answer is an RFC 9457 problem document, the one shape
+   every error of this API has, described under
+   [errors](/reference/api/reporting-api#errors).
+
+3. Make the same call without the file:
+
+   ```sh
+   curl https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources
+   ```
+
+   ```text
+   curl: (60) SSL certificate problem: unable to get local issuer certificate
+   More details here: https://curl.se/docs/sslcerts.html
+
+   curl failed to verify the legitimacy of the server and therefore could not
+   establish a secure connection to it. To learn more about this situation and
+   how to fix it, please visit the web page mentioned above.
+   ```
+
+   This is what the file is for. The `(60)` line has to match, and a `curl`
+   that is not the one macOS ships may word the lines after it differently.
+
+## Mint an API token
+
+1. Point the admin CLI at the dev reporting database:
+
+   ```sh
+   export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+   ```
+
+   The command prints nothing. The URL reaches the dev database through the
+   Gateway's TCP listener, the path a `psql` on your machine takes as well, and
+   `tally-reporting-admin` reads it from the environment.
+
+2. Mint the token and export it:
+
+   ```sh
+   TALLY_API_TOKEN="$(go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'tutorial')"
+   export TALLY_API_TOKEN
+   ```
+
+   ```text
+   created api_tokens f2f68e0c-7228-4c75-a0da-8e344dabd56c
+   the token above is printed this one time: store it now, it will not be shown again
+   ```
+
+   The two lines are the CLI's notices on stderr. The token itself went to
+   stdout and from there into the variable, and it is printed this one time.
+   The id is your own. The first `go run` compiles the binary and, on a machine
+   with Go 1.26, downloads the go1.27.1 toolchain before that, which is why it
+   takes a while.
+
+   The token carries the role `admin`, the role that every operation of this
+   API accepts; the other two roles and how a token is revoked are in
+   [issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials).
+
+   A `dial tcp` error naming `db.tally.127-0-0-1.nip.io:5432` in place of the
+   two notices means `make up` did not finish. Run it again.
+
+## Make your first call
+
+1. Ask the API for the resources it knows:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources'
+   ```
+
+   ```json
+   {"items":[],"next_cursor":null}
+   ```
+
+   The fleet is empty because nothing has reported into it yet, which lesson 2
+   changes. `items` has to be empty and `next_cursor` null. A 401 here means
+   the variable is empty in this shell: the token is printed once, so mint
+   another one with the two commands above.
+
+## What you learned
+
+- The cluster runs the Reporting API, its database, the metrics store and the
+  dashboards behind one Gateway, the arrangement
+  [the system at a glance](/explanation/architecture-and-the-provider-pattern#the-system-at-a-glance)
+  draws.
+- `tally-reporting-admin`, the command that minted the token, is one of
+  [the six binaries](/explanation/architecture-and-the-provider-pattern#the-six-binaries),
+  and you ran it with `go run` instead of from an image.
+- An API token carries a role, and the role decides what it may do:
+  [who may write what](/explanation/architecture-and-the-provider-pattern#who-may-write-what).
+- `GET /api/v1/resources` reads the projection, which stays empty until
+  something reports:
+  [the projection](/explanation/events-as-the-source-of-truth#the-projection).
+
+## Where to go next
+
+[Simulate a month of OpenStack](/tutorials/simulate-a-month-of-openstack) fills
+the empty fleet you just read.
+
+It starts from the state this lesson leaves behind: the kind cluster `tally`
+with the dev overlay running, `tally-ca.crt` at the repository root, and
+`TALLY_REPORTING_DB_URL` and `TALLY_API_TOKEN` in the shell. Keep that shell
+open. The token is printed once, and lesson 2 says how to mint another one if
+the shell was closed.

--- a/docs/tutorials/simulate-a-month-of-openstack.md
+++ b/docs/tutorials/simulate-a-month-of-openstack.md
@@ -1,0 +1,358 @@
+---
+title: Simulate a month of OpenStack
+description: Start the simulator stack beside the dev cluster, publish one generated month of OpenStack notifications onto its broker, and read the month back through the Reporting API.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Simulate a month of OpenStack
+
+In this lesson you start the simulator stack beside the cluster of lesson 1. It
+publishes one generated month of OpenStack notifications onto a broker the
+collector consumes from. You watch the month arrive in the Reporting API,
+finish it at once instead of waiting its pace out, and read it back.
+
+At the end you hold the month of July 2026 of the simulated cloud `os-sim` in
+the reporting database, minus the share the simulator keeps back for a later
+track.
+
+This lesson takes about 15 minutes.
+
+## Before you start
+
+- The state lesson 1 leaves: the kind cluster from `make up`, `tally-ca.crt` at
+  the repository root, `TALLY_REPORTING_DB_URL` and `TALLY_API_TOKEN` in the
+  shell, and that shell at the repository root.
+- Docker Desktop running, with `docker compose` on the path. The stack of this
+  lesson runs beside the cluster, as three containers of its own.
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TALLY_API_TOKEN="$(go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'tutorial')"
+export TALLY_API_TOKEN
+```
+
+A token is printed once, so a closed shell means a new token. The one lesson 1
+minted stays valid until it is revoked the way
+[issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
+says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
+
+## Start the simulator stack
+
+1. Start the stack for July 2026 with the held-back switch on:
+
+   ```sh
+   make simulator-up SIM_PERIOD=2026-07 SIM_FAULTS=held-back
+   ```
+
+   The month `2026-07` is the one period this track uses everywhere. The cloud
+   `os-sim`, the seed 1 and the pace, factor 744, are the `Makefile` defaults,
+   and [run a simulated month](/how-to/simulator/run-a-month) covers the
+   variables that change them. `held-back` is the one fault switch this track
+   turns on, and the others are in
+   [switch on fault switches](/how-to/simulator/switch-on-faults).
+
+   The target first builds the collector and the simulator images, which is
+   Docker build output, and prints `==> writing the dev CA to tally-ca.crt`.
+   The lines shown here start where it issues the credential:
+
+   ```text
+   ==> issuing an ingest credential for os-sim
+   created ingest_credentials 0ce1a769-1794-47e5-97c8-6241a087f49a
+   the token above is printed this one time: store it now, it will not be shown again
+   docker compose -f deploy/compose/compose.yaml up -d
+   ```
+
+   The credential is the ingest token the collector reports under. It went into
+   `deploy/compose/.env` and is printed nowhere else. The id is your own.
+
+   Compose then pulls the broker image and starts the three containers,
+   `rabbitmq`, `collector` and `simulator`, as a progress display the terminal
+   redraws in place. These are the last lines:
+
+   ```text
+   Simulator stack is up:
+     http://127.0.0.1:15672                               broker UI, guest/guest
+     http://127.0.0.1:8090/metrics                        collector
+     http://127.0.0.1:8091/clock                          simulator control
+     http://127.0.0.1:8091/metrics                        simulator inventory, the database exporter stand-in
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1       Reporting API
+     https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics  OTLP endpoint the series are pushed to
+     https://vm.tally.127-0-0-1.nip.io:8443/targets       scrape targets
+
+   Finish the month at once with:
+     curl -X PUT -d '{"factor": 0}' http://127.0.0.1:8091/clock
+   Release the held-back notifications of a run with SIM_FAULTS=held-back with:
+     curl -X POST http://127.0.0.1:8091/release
+   Inspect the registry with the admin token in deploy/compose/.env:
+     curl --cacert tally-ca.crt -H "Authorization: Bearer $(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim'
+   Reconcile the cloud the run serves: docs/how-to/simulator/reconcile-the-simulated-cloud.md
+   ```
+
+   The seven URLs have to match. The four hint lines below them are printed on
+   every run. This track follows the first of them, the `PUT /clock` of a later
+   step, and never the second: the `POST /release` line is what lets the held
+   share out, which the billing track does.
+
+   Three containers now run beside the cluster. The month of July 2026 of seed
+   1 on the cloud `os-sim`, with its six tenants, goes onto the bus at factor
+   744, which puts the 31 days on the bus in an hour. The `held-back` switch
+   keeps 84 of the month's 1812 billable notifications off the bus, and the
+   simulator holds them until a release.
+
+   `ERROR: set SIM_PERIOD to the past month to simulate, e.g. make simulator-up SIM_PERIOD=2026-07`
+   in place of the build output means the period was left off the command. A
+   `dial tcp` error from the admin CLI at the credential step means the cluster
+   is not up, so run the `make up` of lesson 1 again.
+
+## Watch the clock
+
+1. Read the simulator's clock:
+
+   ```sh
+   curl -s http://127.0.0.1:8091/clock
+   ```
+
+   ```json
+   {"virtual_now":"2026-07-01T07:24:26Z","factor":744,"published":430,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   A minute later the same call answers:
+
+   ```sh
+   curl -s http://127.0.0.1:8091/clock
+   ```
+
+   ```json
+   {"virtual_now":"2026-07-01T19:48:56Z","factor":744,"published":902,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   `factor` 744, `total` 15727, `held` 84, `period_from` `2026-07-01T00:00:00Z`
+   and `period_to` `2026-08-01T00:00:00Z` have to match. `virtual_now` and
+   `published` are your own and grow between the two reads: on the run they
+   stood at 430 and then at 902 notifications, twelve virtual hours apart.
+   `holding` is false while the month publishes. Connection refused on 8091
+   means the simulator is not running, and
+   `docker compose -f deploy/compose/compose.yaml ps` shows the three
+   containers while
+   `docker compose -f deploy/compose/compose.yaml logs simulator` says why it
+   stopped.
+
+## Watch the events arrive
+
+1. Count what the Reporting API holds, grouped by cloud and resource type:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/stats/resources?group_by=cloud,resource_type'
+   ```
+
+   ```json
+   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":15,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":25,"resource_type":"volume"}]}
+   ```
+
+   A minute later:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/stats/resources?group_by=cloud,resource_type'
+   ```
+
+   ```json
+   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":20,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":29,"resource_type":"volume"}]}
+   ```
+
+   The counts are your own. They are the resources the collector has delivered
+   at the moment of the call, 15 instances on the run and 20 a minute later.
+   The five resource types are the month's. An empty `items` list two minutes
+   after the start means the collector has delivered nothing yet, which the
+   counter read of the step "Wait for the collector to deliver" diagnoses.
+
+2. Read one row of the fleet:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/resources?cloud=os-sim&resource_type=instance&limit=1'
+   ```
+
+   ```json
+   {"items":[{"cloud":"os-sim","created_at":"2026-07-01T03:17:02Z","deleted_at":null,"last_event_at":"2026-07-02T05:36:15Z","last_event_type":"compute.instance.power_off","last_payload":{"provider":{"oslo_event_type":"compute.instance.power_off.end"},"state":"shutoff"},"platform":"openstack","project_id":"d5a8024946ddf673277b9e2490643a2c","resource_id":"079faae9-9d39-426f-a963-769cb12aa629","resource_type":"instance","size":{"disk_gb":20,"flavor":"m1.small","ram_gb":2,"vcpus":1},"state":"shutoff"}],"next_cursor":"WyJvcy1zaW0iLCJpbnN0YW5jZSIsIjA3OWZhYWU5LTlkMzktNDI2Zi1hOTYzLTc2OWNiMTJhYTYyOSJd"}
+   ```
+
+   That is one row of the projection. Its `state` is `shutoff`, the state the
+   last event left it in. `project_id` names the tenant by id alone, the way
+   the simulated cloud names its tenants, and `size` carries `vcpus`, `ram_gb`,
+   `disk_gb` and `flavor`. `next_cursor` is the handle for the next page. Which
+   row comes first is your own while the month is still arriving.
+
+## Finish the month at once
+
+1. Set the clock's factor to 0:
+
+   ```sh
+   curl -X PUT -d '{"factor": 0}' http://127.0.0.1:8091/clock
+   ```
+
+   ```json
+   {"virtual_now":"2026-07-02T13:14:44Z","factor":0,"published":1174,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   The route rebases the clock on the virtual instant it has reached and
+   answers the clock document. `factor` 0 has to match, and `virtual_now` and
+   `published` are your own. A 400 with
+   `factor must be a JSON object with a number member "factor" that is zero or positive`
+   means the body was not the JSON object shown.
+
+2. Read the clock again once the rest of the month is out:
+
+   ```sh
+   curl -s http://127.0.0.1:8091/clock
+   ```
+
+   On the run the answer below came 15 seconds after the factor changed. A
+   slower machine takes a few minutes.
+
+   ```json
+   {"virtual_now":"2026-07-02T13:14:44Z","factor":0,"published":15643,"total":15727,"held":84,"holding":true,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   `published` 15643, `held` 84, `holding` true and `total` 15727 have to
+   match. `virtual_now` is your own: at factor 0 the clock no longer advances,
+   so it stays at the instant the factor became 0 while the rest of the month
+   goes out at once. The simulator now waits for a release the billing track
+   sends, and this lesson sends none.
+
+## Wait for the collector to deliver
+
+1. Sum the collector's counters over their `event_type` labels:
+
+   ```sh
+   curl -s http://127.0.0.1:8090/metrics | awk '
+     /^tally_collector_consumed_total/ { c += $2 }
+     /^tally_collector_skipped_total/ { s += $2 }
+     /^tally_collector_unparseable_total/ { u += $2 }
+     /^tally_collector_buffer_depth/ { d = $2 }
+     END { print "consumed", c, "skipped", s, "unparseable", u, "depth", d }'
+   ```
+
+   ```text
+   consumed 1728 skipped 13915 unparseable 0 depth 0
+   ```
+
+   Repeat the read until `depth` reads 0, which on the run was three minutes
+   after the month went out. The four numbers have to match. 1728 is the
+   month's 1812 billable notifications minus the 84 held ones, 13915 is the
+   notifications the mapping claims nothing for, and the depth is the outbox
+   the collector drains into the Reporting API.
+
+2. Read what the Reporting API took:
+
+   ```sh
+   curl -s http://127.0.0.1:8090/metrics | grep ^tally_collector_delivered_total
+   ```
+
+   ```text
+   tally_collector_delivered_total 1728
+   ```
+
+   The 1728 delivered are the 1728 consumed. A depth that does not fall while a
+   `tally_collector_delivered_total` stays at 0 means the Reporting API refuses
+   the batches, and
+   `docker compose -f deploy/compose/compose.yaml logs collector` shows the
+   `401` or the `x509` line. The cure is `make simulator-down` and then
+   `make simulator-up SIM_PERIOD=2026-07 SIM_FAULTS=held-back` again, which
+   issues a fresh credential and writes the CA file again.
+
+## Read the month back
+
+1. Count the whole month, the deleted resources included:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/stats/resources?group_by=cloud,resource_type&status=all'
+   ```
+
+   ```json
+   {"items":[{"cloud":"os-sim","count":16,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":668,"resource_type":"instance"},{"cloud":"os-sim","count":5,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":169,"resource_type":"volume"}]}
+   ```
+
+   Every count has to match. They are the seed's: 16 floating IPs, 9 images,
+   668 instances, 5 load balancers and 169 volumes. `status=all` counts the
+   deleted resources too, which the default `active` leaves out.
+
+2. Read the first event the month stored:
+
+   ```sh
+   curl --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/events?cloud=os-sim&limit=1'
+   ```
+
+   ```json
+   {"items":[{"cloud":"os-sim","event_id":"7d16f9f3-740a-4670-9898-bc32b30fd3f9","event_type":"image.create","payload":{"provider":{"oslo_event_type":"image.upload"},"size":{"size_gb":3.5},"state":"active"},"platform":"openstack","project_id":"005be5adeef3d87e280d03d9d57c38b4","received_at":"2026-09-07T12:37:37.784207Z","resource_id":"d45cc80a-b7ea-4988-8873-16b54ec1a39d","resource_type":"image","source":"collector","timestamp":"2026-07-01T00:21:32Z"}],"next_cursor":"WyIyMDI2LTA3LTAxVDAwOjIxOjMyWiIsIjdkMTZmOWYzLTc0MGEtNDY3MC05ODk4LWJjMzJiMzBmZDNmOSJd"}
+   ```
+
+   It is an `image.create` at `2026-07-01T00:21:32Z` with its `size`.
+   `event_id`, `timestamp`, `resource_id`, `project_id` and the payload are the
+   seed's and have to match. `received_at` is your own, the wall-clock instant
+   the collector delivered the event.
+
+## See the metrics land in the store
+
+1. Count the instances that pushed traffic during the month:
+
+   ```sh
+   curl --cacert tally-ca.crt -G 'https://vm.tally.127-0-0-1.nip.io:8443/api/v1/query' --data-urlencode 'query=count(count_over_time(ceilometer_network_outgoing_bytes_total{cloud="os-sim"}[31d]))' --data-urlencode 'time=2026-08-01T00:00:00Z'
+   ```
+
+   ```json
+   {"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1785542400,"667"]}]},"stats":{"seriesFetched": "667","executionTimeMsec":2}}
+   ```
+
+   667 has to match, the instances of the month that pushed traffic. The series
+   carry July 2026 timestamps, which is why the query is asked at the end of
+   the month with `time` and over a window that spans the month, and why lesson
+   4 sets the dashboards' time range to July.
+
+   The plain instant query, without the window and without `time`, is evaluated
+   at the wall clock, where the month's series ended a month ago:
+
+   ```sh
+   curl --cacert tally-ca.crt -G 'https://vm.tally.127-0-0-1.nip.io:8443/api/v1/query' --data-urlencode 'query=count(ceilometer_network_outgoing_bytes_total{cloud="os-sim"})'
+   ```
+
+   ```json
+   {"status":"success","data":{"resultType":"vector","result":[]},"stats":{"seriesFetched": "0","executionTimeMsec":0}}
+   ```
+
+   An empty answer within 30 seconds of the push is the store's latency offset
+   instead, described under
+   [check the result](/how-to/observability/fill-the-dashboards#check-the-result)
+   of the dashboards guide.
+
+## What you learned
+
+- The month holds three classic projects, two Gardener tenants, one CI tenant
+  and one external network:
+  [the world and the workload](/explanation/the-simulated-openstack-world#the-world-and-the-workload).
+- The `held-back` switch keeps one in 20 of the billable transitions off the
+  bus until a release lets them out:
+  [the fault switches](/explanation/the-simulated-openstack-world#the-fault-switches).
+- The collector consumes the broker, keeps what it read in an outbox and
+  delivers it to the Reporting API in batches:
+  [at-least-once over an outbox](/explanation/how-the-collector-consumes-a-bus#at-least-once-over-an-outbox).
+- The stats and the resource row you read come from the projection the events
+  fold into:
+  [the projection](/explanation/events-as-the-source-of-truth#the-projection).
+- The traffic and the inventory series reach the store over OTLP, timestamped
+  in the simulated month:
+  [what is pushed](/explanation/the-openstack-metrics-pipeline#what-is-pushed).
+
+## Where to go next
+
+[Meter and rate your first month](/tutorials/meter-and-rate-your-first-month)
+turns the month you just ingested into rated usage.
+
+It starts from the state this lesson leaves behind: everything lesson 1 left,
+plus the compose stack running with the simulator holding 84 notifications, so
+`GET /clock` answers `holding` true, the collector idle with an empty outbox,
+and the reporting database holding the month of seed 1 on `os-sim` minus that
+held share. The project registry is empty. Nothing of this lesson registers the
+six tenants, and a lesson of the billing track does that.

--- a/docs/tutorials/tear-down-your-local-tally.md
+++ b/docs/tutorials/tear-down-your-local-tally.md
@@ -1,0 +1,188 @@
+---
+title: Tear down your local Tally
+description: Stop the simulator stack, delete the kind cluster, and remove the files and the shell variables the core track wrote.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Tear down your local Tally
+
+In this lesson you take the machine back to where lesson 1 started. The
+simulator stack goes with its broker and its outbox, and the kind cluster goes
+with every database in it: the month of lesson 2, the run of lesson 3 and the
+project registry. Every token and credential the lessons issued goes with those
+databases, because that is where they live. You remove the CA file
+`tally-ca.crt` at the repository root and the export directory
+`~/tally-tutorial` by hand.
+
+What stays is the four `tally-*:dev` images in Docker, the Go build and module
+caches under your home directory, and the clone. A reader going on to the
+billing track does this lesson after that track's last lesson, because the
+billing track continues from the state lesson 4 leaves behind.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state lesson 1 leaves, or the state any later lesson leaves: a cluster
+  from `make up`, and whatever the later lessons added to it. A step that finds
+  nothing to remove says so and changes nothing.
+- A shell at the repository root.
+- The shell that holds the port-forward lesson 3 started in the background, so
+  that it can be stopped there. Any shell ends it with:
+
+  ```sh
+  pkill -f 'port-forward svc/victoriametrics'
+  ```
+
+  It prints nothing and ends the background job lesson 3 started, and on a
+  machine where lesson 3 never ran it ends nothing and exits 1, which is fine.
+
+## Stop the simulator stack
+
+1. Remove the three containers of the stack, their network, the outbox volume
+   and `deploy/compose/.env`:
+
+   ```sh
+   make simulator-down
+   ```
+
+   ```text
+   docker compose -f deploy/compose/compose.yaml down --volumes
+    Container tally-simulator-simulator-1 Stopping 
+    Container tally-simulator-collector-1 Stopping 
+    Container tally-simulator-simulator-1 Stopped 
+    Container tally-simulator-simulator-1 Removing 
+    Container tally-simulator-simulator-1 Removed 
+    Container tally-simulator-collector-1 Stopped 
+    Container tally-simulator-collector-1 Removing 
+    Container tally-simulator-collector-1 Removed 
+    Container tally-simulator-rabbitmq-1 Stopping 
+    Container tally-simulator-rabbitmq-1 Stopped 
+    Container tally-simulator-rabbitmq-1 Removing 
+    Container tally-simulator-rabbitmq-1 Removed 
+    Network tally-simulator_default Removing 
+    Volume tally-simulator_outbox Removing 
+    Volume tally-simulator_outbox Removed 
+    Network tally-simulator_default Removed 
+   rm -f deploy/compose/.env
+   ```
+
+   The names have to match: the three containers, the network
+   `tally-simulator_default` and the volume `tally-simulator_outbox`. The order
+   the `Stopping` and `Stopped` lines arrive in is your own. With the simulator
+   container the 84 notifications it was holding are discarded: no release was
+   sent, and the held share exists nowhere else. The last line removes
+   `deploy/compose/.env`, the file with the ingest credential, and the
+   credential itself stays in the reporting database until the cluster goes in
+   the next step. On a machine where lesson 2 never ran, compose warns about
+   unset `TALLY_SIM_` variables, because no `deploy/compose/.env` exists, and
+   removes nothing, which is fine.
+
+## Delete the cluster
+
+1. Delete the kind cluster:
+
+   ```sh
+   make down
+   ```
+
+   ```text
+   Deleting cluster "tally" ...
+   Deleted nodes: ["tally-control-plane"]
+   ```
+
+   Both lines have to match. With the node go both databases and what they
+   hold: the month, the run, the project registry, and every token and
+   credential the lessons issued. The series lesson 2 pushed and the state the
+   dashboards of lesson 4 read go with it as well.
+
+2. Check that no cluster is left:
+
+   ```sh
+   kind get clusters
+   ```
+
+   ```text
+   No kind clusters found.
+   ```
+
+   The line has to match. It is the state lesson 1 starts from. A second
+   `make down` prints `kind cluster tally does not exist` and changes nothing.
+
+## Remove what the lessons wrote
+
+1. Remove the CA file, the export directory and the seven variables:
+
+   ```sh
+   rm tally-ca.crt
+   rm -r ~/tally-tutorial
+   unset TALLY_REPORTING_DB_URL TALLY_API_TOKEN TALLY_ENGINE_DB_URL TALLY_ENGINE_REPORTING_DB_URL TALLY_ENGINE_COUNTER_SOURCES TALLY_ENGINE_VM_URL RUN_ID
+   ```
+
+   The three commands print nothing. `tally-ca.crt` is stale from here on: the
+   next `make up` creates a new certificate authority, and `make -s ca` writes
+   the file again for it. `~/tally-tutorial` held the export of lesson 3, the
+   six statements with `run.json` and `kickbacks.json` beside them. The seven
+   variables are the shell state lessons 1 to 3 built, and `unset` leaves this
+   shell without them. `rm: tally-ca.crt: No such file or directory` means the
+   file was already gone, which is fine.
+
+## What stays
+
+1. List the images the track built:
+
+   ```sh
+   docker image ls 'tally-*'
+   ```
+
+   ```text
+   IMAGE                           ID             DISK USAGE   CONTENT SIZE   EXTRA
+   tally-engine:dev                5411e0bd59f9       15.3MB             0B        
+   tally-openstack-collector:dev   d879c5ca78ff       15.9MB             0B        
+   tally-openstack-simulator:dev   6527cde4f567       17.6MB             0B        
+   tally-reporting:dev             cf2be4a2bd30       19.3MB             0B        
+   ```
+
+   The four `:dev` images are what `make up` built, and their names have to
+   match. The ids, the sizes and the column layout are Docker's own, and these
+   columns are the ones the run's Docker Desktop 4.86.0 prints. Beside the
+   images stay Docker's build cache from the image builds, which
+   `docker builder prune` removes, the Go build and module caches under your
+   home directory, and the clone.
+
+2. Remove the images if you want the disk back:
+
+   ```sh
+   docker image rm tally-reporting:dev tally-engine:dev tally-openstack-collector:dev tally-openstack-simulator:dev
+   ```
+
+   This is your choice and not a step of the track: the four images cost about
+   70 MB, and the next `make up` builds them again.
+
+## What you learned
+
+- No command of Tally deletes an event. The month is gone because the database
+  went with the cluster:
+  [why the history is append-only](/explanation/events-as-the-source-of-truth#why-the-history-is-append-only).
+- The collector's outbox is a volume of the compose stack, and
+  `make simulator-down` drops it with the stack:
+  [the outbox on disk](/explanation/how-the-collector-consumes-a-bus#the-outbox-on-disk).
+- The four images are four of the six binaries, built by `make up` and rebuilt
+  by the next one:
+  [the six binaries](/explanation/architecture-and-the-provider-pattern#the-six-binaries).
+- A second run of this track renders the same month, byte for byte, because the
+  seed decides what the simulated world does:
+  [determinism](/explanation/the-simulated-openstack-world#determinism).
+
+## Where to go next
+
+[Set up your local Tally](/tutorials/set-up-your-local-tally) runs the track
+again from an empty machine, which is what this machine is now: no kind
+cluster, no compose stack, no `tally-ca.crt`, no `~/tally-tutorial`, and the
+clone.
+
+For a cloud of your own, the [how-to guides](/how-to/) take these commands task
+by task, and the [reference](/reference/) is where the flags, the settings and
+the formats are written down.

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -1,0 +1,297 @@
+---
+title: Watch the month in Grafana
+description: Open the dev cluster's Grafana as an anonymous viewer, point its four dashboards at the simulated cloud and the simulated month, and find the one alert the dev stack fires by design.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Watch the month in Grafana
+
+In this lesson you open the Grafana the cluster runs, point its four dashboards
+at the simulated cloud and at the simulated month, read what each of them
+shows, and find the one alert the dev stack fires by design in vmalert and in
+Alertmanager.
+
+At the end you have a name for what each dashboard and each alert component
+reads, and the whole state of this track, written out, which the billing track
+continues from.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state lesson 3 leaves: the kind cluster with the dev overlay, the
+  simulator stack holding its 84 notifications, the month of July 2026 in the
+  reporting database, and one completed run of that month in the engine
+  database.
+- A browser. The run behind this page used Firefox.
+- `tally-ca.crt` at the repository root, for the `curl` calls beside the
+  browser. A new shell writes the file again with:
+
+  ```sh
+  make -s ca > tally-ca.crt
+  ```
+
+- The dashboards read only what lesson 2 wrote, the events and the pushed
+  series, so the engine's run of lesson 3 changes nothing on them.
+
+## Open Grafana
+
+1. Ask Grafana whether it is up:
+
+   ```sh
+   curl --cacert tally-ca.crt https://grafana.tally.127-0-0-1.nip.io:8443/api/health
+   ```
+
+   ```json
+   {
+     "database": "ok",
+     "version": "13.1.3",
+     "commit": "45a27d64b64a82d666b06aa5c5bb3521587edb0d"
+   }
+   ```
+
+   `database` `ok` has to match. `version` 13.1.3 is the image the manifests
+   pin, so it matches at this commit and moves with the manifests. `commit` is
+   Grafana's own build.
+
+2. Open `https://grafana.tally.127-0-0-1.nip.io:8443` in the browser. The
+   browser stops on a certificate warning: the certificate is signed by the dev
+   CA of lesson 1, which the browser does not know, and that CA is not
+   installed on purpose, because cert-manager creates a new one after every
+   `make up`. Proceed past the warning for this hostname, in Firefox under its
+   Advanced button.
+
+   No login follows. The dev overlay lets an anonymous viewer read every
+   dashboard, which is what `GF_AUTH_ANONYMOUS_ENABLED` with the Viewer role in
+   `deploy/kubernetes/overlays/dev/kustomization.yaml` sets, and
+   [install the Grafana dashboards](/how-to/observability/install-the-grafana-dashboards)
+   covers a deployment with logins.
+
+   Go to the folder `Tally`. It carries four dashboards, `Tally / Fleet
+   Overview`, `Tally / Ingestion Health`, `Tally / Project Drilldown` and
+   `Tally / Reconciliation Drift`, in the order the folder lists them, and
+   [Grafana dashboards](/reference/observability/dashboards) names every panel
+   and the expression it reads.
+
+3. Read the same four through the API:
+
+   ```sh
+   curl --cacert tally-ca.crt 'https://grafana.tally.127-0-0-1.nip.io:8443/api/search?type=dash-db' | jq '.[] | {folderTitle, title, uid}'
+   ```
+
+   ```json
+   {"folderTitle":"Tally","title":"Tally / Fleet Overview","uid":"tally-fleet-overview"}
+   {"folderTitle":"Tally","title":"Tally / Ingestion Health","uid":"tally-ingestion-health"}
+   {"folderTitle":"Tally","title":"Tally / Project Drilldown","uid":"tally-project-drilldown"}
+   {"folderTitle":"Tally","title":"Tally / Reconciliation Drift","uid":"tally-reconciliation-drift"}
+   ```
+
+   The call carries no credential, so this is the anonymous viewer again. The
+   four titles and the four uids have to match. A 401 page in the browser or
+   here means anonymous access is off, which is not the dev overlay.
+
+## Set the cloud and the month
+
+1. Set the `cloud` variable to `os-sim` on every dashboard and leave `platform`
+   on All. Both variables read the clouds off `tally_current_resources`, so
+   `os-sim` is offered once the projection holds the month.
+
+2. Use two time ranges. A dashboard has one range at a time and its panels are
+   split across the two, so you set one range, read the panels that fit it,
+   then set the other.
+
+   The absolute range `2026-07-01 00:00:00` to `2026-08-01 00:00:00` fits every
+   panel that reads an `openstack_*` or a `ceilometer_*` series, because the
+   simulator pushed those at simulated time, inside July 2026. `Last 3 hours`
+   fits every panel that reads a `tally_` series, because those were scraped
+   off the Reporting API at the wall clock while the month went out, on the run
+   between 12:37 and 12:43 UTC. The dashboards open on `Last 6 hours`
+   refreshing every minute. The next step names which panels are which per
+   dashboard.
+
+   Every dashboard file carries `"timezone": "utc"`, so both ranges are read in
+   UTC and no time zone setting is needed.
+
+## Read the four dashboards
+
+1. `Tally / Fleet Overview`. With `Last 3 hours`, `Resources by type and state`
+   shows 37 instances `active`, 630 `deleted` and 1 `shelved`, 16 volumes
+   `available`, 12 `in-use` and 141 `deleted`, 9 floating IPs `active` and 7
+   `deleted`, 7 images `active` and 2 `deleted`, and 4 load balancers `active`
+   and 1 `deleted`. The whole month has ended, so most of the fleet is deleted.
+   `Resource count trend` draws the same counts as lines that jump once, when
+   the month went out, and `Clouds reporting` is 1.
+
+   With the July range, `Projects (OpenStack)` is 6 and `Top 10 projects by
+   instance count` lists the six tenant ids, four of them at 3 instances at the
+   month's end and the CI tenant and the second Gardener tenant at 0. Over the
+   month the CI tenant peaked at 10 and the large Gardener tenant at 11.
+
+2. `Tally / Ingestion Health`. With `Last 3 hours`, `Event ingest rate` shows
+   one spike over the minutes the month went out, up to about five events per
+   second for cloud `os-sim` and source `collector`, 1728 events in all.
+
+   `Dedup rate` and `Rejected events` draw nothing, because the month carried
+   no duplicate and no item was rejected, so those counters were never written.
+   A panel over a counter that does not exist shows `No data`, which here reads
+   as 0. `Collector buffer depth` and `Oldest buffered event age` show
+   `No data` too: the collector runs in the compose stack on your machine and
+   the cluster's store scrapes no target for it, so these two panels stay empty
+   on the dev stack, and lesson 2 read those gauges off the collector directly.
+   `Projection replays` draws nothing.
+
+   `Scrape health` shows `reporting-api` and `otel-collector` up (1) and
+   `ceilometer` down (0), which is the designed dev state, a placeholder target
+   for an exporter that runs beside a real control plane.
+   `openstack-db-exporter` is up (1), because the holding simulator still
+   serves its inventory on port 8091, which that job scrapes. Between simulator
+   runs it reads 0.
+
+3. `Tally / Project Drilldown`. Pick `005be5adeef3d87e280d03d9d57c38b4` in the
+   `project_id` variable, one of the six ids and the Gardener tenant with the
+   largest statement of lesson 3.
+
+   With the July range, at the end of July, `Resources by type` shows 3
+   servers, 8 volumes, 4 floating IPs, 2 routers, 1 image and 4 load balancers,
+   `Volume capacity` reads 480 GB, and the three `Quota usage` gauges read 3 %
+   of the instance quota, 6 % of the vCPU quota and 6 % of the memory quota.
+   With `Last 3 hours`, `Recent lifecycle activity` shows the ingest spike
+   split by event type.
+
+4. `Tally / Reconciliation Drift`. Every query panel is empty (`No data`),
+   because no sync ran in this track, and the `Drift interpretation` text panel
+   says how to read them once one does.
+   [Reconcile the simulated cloud](/how-to/simulator/reconcile-the-simulated-cloud)
+   runs that loop against this same stack.
+
+A panel reading `No data` where a value is named above has the wrong one of the
+two time ranges, or the `cloud` variable is not on `os-sim`.
+
+## Find the alerts
+
+1. Read what vmalert holds as firing:
+
+   ```sh
+   curl --cacert tally-ca.crt https://vmalert.tally.127-0-0-1.nip.io:8443/api/v1/alerts | jq '.data.alerts[] | {alertname: .labels.alertname, state, job: .labels.job}'
+   ```
+
+   ```json
+   {
+     "alertname": "TallyScrapeTargetDown",
+     "state": "firing",
+     "job": "ceilometer"
+   }
+   ```
+
+   This one alert has to be there, and on the run no other rule fired.
+   `TallyScrapeTargetDown` fires about five minutes after `make up` for the
+   `ceilometer` job, whose target is a placeholder for an exporter that runs
+   beside a real control plane, and that is the designed dev state rather than
+   a fault to chase:
+   [TallyScrapeTargetDown](/how-to/alerts/TallyScrapeTargetDown) is its runbook
+   and [alert rules](/reference/observability/alert-rules) states every rule.
+   `openstack-db-exporter` does not fire because the holding simulator serves
+   its inventory.
+
+   `TallyCloudEventsSilent` fires for `os-sim` once no event has been ingested
+   for over an hour from a cloud that reported in the last 24 hours, so a
+   reader who reaches this step more than an hour after lesson 2 sees it beside
+   the first. That one is the holding simulator publishing nothing rather than
+   a fault.
+
+2. Read the same alert as Alertmanager holds it:
+
+   ```sh
+   curl --cacert tally-ca.crt https://alertmanager.tally.127-0-0-1.nip.io:8443/api/v2/alerts | jq '.[] | {alertname: .labels.alertname, runbook: .annotations.runbook}'
+   ```
+
+   ```json
+   {
+     "alertname": "TallyScrapeTargetDown",
+     "runbook": "https://b42labs.github.io/tally/how-to/alerts/TallyScrapeTargetDown"
+   }
+   ```
+
+   The runbook annotation
+   `https://b42labs.github.io/tally/how-to/alerts/TallyScrapeTargetDown` has to
+   match. vmalert is what evaluates the rules against the store, and
+   Alertmanager is what routes what fires.
+
+3. The two UIs render the same in the browser:
+   `https://vmalert.tally.127-0-0-1.nip.io:8443/vmalert/` shows the rules, their
+   state and their last evaluation, and
+   `https://alertmanager.tally.127-0-0-1.nip.io:8443` shows the firing alerts as
+   routed. Both sit behind the same certificate warning as Grafana.
+
+4. Read `/api/v1/rules` when an alert you expect is missing from the list:
+
+   ```sh
+   curl --cacert tally-ca.crt https://vmalert.tally.127-0-0-1.nip.io:8443/api/v1/rules | jq '.data.groups[].rules[] | {name, state, lastError}'
+   ```
+
+   ```json
+   {"name":"TallyCloudEventsSilent","state":"inactive","lastError":""}
+   {"name":"TallyEventsRejected","state":"inactive","lastError":""}
+   {"name":"TallySyncErrors","state":"inactive","lastError":""}
+   {"name":"TallySyncStale","state":"inactive","lastError":""}
+   {"name":"TallyReconciliationDriftHigh","state":"inactive","lastError":""}
+   {"name":"TallyCollectorBufferAging","state":"inactive","lastError":""}
+   {"name":"tally:current_resources:sum","state":"","lastError":""}
+   {"name":"TallyResourceCountAnomaly","state":"inactive","lastError":""}
+   {"name":"TallyRecordedSeriesMissing","state":"inactive","lastError":""}
+   {"name":"TallyScrapeTargetDown","state":"firing","lastError":""}
+   {"name":"TallyScrapeJobMissing","state":"inactive","lastError":""}
+   {"name":"TallyExporterServiceSilent","state":"inactive","lastError":""}
+   ```
+
+   Every `lastError` is empty on the run. A non-empty one names the query that
+   failed, and `state` tells `firing` from `inactive`.
+   `tally:current_resources:sum` is a recording rule and carries no state.
+
+## What you learned
+
+- Grafana reads the store through a read-only proxy in its own pod rather than
+  reaching the store directly:
+  [the datasource and the proxy](/explanation/grafana-and-the-read-only-proxy#the-datasource-and-the-proxy).
+- The pushed series carry the simulated month's timestamps and the scraped ones
+  the wall clock's, which is why the dashboards need two time ranges here:
+  [two paths into one store](/explanation/the-openstack-metrics-pipeline#two-paths-into-one-store).
+- vmalert evaluates the rules against the store and Alertmanager routes what
+  fires: [two components](/explanation/alerting-design#two-components).
+- `TallyScrapeTargetDown` asks whether a configured scrape target answered:
+  [what the rules ask](/explanation/alerting-design#what-the-rules-ask).
+- The drift dashboard reads a sync loop this track never ran, which is why its
+  query panels are empty:
+  [reconciliation](/explanation/dual-ingestion-and-reconciliation#reconciliation).
+
+## Where to go next
+
+The track written next continues from the state this lesson leaves behind:
+"The billing track: finalization, late events and corrections, commercial pricing and related-cost attribution".
+
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
+back to a clean machine. A reader going on to the billing track does lesson 5
+after that track's last lesson.
+
+This is the state this track leaves behind:
+
+- the kind cluster `tally` with the dev overlay;
+- the compose stack with the simulator holding 84 notifications, so
+  `GET /clock` on `http://127.0.0.1:8091/clock` answers `holding` true;
+- the reporting database holding the month of seed 1 on `os-sim` minus the held
+  share, with an empty project registry;
+- the engine database holding the pricing model `2026-03` and one completed,
+  not finalized run of `2026-07`;
+- the JSON export of that run under `~/tally-tutorial/2026-07`;
+- `tally-ca.crt` at the repository root;
+- the VictoriaMetrics port-forward on `127.0.0.1:8428`;
+- in the shell: `TALLY_REPORTING_DB_URL`, `TALLY_API_TOKEN`,
+  `TALLY_ENGINE_DB_URL`, `TALLY_ENGINE_REPORTING_DB_URL`,
+  `TALLY_ENGINE_COUNTER_SOURCES`, `TALLY_ENGINE_VM_URL` and `RUN_ID`.
+
+The cluster's hourly `tally-engine` scheduler keeps ticking meanwhile. It moves
+the periods along and may bill `2026-08` on its own once that month's grace
+window has passed, which leaves a run of `2026-08` beside the one of `2026-07`
+and changes nothing above.


### PR DESCRIPTION
Closes #109

Writes the core tutorial track of the docs site: five lessons under `docs/tutorials/` that take a reader from a Mac with the prerequisites installed to a rated month of simulated OpenStack usage, the tutorials index rewritten as the track overview, the `Core track` sidebar group that chains the lessons, and `Tally` added to `proper-nouns.txt` so the two lesson titles that carry it pass the sentence-case gate. Every output block on every lesson is pasted from one real run of the whole track on this machine; nothing in a fence is written by hand.

After this branch, `find docs/tutorials -name '*.md'` prints six files (the index and the five lessons), and `git diff --stat main -- docs/how-to docs/reference docs/explanation docs/contributing docs/drills Makefile deploy cmd internal .github docs/.vitepress/config.mts docs/.vitepress/nav.json` is empty.

## The change set in commit order

Each lesson carries the frontmatter contract, one provenance comment on line 7, an opening that ends in `This lesson takes about <n> minutes.`, `## Before you start`, exactly the step headings issue #109 lists for it, `## What you learned` with one explanation link per bullet, and `## Where to go next`. The sidebar was extended one entry per commit so `go test ./docs/` stays green at every commit.

- `6e2c506` — **Set up your local Tally**: the tool list with versions and printing commands, `make up` shown from `Stack is up:` with the three real timeout errors the run hit and their cure, the dev CA, the admin token, and the first call to `GET /api/v1/resources`.
- `63a524d` — **Simulate a month of OpenStack**: `make simulator-up` for `2026-07` at seed 1 with the `held-back` switch on, the clock at factor 744 then stopped with `PUT /clock`, 15643 notifications published and 84 held, 1728 consumed and 13915 skipped by the collector, and the first `image.create` read back.
- `6fd03cd` — **Meter and rate your first month**: the four engine variables and the VictoriaMetrics port-forward, the pricing import, one run of `2026-07` with its 38 metering warnings attributed per tenant, the JSON export under `~/tally-tutorial/2026-07`, and a walk through the largest project statement.
- `84809ce` — **Watch the month in Grafana**: the health call, the four dashboards with the values the run produced, `TallyScrapeTargetDown` firing for `ceilometer`, the Alertmanager read with its runbook URL, and the end state the billing track (#110) picks up, item by item.
- `920d7a2` — **Tear down your local Tally**: `make simulator-down`, `make down`, the file and directory the lessons wrote, the seven variables, and the four images that stay.
- `b631a57` — the index becomes the track overview: what a tutorial promises, the core track as an ordered list, the billing track named without a link, and the simulated cloud's counts (15727 notifications, 1812 billable, 84 held).

## Provenance of the shown output

One run in lesson order on 2026-09-07 at commit d0d5905, on macOS 15.7.4 with Docker Desktop 4.86.0 (6 CPUs, 8 GB), kind v0.32.0, kubectl v1.36.1, Go 1.27.1 toolchain over host go1.26.1, jq 1.8.1, curl 8.7.1, git 2.51.0. Lesson 1 ran 11:33 to 12:33 UTC (four `make up` calls, three image-pull timeouts), lessons 2 to 4 ran 12:34 to 12:53 UTC, and lesson 5 ran last at 13:24 UTC. Every `text` and `json` fence line was checked against the run transcripts with `grep -Fxq`; the transcripts stay outside the repository.

## Notes for the reviewer

- **Four places where the run contradicted the issue's literal expectation.** Each lesson pastes what the run printed and says so. `virtual_now` after `PUT /clock {"factor": 0}` stays at the rebase instant, not at `2026-08-01T00:00:00Z`, because the clock stops advancing at factor 0. The section 5 metrics query as written answers an empty result at the wall clock, so lesson 2 shows the same call with `time=2026-08-01T00:00:00Z` and a `[31d]` window answering 667, then the literal call's empty answer as the mismatch. `.line_items[0]` of the largest statement is a floating IP, so lesson 3 adds one `jq` read selecting the first instance line item to show `egress_gb`. With `held-back` alone the run recorded 38 `history_starts_without_create` warnings across 28 instances, 9 volumes and 1 floating IP, not only CI runners; lesson 3 attributes all of them.
- **Two transcripts are cut, not edited.** The `make simulator-up` block is shown as two verbatim cuts with the compose pull and container lines between them summarised in prose, because on a pipe they are a 500-line event stream. The `make up` block starts at `Stack is up:` as the issue asks.
- **Lesson 4's panel values were read off the store with the panels' own expressions**, and the folder and dashboard titles through Grafana's API as the anonymous viewer, not by eye. The certificate-warning sentence is therefore generic.
- **The 13:00 UTC lifecycle tick during the run moved `2026-07` and `2026-08` to `grace` and billed nothing.** On a reader's cluster a later tick bills `2026-08`; no lesson depends on it.
- **Lesson 3's `jq .stats` block was reduced from 283 to 68 lines** by counting the metering warnings per resource type instead of listing 38 UUIDs. The new filter was run through the real `jq 1.8.1` against the pasted `.stats` document and matches byte for byte.
- `go test ./docs/` and `make docs-build` pass on HEAD. `go test` over the other 57 packages passed on the implementation commit; no Go code changes on this branch. `make lint` was skipped because no Go code changed and the host's golangci-lint does not match the module's toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)