### PR TITLE
Stop make up leaving a cluster whose migrations never ran

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,13 @@ TALLY_DEV_ENGINE_DB_URL ?= postgres://tally:tally-dev-password@db.tally.127-0-0-
 # shell once and stores the result, so whatever the manifest carries here is
 # what `docker run` below is handed: a class that admitted ';' or '$$' would let
 # a manifest line decide what CI runs.
+# Every image the stack runs that is not built here, read out of the manifests
+# for the same reason and with the same care as the two below: the class admits
+# what a repository and a tag may hold and nothing else, so no manifest line can
+# decide what `up` pulls. The `:dev` tags are what `images` builds, and the
+# SERVICES loop of `up` puts those on the node.
+NODE_IMAGES := $(shell grep -rhoE 'image: [A-Za-z0-9._/-]+:[A-Za-z0-9._-]+' deploy/kubernetes/base | sed 's/^image: //' | grep -v ':dev$$' | sort -u)
+
 VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' deploy/kubernetes/base/vmalert/vmalert.yaml | head -n1)
 ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
 
@@ -152,6 +159,27 @@ up:
 	@echo '==> loading images into the cluster'
 	@for service in $(SERVICES); do \
 		kind load docker-image "$$service:dev" --name '$(CLUSTER_NAME)'; \
+	done
+	@# A kind node holds none of the stack's other images on the first `make up`,
+	@# so it pulls each of them itself, one at a time, inside the readiness waits
+	@# below. That is where `up` used to end: on the machine the tutorials were
+	@# captured on the node spent half an hour on TimescaleDB alone, past the
+	@# budget of its wait, while the host Docker already held that very image. So
+	@# the host's copy goes onto the node here, where nothing is timing it, and
+	@# only an image the host lacks is fetched at all. It is what the phase 3
+	@# drill did by hand, docs/drills/phase3.md, before `up` did it.
+	@#
+	@# An image the node already carries is skipped, which is what keeps a second
+	@# `make up` from moving every one of them again.
+	@for image in $(NODE_IMAGES); do \
+		if docker exec '$(CLUSTER_NAME)-control-plane' crictl inspecti "$$image" >/dev/null 2>&1; then \
+			continue; \
+		fi; \
+		docker image inspect "$$image" >/dev/null 2>&1 || { \
+			echo "==> pulling $$image"; \
+			docker pull --quiet "$$image" >/dev/null; \
+		}; \
+		kind load docker-image "$$image" --name '$(CLUSTER_NAME)'; \
 	done
 	@echo '==> applying the dev overlay'
 	$(KUBECTL) apply -k $(DEV_OVERLAY)

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,31 @@ COMPOSE := docker compose -f deploy/compose/compose.yaml
 KUBE_CONTEXT := kind-$(CLUSTER_NAME)
 KUBECTL := kubectl --context $(KUBE_CONTEXT)
 
+# How long one readiness wait may take, and how many of them a rollout gets. The
+# product is the budget. A first `make up` on a fresh node pulls every image the
+# stack runs, and a pull outlasting one wait is the normal case on a slow line
+# rather than a fault: TimescaleDB, the largest at 555 MB, took fifteen minutes
+# on the machine the tutorials were captured on, where a single five-minute wait
+# ended the run three times over and left a stack whose migration chain had
+# never been applied. So an expired wait is repeated, which leaves a pull that is
+# still running to finish, while a rollout that is genuinely stuck still ends the
+# run once the budget is spent.
+WAIT_TIMEOUT ?= 300s
+WAIT_ATTEMPTS ?= 6
+
+# await runs one readiness wait under that budget. $(1) is the kubectl arguments
+# to wait with, without the timeout, and $(2) is what the messages call the thing
+# waited on.
+#
+# The failure names what stopping here costs, because the expensive one is
+# silent: `up` applies the two migration chains after these waits, the Reporting
+# API never migrates on its own, and its readiness probe answers 503 for as long
+# as its database carries no schema. A reader who does not know that sees a pod
+# sitting at 0/1 and no reason for it.
+define await
+	@attempt=1; 	until $(KUBECTL) $(1) --timeout=$(WAIT_TIMEOUT); do 		if [ "$$attempt" -ge '$(WAIT_ATTEMPTS)' ]; then 			echo '' >&2; 			echo 'ERROR: $(2) did not become ready in $(WAIT_ATTEMPTS) waits of $(WAIT_TIMEOUT).' >&2; 			echo '       make up stops here, so the stack is incomplete. Stopping before' >&2; 			echo '       the migration chain leaves the Reporting API at 0/1 until a later' >&2; 			echo '       make up applies it: it never migrates on its own.' >&2; 			echo '       kubectl --context $(KUBE_CONTEXT) get pods -A, and the events of' >&2; 			echo '       the pod that is not ready, say why it is not.' >&2; 			echo '       make up is safe to run again: it reuses the cluster and carries on.' >&2; 			exit 1; 		fi; 		attempt=$$((attempt + 1)); 		echo '==> $(2) is not ready after $(WAIT_TIMEOUT); the node may still be pulling an image, waiting again ('"$$attempt"'/$(WAIT_ATTEMPTS))'; 	done
+endef
+
 # Reaches TimescaleDB through the Gateway's TCP listener, which is the same path
 # a developer's psql takes.
 TALLY_DEV_DB_URL ?= postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable
@@ -107,12 +132,12 @@ up:
 	fi
 	@echo '==> installing cert-manager $(CERT_MANAGER_VERSION)'
 	$(KUBECTL) apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager --timeout=300s
-	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager-webhook --timeout=300s
-	$(KUBECTL) -n cert-manager rollout status deployment/cert-manager-cainjector --timeout=300s
+	$(call await,-n cert-manager rollout status deployment/cert-manager,cert-manager)
+	$(call await,-n cert-manager rollout status deployment/cert-manager-webhook,the cert-manager webhook)
+	$(call await,-n cert-manager rollout status deployment/cert-manager-cainjector,the cert-manager cainjector)
 	@echo '==> installing Envoy Gateway $(ENVOY_GATEWAY_VERSION)'
 	$(KUBECTL) apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/$(ENVOY_GATEWAY_VERSION)/install.yaml
-	$(KUBECTL) -n envoy-gateway-system rollout status deployment/envoy-gateway --timeout=300s
+	$(call await,-n envoy-gateway-system rollout status deployment/envoy-gateway,Envoy Gateway)
 	@echo '==> checking for the experimental Gateway API channel'
 	@$(KUBECTL) get crd tcproutes.gateway.networking.k8s.io >/dev/null 2>&1 || { \
 		echo 'ERROR: the TCPRoute CRD is missing, so Postgres cannot be routed.' >&2; \
@@ -130,19 +155,19 @@ up:
 	done
 	@echo '==> applying the dev overlay'
 	$(KUBECTL) apply -k $(DEV_OVERLAY)
-	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/timescaledb --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/victoriametrics --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/otel-collector --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/grafana --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) rollout status statefulset/alertmanager --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/vmalert --timeout=300s
-	$(KUBECTL) -n $(NAMESPACE) wait gateway/tally --for=condition=Programmed --timeout=300s
+	$(call await,-n $(NAMESPACE) rollout status statefulset/timescaledb,TimescaleDB)
+	$(call await,-n $(NAMESPACE) rollout status statefulset/victoriametrics,VictoriaMetrics)
+	$(call await,-n $(NAMESPACE) rollout status deployment/otel-collector,the OpenTelemetry collector)
+	$(call await,-n $(NAMESPACE) rollout status deployment/grafana,Grafana)
+	$(call await,-n $(NAMESPACE) rollout status statefulset/alertmanager,Alertmanager)
+	$(call await,-n $(NAMESPACE) rollout status deployment/vmalert,vmalert)
+	$(call await,-n $(NAMESPACE) wait gateway/tally --for=condition=Programmed,the Gateway)
 	@# The API stays unready until the database carries its schema, and it never
 	@# migrates on its own, so the chain has to be applied before the rollout can
 	@# finish. It runs through the Gateway, which is what the wait above is for.
 	@echo '==> applying the migration chain'
 	$(MAKE) migrate
-	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/reporting-api --timeout=300s
+	$(call await,-n $(NAMESPACE) rollout status deployment/reporting-api,the Reporting API)
 	@echo
 	@echo 'Stack is up:'
 	@echo '  https://api.tally.127-0-0-1.nip.io:8443/api/v1        Reporting API'

--- a/docs/tutorials/set-up-your-local-tally.md
+++ b/docs/tutorials/set-up-your-local-tally.md
@@ -18,7 +18,7 @@ At the end you have a running Tally answering on
 shell, and the CA certificate in `tally-ca.crt` at the repository root. That is
 the state the rest of this track starts from.
 
-This lesson takes about 60 minutes.
+This lesson takes about 30 minutes, most of it `make up` moving images.
 
 ## Before you start
 
@@ -45,9 +45,11 @@ This lesson takes about 60 minutes.
 - No kind cluster named `tally` on the machine. `kind get clusters` printed
   `No kind clusters found.` on the run. If it prints `tally`, tear that cluster
   down with the `make down` of lesson 5 first.
-- 10 GB of free disk for Docker Desktop. Its usage grew by 9.5 GB over this
-  lesson on the run, measured with `docker system df` before and after across
-  images, volumes and build cache.
+- 13 GB of free disk for Docker Desktop, measured with `docker system df`
+  across images, volumes and build cache. The eight images the stack runs come
+  to 3.3 GB and are held twice from here on, once by Docker and once inside the
+  node, which is what lets `make up` copy them onto the node instead of leaving
+  it to fetch them.
 
 ## Get the code
 
@@ -97,10 +99,10 @@ This lesson takes about 60 minutes.
    `==> creating kind cluster tally`, installs cert-manager v1.21.1 and Envoy
    Gateway v1.8.3 and waits for their rollouts, applies the dev certificate
    authority, builds the four images (`tally-reporting`, `tally-engine`,
-   `tally-openstack-collector` and `tally-openstack-simulator`), loads them into
-   the cluster, applies the dev overlay, and applies the two migration chains,
-   the reporting one and the engine one. Several hundred lines go by. These are
-   the last ones:
+   `tally-openstack-collector` and `tally-openstack-simulator`), puts those and
+   the eight images the stack runs on the node, applies the dev overlay, and
+   applies the two migration chains, the reporting one and the engine one.
+   Several hundred lines go by. These are the last ones:
 
    ```text
    Stack is up:
@@ -118,25 +120,52 @@ This lesson takes about 60 minutes.
    The seven URLs and the last line have to match exactly. Everything above
    them differs in timing and in the ids Kubernetes hands out.
 
-2. Read the error if `make up` stopped on a rollout instead of printing that
-   block. The run behind this page needed four calls. The first ended after
-   eight minutes under
-   `kubectl --context kind-tally -n envoy-gateway-system rollout status
-   deployment/envoy-gateway --timeout=300s`:
+2. Leave it alone while it moves the images. A new node carries none of them,
+   so the step before the overlay puts all twelve there: the four built above,
+   and the eight the stack runs. An image your Docker already holds is copied
+   straight onto the node, and only an image it lacks is fetched from the
+   network, which is what the `==> pulling` lines are:
 
    ```text
-   Waiting for deployment "envoy-gateway" rollout to finish: 0 of 1 updated replicas are available...
-   error: timed out waiting for the condition
+   ==> pulling busybox:1.37
+   Image: "busybox:1.37" with ID "sha256:6df9636795d37473994366014c25264edeb6c00d7a57188ff62d5a94276b4297" not yet present on node "tally-control-plane", loading...
+   ```
+
+   The run behind this page fetched three of the eight and copied the other
+   five, `make up` took seventeen minutes end to end, and every pod was ready
+   two minutes after the overlay went on. Which of the eight are fetched is
+   your machine's, and a second `make up` moves none of them: an image the node
+   already carries is skipped.
+
+3. Let it wait if a readiness wait expires. One is given five minutes, and an
+   expired one is repeated rather than ending the run:
+
+   ```text
+   ==> TimescaleDB is not ready after 300s; the node may still be pulling an image, waiting again (2/6)
+   ```
+
+   An `error: timed out waiting for the condition` above such a line is that
+   wait expiring, not a fault. Six waits is the budget one rollout gets, half
+   an hour; `make up WAIT_ATTEMPTS=12` doubles it, and `WAIT_TIMEOUT` changes
+   how long one wait lasts. cert-manager and Envoy Gateway install from their
+   own manifests, so the node still fetches their images itself, and those are
+   the waits most likely to repeat.
+
+4. Read the error if `make up` stopped instead of printing that block. A
+   rollout that never comes up spends the budget and ends the run:
+
+   ```text
+   ERROR: TimescaleDB did not become ready in 6 waits of 300s.
+          make up stops here, so the stack is incomplete. Stopping before
+          the migration chain leaves the Reporting API at 0/1 until a later
+          make up applies it: it never migrates on its own.
+          kubectl --context kind-tally get pods -A, and the events of
+          the pod that is not ready, say why it is not.
+          make up is safe to run again: it reuses the cluster and carries on.
    make: *** [up] Error 1
    ```
 
-   The second ended on the same error under the `statefulset/timescaledb`
-   rollout, the third on `error: deployment "reporting-api" exceeded its
-   progress deadline`. Each time the node was still pulling an image: the
-   cluster pulls its images on the first `make up`, and a slow network outlasts
-   the five-minute rollout timeout.
-
-3. Wait until every pod but `reporting-api` reads `Running` before the next
+5. Wait until every pod but `reporting-api` reads `Running` before the next
    call:
 
    ```sh
@@ -172,14 +201,15 @@ This lesson takes about 60 minutes.
    `make up` applies the two chains after the rollouts it waited on. So run
    `make up` again once the other pods read `Running`: against a cluster that
    already exists it reuses it, applies the overlay again, applies both chains
-   and prints the block above. The fourth call did that in 16 seconds.
+   and prints the block above. It moves no image it moved before, so a repeated
+   call is short.
 
    `==> kind cluster tally already exists` as the first line of a first
    `make up` means a cluster from an earlier run of this track is still on the
    machine. Tear it down with the `make down` of lesson 5 and start over. On a
    repeated call after a timeout that line is the expected one.
 
-4. Read the pods once `make up` has printed its block:
+6. Read the pods once `make up` has printed its block:
 
    ```sh
    kubectl --context kind-tally -n tally get pods

--- a/docs/tutorials/set-up-your-local-tally.md
+++ b/docs/tutorials/set-up-your-local-tally.md
@@ -4,7 +4,7 @@ description: Create a kind cluster with the Tally dev overlay, trust its certifi
 quadrant: tutorial
 audience: all
 ---
-<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+<!-- Shown output captured on 2026-09-07 from commit 789d782 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
 
 # Set up your local Tally
 
@@ -78,11 +78,11 @@ This lesson takes about 60 minutes.
    ```
 
    ```text
-   d0d5905
+   789d782
    ```
 
    A newer commit is fine. Every output this page shows comes from a run at
-   `d0d5905`. Every command from here on runs from this directory, the
+   `789d782`. Every command from here on runs from this directory, the
    repository root.
 
 ## Create the cluster and bring the stack up
@@ -136,7 +136,8 @@ This lesson takes about 60 minutes.
    cluster pulls its images on the first `make up`, and a slow network outlasts
    the five-minute rollout timeout.
 
-3. Wait until every pod of the stack is `Running` before the next call:
+3. Wait until every pod but `reporting-api` reads `Running` before the next
+   call:
 
    ```sh
    kubectl --context kind-tally -n tally get pods
@@ -144,27 +145,65 @@ This lesson takes about 60 minutes.
 
    ```text
    NAME                             READY   STATUS    RESTARTS   AGE
-   alertmanager-0                   1/1     Running   0          33m
-   grafana-6c58589c8b-fjpjz         2/2     Running   0          33m
-   otel-collector-599c64db4-9m2hv   1/1     Running   0          33m
-   reporting-api-6b8ffd9598-bvxnn   1/1     Running   0          33m
-   tally-engine-29813040-6kd9c      0/1     Error     0          32m
-   timescaledb-0                    1/1     Running   0          33m
-   victoriametrics-0                1/1     Running   0          33m
-   vmalert-7699459f4-t89tm          1/1     Running   0          33m
+   alertmanager-0                   1/1     Running   0          37m
+   grafana-6c58589c8b-fg4tm         2/2     Running   0          37m
+   otel-collector-599c64db4-vbh2z   1/1     Running   0          37m
+   reporting-api-6b8ffd9598-smsw8   0/1     Running   0          37m
+   timescaledb-0                    1/1     Running   0          37m
+   victoriametrics-0                1/1     Running   0          37m
+   vmalert-7699459f4-gf2nc          1/1     Running   0          37m
    ```
 
-   The names carry ids of their own and the ages are your machine's. The
-   `tally-engine-<id>` pod is a Job of the hourly scheduler, and it shows
-   `Error` until lesson 3 imports a pricing model, which is expected here.
-   Every other pod reads `Running`. Then run `make up` again: against a cluster
-   that already exists it reuses it, applies the overlay again and prints the
-   block above. The fourth call did that in 16 seconds.
+   The names carry ids of their own and the ages are your machine's.
+   `reporting-api` reads `0/1` here, and waiting does not change it: a
+   `make up` that stopped on a rollout never reached its migration step, and
+   the API holds itself unready while its database carries no schema. Its log
+   says so once per readiness probe:
+
+   ```sh
+   kubectl --context kind-tally -n tally logs deployment/reporting-api | grep readiness | tail -1
+   ```
+
+   ```text
+   {"time":"2026-09-07T18:57:55.783841918Z","level":"WARN","msg":"readiness probe could not use the database","service":"tally-reporting","request_id":"4bc504a2-732d-4902-8c80-d04cd5e5ed2e","error":"reading the schema version: ERROR: relation \"goose_db_version\" does not exist (SQLSTATE 42P01)"}
+   ```
+
+   `goose_db_version` is the table a migration chain records itself in, and
+   `make up` applies the two chains after the rollouts it waited on. So run
+   `make up` again once the other pods read `Running`: against a cluster that
+   already exists it reuses it, applies the overlay again, applies both chains
+   and prints the block above. The fourth call did that in 16 seconds.
 
    `==> kind cluster tally already exists` as the first line of a first
    `make up` means a cluster from an earlier run of this track is still on the
    machine. Tear it down with the `make down` of lesson 5 and start over. On a
    repeated call after a timeout that line is the expected one.
+
+4. Read the pods once `make up` has printed its block:
+
+   ```sh
+   kubectl --context kind-tally -n tally get pods
+   ```
+
+   ```text
+   NAME                             READY   STATUS      RESTARTS   AGE
+   alertmanager-0                   1/1     Running     0          41m
+   grafana-6c58589c8b-fg4tm         2/2     Running     0          41m
+   otel-collector-599c64db4-vbh2z   1/1     Running     0          41m
+   reporting-api-6b8ffd9598-smsw8   1/1     Running     0          41m
+   tally-engine-29813460-mhpnt      0/1     Completed   0          4m18s
+   timescaledb-0                    1/1     Running     0          41m
+   victoriametrics-0                1/1     Running     0          41m
+   vmalert-7699459f4-gf2nc          1/1     Running     0          41m
+   ```
+
+   `reporting-api` reads `1/1` now: the chain that call applied gave the
+   readiness probe the schema it asks for. Every other long-running pod reads
+   `Running`. The `tally-engine-<id>` pod is a Job of the hourly scheduler and
+   appears once the clock has passed an hour mark. Its first tick moves the
+   month that has ended into its grace window and reads `Completed`; a later
+   tick meters that month, finds no pricing model and reads `Error`, which is
+   expected until lesson 3 imports one.
 
 ## Trust the dev CA
 

--- a/docs/tutorials/simulate-a-month-of-openstack.md
+++ b/docs/tutorials/simulate-a-month-of-openstack.md
@@ -4,7 +4,7 @@ description: Start the simulator stack beside the dev cluster, publish one gener
 quadrant: tutorial
 audience: all
 ---
-<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+<!-- Shown output captured on 2026-09-07 from commit 789d782 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
 
 # Simulate a month of OpenStack
 
@@ -306,10 +306,13 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    {"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1785542400,"667"]}]},"stats":{"seriesFetched": "667","executionTimeMsec":2}}
    ```
 
-   667 has to match, the instances of the month that pushed traffic. The series
-   carry July 2026 timestamps, which is why the query is asked at the end of
-   the month with `time` and over a window that spans the month, and why lesson
-   4 sets the dashboards' time range to July.
+   667 has to match, the instances of the month that pushed traffic. A smaller
+   count means the simulator is still pushing the month's series, which it goes
+   on doing after the last notification is out; repeat the read until it stands
+   at 667, which took another minute on the run. The series carry July 2026
+   timestamps, which is why the query is asked at the end of the month with
+   `time` and over a window that spans the month, and why lesson 4 sets the
+   dashboards' time range to July.
 
    The plain instant query, without the window and without `time`, is evaluated
    at the wall clock, where the month's series ended a month ago:

--- a/docs/tutorials/tear-down-your-local-tally.md
+++ b/docs/tutorials/tear-down-your-local-tally.md
@@ -4,7 +4,7 @@ description: Stop the simulator stack, delete the kind cluster, and remove the f
 quadrant: tutorial
 audience: all
 ---
-<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+<!-- Shown output captured on 2026-09-07 from commit 789d782 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
 
 # Tear down your local Tally
 
@@ -109,7 +109,9 @@ This lesson takes about 5 minutes.
    ```
 
    The line has to match. It is the state lesson 1 starts from. A second
-   `make down` prints `kind cluster tally does not exist` and changes nothing.
+   `make down` prints that same line again, from the check it makes before it
+   deletes anything, and then `kind cluster tally does not exist`. It changes
+   nothing.
 
 ## Remove what the lessons wrote
 

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -4,7 +4,7 @@ description: Open the dev cluster's Grafana as an anonymous viewer, point its fo
 quadrant: tutorial
 audience: all
 ---
-<!-- Shown output captured on 2026-09-07 from commit d0d5905 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+<!-- Shown output captured on 2026-09-07 from commit 789d782 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
 
 # Watch the month in Grafana
 
@@ -130,8 +130,11 @@ This lesson takes about 5 minutes.
    month the CI tenant peaked at 10 and the large Gardener tenant at 11.
 
 2. `Tally / Ingestion Health`. With `Last 3 hours`, `Event ingest rate` shows
-   one spike over the minutes the month went out, up to about five events per
-   second for cloud `os-sim` and source `collector`, 1728 events in all.
+   one spike for cloud `os-sim` and source `collector` over the minutes the
+   month went out, 1728 events in all. How high the spike stands is your
+   machine's, because it is those events over the span the collector took to
+   drain its outbox: about five events per second where that took three
+   minutes, and above 30 where it took half a minute.
 
    `Dedup rate` and `Rejected events` draw nothing, because the month carried
    no duplicate and no item was rejected, so those counters were never written.


### PR DESCRIPTION
## What broke

A `reporting-api` pod on a running dev cluster sat at `0/1 Running`, its readiness probe answering 503:

```
"readiness probe could not use the database"
error: reading the schema version: ERROR: relation "goose_db_version" does not exist (SQLSTATE 42P01)
```

Neither migration chain had ever been applied. The events give the reason: the node's pull of `timescale/timescaledb:latest-pg16` took **15m28s**, so `rollout status statefulset/timescaledb --timeout=300s` timed out and `make up` aborted — before `make migrate`, the step that applies both chains. The abort printed `make: *** [up] Error 1` and nothing else, so the pod stayed unready with no reason given.

This is not new. `docs/drills/phase3.md` records the same failure from another machine, where the cluster took three `make up` calls, and lesson 1 of the tutorials was written around a run that needed four.

## The cause

A kind node carries no images when it is created, so every image of the stack came over the network *after* the overlay was applied — one at a time, inside the readiness waits. Meanwhile the host Docker, the same daemon that builds the `tally-*:dev` images `make up` already side-loads, **held those images all along**. The drill record describes doing this by hand as the workaround: load what the host has, pull the few it lacks, run `make up` again.

## What this changes

**`make up` puts the images on the node itself**, before it applies the overlay. `NODE_IMAGES` is read out of the manifests, the way `VMALERT_IMAGE` and `ALERTMANAGER_IMAGE` already are. An image the node already carries is skipped, so a second `make up` moves none of them; an image the host lacks is pulled there, where nothing is timing it.

**A readiness wait that expires is repeated** rather than ending the run, through a new `await` helper:

```
==> TimescaleDB is not ready after 300s; the node may still be pulling an image, waiting again (2/6)
```

The budget is `WAIT_ATTEMPTS` waits of `WAIT_TIMEOUT`, six of five minutes, both overridable. This stays as the net for cert-manager and Envoy Gateway, which install from their own upstream manifests and whose images the node still fetches. A rollout that never comes up still fails, and now says what stopping there costs and that `make up` is safe to repeat.

**The tutorials say what the commands now do.** Lesson 1's recovery step told the reader to wait until every pod reads `Running` and showed `reporting-api` at `1/1` — a state unreachable there, because without the migration chain the pod never becomes ready. That instruction was an indefinite wait, and it is how the cluster above got into its state. Three more outputs across lessons 2, 4 and 5 were corrected, each listed in the commit that makes it.

## How it was verified

Three full `make up` runs from an empty machine, plus one end-to-end pass of the whole core track at `789d782` — the simulated month, metering and rating, the dashboards, the teardown — with every output on the five pages read back against the page that shows it.

| Run | Result |
|---|---|
| Before, tutorial's own | four calls |
| Before, drill record | three calls |
| Before, this branch's baseline | **failed** after 30 min, budget spent on one image the host already had |
| After | **one call**, 17 min, zero repeated waits, every pod ready 2 min after the overlay |

Everything on the tutorial pages held byte for byte except the four corrected here — including the whole of lesson 3 (`metered 867 candidates into 945 usage records, 3101 rated records`, all six statement totals, both line items) and every panel value of lesson 4, read off the store with the panels' own expressions.

Both paths of `await` were exercised against a stub `kubectl` before the real runs, and both were then seen for real. `go test ./docs/` and `make docs-build` are green.

## Note for the reviewer

The disk prerequisite in lesson 1 goes from 10 GB to 13 GB. The stack's images are held twice now, once by Docker and once inside the node, which is exactly what lets them be copied instead of fetched; they come to 3.3 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZjSW6CYqLUiezfecS1ST7