### PR TITLE
Write the billing tutorial track: finalization, corrections, commercial pricing and attribution

### DIFF
--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -32,7 +32,8 @@
             { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" },
             { "text": "Pay a reseller a kickback", "link": "/tutorials/pay-a-reseller-a-kickback" },
             { "text": "Attribute a tenant to its Gardener project", "link": "/tutorials/attribute-a-tenant-to-its-gardener-project" },
-            { "text": "Finalize the month and export it", "link": "/tutorials/finalize-the-month-and-export-it" }
+            { "text": "Finalize the month and export it", "link": "/tutorials/finalize-the-month-and-export-it" },
+            { "text": "Book the late events as a credit note", "link": "/tutorials/book-the-late-events-as-a-credit-note" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -31,7 +31,8 @@
           "items": [
             { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" },
             { "text": "Pay a reseller a kickback", "link": "/tutorials/pay-a-reseller-a-kickback" },
-            { "text": "Attribute a tenant to its Gardener project", "link": "/tutorials/attribute-a-tenant-to-its-gardener-project" }
+            { "text": "Attribute a tenant to its Gardener project", "link": "/tutorials/attribute-a-tenant-to-its-gardener-project" },
+            { "text": "Finalize the month and export it", "link": "/tutorials/finalize-the-month-and-export-it" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -29,7 +29,8 @@
         {
           "text": "Billing track",
           "items": [
-            { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" }
+            { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" },
+            { "text": "Pay a reseller a kickback", "link": "/tutorials/pay-a-reseller-a-kickback" }
           ]
         }
       ]

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -25,6 +25,12 @@
             { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" },
             { "text": "Tear down your local Tally", "link": "/tutorials/tear-down-your-local-tally" }
           ]
+        },
+        {
+          "text": "Billing track",
+          "items": [
+            { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" }
+          ]
         }
       ]
     }

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -30,7 +30,8 @@
           "text": "Billing track",
           "items": [
             { "text": "Discount a customer group", "link": "/tutorials/discount-a-customer-group" },
-            { "text": "Pay a reseller a kickback", "link": "/tutorials/pay-a-reseller-a-kickback" }
+            { "text": "Pay a reseller a kickback", "link": "/tutorials/pay-a-reseller-a-kickback" },
+            { "text": "Attribute a tenant to its Gardener project", "link": "/tutorials/attribute-a-tenant-to-its-gardener-project" }
           ]
         }
       ]

--- a/docs/tutorials/attribute-a-tenant-to-its-gardener-project.md
+++ b/docs/tutorials/attribute-a-tenant-to-its-gardener-project.md
@@ -1,0 +1,485 @@
+---
+title: Attribute a tenant to its Gardener project
+description: Register the two Gardener projects and the tenants their shoots run on, relate each project to its tenant, see the registry refuse a cycle, run July 2026 again, and read the tenant's costs on the Gardener project's statement.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit 01d2aff with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Attribute a tenant to its Gardener project
+
+In this lesson you register the two Gardener projects of the simulated month and
+the two OpenStack tenants their shoots run on, relate each project to its tenant
+with an `infrastructure_tenant` relation, see the registry refuse the reverse
+relation as a cycle, run July 2026 again, and read the tenant's costs on the
+Gardener project's statement and nowhere else.
+
+At the end the registry holds every tenant of the month and both Gardener
+projects, `RUN_ID` names the run that attributes the two tenants, the JSON
+export of that run is under `~/tally-tutorial/2026-07-attributed`, and
+`ALPHA_TENANT_ID`, `BETA_TENANT_ID`, `ALPHA_ID` and `BETA_ID` are in the shell.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state [Pay a reseller a kickback](/tutorials/pay-a-reseller-a-kickback)
+  leaves:
+
+  - everything Discount a customer group left;
+  - the registry holding four tenants, the meta-project `acme`, the partner
+    `cloudhouse` and four relations;
+  - `RUN_ID` on the reseller run;
+  - the export under `~/tally-tutorial/2026-07-reseller`;
+  - `CI_ID` and `PARTNER_ID` in the shell.
+
+- `jq` 1.8.1 (`jq --version`).
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TALLY_API_TOKEN="$(go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'tutorial')"
+export TALLY_API_TOKEN
+export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+export TALLY_ENGINE_COUNTER_SOURCES=deploy/kubernetes/overlays/dev/counter-sources.yaml
+export TALLY_ENGINE_VM_URL=http://127.0.0.1:8428
+kubectl --context kind-tally -n tally port-forward svc/victoriametrics 8428:8428 &
+make -s ca > tally-ca.crt
+```
+
+A token is printed once, so a closed shell means a new token. The one you minted
+before stays valid until it is revoked, which takes the id on the
+`created api_tokens <id>` line the command printed beside it, so keep that line
+where you mean to revoke, the way
+[issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
+says. Every token this track mints goes with the cluster
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) removes.
+The port-forward line and the CA line are for a shell that lost them. `RUN_ID`
+is not needed before this lesson sets it anew, and this lesson reads none of
+the four `ACME_` variables, `CI_ID` or `PARTNER_ID`.
+
+A connection error from any `go run` command means the cluster is not up, and
+`kind get clusters` then prints nothing. `curl: (7)` on the API hostname means
+the same. Both are cured by
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
+
+## Register the Gardener projects and their tenants
+
+1. Register the tenant the shoots of `alpha` run on:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "005be5adeef3d87e280d03d9d57c38b4", "name": "Infrastructure tenant of alpha"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq .
+   ```
+
+   ```json
+   {
+     "cloud": "os-sim",
+     "created_at": "2026-09-07T21:28:08.425664Z",
+     "external_id": "005be5adeef3d87e280d03d9d57c38b4",
+     "id": "e9e6a14a-14c0-4fa6-95b2-6b284c873f0d",
+     "metadata": {},
+     "name": "Infrastructure tenant of alpha",
+     "platform": "openstack"
+   }
+   ```
+
+   This is the tenant with 309 resources and the largest statement of the
+   list-price run, 3661.32. It is `alpha`'s tenant because `alpha` runs two
+   shoots all month while `beta` runs one shoot for about two weeks:
+   [the Gardener projects](/explanation/the-simulated-openstack-world#the-gardener-projects).
+
+   `cloud` `os-sim`, `external_id`, `name` `Infrastructure tenant of alpha`,
+   `platform` `openstack` and `metadata` `{}` have to match. `id` and
+   `created_at` are your own.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a project with this cloud and external id is already registered` means this
+   step ran before, and the read-back below reads the id it needs anyway. A 401
+   with `type` `urn:tally:error:unauthorized` means `TALLY_API_TOKEN` is empty
+   in this shell, so mint one with the restore block above. A 403 with `type`
+   `urn:tally:error:forbidden` means the token is not an admin token.
+
+2. Register the other tenant and the two Gardener projects:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "e31f9083a7e5ee15071a3bd53cb2bac7", "name": "Infrastructure tenant of beta"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq -c '{id, cloud, external_id, name}'
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "gardener", "cloud": "garden-sim", "external_id": "alpha", "name": "Gardener project alpha"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq -c '{id, cloud, external_id, name}'
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "gardener", "cloud": "garden-sim", "external_id": "beta", "name": "Gardener project beta"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq -c '{id, cloud, external_id, name}'
+   ```
+
+   ```json
+   {"id":"75b72e57-da37-48db-adb8-fe00ac3f812a","cloud":"os-sim","external_id":"e31f9083a7e5ee15071a3bd53cb2bac7","name":"Infrastructure tenant of beta"}
+   {"id":"0fec01ef-dc9b-4a2e-9545-10b8ed64f77f","cloud":"garden-sim","external_id":"alpha","name":"Gardener project alpha"}
+   {"id":"c86423ed-e394-44a4-8e07-136fdd50e7dc","cloud":"garden-sim","external_id":"beta","name":"Gardener project beta"}
+   ```
+
+   `cloud`, `external_id` and `name` have to match on every line, and the ids
+   are your own.
+
+   A cloud is one installation of one platform, which is why the two Gardener
+   rows carry the cloud `garden-sim` and the platform `gardener` rather than the
+   tenants' `os-sim`. A Gardener project keyed under the tenants' cloud would be
+   a row of the OpenStack installation.
+
+   These are the rows the simulator's registration switch would have posted at
+   start, without its metadata:
+   [register simulated projects](/how-to/simulator/register-simulated-projects).
+
+   The same three refusals apply.
+
+3. Read the four ids back into the shell:
+
+   ```sh
+   ALPHA_TENANT_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=005be5adeef3d87e280d03d9d57c38b4' | jq -r '.items[0].id')"
+   BETA_TENANT_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=e31f9083a7e5ee15071a3bd53cb2bac7' | jq -r '.items[0].id')"
+   ALPHA_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=garden-sim&external_id=alpha' | jq -r '.items[0].id')"
+   BETA_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=garden-sim&external_id=beta' | jq -r '.items[0].id')"
+   export ALPHA_TENANT_ID BETA_TENANT_ID ALPHA_ID BETA_ID
+   echo "$ALPHA_TENANT_ID $BETA_TENANT_ID $ALPHA_ID $BETA_ID"
+   ```
+
+   ```text
+   e9e6a14a-14c0-4fa6-95b2-6b284c873f0d 75b72e57-da37-48db-adb8-fe00ac3f812a 0fec01ef-dc9b-4a2e-9545-10b8ed64f77f c86423ed-e394-44a4-8e07-136fdd50e7dc
+   ```
+
+   The four ids are your own, and they are the ids the calls above printed, in
+   that order. This read is what a reader who saw a 409 runs, because it reads
+   what is registered whether this shell registered it or not. An id printing
+   `null` means that registration did not happen, and the cure is the
+   registration above.
+
+## Relate each project to its tenant
+
+1. Name the tenant of the Gardener project `alpha`:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ALPHA_ID/relations" <<EOF | jq .
+   {
+     "target_id": "$ALPHA_TENANT_ID",
+     "relation_type": "infrastructure_tenant",
+     "valid_from": "2026-07-01T00:00:00Z"
+   }
+   EOF
+   ```
+
+   ```json
+   {
+     "created_at": "2026-09-07T21:28:08.615857Z",
+     "id": "700508b3-e5e4-42ce-be04-970febb813f9",
+     "metadata": {},
+     "relation_type": "infrastructure_tenant",
+     "source_id": "0fec01ef-dc9b-4a2e-9545-10b8ed64f77f",
+     "target_id": "e9e6a14a-14c0-4fa6-95b2-6b284c873f0d",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "valid_to": null
+   }
+   ```
+
+   The relation leaves the project that pays and reaches the project whose costs
+   move, so it starts at the Gardener project and names its tenant as
+   `target_id`. `infrastructure_tenant` is the one relation type the engine
+   attributes cost over by default (`TALLY_ENGINE_ATTRIBUTING_RELATION_TYPES`),
+   and it carries no adjustments.
+
+   `relation_type` `infrastructure_tenant`, `valid_from` `2026-07-01T00:00:00Z`,
+   `valid_to` null and `metadata` `{}` have to match. `id`, `source_id`,
+   `target_id` and `created_at` are your own. `valid_from` is the first instant
+   of July for the reason Discount a customer group gives.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a relation of this type between these projects is already active` means this
+   step ran before. A 400 with `type` `urn:tally:error:validation` whose error
+   is located at `body.target_id` means `ALPHA_TENANT_ID` is empty in this
+   shell.
+
+2. Name the tenant of `beta`:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$BETA_ID/relations" <<EOF | jq -c '{id, relation_type}'
+   {
+     "target_id": "$BETA_TENANT_ID",
+     "relation_type": "infrastructure_tenant",
+     "valid_from": "2026-07-01T00:00:00Z"
+   }
+   EOF
+   ```
+
+   ```json
+   {"id":"cc791285-89f8-4c22-ba4e-7ee34b701853","relation_type":"infrastructure_tenant"}
+   ```
+
+   `relation_type` has to match, and the id is your own.
+
+3. Walk what `alpha` attributes:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ALPHA_ID/related?relation_type=infrastructure_tenant" | jq '.items[] | {depth, relation_type, project: .project.external_id}'
+   ```
+
+   ```json
+   {
+     "depth": 1,
+     "relation_type": "infrastructure_tenant",
+     "project": "005be5adeef3d87e280d03d9d57c38b4"
+   }
+   ```
+
+   The walk goes one relation out of `alpha` and reaches its tenant at `depth` 1
+   over `infrastructure_tenant`. `project` is the tenant's external id and has
+   to match, as do the depth and the type.
+
+## See the registry refuse a cycle
+
+1. Send the same relation the other way round:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ALPHA_TENANT_ID/relations" <<EOF | jq .
+   {
+     "target_id": "$ALPHA_ID",
+     "relation_type": "infrastructure_tenant",
+     "valid_from": "2026-07-01T00:00:00Z"
+   }
+   EOF
+   ```
+
+   ```json
+   {
+     "type": "urn:tally:error:relation_cycle",
+     "title": "Relation cycle",
+     "status": 422,
+     "detail": "this relation would close a cycle over the relation types that attribute cost"
+   }
+   ```
+
+   The reverse relation would let the tenant attribute the project that already
+   attributes it, and attribution is a forest. The registry walks the
+   attributing relations out of the target first, finds the source, and answers
+   422 without writing anything. `type` `urn:tally:error:relation_cycle`,
+   `status` 422 and the detail
+   `this relation would close a cycle over the relation types that attribute cost`
+   have to match.
+
+## Run the month
+
+1. Meter and rate July 2026 once more:
+
+   ```sh
+   go run ./cmd/tally-engine run --period 2026-07
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 completed for 2026-07 with pricing model 2026-03
+   metered 867 candidates into 945 usage records, 3101 rated records and 6 project statements
+   applied 5 pricing adjustments
+   superseded run 72584a66-9bb2-4d5b-9cf2-fa43fcb6e886
+   warnings recorded in runs.stats: 38 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 0 unregistered projects
+   ```
+
+   The `metered` line, `applied 5 pricing adjustments` and the warnings line
+   have to match. Both run ids are your own, and the superseded one is the run
+   Pay a reseller a kickback made.
+
+   The statement count stays 6: the four tenants billed on their own and the two
+   Gardener projects, while the two Gardener tenants get no statement. The
+   warnings line reads `0 attribution`, so no tenant was claimed twice or sat in
+   a cycle, and it ends in `0 unregistered projects`: the registry now holds
+   every tenant of the month.
+
+2. Put the id from the first line of your own output in place of this one:
+
+   ```sh
+   export RUN_ID=77fb51f8-82c9-4d52-98a2-7fd3e0b43c53
+   ```
+
+   Every command below reads `RUN_ID`.
+
+3. Read what stands there instead if the run printed something else:
+
+   - A non-zero `attribution` count on the warnings line means a second path
+     claimed one of the tenants, and
+     `GET /api/v1/projects/$ALPHA_TENANT_ID/relations?direction=incoming`,
+     called with the `curl` prefix of the steps above, lists the relations that
+     reach it.
+   - `no pricing model is valid for this period` means the model Meter and rate
+     your first month imported is missing. Import it and run the month again.
+   - An error opening on `another run of this period is in progress` means
+     another `tally-engine run` of this period is live, in this shell or in
+     another one. Let that run end; the hourly tick is not it, because the tick
+     leaves a month that already carries a completed run alone.
+   - A non-zero `counter` count on the warnings line means the port-forward died
+     before the run read the store. Start it again and run the month again.
+   - `reading the counter sources deploy/kubernetes/overlays/dev/counter-sources.yaml: open deploy/kubernetes/overlays/dev/counter-sources.yaml: no such file or directory`
+     means the shell is not at the repository root, or
+     `TALLY_ENGINE_COUNTER_SOURCES` is not exported.
+
+## Read the attributed statement
+
+1. Export the run:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07-attributed
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-attributed
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 1 kickbacks
+   ```
+
+   The second and the third line have to match. The run id and the home
+   directory are your own.
+
+2. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07-attributed
+   ```
+
+   ```text
+   kickbacks.json
+   run.json
+   statement-garden-sim%2Falpha.json
+   statement-garden-sim%2Fbeta.json
+   statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   statement-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json
+   statement-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json
+   ```
+
+   The eight names have to match. `statement-garden-sim%2Falpha.json` and
+   `statement-garden-sim%2Fbeta.json` stand beside four
+   `statement-os-sim%2F<id>.json` files, and neither Gardener tenant has a
+   statement any more.
+
+3. Read what the Gardener project `alpha` owes:
+
+   ```sh
+   jq '{project_id, platform, own_items: (.line_items | length), related_costs: [.related_costs[] | {relation_type, project_id, platform, items: (.line_items | length), total}], total}' ~/tally-tutorial/2026-07-attributed/statement-garden-sim%2Falpha.json
+   ```
+
+   ```json
+   {
+     "project_id": "alpha",
+     "platform": "gardener",
+     "own_items": 0,
+     "related_costs": [
+       {
+         "relation_type": "infrastructure_tenant",
+         "project_id": "005be5adeef3d87e280d03d9d57c38b4",
+         "platform": "openstack",
+         "items": 309,
+         "total": 3661.32
+       }
+     ],
+     "total": 3661.32
+   }
+   ```
+
+   `alpha` has 0 line items of its own and one related cost, of type
+   `infrastructure_tenant`, for `005be5adeef3d87e280d03d9d57c38b4` on platform
+   `openstack`, with 309 items and the total 3661.32, and its statement total is
+   3661.32. All of it has to match. The 309 line items are the ones Meter and
+   rate your first month read on the tenant's own statement, moved whole under
+   `related_costs`.
+
+## See that nothing is billed twice
+
+1. List every statement of the run with its total:
+
+   ```sh
+   jq -r '.statements[] | "\(.cloud)/\(.project_id)\t\(.total)"' ~/tally-tutorial/2026-07-attributed/run.json
+   ```
+
+   ```text
+   garden-sim/alpha	3661.32
+   garden-sim/beta	651.24
+   os-sim/018504a6cc10019a40e3f9eef4dae529	788.97
+   os-sim/10e287d5788957a2a331cabd1b5dccdf	593.55
+   os-sim/34e991db9fc6466f8ca69b43f70fce65	538.55
+   os-sim/d5a8024946ddf673277b9e2490643a2c	814.59
+   ```
+
+   Six statements: the two Gardener projects at their tenants' totals, 3661.32
+   and 651.24, and the four tenants at the totals the two lessons before
+   produced. All six have to match.
+
+2. Sum the statements of the reseller run and of this one:
+
+   ```sh
+   jq '[.statements[].total] | add' ~/tally-tutorial/2026-07-reseller/run.json
+   ```
+
+   ```text
+   7048.22
+   ```
+
+   ```sh
+   jq '[.statements[].total] | add' ~/tally-tutorial/2026-07-attributed/run.json
+   ```
+
+   ```text
+   7048.220000000001
+   ```
+
+   The two sums are equal. The trailing digits of the second are `jq`'s
+   floating-point rendering of the same sum, which it adds in double precision.
+   Attribution moves costs from one statement to another and adds none.
+
+3. Read the list of projects the run found no registry row for:
+
+   ```sh
+   jq '.stats.unregistered_projects' ~/tally-tutorial/2026-07-attributed/run.json
+   ```
+
+   ```text
+   null
+   ```
+
+   The list is absent because the registry is full, so `jq` prints null. The
+   list-price run of Meter and rate your first month carried six entries here.
+
+## What you learned
+
+- Every project is billed in exactly one place, and a project an attributing
+  relation names is excluded from direct billing:
+  [exclusive attribution](/explanation/project-registry-relations-and-attribution#exclusive-attribution).
+- The engine resolves that in one breadth-first walk where the shortest path
+  claims a project and the smallest relation id breaks a tie, and a second path
+  is a warning rather than a second bill:
+  [exclusive attribution](/explanation/project-registry-relations-and-attribution#exclusive-attribution).
+- The pattern you built is the one the concept page draws:
+  [a Gardener project and its infrastructure tenant](/explanation/project-registry-relations-and-attribution#a-gardener-project-and-its-infrastructure-tenant).
+- A rendered statement of that shape, with a management fee of its own beside
+  the related costs, is in
+  [related costs: Gardener and OpenStack](/explanation/worked-examples#related-costs-gardener-and-openstack).
+- The `related_costs` member is specified in
+  [statements](/reference/formats/exports#statements) and the registry endpoints
+  you called in [the Reporting API](/reference/api/reporting-api).
+
+## Where to go next
+
+[Finalize the month and export it](/tutorials/finalize-the-month-and-export-it)
+closes July 2026 on the run you just made.
+
+It starts from the state this lesson leaves behind:
+
+- everything Pay a reseller a kickback left;
+- the registry complete, with eight projects (the six `os-sim` tenants,
+  `garden-sim/alpha` and `garden-sim/beta`), the meta-project `acme`, the
+  partner `cloudhouse` and six relations;
+- `RUN_ID` on the attributed run, which superseded the reseller run;
+- the export under `~/tally-tutorial/2026-07-attributed`;
+- `ALPHA_TENANT_ID`, `BETA_TENANT_ID`, `ALPHA_ID` and `BETA_ID` in the shell.

--- a/docs/tutorials/book-the-late-events-as-a-credit-note.md
+++ b/docs/tutorials/book-the-late-events-as-a-credit-note.md
@@ -1,0 +1,565 @@
+---
+title: Book the late events as a credit note
+description: Release the notifications the simulator held back, see the engine find them as late, book them as a correction of the closed month, read the credit notes and close the correction.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit 01d2aff with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Book the late events as a credit note
+
+In this lesson you let the simulator publish the 84 notifications it held back,
+see the engine find them as late arrivals, book them as a correction of the
+month you closed, read the credit notes the correction writes, and close the
+correction.
+
+At the end the simulator container has exited after publishing its held share,
+the engine database holds one finalized correction of `2026-07` beside the
+finalized run, the credit notes are under `~/tally-tutorial/2026-07-notes`, and
+`CORRECTION_ID` is in the shell. This is the last lesson of the billing track.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state
+  [Finalize the month and export it](/tutorials/finalize-the-month-and-export-it)
+  leaves:
+
+  - everything Attribute a tenant to its Gardener project left;
+  - `2026-07` finalized on `RUN_ID`;
+  - the three export directories `~/tally-tutorial/2026-07-final`,
+    `2026-07-final-again` and `2026-07-final-csv`;
+  - the simulator still holding its 84 notifications.
+
+- The shell that holds the port-forward Meter and rate your first month
+  started: a correction meters the month again and reads the egress counter
+  from the store through it.
+- Docker Desktop running, with the three containers of the simulator stack.
+- `jq` 1.8.1 (`jq --version`).
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+export TALLY_ENGINE_COUNTER_SOURCES=deploy/kubernetes/overlays/dev/counter-sources.yaml
+export TALLY_ENGINE_VM_URL=http://127.0.0.1:8428
+kubectl --context kind-tally -n tally port-forward svc/victoriametrics 8428:8428 &
+export RUN_ID="$(jq -r .run_id ~/tally-tutorial/2026-07-final/run.json)"
+```
+
+No registry call follows, so this lesson needs no token and no `tally-ca.crt`.
+The correction meters, so it needs the four engine variables and the
+port-forward. `RUN_ID` is read back off the finalized export's `run.json`, and
+this lesson reads it only to compare it with what `periods list` prints.
+
+A connection error from any `go run` command means the cluster is not up, and
+`kind get clusters` then prints nothing. That is cured by
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
+
+## Release the held share
+
+1. Read the simulator's clock:
+
+   ```sh
+   curl -s http://127.0.0.1:8091/clock
+   ```
+
+   ```json
+   {"virtual_now":"2026-07-02T07:30:56Z","factor":0,"published":15643,"total":15727,"held":84,"holding":true,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   `factor` 0, `published` 15643, `total` 15727, `held` 84 and `holding` true
+   have to match, the state Simulate a month of OpenStack left the simulator
+   in. `virtual_now` is your own.
+
+2. Let the held notifications out:
+
+   ```sh
+   curl -s -X POST http://127.0.0.1:8091/release
+   ```
+
+   ```json
+   {"virtual_now":"2026-07-02T07:30:56Z","factor":0,"published":15643,"total":15727,"held":0,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   ```
+
+   The route answers with the document as it stood the moment before the
+   release, with `held` 0 and `holding` false, the two members the release
+   changed. `published` 15643, `total` 15727, `held` 0 and `holding` false have
+   to match, and `virtual_now` is your own.
+
+   The 84 notifications go onto the bus at once, each under the July timestamp
+   it always carried. That is what a late arrival at the Reporting API is: an
+   event inside July received after the run that billed July read the month.
+   `held-back` is the switch that kept them off the bus:
+   [the fault switches](/explanation/the-simulated-openstack-world#the-fault-switches).
+
+   A 409 with `the held-back notifications were already released`, or a refused
+   connection, means the release was sent before, because the simulator exits
+   once its share is out. A 409 with
+   `the month is still publishing; release once /clock reports holding true`
+   means
+   [Simulate a month of OpenStack](/tutorials/simulate-a-month-of-openstack) did
+   not finish.
+
+## Watch the notifications arrive
+
+1. Sum the collector's counters over their `event_type` labels:
+
+   ```sh
+   curl -s http://127.0.0.1:8090/metrics | awk '
+     /^tally_collector_consumed_total/ { c += $2 }
+     /^tally_collector_skipped_total/ { s += $2 }
+     /^tally_collector_unparseable_total/ { u += $2 }
+     /^tally_collector_buffer_depth/ { d = $2 }
+     END { print "consumed", c, "skipped", s, "unparseable", u, "depth", d }'
+   ```
+
+   ```text
+   consumed 1812 skipped 13915 unparseable 0 depth 0
+   ```
+
+   Repeat the read until `depth` reads 0. The four numbers have to match. 1812
+   is the 1728 Simulate a month of OpenStack counted plus the 84, 13915 is
+   unchanged because the held share carried only billable transitions, and a
+   depth of 0 is the outbox drained into the Reporting API.
+
+2. Read the clock once more:
+
+   ```sh
+   curl -sS http://127.0.0.1:8091/clock
+   ```
+
+   ```text
+   curl: (7) Failed to connect to 127.0.0.1 port 8091 after 0 ms: Couldn't connect to server
+   ```
+
+   The simulator's run ended once the whole month was out, so the control
+   endpoint answers nothing and the container has exited. `-S` shows the error
+   that `-s` alone hides, and the wording after `(7)` is your own `curl`'s.
+
+   From now on the `openstack-db-exporter` scrape job has no target, so
+   `TallyScrapeTargetDown` fires for it about five minutes later, beside the
+   `ceilometer` one Watch the month in Grafana found. That is the designed
+   state between simulator runs.
+
+## Ask the month what arrived late
+
+1. Report what reached the reporting database after the finalized run read it:
+
+   ```sh
+   go run ./cmd/tally-engine detect-late --period 2026-07
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 read 2026-07 at 2026-09-07T21:28:09Z
+   os-sim/openstack/floating_ip/c8d4f029-050e-488c-a7d3-6e93f99561ff: 1 late events, last received 2026-09-07T22:05:22Z
+   os-sim/openstack/floating_ip/e04358d1-1601-403c-b0d8-25f6f708c8ba: 1 late events, last received 2026-09-07T22:05:22Z
+   os-sim/openstack/image/6a493a19-c938-461b-883f-5444a7310e78: 1 late events, last received 2026-09-07T22:05:22Z
+   ```
+
+   77 more lines of the same shape follow, one per resource, and the report
+   ends with these two lines:
+
+   ```text
+   os-sim/openstack/volume/f74f35a4-f24f-49e3-8952-21554eefbebe: 1 late events, last received 2026-09-07T22:05:22Z
+   book them with tally-engine correct --period 2026-07
+   ```
+
+   The report names 81 resources, 78 of them with one late event and 3 with
+   two, which is the 84: 62 instances, 15 volumes, 2 floating IPs, 1 image and
+   1 load balancer. The resource ids and their counts are the seed's and have
+   to match, while the run id, which is `RUN_ID`, the snapshot and every
+   `last received` instant are your own.
+
+   A late event is one whose `received_at` is after the instant the finalized
+   run read the month and whose timestamp is inside July. The report reads and
+   changes nothing:
+   [corrections](/explanation/billing-period-lifecycle-and-corrections#corrections).
+
+   `no events arrived later` means the collector has not delivered the share
+   yet, which the counter read above shows. An error
+   `2026-07 has no finalized run, and late events are late against one: tally-engine run --period 2026-07 and tally-engine finalize produce it`
+   means Finalize the month and export it was skipped.
+
+## Book them as a correction
+
+1. Meter the month again and diff it against the finalized run:
+
+   ```sh
+   go run ./cmd/tally-engine correct --period 2026-07
+   ```
+
+   ```text
+   run 9a8770d7-89d9-45dc-a127-7edfe77b9018 completed as a correction of run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 for 2026-07 with pricing model 2026-03
+   metered 871 candidates into 996 usage records and 3265 rated records
+   184 deltas and 5 adjustment deltas in 6 credit notes
+   warnings recorded in runs.stats: 0 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 0 unregistered projects
+   ```
+
+   The `metered` line, `184 deltas and 5 adjustment deltas in 6 credit notes`
+   and the warnings line have to match. Both run ids are your own, the second
+   being `RUN_ID`.
+
+   A correction is a run of its own that names the run it corrects. It meters
+   the month again in full with the finalized run's pricing model, diffs the
+   amounts against the finalized run per resource, project and dimension, and
+   stores the non-zero deltas. The finalized run stays as it is.
+
+   The counts moved because the 84 notifications changed the histories. There
+   are 871 candidates rather than 867: the four new ones are resources whose
+   create and delete were both held, so the finalized run never saw them. The
+   usage records are 996 and the rated records 3265, rather than 945 and 3101.
+   The warnings line reads `0 metering`: the 38
+   `history_starts_without_create` warnings of Meter and rate your first month
+   are gone because every create is in the history now. The 184 deltas reach
+   every one of the six projects, and all five adjustment lines of the month
+   moved with their bases, which is the `5 adjustment deltas`.
+
+   Which way a delta goes depends on which notification was held. A held delete
+   left the finalized run without the resource's end, so it billed the resource
+   to the end of the month, and the correction credits the hours after the
+   delete. A held create left it without the resource's start, so it billed
+   nothing before the first event it had, and the correction debits the hours
+   the resource lived. Both are among the 84: of the CI tenant's 37 runners in
+   its note, 20 are credits and 17 are debits, and across all six notes 35 line
+   items are credits and 36 debits.
+
+2. Put the first id on the first line of your own output in place of this one:
+
+   ```sh
+   export CORRECTION_ID=9a8770d7-89d9-45dc-a127-7edfe77b9018
+   ```
+
+   Every command below reads `CORRECTION_ID`.
+
+3. Read what stands there instead if the correction printed something else:
+
+   - An error opening on `the billing period is not finalized` means Finalize
+     the month and export it was skipped.
+   - `no deltas: the finalized numbers of 2026-07 stand` on the third line
+     means the release never reached the database, which the counter read above
+     shows.
+   - An error opening on `another run of this period is in progress` means
+     another `tally-engine correct` of this period is live, in this shell or in
+     another one. Let that run end; the hourly tick is not it, because the tick
+     leaves a finalized month alone.
+   - A non-zero `counter` count on the warnings line means the port-forward
+     died before the correction read the store. Start it again and run the
+     correction again.
+
+## Read the credit notes
+
+1. Export the correction:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$CORRECTION_ID" --format json --out ~/tally-tutorial/2026-07-notes
+   ```
+
+   ```text
+   run 9a8770d7-89d9-45dc-a127-7edfe77b9018 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-notes
+   wrote run.json and 6 credit notes
+   wrote kickbacks.json with 1 kickback deltas
+   ```
+
+   `wrote run.json and 6 credit notes` and
+   `wrote kickbacks.json with 1 kickback deltas` have to match. The run id and
+   the home directory are your own. A correction is exported the way a run is,
+   and what it writes is a credit note per project and the kickback deltas
+   rather than statements and kickbacks.
+
+2. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07-notes
+   ```
+
+   ```text
+   credit-note-garden-sim%2Falpha.json
+   credit-note-garden-sim%2Fbeta.json
+   credit-note-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   credit-note-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   credit-note-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json
+   credit-note-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json
+   kickbacks.json
+   run.json
+   ```
+
+   Six `credit-note-<key>.json` files stand beside `run.json` and
+   `kickbacks.json`, one per project a delta reached. The eight names have to
+   match.
+
+3. List every credit note with its total:
+
+   ```sh
+   jq -r '.statements[] | "\(.cloud)/\(.project_id)\t\(.total)"' ~/tally-tutorial/2026-07-notes/run.json
+   ```
+
+   ```text
+   garden-sim/alpha	-513.91
+   garden-sim/beta	10.21
+   os-sim/018504a6cc10019a40e3f9eef4dae529	-2.58
+   os-sim/10e287d5788957a2a331cabd1b5dccdf	-580.49
+   os-sim/34e991db9fc6466f8ca69b43f70fce65	18.28
+   os-sim/d5a8024946ddf673277b9e2490643a2c	225.72
+   ```
+
+   One signed total per note, a negative one a credit and a positive one a
+   debit. All six have to match. The CI tenant's is the largest credit,
+   `alpha`'s the next, and the classic project
+   `d5a8024946ddf673277b9e2490643a2c` carries the largest debit. The CI tenant,
+   `alpha`, `beta` and that classic project are the four tenants the 38
+   warnings of Meter and rate your first month named, and the two other Acme
+   members got a note as well, from held transitions of their own.
+
+4. Read the head of the CI tenant's note:
+
+   ```sh
+   jq '{corrects_run_id, items: (.line_items | length), base_delta, adjustments, net_delta, kickback_delta, total}' ~/tally-tutorial/2026-07-notes/credit-note-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   ```
+
+   ```json
+   {
+     "corrects_run_id": "77fb51f8-82c9-4d52-98a2-7fd3e0b43c53",
+     "items": 37,
+     "base_delta": -682.93,
+     "adjustments": [
+       {
+         "type": "discount",
+         "relation_type": "managed_by",
+         "relation_target": "cloudhouse",
+         "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+         "scope": "all",
+         "rate": 0.150000,
+         "old": -104.74,
+         "new": -2.30,
+         "delta": 102.44
+       },
+       {
+         "type": "kickback",
+         "relation_type": "managed_by",
+         "relation_target": "cloudhouse",
+         "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+         "scope": "all",
+         "rate": 0.100000,
+         "old": 59.36,
+         "new": 1.31,
+         "delta": -58.05
+       }
+     ],
+     "net_delta": -580.49,
+     "kickback_delta": -58.05,
+     "total": -580.49
+   }
+   ```
+
+   `corrects_run_id` is `RUN_ID` and is your own, and the rest has to match.
+   The note carries 37 line items and a `base_delta` of -682.93, the corrected
+   base cost being 15.36 in place of 698.29. Each `adjustments` entry carries
+   `old`, `new` and `delta`: the discount moves from -104.74 to -2.30, fifteen
+   percent of the corrected base, so its delta is 102.44; the kickback moves
+   from 59.36 to 1.31, ten percent of the corrected net of 13.06, so its delta
+   is -58.05. `net_delta` -580.49 is the base delta plus the discount delta,
+   `kickback_delta` is the kickback's delta, and `total` is the net delta.
+
+5. Read the first line item of that note:
+
+   ```sh
+   jq '.line_items[0]' ~/tally-tutorial/2026-07-notes/credit-note-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   ```
+
+   ```json
+   {
+     "resource_type": "instance",
+     "resource_id": "06306b76-171b-4a72-a8d9-1c4b13583ed6",
+     "platform": "openstack",
+     "dimensions": {
+       "disk_gb": {
+         "old": 0.00,
+         "new": 0.02,
+         "delta": 0.02
+       },
+       "egress_gb": {
+         "old": 0.00,
+         "new": 0.01,
+         "delta": 0.01
+       },
+       "ram_gb": {
+         "old": 0.00,
+         "new": 0.01,
+         "delta": 0.01
+       },
+       "vcpus": {
+         "old": 0.00,
+         "new": 0.02,
+         "delta": 0.02
+       }
+     },
+     "total": 0.06
+   }
+   ```
+
+   One runner with its four `dimensions`, each as `old`, `new` and `delta`, and
+   a total of 0.06. Every `old` is 0.00 because the finalized run had this
+   runner's delete and not its create, so it billed nothing for it, and the
+   correction debits the minutes it lived. The document has to match.
+
+6. Read what the Gardener project `alpha` gets:
+
+   ```sh
+   jq '{project_id, related_costs: [.related_costs[] | {relation_type, project_id, items: (.line_items | length), total}], total}' ~/tally-tutorial/2026-07-notes/credit-note-garden-sim%2Falpha.json
+   ```
+
+   ```json
+   {
+     "project_id": "alpha",
+     "related_costs": [
+       {
+         "relation_type": "infrastructure_tenant",
+         "project_id": "005be5adeef3d87e280d03d9d57c38b4",
+         "items": 27,
+         "total": -513.91
+       }
+     ],
+     "total": -513.91
+   }
+   ```
+
+   `alpha`'s note carries its tenant's 27 deltas under `related_costs` with the
+   total -513.91, and the note's total is that. The document has to match. The
+   correction attributes the way the run did: the tenant's deltas stand on the
+   Gardener project's note and nowhere else.
+
+7. Read what the correction moves for the partner:
+
+   ```sh
+   go run ./cmd/tally-engine kickbacks --period 2026-07 --run "$CORRECTION_ID"
+   ```
+
+   ```json
+   {
+     "run_id": "9a8770d7-89d9-45dc-a127-7edfe77b9018",
+     "kind": "correction",
+     "corrects_run_id": "77fb51f8-82c9-4d52-98a2-7fd3e0b43c53",
+     "period_from": "2026-07-01T00:00:00Z",
+     "period_to": "2026-08-01T00:00:00Z",
+     "beneficiaries": [
+       {
+         "beneficiary": "cloudhouse",
+         "currency": "EUR",
+         "kickback_total": -58.05,
+         "projects": 1,
+         "breakdown": [
+           {
+             "cloud": "os-sim",
+             "project_id": "10e287d5788957a2a331cabd1b5dccdf",
+             "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+             "scope": "all",
+             "rate": 0.100000,
+             "base": -580.49,
+             "amount": -58.05
+           }
+         ]
+       }
+     ]
+   }
+   ```
+
+   `kind` `correction`, `corrects_run_id` naming the finalized run, one
+   beneficiary `cloudhouse` with `kickback_total` -58.05, `projects` 1 and one
+   `breakdown` entry with `base` -580.49 and `amount` -58.05 have to match. The
+   ids are your own. A correction named with `--run` reports the differences to
+   the run it corrects, so this is what `cloudhouse` is owed less than the
+   settlement of Pay a reseller a kickback said.
+
+## Close the correction
+
+1. Finalize the correction run:
+
+   ```sh
+   go run ./cmd/tally-engine finalize --period 2026-07 --run "$CORRECTION_ID"
+   ```
+
+   ```text
+   correction run 9a8770d7-89d9-45dc-a127-7edfe77b9018 finalized for 2026-07
+   ```
+
+   The line has to match with your own correction id in it. A correction closes
+   itself alone.
+
+2. List the periods the engine holds:
+
+   ```sh
+   go run ./cmd/tally-engine periods list
+   ```
+
+   ```text
+   2026-07 finalized finalized_run=77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 finalized_at=2026-09-07T22:04:35Z
+   2026-08 grace
+   ```
+
+   `finalized_run` still names `RUN_ID`, the regular run that closed the month,
+   and not the correction. `finalized_at` and the `2026-08` line are your own.
+
+3. Ask the month what arrived late once more:
+
+   ```sh
+   go run ./cmd/tally-engine detect-late --period 2026-07
+   ```
+
+   ```text
+   run 9a8770d7-89d9-45dc-a127-7edfe77b9018 read 2026-07 at 2026-09-07T22:05:50Z
+   no events arrived later
+   ```
+
+   The report now holds the events against the correction, whose id and
+   snapshot are your own, and answers `no events arrived later`. The next
+   correction would diff against this one.
+
+## What you learned
+
+- A closed month is never edited, because its numbers may already stand in an
+  ERP:
+  [why finalization is a human gate](/explanation/billing-period-lifecycle-and-corrections#why-finalization-is-a-human-gate).
+- A correction diffs a full re-meter against the finalized run and stores only
+  the non-zero deltas, one credit note per project:
+  [corrections](/explanation/billing-period-lifecycle-and-corrections#corrections).
+- The re-meter is full rather than a patch because a full one is deterministic
+  and reproducible:
+  [corrections](/explanation/billing-period-lifecycle-and-corrections#corrections).
+- The simulator held one in 20 of the billable transitions back so that a late
+  arrival could be produced on demand:
+  [the fault switches](/explanation/the-simulated-openstack-world#the-fault-switches).
+- The members of a credit note are in
+  [credit notes](/reference/formats/exports#credit-notes), and the release
+  route in
+  [tally-openstack-simulator](/reference/command-line/tally-openstack-simulator).
+
+## Where to go next
+
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
+back to a clean machine. It removes everything below.
+
+A contributor who wants to hold the corrected export against the simulator's
+oracle finds that in
+[compare an export against the oracle](/how-to/simulator/compare-an-export).
+
+This is the state the billing track leaves behind:
+
+- everything the core track left, except that the simulator container has
+  exited after publishing its held share, so `GET /clock` on
+  `http://127.0.0.1:8091/clock` answers nothing;
+- the registry holding eight projects (the six `os-sim` tenants,
+  `garden-sim/alpha` and `garden-sim/beta`), the meta-project `meta/acme`, the
+  partner `partner/cloudhouse` and six relations;
+- the engine database holding the period `2026-07` finalized on the attributed
+  run and one finalized correction of it;
+- the seven export directories `~/tally-tutorial/2026-07-group`,
+  `2026-07-reseller`, `2026-07-attributed`, `2026-07-final`,
+  `2026-07-final-again`, `2026-07-final-csv` and `2026-07-notes` beside the
+  core track's `2026-07`;
+- in the shell, beside the seven variables of the core track: `ACME_1_ID`,
+  `ACME_2_ID`, `ACME_3_ID`, `ACME_ID`, `CI_ID`, `PARTNER_ID`,
+  `ALPHA_TENANT_ID`, `BETA_TENANT_ID`, `ALPHA_ID`, `BETA_ID` and
+  `CORRECTION_ID`, with `RUN_ID` on the attributed run.

--- a/docs/tutorials/discount-a-customer-group.md
+++ b/docs/tutorials/discount-a-customer-group.md
@@ -1,0 +1,567 @@
+---
+title: Discount a customer group
+description: Register three projects of the simulated cloud, group them under a customer with a discount on each membership, run July 2026 again, and read a discounted statement and the group's rollup.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit 01d2aff with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Discount a customer group
+
+In this lesson you register three projects of the simulated cloud in the
+project registry, group them under a customer, put a 10% discount on each
+membership, run July 2026 again, and read one discounted statement and the
+group's rollup.
+
+At the end you hold the project registry with its first four rows, a new run of
+July 2026 with its id in `RUN_ID`, and the JSON export of that run under
+`~/tally-tutorial/2026-07-group`.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state [Watch the month in Grafana](/tutorials/watch-the-month-in-grafana)
+  leaves, which is the state Meter and rate your first month leaves:
+
+  - the kind cluster `tally` with the dev overlay;
+  - the compose stack with the simulator holding its 84 notifications, so
+    `GET /clock` on `http://127.0.0.1:8091/clock` answers `holding` true;
+  - the reporting database holding the month of July 2026 minus the held share,
+    with an empty project registry;
+  - the engine database holding the pricing model `2026-03` and one completed,
+    not finalized run of `2026-07`;
+  - the JSON export of that run under `~/tally-tutorial/2026-07`;
+  - `tally-ca.crt` at the repository root;
+  - the VictoriaMetrics port-forward on `127.0.0.1:8428`;
+  - the seven variables `TALLY_REPORTING_DB_URL`, `TALLY_API_TOKEN` (an admin
+    token), `TALLY_ENGINE_DB_URL`, `TALLY_ENGINE_REPORTING_DB_URL`,
+    `TALLY_ENGINE_COUNTER_SOURCES`, `TALLY_ENGINE_VM_URL` and `RUN_ID` in a
+    shell at the repository root.
+
+- `jq` 1.8.1 (`jq --version`).
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TALLY_API_TOKEN="$(go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'tutorial')"
+export TALLY_API_TOKEN
+export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+export TALLY_ENGINE_COUNTER_SOURCES=deploy/kubernetes/overlays/dev/counter-sources.yaml
+export TALLY_ENGINE_VM_URL=http://127.0.0.1:8428
+kubectl --context kind-tally -n tally port-forward svc/victoriametrics 8428:8428 &
+make -s ca > tally-ca.crt
+```
+
+A token is printed once, so a closed shell means a new token. The one you minted
+before stays valid until it is revoked, which takes the id on the
+`created api_tokens <id>` line the command printed beside it, so keep that line
+where you mean to revoke, the way
+[issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
+says. Every token this track mints goes with the cluster
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) removes.
+The port-forward line and the CA line are for a shell that lost them. `RUN_ID`
+is not needed before this lesson sets it anew.
+
+A connection error from any `go run` command means the cluster is not up, and
+`kind get clusters` then prints nothing. `curl: (7)` on the API hostname means
+the same. Both are cured by
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
+
+## Register the three classic projects
+
+1. Register the first of the three tenants:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "018504a6cc10019a40e3f9eef4dae529", "name": "Acme team 1"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq .
+   ```
+
+   ```json
+   {
+     "cloud": "os-sim",
+     "created_at": "2026-09-07T21:26:32.361891Z",
+     "external_id": "018504a6cc10019a40e3f9eef4dae529",
+     "id": "8e4e84bd-e6fb-4c38-a2eb-cde386f94202",
+     "metadata": {},
+     "name": "Acme team 1",
+     "platform": "openstack"
+   }
+   ```
+
+   `-d` makes the call a `POST /api/v1/projects`. The registry is keyed by
+   cloud and external id, and the answer is the row as it is now registered.
+   `cloud` `os-sim`, `external_id`, `name` `Acme team 1`, `platform`
+   `openstack` and `metadata` `{}` have to match. `id` and `created_at` are
+   your own.
+
+   The three classic projects of the month are named after their place in the
+   customer group, because the simulated cloud carries no tenant names on the
+   bus.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a project with this cloud and external id is already registered` means this
+   step ran before, and the read-back below reads the id it needs anyway. A 401
+   with `type` `urn:tally:error:unauthorized` means `TALLY_API_TOKEN` is empty
+   in this shell, so mint one with the restore block above. A 403 with `type`
+   `urn:tally:error:forbidden` means the token is not an admin token.
+
+2. Register the other two:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "34e991db9fc6466f8ca69b43f70fce65", "name": "Acme team 2"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq -c '{id, external_id, name}'
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "d5a8024946ddf673277b9e2490643a2c", "name": "Acme team 3"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq -c '{id, external_id, name}'
+   ```
+
+   ```json
+   {"id":"1bb9b4d0-b256-4e78-bc0c-385787c23495","external_id":"34e991db9fc6466f8ca69b43f70fce65","name":"Acme team 2"}
+   {"id":"7e35789b-36b1-4f90-b5fb-f924d79ebfa6","external_id":"d5a8024946ddf673277b9e2490643a2c","name":"Acme team 3"}
+   ```
+
+   `external_id` and `name` have to match on both lines, and the ids are your
+   own. The same three refusals apply.
+
+3. Read the three ids back into the shell:
+
+   ```sh
+   ACME_1_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=018504a6cc10019a40e3f9eef4dae529' | jq -r '.items[0].id')"
+   ACME_2_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=34e991db9fc6466f8ca69b43f70fce65' | jq -r '.items[0].id')"
+   ACME_3_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=d5a8024946ddf673277b9e2490643a2c' | jq -r '.items[0].id')"
+   export ACME_1_ID ACME_2_ID ACME_3_ID
+   echo "$ACME_1_ID $ACME_2_ID $ACME_3_ID"
+   ```
+
+   ```text
+   8e4e84bd-e6fb-4c38-a2eb-cde386f94202 1bb9b4d0-b256-4e78-bc0c-385787c23495 7e35789b-36b1-4f90-b5fb-f924d79ebfa6
+   ```
+
+   The three ids are your own, and they are the ids the calls above printed.
+   This read is what a reader who saw the 409 runs, because it reads what is
+   registered whether this shell registered it or not. The registry answers
+   `{"items": [...], "next_cursor": null}`, and `.items[0].id` is the id of the
+   one row the cloud and the external id name.
+
+   An id printing `null` means that registration did not happen, so `items` is
+   empty, and the cure is the registration above. A relation sent with `null`
+   in its path is answered 400 with `type` `urn:tally:error:validation` and one
+   error located at `path.id`, because `null` is not a uuid.
+
+## Create the customer group
+
+1. Register the meta-project the three tenants become members of:
+
+   ```sh
+   ACME_ID="$(go run ./cmd/tally-reporting-admin create-meta-project --external-id acme --name 'Acme')"
+   export ACME_ID
+   echo "$ACME_ID"
+   ```
+
+   ```text
+   registered meta-project acme
+   13a5e981-edc2-4666-b22e-65e7696de02b
+   ```
+
+   `registered meta-project acme` is the CLI's notice on stderr. The id went to
+   stdout and into the variable, and it is your own.
+
+   A meta-project is a `projects` row with platform and cloud both `meta`. It
+   owns no resource and exists to be the target of `member_of` relations:
+   [meta-projects and partners](/explanation/commercial-pricing-on-relations#meta-projects-and-partners).
+
+   `Error: meta-project acme: already registered` with exit status 1 means the
+   row exists from an earlier run of this step, and
+   `GET /api/v1/projects?cloud=meta&external_id=acme` piped into
+   `jq -r '.items[0].id'` reads its id the way the read-back above reads the
+   tenants'. `TALLY_REPORTING_DB_URL` has to be exported for the CLI to reach
+   the registry, and a `dial tcp` error means it is not, or the cluster is
+   down.
+
+## Put the discount on the memberships
+
+1. Relate the first tenant to the group:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ACME_1_ID/relations" <<EOF | jq .
+   {
+     "target_id": "$ACME_ID",
+     "relation_type": "member_of",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "metadata": {
+       "pricing_adjustments": [
+         {"type": "project_discount", "rate": "0.10", "scope": "all", "description": "Acme group discount"}
+       ]
+     }
+   }
+   EOF
+   ```
+
+   ```json
+   {
+     "created_at": "2026-09-07T21:26:57.706276Z",
+     "id": "8d9aaff5-56f2-43ba-8e04-6a73906136cf",
+     "metadata": {
+       "pricing_adjustments": [
+         {
+           "description": "Acme group discount",
+           "rate": "0.10",
+           "scope": "all",
+           "type": "project_discount"
+         }
+       ]
+     },
+     "relation_type": "member_of",
+     "source_id": "8e4e84bd-e6fb-4c38-a2eb-cde386f94202",
+     "target_id": "13a5e981-edc2-4666-b22e-65e7696de02b",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "valid_to": null
+   }
+   ```
+
+   The body is sent as a heredoc so that `$ACME_ID` expands inside real JSON.
+   `<<EOF | jq .` is one command: the heredoc feeds `curl` and the pipe feeds
+   `jq`.
+
+   `relation_type` `member_of`, `valid_from` `2026-07-01T00:00:00Z`,
+   `valid_to` null and the one `pricing_adjustments` entry have to match. `id`,
+   `source_id`, `target_id` and `created_at` are your own.
+
+   `valid_from` is the first instant of July because the default is the instant
+   the relation is written, which is now and not in July, and a relation
+   applies to a period only where its validity overlaps it. The rate is a
+   string, `"0.10"`, never a number. The adjustments of a relation are fixed
+   for its lifetime, and a change is a closed relation and a successor, as
+   [model a customer group with a discount](/how-to/engine/model-a-customer-group)
+   shows.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a relation of this type between these projects is already active` means
+   this step ran before and nothing needs doing. A 400 with `type`
+   `urn:tally:error:validation` whose error is located at `body.target_id`
+   means `ACME_ID` is empty in this shell. A 422 with `type`
+   `urn:tally:error:validation`, the detail
+   `the pricing adjustments of this relation do not match the adjustments schema`
+   and an error at `body.metadata.pricing_adjustments.0.rate` reading
+   `got number, want string` means the rate was sent as a number.
+
+2. Relate the other two:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ACME_2_ID/relations" <<EOF | jq -c '{id, source_id, relation_type}'
+   {
+     "target_id": "$ACME_ID",
+     "relation_type": "member_of",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "metadata": {
+       "pricing_adjustments": [
+         {"type": "project_discount", "rate": "0.10", "scope": "all", "description": "Acme group discount"}
+       ]
+     }
+   }
+   EOF
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ACME_3_ID/relations" <<EOF | jq -c '{id, source_id, relation_type}'
+   {
+     "target_id": "$ACME_ID",
+     "relation_type": "member_of",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "metadata": {
+       "pricing_adjustments": [
+         {"type": "project_discount", "rate": "0.10", "scope": "all", "description": "Acme group discount"}
+       ]
+     }
+   }
+   EOF
+   ```
+
+   ```json
+   {"id":"071e2e14-d251-4bd2-a229-3f15ec97eacf","source_id":"1bb9b4d0-b256-4e78-bc0c-385787c23495","relation_type":"member_of"}
+   {"id":"14b925a3-08e4-4e27-ace8-5ebb3837747b","source_id":"7e35789b-36b1-4f90-b5fb-f924d79ebfa6","relation_type":"member_of"}
+   ```
+
+   `relation_type` has to match on both lines. The ids are your own, and
+   `source_id` is the member each relation leaves.
+
+3. Count the memberships the group holds:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$ACME_ID/relations?direction=incoming&at=2026-07-01T00:00:00Z" | jq '.items | length'
+   ```
+
+   ```text
+   3
+   ```
+
+   The count has to be 3, the three memberships valid at the first instant of
+   July. `direction=incoming` lists the relations that reach the meta-project,
+   and `at` is the instant the answer describes.
+
+## Run the month again
+
+1. Meter and rate July 2026 once more:
+
+   ```sh
+   go run ./cmd/tally-engine run --period 2026-07
+   ```
+
+   ```text
+   run ee0b363e-2449-4085-bca4-218150d1e546 completed for 2026-07 with pricing model 2026-03
+   metered 867 candidates into 945 usage records, 3101 rated records and 6 project statements
+   applied 3 pricing adjustments
+   superseded run 6ed8bcbd-1f79-4b65-b954-5fd346848128
+   warnings recorded in runs.stats: 38 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 3 unregistered projects
+   ```
+
+   The `metered` line, `applied 3 pricing adjustments` and the warnings line
+   have to match. Both run ids are your own, and the superseded one is the run
+   Meter and rate your first month made.
+
+   The `metered` counts are the ones that run printed, 867 candidates, 945
+   usage records, 3101 rated records and 6 statements, because nothing in the
+   month changed. An adjustment is a record of its own kind beside the rated
+   records, which is what `applied 3` counts, one line per member statement.
+   The warnings line now ends in `3 unregistered projects`: the three
+   registered ones left the list.
+
+   A run before finalization supersedes the run before it in the same
+   transaction, so the period never has two completed runs:
+   [runs before finalization](/explanation/billing-period-lifecycle-and-corrections#runs-before-finalization).
+
+2. Put the id from the first line of your own output in place of this one:
+
+   ```sh
+   export RUN_ID=ee0b363e-2449-4085-bca4-218150d1e546
+   ```
+
+   Every command below reads `RUN_ID`.
+
+3. Read what stands there instead if the run printed something else:
+
+   - `no pricing model is valid for this period` means the model Meter and rate
+     your first month imported is missing. Import it and run the month again.
+   - An error opening on `another run of this period is in progress` means
+     another `tally-engine run` of this period is live, in this shell or in
+     another one. Let that run end; the hourly tick is not it, because the tick
+     leaves a month that already carries a completed run alone.
+   - A non-zero `counter` count on the warnings line means the port-forward
+     died before the run read the store. Start it again and run the month
+     again.
+   - `reading the counter sources deploy/kubernetes/overlays/dev/counter-sources.yaml: open deploy/kubernetes/overlays/dev/counter-sources.yaml: no such file or directory`
+     means the shell is not at the repository root, or
+     `TALLY_ENGINE_COUNTER_SOURCES` is not exported.
+
+## Read a discounted statement
+
+1. Export the run with a rollup over `member_of`:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07-group --rollup member_of
+   ```
+
+   ```text
+   run ee0b363e-2449-4085-bca4-218150d1e546 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-group
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 0 kickbacks
+   wrote 1 rollup documents over member_of
+   ```
+
+   The second, the third and the fourth line have to match, and
+   `wrote 1 rollup documents over member_of` is the line `--rollup member_of`
+   adds. The run id and the home directory are your own. The export of Meter
+   and rate your first month under `~/tally-tutorial/2026-07` stays as the
+   list-price comparison, and a directory that already holds files is refused,
+   which is why every export of this track gets a directory of its own.
+
+2. Read what the first Acme tenant owes:
+
+   ```sh
+   jq '{base_cost, adjustments, net_cost, total}' ~/tally-tutorial/2026-07-group/statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   ```
+
+   ```json
+   {
+     "base_cost": 876.63,
+     "adjustments": [
+       {
+         "type": "project_discount",
+         "relation_type": "member_of",
+         "relation_target": "acme",
+         "relation_id": "8d9aaff5-56f2-43ba-8e04-6a73906136cf",
+         "scope": "all",
+         "description": "Acme group discount",
+         "rate": 0.100000,
+         "base": 876.63,
+         "amount": -87.66
+       }
+     ],
+     "net_cost": 788.97,
+     "total": 788.97
+   }
+   ```
+
+   `base_cost` 876.63 is the total the same statement carried at list price.
+   The one `adjustments` line has `type` `project_discount`, `relation_type`
+   `member_of`, `relation_target` `acme`, `scope` `all`, `rate` 0.100000,
+   `base` 876.63 and `amount` -87.66, the base times the rate rounded once to
+   two places. `net_cost` 788.97 is the base plus the signed amount, and
+   `total` is the net. All of these have to match. `relation_id` is your own,
+   the id of the membership this line traces back to. The amount is rounded the
+   way every other amount is:
+   [why rounding happens once](/explanation/money-and-rounding#why-rounding-happens-once).
+
+3. Read what a tenant outside the group owes:
+
+   ```sh
+   jq '{base_cost, total}' ~/tally-tutorial/2026-07-group/statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   ```
+
+   ```json
+   {
+     "base_cost": null,
+     "total": 698.29
+   }
+   ```
+
+   This is the CI tenant, which no membership reaches, so its statement carries
+   none of the four members `base_cost`, `adjustments`, `net_cost` and
+   `kickback_total`, and `jq` prints an absent member as null. Its total 698.29
+   has to match and is unchanged from the list-price run.
+
+## Read the rollup
+
+1. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07-group
+   ```
+
+   ```text
+   kickbacks.json
+   rollup-meta%2Facme.json
+   run.json
+   statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   statement-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json
+   statement-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json
+   statement-os-sim%2Fe31f9083a7e5ee15071a3bd53cb2bac7.json
+   ```
+
+   The nine names have to match. `rollup-meta%2Facme.json` stands beside
+   `run.json`, `kickbacks.json` and the six statements.
+
+2. Read the group's rollup document:
+
+   ```sh
+   jq . ~/tally-tutorial/2026-07-group/rollup-meta%2Facme.json
+   ```
+
+   ```json
+   {
+     "billing_period": {
+       "from": "2026-07-01T00:00:00Z",
+       "to": "2026-08-01T00:00:00Z"
+     },
+     "project_id": "acme",
+     "platform": "meta",
+     "relation_type": "member_of",
+     "kind": "regular",
+     "corrects_run_id": null,
+     "members": [
+       {
+         "file": "statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json",
+         "cloud": "os-sim",
+         "project_id": "018504a6cc10019a40e3f9eef4dae529",
+         "total": 788.97,
+         "currency": "EUR"
+       },
+       {
+         "file": "statement-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json",
+         "cloud": "os-sim",
+         "project_id": "34e991db9fc6466f8ca69b43f70fce65",
+         "total": 538.55,
+         "currency": "EUR"
+       },
+       {
+         "file": "statement-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json",
+         "cloud": "os-sim",
+         "project_id": "d5a8024946ddf673277b9e2490643a2c",
+         "total": 814.59,
+         "currency": "EUR"
+       }
+     ],
+     "total": 2142.11,
+     "currency": "EUR"
+   }
+   ```
+
+   `project_id` `acme`, `platform` `meta`, `relation_type` `member_of`, `kind`
+   `regular`, the three `members` with their files and their totals 788.97,
+   538.55 and 814.59, and the `total` 2142.11, their sum, have to match. The
+   rollup is read from the registry at export time and sums the statements
+   without changing them: [rollup](/reference/formats/exports#rollup).
+
+3. Read the index entry the export wrote for it:
+
+   ```sh
+   jq .rollup ~/tally-tutorial/2026-07-group/run.json
+   ```
+
+   ```json
+   {
+     "relation_type": "member_of",
+     "documents": [
+       {
+         "file": "rollup-meta%2Facme.json",
+         "cloud": "meta",
+         "project_id": "acme",
+         "members": 3,
+         "total": 2142.11,
+         "currency": "EUR"
+       }
+     ]
+   }
+   ```
+
+   `members` 3 and the total have to match. The index names every rollup
+   document the export wrote.
+
+## What you learned
+
+- Adjustments live on relations, so every discount line traces back to one
+  relation and its target:
+  [why adjustments live on relations](/explanation/commercial-pricing-on-relations#why-adjustments-live-on-relations).
+- A meta-project is a project that owns nothing and exists to be related to:
+  [meta-projects and partners](/explanation/commercial-pricing-on-relations#meta-projects-and-partners).
+- A relation applies to a period its validity overlaps, which is why
+  `valid_from` had to be in July:
+  [temporal validity](/explanation/project-registry-relations-and-attribution#temporal-validity).
+- A run before finalization supersedes the run before it:
+  [runs before finalization](/explanation/billing-period-lifecycle-and-corrections#runs-before-finalization).
+- The adjustments array is specified in
+  [pricing adjustments](/reference/formats/pricing-adjustments) and the
+  statement members `base_cost`, `adjustments`, `net_cost` and `total` in
+  [statements](/reference/formats/exports#statements).
+
+## Where to go next
+
+[Pay a reseller a kickback](/tutorials/pay-a-reseller-a-kickback) puts one
+tenant under a partner with a discount and a kickback.
+
+It starts from the state this lesson leaves behind:
+
+- everything Watch the month in Grafana left;
+- the registry holding the three tenants, the meta-project `acme` and three
+  `member_of` relations;
+- `RUN_ID` on the discounted run, which superseded the list-price run;
+- the export under `~/tally-tutorial/2026-07-group` beside the one under
+  `~/tally-tutorial/2026-07`;
+- `ACME_ID`, `ACME_1_ID`, `ACME_2_ID` and `ACME_3_ID` in the shell.

--- a/docs/tutorials/finalize-the-month-and-export-it.md
+++ b/docs/tutorials/finalize-the-month-and-export-it.md
@@ -1,0 +1,343 @@
+---
+title: Finalize the month and export it
+description: Close July 2026 on the attributed run, see that the month cannot be metered again, and export it as JSON documents and as CSV tables.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit 01d2aff with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Finalize the month and export it
+
+In this lesson you close July 2026 on the run Attribute a tenant to its
+Gardener project made, see the engine refuse to meter the month again and
+refuse a second close, and export the finalized run twice as JSON and once as
+CSV.
+
+At the end the engine database holds `2026-07` finalized on `RUN_ID`, three new
+export directories stand under `~/tally-tutorial/` (`2026-07-final`,
+`2026-07-final-again` and `2026-07-final-csv`), and the simulator still holds
+its 84 notifications for the lesson after this one.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state
+  [Attribute a tenant to its Gardener project](/tutorials/attribute-a-tenant-to-its-gardener-project)
+  leaves:
+
+  - everything Pay a reseller a kickback left;
+  - the registry complete, with eight projects, the meta-project `acme`, the
+    partner `cloudhouse` and six relations;
+  - `RUN_ID` on the attributed run;
+  - the export under `~/tally-tutorial/2026-07-attributed`.
+
+- `jq` 1.8.1 (`jq --version`).
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+export RUN_ID="$(jq -r .run_id ~/tally-tutorial/2026-07-attributed/run.json)"
+```
+
+This lesson meters nothing, so it needs no token, no counter sources and no
+port-forward. `finalize` and `periods list` read the engine database, and
+`export` reads the reporting database as well, for the membership its rollup
+sums. `RUN_ID` is read back off the last export's `run.json`, which carries the
+id of the attributed run.
+
+A connection error from any `go run` command means the cluster is not up, and
+`kind get clusters` then prints nothing. That is cured by
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
+
+## Close the month
+
+1. Close July 2026 on the attributed run:
+
+   ```sh
+   go run ./cmd/tally-engine finalize --period 2026-07 --run "$RUN_ID"
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 finalized, period 2026-07 closed
+   ```
+
+   The line has to match with your own run id in it, the id `RUN_ID` carries.
+   The run and the period move in one transaction.
+
+   Finalization is a person's step because the finalized numbers may reach an
+   ERP, and the hourly tick never takes it on the dev stack:
+   [why finalization is a human gate](/explanation/billing-period-lifecycle-and-corrections#why-finalization-is-a-human-gate).
+
+   An error opening on `the run is not completed` and naming the run as
+   `superseded` means `RUN_ID` names a run a later run replaced. The last line
+   of the restore block above sets it to the id the last export carries, which
+   is the cure where only the shell lost it. Where that export is itself the
+   stale one, because the month was metered again after it was written, meter it
+   once more in a shell that carries `TALLY_ENGINE_COUNTER_SOURCES`,
+   `TALLY_ENGINE_VM_URL` and the VictoriaMetrics port-forward, which
+   [Attribute a tenant to its Gardener project](/tutorials/attribute-a-tenant-to-its-gardener-project)
+   restores: `go run ./cmd/tally-engine run --period 2026-07` prints a fresh
+   completed run id on its first line. Its warnings line has to read
+   `0 counter` before you close over that run, because a run made without the
+   counter source or without the port-forward completes with the `egress_gb`
+   quantity missing rather than with an error, and a finalized run is changed by
+   nothing but a correction. Put the id of that first line into `RUN_ID` with
+   `export RUN_ID=<that id>` before you close over it, because `RUN_ID` still
+   names the run the fresh one superseded. Closing over the fresh run produces
+   the same numbers, because nothing in the month or the registry changed.
+   An error opening on `the billing period is finalized` means this step ran
+   before.
+
+2. List the periods the engine holds:
+
+   ```sh
+   go run ./cmd/tally-engine periods list
+   ```
+
+   ```text
+   2026-07 finalized finalized_run=77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 finalized_at=2026-09-07T22:04:35Z
+   2026-08 grace
+   ```
+
+   The first line has to read `2026-07 finalized`, and its `finalized_run` has
+   to be the id in `RUN_ID`. `finalized_at` is your own.
+
+   The `2026-08` line is the tick's: the cluster's hourly `tally-engine`
+   scheduler opens the months that have ended and moves them into their grace
+   window. Its status is your own, `grace` on this run, and the line is absent
+   on a machine whose cluster has not passed an hour mark yet.
+
+## See that the month is closed
+
+1. Meter the month again:
+
+   ```sh
+   go run ./cmd/tally-engine run --period 2026-07
+   ```
+
+   ```text
+   Error: the billing period is finalized: 2026-07 was closed by run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53, and a finalized period is changed with tally-engine correct --period 2026-07
+   exit status 1
+   ```
+
+   The error has to match with your own run id in it. The refusal comes before
+   a run row exists, and it names the command that changes a finalized period,
+   `tally-engine correct --period 2026-07`, which the next lesson runs.
+
+2. Close the month a second time:
+
+   ```sh
+   go run ./cmd/tally-engine finalize --period 2026-07 --run "$RUN_ID"
+   ```
+
+   ```text
+   Error: the run is not completed: run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 is finalized, and a period is closed over a completed run, which tally-engine run --period 2026-07 produces
+   exit status 1
+   ```
+
+   The error has to match with your own run id in it. The run's own status,
+   `finalized`, is what refuses the second close, and it is checked before the
+   period is.
+
+   The records of a finalized run are held by database triggers rather than by
+   the CLI alone, so a script against the engine database cannot rewrite them
+   either:
+   [why a finalized run is immutable](/explanation/billing-period-lifecycle-and-corrections#why-a-finalized-run-is-immutable).
+   The hourly tick leaves a finalized month alone.
+
+## Export the statements as JSON
+
+1. Export the finalized run with a rollup over `member_of`:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07-final --rollup member_of
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-final
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 1 kickbacks
+   wrote 1 rollup documents over member_of
+   ```
+
+   The last three lines have to match. The run id and the home directory are
+   your own.
+
+2. Read the head of the index the export wrote:
+
+   ```sh
+   jq '{run_id, kind, status, pricing_version, corrects_run_id}' ~/tally-tutorial/2026-07-final/run.json
+   ```
+
+   ```json
+   {
+     "run_id": "77fb51f8-82c9-4d52-98a2-7fd3e0b43c53",
+     "kind": "regular",
+     "status": "finalized",
+     "pricing_version": "2026-03",
+     "corrects_run_id": null
+   }
+   ```
+
+   `kind` `regular`, `status` `finalized`, `pricing_version` `2026-03` and
+   `corrects_run_id` null have to match. `run_id` is your own. `status` is the
+   one member that differs from the export Attribute a tenant to its Gardener
+   project wrote of the same run.
+
+3. Export the same run a second time, into a directory of its own:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07-final-again --rollup member_of
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-final-again
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 1 kickbacks
+   wrote 1 rollup documents over member_of
+   ```
+
+   The same three lines have to match.
+
+4. Compare the two directories:
+
+   ```sh
+   diff -r ~/tally-tutorial/2026-07-final ~/tally-tutorial/2026-07-final-again
+   ```
+
+   The command prints nothing: the two directories are byte-identical, the
+   rollup included, because no relation changed between the two exports. The
+   statements are a function of the run alone, but a rollup reads the registry
+   when the export runs, so a relation created or closed retroactively between
+   two exports of one finalized run changes the rollup document, and with it the
+   rollup index `run.json` carries:
+   [rollup](/reference/formats/exports#rollup).
+
+   An
+   `Error: --out: ... is not empty, and an export does not remove what an earlier one left there`
+   refusal instead of the four lines above means the directory was used before,
+   and a fresh directory name is the cure.
+
+## Export the statements as CSV
+
+1. Export the same run as tables:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format csv --out ~/tally-tutorial/2026-07-final-csv
+   ```
+
+   ```text
+   run 77fb51f8-82c9-4d52-98a2-7fd3e0b43c53 exported for 2026-07 as csv into /Users/berendt/tally-tutorial/2026-07-final-csv
+   wrote rated.csv with 3101 rated records
+   wrote kickbacks.csv with 1 kickbacks
+   ```
+
+   `wrote rated.csv with 3101 rated records` and
+   `wrote kickbacks.csv with 1 kickbacks` have to match. 3101 is the rated
+   record count the `metered` line of every run of this track printed.
+
+2. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07-final-csv
+   ```
+
+   ```text
+   kickbacks.csv
+   rated.csv
+   ```
+
+   Two files, and no index beside them: every row of a table carries the run
+   and its period, so a table says which run it belongs to on its own.
+
+3. Read the header and the first two rows of the rated table:
+
+   ```sh
+   head -3 ~/tally-tutorial/2026-07-final-csv/rated.csv
+   ```
+
+   ```text
+   run_id,kind,corrects_run_id,period_from,period_to,cloud,platform,resource_type,resource_id,project_id,state,from_ts,to_ts,dimension,quantity,amount,currency
+   77fb51f8-82c9-4d52-98a2-7fd3e0b43c53,regular,,2026-07-01T00:00:00Z,2026-08-01T00:00:00Z,os-sim,openstack,floating_ip,11327c4f-5563-4b70-9769-7ec877ff59b8,018504a6cc10019a40e3f9eef4dae529,active,2026-07-01T02:31:36Z,2026-07-22T01:55:52Z,count,1.0000,2.52,EUR
+   77fb51f8-82c9-4d52-98a2-7fd3e0b43c53,regular,,2026-07-01T00:00:00Z,2026-08-01T00:00:00Z,os-sim,openstack,floating_ip,28b8f170-6b0c-474a-8b0d-a65b479c8e98,d5a8024946ddf673277b9e2490643a2c,active,2026-07-01T03:07:27Z,2026-08-01T00:00:00Z,count,1.0000,3.70,EUR
+   ```
+
+   The header has to match, and it is the column order of the table. There is
+   one row per rated record, a resource, a state span and a dimension each. The
+   run id in every row is your own, and the rest of a row is the seed's.
+
+4. Count the lines of the table:
+
+   ```sh
+   wc -l < ~/tally-tutorial/2026-07-final-csv/rated.csv
+   ```
+
+   ```text
+       3102
+   ```
+
+   3102 has to match, the 3101 records and the header. The leading spaces are
+   how the `wc` of macOS pads its count.
+
+5. Count the rows of one tenant:
+
+   ```sh
+   awk -F, '$10 == "005be5adeef3d87e280d03d9d57c38b4"' ~/tally-tutorial/2026-07-final-csv/rated.csv | wc -l
+   ```
+
+   ```text
+        827
+   ```
+
+   827 has to match: the rows whose tenth column, `project_id`, is the tenant
+   of `alpha`. The table carries the tenant that owned each resource, and the
+   attribution to `alpha` stands in the statements alone, which is why the JSON
+   export has no statement for that tenant while the table has its rows.
+
+6. Read the kickback table:
+
+   ```sh
+   cat ~/tally-tutorial/2026-07-final-csv/kickbacks.csv
+   ```
+
+   ```text
+   run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency
+   77fb51f8-82c9-4d52-98a2-7fd3e0b43c53,regular,,2026-07-01T00:00:00Z,2026-08-01T00:00:00Z,cloudhouse,os-sim,10e287d5788957a2a331cabd1b5dccdf,2ccfc925-6f65-41e5-a180-4d12d25e283a,all,0.100000,593.55,59.36,EUR
+   ```
+
+   The header has to match, and there is one row, the `cloudhouse` kickback of
+   Pay a reseller a kickback, with the ids in it your own.
+
+## What you learned
+
+- A period moves from open through grace to finalized, and the close is the one
+  step a person takes:
+  [the lifecycle](/explanation/billing-period-lifecycle-and-corrections#the-lifecycle).
+- A finalized run cannot be metered again or rewritten, because the database
+  refuses it:
+  [why a finalized run is immutable](/explanation/billing-period-lifecycle-and-corrections#why-a-finalized-run-is-immutable).
+- The statements an export writes are reproducible because they are a function
+  of the run and nothing else, while a rollup reads the registry as it runs:
+  [exports](/explanation/billing-period-lifecycle-and-corrections#exports).
+- The files an export writes are in
+  [files](/reference/formats/exports#files), the columns of the tables in
+  [CSV tables](/reference/formats/exports#csv-tables), and the flags of
+  `finalize`, `periods list` and `export` in
+  [tally-engine](/reference/command-line/tally-engine).
+
+## Where to go next
+
+[Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note)
+releases the 84 notifications the simulator holds and books them as a
+correction of the month you just closed.
+
+It starts from the state this lesson leaves behind:
+
+- everything Attribute a tenant to its Gardener project left;
+- `2026-07` finalized on `RUN_ID` in the engine database;
+- the three export directories `~/tally-tutorial/2026-07-final`,
+  `2026-07-final-again` and `2026-07-final-csv`;
+- the simulator still holding its 84 notifications.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials
-description: Lessons that take you by the hand from an empty machine to a rated month, and the track that continues from there.
+description: Lessons that take you by the hand from an empty machine to a rated month, and on through finalization, corrections, commercial pricing and attribution.
 quadrant: tutorial
 audience: all
 ---
@@ -49,15 +49,37 @@ system you built yourself, and a name for each part of it.
 
 The fifth lesson is where the track ends when you want a clean machine. A
 reader going on to the billing track does it after that track's last lesson,
-because the billing track continues from the state the fourth lesson leaves
-behind.
+because the billing track starts with
+[Discount a customer group](/tutorials/discount-a-customer-group) and continues
+from the state the fourth lesson leaves behind.
 
 ### Billing track
 
-"The billing track: finalization, late events and corrections, commercial pricing and related-cost attribution"
-is the track written next. It continues from the state the fourth lesson of the
-core track leaves behind: the cluster up, the simulator holding its 84
-notifications, the month rated but not finalized, the registry empty.
+1. [Discount a customer group](/tutorials/discount-a-customer-group): register
+   three projects, group them under a customer with a discount on each
+   membership, run the month again and read a discounted statement and the
+   group's rollup. Assumes Watch the month in Grafana.
+2. [Pay a reseller a kickback](/tutorials/pay-a-reseller-a-kickback): register
+   the CI tenant, put it under a partner with a discount and a kickback, run
+   the month and read the statement and the kickback report.
+   Assumes Discount a customer group.
+3. [Attribute a tenant to its Gardener project](/tutorials/attribute-a-tenant-to-its-gardener-project):
+   register the two Gardener projects and their tenants, relate each project to
+   its tenant, see the registry refuse a cycle, run the month and read the
+   attributed statement. Assumes Pay a reseller a kickback.
+4. [Finalize the month and export it](/tutorials/finalize-the-month-and-export-it):
+   finalize the month on the attributed run, see the engine refuse to meter it
+   again, and export it as JSON and as CSV.
+   Assumes Attribute a tenant to its Gardener project.
+5. [Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note):
+   release the notifications the simulator held back, book them as a
+   correction, read the credit notes and close the correction.
+   Assumes Finalize the month and export it.
+
+The fifth lesson is where the billing track ends, and the state it leaves is
+written out on that page.
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
+back to a clean machine.
 
 ## The simulated cloud
 
@@ -65,7 +87,10 @@ Every lesson works on the same generated month: seed 1, July 2026, the cloud
 `os-sim`, six tenants, of which three are classic projects, two are Gardener
 tenants and one is a CI tenant. That month renders 15727 notifications, 1812 of
 them billable, and 84 of those stay held back by the switch the second lesson
-turns on, so the counts a lesson shows are the counts every machine gets.
+turns on, so the counts a lesson shows are the counts every machine gets. The
+two Gardener projects are `alpha` and `beta`, and the billing track registers
+them under the cloud `garden-sim`, one installation of one platform, beside the
+tenants of `os-sim`.
 
 What the month holds is in
 [the simulated OpenStack world](/explanation/the-simulated-openstack-world).

--- a/docs/tutorials/pay-a-reseller-a-kickback.md
+++ b/docs/tutorials/pay-a-reseller-a-kickback.md
@@ -1,0 +1,497 @@
+---
+title: Pay a reseller a kickback
+description: Register the CI tenant of the simulated cloud, create a partner, put the tenant under its management with a discount and a kickback, run July 2026 again, and read the tenant's statement and the kickback report.
+quadrant: tutorial
+audience: all
+---
+<!-- Shown output captured on 2026-09-07 from commit 01d2aff with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
+
+# Pay a reseller a kickback
+
+In this lesson you register the CI tenant of the simulated cloud, create a
+partner, put the tenant under the partner's management with a 15% discount and
+a 10% kickback on one relation, run July 2026 again, and read the tenant's
+statement and the kickback report.
+
+At the end the registry holds the CI tenant and the partner `cloudhouse` beside
+the rows of Discount a customer group, `RUN_ID` names a new run of July 2026,
+the JSON export of that run is under `~/tally-tutorial/2026-07-reseller`, and
+`CI_ID` and `PARTNER_ID` are in the shell.
+
+This lesson takes about 5 minutes.
+
+## Before you start
+
+- The state [Discount a customer group](/tutorials/discount-a-customer-group)
+  leaves:
+
+  - everything Watch the month in Grafana left;
+  - the registry holding the three tenants, the meta-project `acme` and three
+    `member_of` relations;
+  - `RUN_ID` on the discounted run;
+  - the export under `~/tally-tutorial/2026-07-group`;
+  - `ACME_ID`, `ACME_1_ID`, `ACME_2_ID` and `ACME_3_ID` in the shell.
+
+- `jq` 1.8.1 (`jq --version`).
+
+If you closed that shell, restore it with this block:
+
+```sh
+export TALLY_REPORTING_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+TALLY_API_TOKEN="$(go run ./cmd/tally-reporting-admin create-api-token --role admin --description 'tutorial')"
+export TALLY_API_TOKEN
+export TALLY_ENGINE_DB_URL='postgres://tally:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_engine?sslmode=disable'
+export TALLY_ENGINE_REPORTING_DB_URL='postgres://tally_engine:tally-dev-password@db.tally.127-0-0-1.nip.io:5432/tally_reporting?sslmode=disable'
+export TALLY_ENGINE_COUNTER_SOURCES=deploy/kubernetes/overlays/dev/counter-sources.yaml
+export TALLY_ENGINE_VM_URL=http://127.0.0.1:8428
+kubectl --context kind-tally -n tally port-forward svc/victoriametrics 8428:8428 &
+make -s ca > tally-ca.crt
+```
+
+A token is printed once, so a closed shell means a new token. The one you minted
+before stays valid until it is revoked, which takes the id on the
+`created api_tokens <id>` line the command printed beside it, so keep that line
+where you mean to revoke, the way
+[issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
+says. Every token this track mints goes with the cluster
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally) removes.
+The port-forward line and the CA line are for a shell that lost them. `RUN_ID`
+is not needed before this lesson sets it anew, and this lesson reads none of
+the four `ACME_` variables.
+
+A connection error from any `go run` command means the cluster is not up, and
+`kind get clusters` then prints nothing. `curl: (7)` on the API hostname means
+the same. Both are cured by
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
+
+## Register the CI tenant
+
+1. Register the tenant the partner manages:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d '{"platform": "openstack", "cloud": "os-sim", "external_id": "10e287d5788957a2a331cabd1b5dccdf", "name": "ci"}' \
+     https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects | jq .
+   ```
+
+   ```json
+   {
+     "cloud": "os-sim",
+     "created_at": "2026-09-07T21:27:25.758052Z",
+     "external_id": "10e287d5788957a2a331cabd1b5dccdf",
+     "id": "d4fed605-70b4-4350-9d9e-1b8b58e1dbae",
+     "metadata": {},
+     "name": "ci",
+     "platform": "openstack"
+   }
+   ```
+
+   This is [the CI tenant](/explanation/the-simulated-openstack-world#the-ci-tenant),
+   which boots and deletes runners on every working day of the month. It
+   carries 447 resources, more than any other tenant of the month, and its
+   total in the list-price run is 698.29.
+
+   `cloud` `os-sim`, `external_id`, `name` `ci`, `platform` `openstack` and
+   `metadata` `{}` have to match. `id` and `created_at` are your own.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a project with this cloud and external id is already registered` means this
+   step ran before, and the read-back below reads the id it needs anyway. A 401
+   with `type` `urn:tally:error:unauthorized` means `TALLY_API_TOKEN` is empty
+   in this shell, so mint one with the restore block above. A 403 with `type`
+   `urn:tally:error:forbidden` means the token is not an admin token.
+
+2. Read the id back into the shell:
+
+   ```sh
+   CI_ID="$(curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim&external_id=10e287d5788957a2a331cabd1b5dccdf' | jq -r '.items[0].id')"
+   export CI_ID
+   echo "$CI_ID"
+   ```
+
+   ```text
+   d4fed605-70b4-4350-9d9e-1b8b58e1dbae
+   ```
+
+   The id is your own, and it is the id the registration printed. This read is
+   what a reader who saw the 409 runs, because it reads what is registered
+   whether this shell registered it or not. An id printing `null` means the
+   registration did not happen, and the cure is the call above.
+
+## Create the partner
+
+1. Register the partner that manages the tenant:
+
+   ```sh
+   PARTNER_ID="$(go run ./cmd/tally-reporting-admin create-partner --external-id cloudhouse --name 'Cloudhouse')"
+   export PARTNER_ID
+   echo "$PARTNER_ID"
+   ```
+
+   ```text
+   registered partner cloudhouse
+   764c13ba-f5e1-4d3a-8253-2d0813016aee
+   ```
+
+   `registered partner cloudhouse` is the CLI's notice on stderr. The id went
+   to stdout and into the variable, and it is your own.
+
+   A partner is a `projects` row with platform and cloud both `partner`. It
+   owns no resource and is what a `managed_by` relation points at:
+   [meta-projects and partners](/explanation/commercial-pricing-on-relations#meta-projects-and-partners).
+
+   Check that the `echo` printed one uuid before you go on. The target of the
+   relation in the next step cannot be corrected inside July once it is sent,
+   for the reason the run step gives.
+
+   `Error: partner cloudhouse: already registered` with exit status 1 means the
+   row exists from an earlier run of this step, and
+   `GET /api/v1/projects?cloud=partner&external_id=cloudhouse` piped into
+   `jq -r '.items[0].id'` reads its id the way the read-back above reads the
+   tenant's.
+
+## Put the discount and the kickback on the management
+
+1. Relate the tenant to the partner:
+
+   ```sh
+   curl -s --cacert tally-ca.crt -H "Authorization: Bearer $TALLY_API_TOKEN" -H 'Content-Type: application/json' \
+     -d @- "https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects/$CI_ID/relations" <<EOF | jq .
+   {
+     "target_id": "$PARTNER_ID",
+     "relation_type": "managed_by",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "metadata": {
+       "pricing_adjustments": [
+         {"type": "discount", "rate": "0.15", "scope": "all", "description": "Cloudhouse end-customer discount"},
+         {"type": "kickback", "rate": "0.10", "scope": "all", "description": "Cloudhouse commission"}
+       ]
+     }
+   }
+   EOF
+   ```
+
+   ```json
+   {
+     "created_at": "2026-09-07T21:27:26.302705Z",
+     "id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+     "metadata": {
+       "pricing_adjustments": [
+         {
+           "description": "Cloudhouse end-customer discount",
+           "rate": "0.15",
+           "scope": "all",
+           "type": "discount"
+         },
+         {
+           "description": "Cloudhouse commission",
+           "rate": "0.10",
+           "scope": "all",
+           "type": "kickback"
+         }
+       ]
+     },
+     "relation_type": "managed_by",
+     "source_id": "d4fed605-70b4-4350-9d9e-1b8b58e1dbae",
+     "target_id": "764c13ba-f5e1-4d3a-8253-2d0813016aee",
+     "valid_from": "2026-07-01T00:00:00Z",
+     "valid_to": null
+   }
+   ```
+
+   `relation_type` `managed_by`, `valid_from` `2026-07-01T00:00:00Z`,
+   `valid_to` null and the two `pricing_adjustments` entries, a `discount` of
+   rate `0.15` and a `kickback` of rate `0.10`, both on scope `all`, have to
+   match. `id`, `source_id`, `target_id` and `created_at` are your own.
+
+   A `managed_by` relation places the tenant under the partner and attributes
+   no cost. The rates are strings, `"0.15"` and `"0.10"`, never numbers, and
+   `valid_from` is the first instant of July for the reason Discount a customer
+   group gives.
+
+   The engine applies what it collects in the fixed order surcharge, discount,
+   project discount, kickback, whatever order the array has. A kickback is what
+   the partner is owed rather than what the customer pays.
+
+   A 409 with `type` `urn:tally:error:conflict` and the detail
+   `a relation of this type between these projects is already active` means
+   this step ran before. A 400 with `type` `urn:tally:error:validation` whose
+   error is located at `body.target_id` means `PARTNER_ID` is empty in this
+   shell. A 422 with `type` `urn:tally:error:validation` and an error at
+   `body.metadata.pricing_adjustments.0.rate` reading `got number, want string`
+   means a rate was sent as a number. A `target_id` that is the meta-project's
+   id, `ACME_ID`, is stored by the registry like any other, and the run then
+   drops the kickback with one `adjustment` warning, which the next step names.
+
+## Run the month
+
+1. Meter and rate July 2026 once more:
+
+   ```sh
+   go run ./cmd/tally-engine run --period 2026-07
+   ```
+
+   ```text
+   run 72584a66-9bb2-4d5b-9cf2-fa43fcb6e886 completed for 2026-07 with pricing model 2026-03
+   metered 867 candidates into 945 usage records, 3101 rated records and 6 project statements
+   applied 5 pricing adjustments
+   superseded run ee0b363e-2449-4085-bca4-218150d1e546
+   warnings recorded in runs.stats: 38 metering, 0 counter, 0 attribution, 0 adjustment, 2 unpriced resource types, 0 unreadable fields, 2 unregistered projects
+   ```
+
+   The `metered` line, `applied 5 pricing adjustments` and the warnings line
+   have to match. Both run ids are your own, and the superseded one is the run
+   Discount a customer group made.
+
+   `applied 5` counts the three membership lines plus the two lines of this
+   relation, one per adjustment on the CI tenant's statement. The warnings line
+   ends in `0 adjustment`, so no kickback was dropped, and in
+   `2 unregistered projects`, the two Gardener tenants the next lesson
+   registers.
+
+2. Put the id from the first line of your own output in place of this one:
+
+   ```sh
+   export RUN_ID=72584a66-9bb2-4d5b-9cf2-fa43fcb6e886
+   ```
+
+   Every command below reads `RUN_ID`.
+
+3. Read what stands there instead if the run printed something else:
+
+   - `1 adjustment` on the warnings line together with a
+     `warning: adjustment_kickback_target_not_partner` line means the
+     relation's target is not the partner row, so the kickback was dropped and
+     the discount stayed. There is no cure inside July: a relation is closed
+     rather than deleted, `valid_to` has to be after `valid_from`, and a
+     relation whose validity overlaps a period at any instant applies to it
+     ([temporal validity](/explanation/project-registry-relations-and-attribution#temporal-validity)),
+     so the run bills with that relation as it stands. A reader who wants the
+     numbers of this page starts both tracks again from
+     [Tear down your local Tally](/tutorials/tear-down-your-local-tally). This
+     is why the step before had you check `PARTNER_ID`.
+   - `no pricing model is valid for this period` means the model Meter and rate
+     your first month imported is missing. Import it and run the month again.
+   - An error opening on `another run of this period is in progress` means
+     another `tally-engine run` of this period is live, in this shell or in
+     another one. Let that run end; the hourly tick is not it, because the tick
+     leaves a month that already carries a completed run alone.
+   - A non-zero `counter` count on the warnings line means the port-forward
+     died before the run read the store. Start it again and run the month
+     again.
+   - `reading the counter sources deploy/kubernetes/overlays/dev/counter-sources.yaml: open deploy/kubernetes/overlays/dev/counter-sources.yaml: no such file or directory`
+     means the shell is not at the repository root, or
+     `TALLY_ENGINE_COUNTER_SOURCES` is not exported.
+
+## Read the reseller's statement
+
+1. Export the run:
+
+   ```sh
+   go run ./cmd/tally-engine export --run "$RUN_ID" --format json --out ~/tally-tutorial/2026-07-reseller
+   ```
+
+   ```text
+   run 72584a66-9bb2-4d5b-9cf2-fa43fcb6e886 exported for 2026-07 as json into /Users/berendt/tally-tutorial/2026-07-reseller
+   wrote run.json and 6 statements
+   wrote kickbacks.json with 1 kickbacks
+   ```
+
+   The second and the third line have to match, and
+   `wrote kickbacks.json with 1 kickbacks` is the settlement this run has that
+   the run before had none of. The run id and the home directory are your own.
+   A directory that already holds files is refused, so this export gets a
+   directory of its own.
+
+2. Read what the CI tenant owes:
+
+   ```sh
+   jq '{base_cost, adjustments, net_cost, kickback_total, total}' ~/tally-tutorial/2026-07-reseller/statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   ```
+
+   ```json
+   {
+     "base_cost": 698.29,
+     "adjustments": [
+       {
+         "type": "discount",
+         "relation_type": "managed_by",
+         "relation_target": "cloudhouse",
+         "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+         "scope": "all",
+         "description": "Cloudhouse end-customer discount",
+         "rate": 0.150000,
+         "base": 698.29,
+         "amount": -104.74
+       },
+       {
+         "type": "kickback",
+         "relation_type": "managed_by",
+         "relation_target": "cloudhouse",
+         "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+         "scope": "all",
+         "description": "Cloudhouse commission",
+         "rate": 0.100000,
+         "base": 593.55,
+         "amount": 59.36
+       }
+     ],
+     "net_cost": 593.55,
+     "kickback_total": 59.36,
+     "total": 593.55
+   }
+   ```
+
+   `base_cost` 698.29 is the tenant's total at list price. The `discount` line
+   is computed on that base: 698.29 times 0.15, rounded once to two places, is
+   `amount` -104.74. `net_cost` 593.55 is the base plus that amount, and
+   `total` is the net. The `kickback` line is computed on the running net:
+   `base` 593.55 times 0.10, rounded once, is `amount` 59.36, and it leaves the
+   net alone. `kickback_total` 59.36 stands beside `net_cost`, not inside it.
+
+   All of these have to match. The two `relation_id` values are your own, and
+   both name the one relation. The two lines stand in the order the engine
+   applied them.
+
+3. List what the export wrote:
+
+   ```sh
+   ls ~/tally-tutorial/2026-07-reseller
+   ```
+
+   ```text
+   kickbacks.json
+   run.json
+   statement-os-sim%2F005be5adeef3d87e280d03d9d57c38b4.json
+   statement-os-sim%2F018504a6cc10019a40e3f9eef4dae529.json
+   statement-os-sim%2F10e287d5788957a2a331cabd1b5dccdf.json
+   statement-os-sim%2F34e991db9fc6466f8ca69b43f70fce65.json
+   statement-os-sim%2Fd5a8024946ddf673277b9e2490643a2c.json
+   statement-os-sim%2Fe31f9083a7e5ee15071a3bd53cb2bac7.json
+   ```
+
+   The eight names have to match: six statements beside `run.json` and
+   `kickbacks.json`. There is no `statement-partner%2Fcloudhouse.json`, because
+   a partner is billed nothing and what it is owed is in the settlement.
+
+## Read the kickback report
+
+1. Report what the run owes its partners:
+
+   ```sh
+   go run ./cmd/tally-engine kickbacks --period 2026-07
+   ```
+
+   ```json
+   {
+     "run_id": "72584a66-9bb2-4d5b-9cf2-fa43fcb6e886",
+     "kind": "regular",
+     "corrects_run_id": null,
+     "period_from": "2026-07-01T00:00:00Z",
+     "period_to": "2026-08-01T00:00:00Z",
+     "beneficiaries": [
+       {
+         "beneficiary": "cloudhouse",
+         "currency": "EUR",
+         "kickback_total": 59.36,
+         "projects": 1,
+         "breakdown": [
+           {
+             "cloud": "os-sim",
+             "project_id": "10e287d5788957a2a331cabd1b5dccdf",
+             "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+             "scope": "all",
+             "rate": 0.100000,
+             "base": 593.55,
+             "amount": 59.36
+           }
+         ]
+       }
+     ]
+   }
+   ```
+
+   `kind` `regular`, the one beneficiary `cloudhouse` in `EUR`, its
+   `kickback_total` 59.36 equal to the statement's, `projects` 1 and the one
+   `breakdown` entry with its cloud `os-sim`, its project
+   `10e287d5788957a2a331cabd1b5dccdf`, its relation id, its scope `all`, its
+   rate 0.100000, its base 593.55 and its amount 59.36 have to match. `run_id`
+   and `relation_id` are your own.
+
+   A month named alone reports the regular run that bills it. The document
+   alone reaches stdout, so it pipes into a file as it is.
+
+2. Report the same settlement as CSV:
+
+   ```sh
+   go run ./cmd/tally-engine kickbacks --period 2026-07 --format csv
+   ```
+
+   ```text
+   run_id,kind,corrects_run_id,period_from,period_to,beneficiary,cloud,project_id,relation_id,scope,rate,base,amount,currency
+   72584a66-9bb2-4d5b-9cf2-fa43fcb6e886,regular,,2026-07-01T00:00:00Z,2026-08-01T00:00:00Z,cloudhouse,os-sim,10e287d5788957a2a331cabd1b5dccdf,2ccfc925-6f65-41e5-a180-4d12d25e283a,all,0.100000,593.55,59.36,EUR
+   ```
+
+   The header has to match. There is one row per kickback record, and the ids
+   in the row are your own.
+
+3. Read the settlement the export left beside the statements:
+
+   ```sh
+   jq .beneficiaries ~/tally-tutorial/2026-07-reseller/kickbacks.json
+   ```
+
+   ```json
+   [
+     {
+       "beneficiary": "cloudhouse",
+       "currency": "EUR",
+       "kickback_total": 59.36,
+       "projects": 1,
+       "breakdown": [
+         {
+           "cloud": "os-sim",
+           "project_id": "10e287d5788957a2a331cabd1b5dccdf",
+           "relation_id": "2ccfc925-6f65-41e5-a180-4d12d25e283a",
+           "scope": "all",
+           "rate": 0.100000,
+           "base": 593.55,
+           "amount": 59.36
+         }
+       ]
+     }
+   ]
+   ```
+
+   The export wrote the same settlement beside the statements, so what you hand
+   the partner is in the export directory too.
+
+## What you learned
+
+- A partner is an ordinary registry row, and a kickback is a line of its own
+  computed on the running net that leaves the customer's net alone:
+  [how adjustments apply](/explanation/commercial-pricing-on-relations#how-adjustments-apply).
+- What a partner is owed is a sum across statements, which is why the
+  settlement is a report of its own:
+  [kickbacks and the rollup](/explanation/commercial-pricing-on-relations#kickbacks-and-the-rollup).
+- The rate is stored on the relation rather than derived from the period's
+  volume, so a correction rates the same way:
+  [why volume tiers are not computed](/explanation/commercial-pricing-on-relations#why-volume-tiers-are-not-computed).
+- The settlement's members are in
+  [kickback settlement](/reference/formats/exports#kickback-settlement) and the
+  flags of `kickbacks` in
+  [tally-engine](/reference/command-line/tally-engine).
+
+## Where to go next
+
+[Attribute a tenant to its Gardener project](/tutorials/attribute-a-tenant-to-its-gardener-project)
+registers the two Gardener projects and moves their tenants' costs onto them.
+
+It starts from the state this lesson leaves behind:
+
+- everything Discount a customer group left;
+- the registry holding four tenants, the meta-project `acme`, the partner
+  `cloudhouse` and four relations;
+- `RUN_ID` on this run, which superseded the discounted one;
+- the export under `~/tally-tutorial/2026-07-reseller`;
+- `CI_ID` and `PARTNER_ID` in the shell.

--- a/docs/tutorials/tear-down-your-local-tally.md
+++ b/docs/tutorials/tear-down-your-local-tally.md
@@ -18,8 +18,11 @@ databases, because that is where they live. You remove the CA file
 
 What stays is the four `tally-*:dev` images in Docker, the Go build and module
 caches under your home directory, and the clone. A reader going on to the
-billing track does this lesson after that track's last lesson, because the
-billing track continues from the state lesson 4 leaves behind.
+billing track, which starts with
+[Discount a customer group](/tutorials/discount-a-customer-group), does this
+lesson after its last lesson,
+[Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note),
+because the billing track continues from the state lesson 4 leaves behind.
 
 This lesson takes about 5 minutes.
 
@@ -115,21 +118,28 @@ This lesson takes about 5 minutes.
 
 ## Remove what the lessons wrote
 
-1. Remove the CA file, the export directory and the seven variables:
+1. Remove the CA file, the export directory, the seven variables of the core
+   track and the eleven of the billing track:
 
    ```sh
    rm tally-ca.crt
    rm -r ~/tally-tutorial
-   unset TALLY_REPORTING_DB_URL TALLY_API_TOKEN TALLY_ENGINE_DB_URL TALLY_ENGINE_REPORTING_DB_URL TALLY_ENGINE_COUNTER_SOURCES TALLY_ENGINE_VM_URL RUN_ID
+   unset TALLY_REPORTING_DB_URL TALLY_API_TOKEN TALLY_ENGINE_DB_URL TALLY_ENGINE_REPORTING_DB_URL TALLY_ENGINE_COUNTER_SOURCES TALLY_ENGINE_VM_URL RUN_ID ACME_1_ID ACME_2_ID ACME_3_ID ACME_ID CI_ID PARTNER_ID ALPHA_TENANT_ID BETA_TENANT_ID ALPHA_ID BETA_ID CORRECTION_ID
    ```
 
    The three commands print nothing. `tally-ca.crt` is stale from here on: the
    next `make up` creates a new certificate authority, and `make -s ca` writes
    the file again for it. `~/tally-tutorial` held the export of lesson 3, the
-   six statements with `run.json` and `kickbacks.json` beside them. The seven
+   six statements with `run.json` and `kickbacks.json` beside them. After the
+   billing track it also held that track's seven export directories,
+   `2026-07-group`, `2026-07-reseller`, `2026-07-attributed`, `2026-07-final`,
+   `2026-07-final-again`, `2026-07-final-csv` and `2026-07-notes`. The seven
    variables are the shell state lessons 1 to 3 built, and `unset` leaves this
-   shell without them. `rm: tally-ca.crt: No such file or directory` means the
-   file was already gone, which is fine.
+   shell without them. The eleven after `RUN_ID` are the billing track's, and
+   `unset` skips a variable that is not set without a word, so the line is the
+   same on a machine where the billing track never ran.
+   `rm: tally-ca.crt: No such file or directory` means the file was already
+   gone, which is fine.
 
 ## What stays
 

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -271,8 +271,9 @@ two time ranges, or the `cloud` variable is not on `os-sim`.
 
 ## Where to go next
 
-The track written next continues from the state this lesson leaves behind:
-"The billing track: finalization, late events and corrections, commercial pricing and related-cost attribution".
+[Discount a customer group](/tutorials/discount-a-customer-group) is the first
+lesson of the billing track, which continues from the state this lesson leaves
+behind.
 
 [Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
 back to a clean machine. A reader going on to the billing track does lesson 5


### PR DESCRIPTION
Closes #110

This branch writes the billing tutorial track: five lessons under `docs/tutorials/` that continue from the state the core track (#109) leaves behind — the cluster up, the simulator holding its 84 notifications, July 2026 rated but not finalized, the registry empty — and end with a finalized, corrected and commercially priced month. Every output block on every page is pasted from one real run of both tracks on 2026-09-07 at commit `01d2aff`.

## The change set, in commit order

- **`a36a262` Write the tutorial that discounts a customer group** — `docs/tutorials/discount-a-customer-group.md`. The reader registers the three classic tenants through `POST /api/v1/projects`, creates the meta-project `acme` with `tally-reporting-admin create-meta-project`, puts a `project_discount` of rate `0.10` on scope `all` on each `member_of` membership, reruns the month and reads a discounted statement plus the group's `member_of` rollup. Adds the `Billing track` group to `docs/.vitepress/sidebar.json` holding this lesson.
- **`492f3cd` Write the tutorial that pays a reseller a kickback** — `docs/tutorials/pay-a-reseller-a-kickback.md`. Registers the CI tenant, creates the partner `cloudhouse`, puts a `discount` of `0.15` and a `kickback` of `0.10` on one `managed_by` relation, reruns the month and reads the tenant's statement and the kickback report.
- **`36f7963` Write the tutorial that attributes a tenant to a Gardener project** — `docs/tutorials/attribute-a-tenant-to-its-gardener-project.md`. Registers `garden-sim/alpha` and `garden-sim/beta` and the two OpenStack tenants their shoots run on, relates each project to its tenant with `infrastructure_tenant`, shows the registry refusing the reverse relation as a cycle, reruns the month and reads the tenant costs as `related_costs` on the Gardener project statement — including the step that shows nothing is billed twice.
- **`0abf278` Write the tutorial that finalizes the month and exports it** — `docs/tutorials/finalize-the-month-and-export-it.md`. Finalizes `2026-07` on the attributed run, shows the two refusals a finalized period answers with, and exports that run as JSON twice and as CSV once.
- **`b6656d9` Write the tutorial that books the late events as a credit note** — `docs/tutorials/book-the-late-events-as-a-credit-note.md`. Releases the 84 held notifications, has the engine find them as late arrivals, books them as a correction of the closed month, reads the credit notes and finalizes the correction. Ends by stating the state the track leaves behind.
- **`2473aa9` Link the billing track from the index and the core track** — `docs/tutorials/index.md` replaces the unlinked `### Billing track` placeholder with the ordered list of the five lessons (what the reader does, which lesson each assumes) and names `garden-sim`; `docs/tutorials/watch-the-month-in-grafana.md` links `Discount a customer group` as the next lesson; `docs/tutorials/tear-down-your-local-tally.md` links both ends of the track, names the track's seven export directories and extends its `unset` line with the eleven variables the track adds.

## Fixed choices the track states where the reader meets them

- Every relation carries `valid_from: 2026-07-01T00:00:00Z` and no `valid_to`, because `valid_from` otherwise defaults to the instant the relation is written — September — and would not overlap July.
- The Gardener projects and their tenants are registered by hand rather than with `SIM_REGISTER_PROJECTS=true`, because that switch registers only when the simulator starts and a restart would discard the 84 held notifications the last lesson needs.
- The customer-group graph and the reseller graph stay disjoint: no project is both a member and managed, so each statement carries the lines of exactly one lesson.
- The track adds eleven shell variables (`ACME_1_ID`, `ACME_2_ID`, `ACME_3_ID`, `ACME_ID`, `CI_ID`, `PARTNER_ID`, `ALPHA_TENANT_ID`, `BETA_TENANT_ID`, `ALPHA_ID`, `BETA_ID`, `CORRECTION_ID`) and reuses `RUN_ID`; the tear-down lesson unsets all of them.

## Divergence from the issue as drafted

The issue's title and its first draft order put finalization first. The lessons ship in the order **customer group, reseller, attribution, finalization, late events**, which is the order the issue's own Description settles: a finalized period refuses `run --period 2026-07`, so with finalization first the three modelling lessons would have had to run as corrections and the reader would never read a discounted statement, a regular kickback report or a Gardener statement with `related_costs`. In the shipped order each modelling lesson is one more `run` that supersedes the one before it, the finalization lesson closes the last of them, and the late-events lesson books the held share as the single correction.

Nothing outside `docs/tutorials/` and `docs/.vitepress/sidebar.json` changes; the first three core lessons are untouched.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 7ea363b with Claude:claude-opus-5_
