### PR TITLE
Check the tools with a target rather than name their versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,103 @@ NODE_IMAGES := $(shell grep -rhoE 'image: [A-Za-z0-9._/-]+:[A-Za-z0-9._-]+' depl
 VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' deploy/kubernetes/base/vmalert/vmalert.yaml | head -n1)
 ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
 
-.PHONY: up down dev ca test lint fmt check-alerting migrate generate images \
-	simulator-up simulator-down docs docs-build
+.PHONY: check-tools up down dev ca test lint fmt check-alerting migrate generate \
+	images simulator-up simulator-down docs docs-build
+
+# What `check-tools` holds the Docker engine to. One kind node runs the whole
+# stack, and an engine given less than this spends the readiness waits of `up`
+# swapping rather than pulling. They are floors, not the size of the machine
+# this was written on: what the engine was actually given is printed beside
+# them.
+DOCKER_MIN_CPUS ?= 4
+DOCKER_MIN_MEMORY_GB ?= 8
+
+# The language version go.mod states, which is the minimum a toolchain on the
+# host has to satisfy. It is read out of the file rather than written a second
+# time here, so a bumped module carries this with it. That Go downloads the
+# version the `toolchain` line names on its first run inside the repository,
+# which is why nothing here asks for that one.
+GO_MIN_VERSION := $(shell sed -n 's/^go \([0-9][0-9.]*\)$$/\1/p' go.mod)
+
+# check-tools runs one probe per tool and prints what the probe answered, rather
+# than judging a version against a list. A version written here would be a
+# second pin beside the ones that decide anything, deploy/kind/kind.yaml, the
+# manifests and go.mod, and it would age on its own, telling a reader whose
+# machine works that their machine is wrong. What the target asserts is that the
+# tool is on the path and answers, and for Go that it satisfies the minimum the
+# module itself states.
+#
+# The probe function takes what to call the tool, what needs it, and the command
+# that proves it works. A command that is not there exits 127, which is what
+# separates a tool nobody installed from one that is installed and answering
+# with an error: a Docker whose engine is not running fails the second way, and
+# a reader told to install Docker there would look for a long time.
+#
+# What Docker Desktop was given is a warning rather than a failure. The stack
+# comes up on less, more slowly, and that number is the first thing to look at
+# when a readiness wait of `up` runs out.
+#
+# Nothing here touches a cluster, so the target runs before `up` ever has, which
+# is where a missing tool is cheapest to find. The Node toolchain is not probed:
+# `docs` and `docs-build` are the only targets that need it, and the `npm ci`
+# they run says plainly enough what is missing.
+## check-tools: check that the tools the dev stack and the tutorials need answer
+check-tools:
+	@failed=0; \
+	report() { printf '%-8s %-15s %s\n' "$$1" "$$2" "$$3"; }; \
+	first() { printf '%s\n' "$$1" | head -n1; }; \
+	probe() { \
+		label="$$1"; need="$$2"; shift 2; \
+		if output="$$("$$@" 2>&1)"; then \
+			report ok "$$label" "$$(first "$$output")"; \
+			return 0; \
+		else \
+			status=$$?; \
+		fi; \
+		failed=$$((failed + 1)); \
+		if [ "$$status" -eq 127 ]; then \
+			report missing "$$label" "not on the path, and $$need needs it"; \
+		else \
+			report broken "$$label" "$$(first "$$output")"; \
+		fi; \
+	}; \
+	echo '==> the tools the dev stack, the simulator stack and the tutorials are driven with'; \
+	probe git 'cloning the repository' git --version; \
+	probe docker 'building the images and running the kind node' docker version --format 'engine {{.Server.Version}}'; \
+	probe 'docker compose' 'the simulator stack of deploy/compose' docker compose version; \
+	probe kind 'creating the dev cluster' kind version; \
+	probe kubectl 'every call the targets make against the cluster' kubectl version --client; \
+	probe jq 'reading the JSON the lessons print' jq --version; \
+	probe curl 'the calls against the Reporting API' curl --version; \
+	if goversion="$$(go env GOVERSION 2>&1)"; then \
+		if [ "$$(printf '%s\n%s\n' '$(GO_MIN_VERSION)' "$${goversion#go}" | sort -V | head -n1)" = '$(GO_MIN_VERSION)' ]; then \
+			report ok go "$$goversion, at or above the go $(GO_MIN_VERSION) of go.mod"; \
+		else \
+			report old go "$$goversion is under the go $(GO_MIN_VERSION) go.mod asks for"; \
+			failed=$$((failed + 1)); \
+		fi; \
+	else \
+		report missing go 'not on the path, and every binary here is built with it'; \
+		failed=$$((failed + 1)); \
+	fi; \
+	if resources="$$(docker info --format '{{.NCPU}} {{.MemTotal}}' 2>/dev/null)"; then \
+		cpus="$${resources%% *}"; \
+		gb=$$(( ($${resources##* } + 536870912) / 1073741824 )); \
+		if [ "$$cpus" -ge '$(DOCKER_MIN_CPUS)' ] && [ "$$gb" -ge '$(DOCKER_MIN_MEMORY_GB)' ]; then \
+			report ok 'docker size' "$$cpus CPUs and $$gb GB"; \
+		else \
+			report warn 'docker size' "$$cpus CPUs and $$gb GB, under the $(DOCKER_MIN_CPUS) CPUs and $(DOCKER_MIN_MEMORY_GB) GB make up wants"; \
+		fi; \
+	fi; \
+	echo; \
+	if [ "$$failed" -gt 0 ]; then \
+		echo "ERROR: $$failed of the checks above did not pass. make up would reach" >&2; \
+		echo '       the same tool minutes in and stop there, with a stack half' >&2; \
+		echo '       created. docs/contributing/dev-stack.md says what each of them' >&2; \
+		echo '       is used for.' >&2; \
+		exit 1; \
+	fi; \
+	echo 'Every tool answered. make up creates the cluster.'
 
 ## up: create the kind cluster, install the add-ons, and deploy the dev overlay
 up:

--- a/docs/contributing/dev-stack.md
+++ b/docs/contributing/dev-stack.md
@@ -14,6 +14,30 @@ over HTTPS under `*.tally.127-0-0-1.nip.io:8443`. Lesson 1 of the tutorials,
 once with the output it prints. This page says what the pieces are and which
 target owns each of them.
 
+## What the machine needs
+
+The targets on this page are driven by tools on the host: `git`, `docker` with
+its `compose` plugin, `kind`, `kubectl`, Go, `jq` and `curl`. `make check-tools`
+probes each of them and prints one line per tool, `ok` with what the tool
+answered, `missing` when it is not on the path, or `broken` with the error it
+answered instead. It exits non-zero when any of them failed, which is the cheap
+way to find a tool that is not there: `make up` reaches the same tool minutes
+in and stops with a half-created cluster behind it.
+
+No version is asserted. The pins that decide anything live where the thing they
+pin does, in `deploy/kind/kind.yaml`, in the manifests and in `go.mod`, and a
+list of versions in the `Makefile` would age beside them and start calling a
+working machine wrong. The one comparison the target makes is the Go on the
+path against the `go` line of `go.mod`, which it reads out of the file. Beside
+the tools it prints what the Docker engine was given and warns, rather than
+fails, when that is under `DOCKER_MIN_CPUS` CPUs or `DOCKER_MIN_MEMORY_GB` GB:
+the stack comes up on less, more slowly, and that number is the first thing to
+look at when a readiness wait runs out.
+
+`docs` and `docs-build` need a Node toolchain besides, which `check-tools`
+leaves alone because `npm ci` says plainly enough what is missing.
+[The toolchain](/contributing/toolchain#dependencies) names the version.
+
 ## The kind cluster
 
 [`deploy/kind/kind.yaml`](https://github.com/B42Labs/tally/blob/main/deploy/kind/kind.yaml)
@@ -265,6 +289,7 @@ The table below is rendered from the `## target: description` comments of the
 <!-- refdoc:begin make-targets -->
 | Target | What it does |
 | --- | --- |
+| `check-tools` | check that the tools the dev stack and the tutorials need answer |
 | `up` | create the kind cluster, install the add-ons, and deploy the dev overlay |
 | `images` | build one container image per binary |
 | `down` | delete the kind cluster |
@@ -293,6 +318,8 @@ line, as in `make up WAIT_ATTEMPTS=12`.
 - `WAIT_TIMEOUT` (`300s`) is how long one readiness wait may take.
 - `WAIT_ATTEMPTS` (`6`) is how many of those waits a rollout gets before `up`
   gives up on it.
+- `DOCKER_MIN_CPUS` (`4`) and `DOCKER_MIN_MEMORY_GB` (`8`) are the floors
+  `check-tools` warns about the Docker engine under.
 - `ENVOY_GATEWAY_VERSION` (`v1.8.3`) is the Envoy Gateway release `up` installs
   the manifests of.
 - `CERT_MANAGER_VERSION` (`v1.21.1`) is the cert-manager release beside it.

--- a/docs/contributing/writing-documentation.md
+++ b/docs/contributing/writing-documentation.md
@@ -187,7 +187,9 @@ A reviewer of a documentation change looks at this:
   and `npm run docs:build` in the `docs` job.
 - The page sits in the quadrant its one-sentence purpose names.
 - A tutorial's shown output comes from a run at the commit its capture comment
-  names.
+  names, and that run stays in the comment: no step has the reader print the
+  commit they are on, and no sentence names the machine, the browser or the
+  tool versions the page was captured with. A reader cannot act on any of it.
 - A how-to guide opens with `## Before you start`, closes with
   `## Check the result`, and links its reasoning instead of stating it.
 - A reference page's generated blocks were refreshed by `make generate` rather

--- a/docs/tutorials/attribute-a-tenant-to-its-gardener-project.md
+++ b/docs/tutorials/attribute-a-tenant-to-its-gardener-project.md
@@ -33,7 +33,7 @@ This lesson takes about 5 minutes.
   - the export under `~/tally-tutorial/2026-07-reseller`;
   - `CI_ID` and `PARTNER_ID` in the shell.
 
-- `jq` 1.8.1 (`jq --version`).
+- `jq` on the path, which the `make check-tools` of lesson 1 called.
 
 If you closed that shell, restore it with this block:
 

--- a/docs/tutorials/book-the-late-events-as-a-credit-note.md
+++ b/docs/tutorials/book-the-late-events-as-a-credit-note.md
@@ -36,7 +36,7 @@ This lesson takes about 5 minutes.
   started: a correction meters the month again and reads the egress counter
   from the store through it.
 - Docker Desktop running, with the three containers of the simulator stack.
-- `jq` 1.8.1 (`jq --version`).
+- `jq` on the path, which the `make check-tools` of lesson 1 called.
 
 If you closed that shell, restore it with this block:
 

--- a/docs/tutorials/discount-a-customer-group.md
+++ b/docs/tutorials/discount-a-customer-group.md
@@ -39,7 +39,7 @@ This lesson takes about 5 minutes.
     `TALLY_ENGINE_COUNTER_SOURCES`, `TALLY_ENGINE_VM_URL` and `RUN_ID` in a
     shell at the repository root.
 
-- `jq` 1.8.1 (`jq --version`).
+- `jq` on the path, which the `make check-tools` of lesson 1 called.
 
 If you closed that shell, restore it with this block:
 

--- a/docs/tutorials/finalize-the-month-and-export-it.md
+++ b/docs/tutorials/finalize-the-month-and-export-it.md
@@ -32,7 +32,7 @@ This lesson takes about 5 minutes.
   - `RUN_ID` on the attributed run;
   - the export under `~/tally-tutorial/2026-07-attributed`.
 
-- `jq` 1.8.1 (`jq --version`).
+- `jq` on the path, which the `make check-tools` of lesson 1 called.
 
 If you closed that shell, restore it with this block:
 
@@ -107,8 +107,8 @@ A connection error from any `go run` command means the cluster is not up, and
 
    The `2026-08` line is the tick's: the cluster's hourly `tally-engine`
    scheduler opens the months that have ended and moves them into their grace
-   window. Its status is your own, `grace` on this run, and the line is absent
-   on a machine whose cluster has not passed an hour mark yet.
+   window. Its status is your own, and the line is absent on a machine whose
+   cluster has not passed an hour mark yet.
 
 ## See that the month is closed
 

--- a/docs/tutorials/meter-and-rate-your-first-month.md
+++ b/docs/tutorials/meter-and-rate-your-first-month.md
@@ -24,7 +24,7 @@ This lesson takes about 5 minutes.
   simulator stack holding its 84 notifications, the month of July 2026 in the
   reporting database, `tally-ca.crt` at the repository root, and that shell at
   the repository root.
-- `jq` 1.8.1 (`jq --version`), the one lesson 1 asks for.
+- `jq` on the path, the one lesson 1 asks for.
 - The engine commands below run with `go run` from the repository root, the way
   lesson 1 ran the admin CLI.
 
@@ -147,7 +147,7 @@ both. Lesson 4 needs neither.
 
    The `metered` line and the warnings line have to match. The run id on the
    first line is your own. `2026-07` is the period this track uses everywhere,
-   and the run took a second on the machine behind this page.
+   and the run takes about a second.
 
    The run is completed, not finalized:
    [the lifecycle](/explanation/billing-period-lifecycle-and-corrections#the-lifecycle)
@@ -212,10 +212,10 @@ both. Lesson 4 needs neither.
    seed's and have to match. The billing track's correction lesson settles the
    38 once the held share is released.
 
-   The other four classes read 0 on this run: no counter source failed, no
-   project was claimed twice, no kickback was dropped and no usage field was
-   unreadable. A non-zero `counter` count means the port-forward died before
-   the run read the store, the fourth mismatch above.
+   The other four classes read 0: no counter source failed, no project was
+   claimed twice, no kickback was dropped and no usage field was unreadable. A
+   non-zero `counter` count means the port-forward died before the run read the
+   store, the fourth mismatch above.
 
 ## Export the statements
 

--- a/docs/tutorials/pay-a-reseller-a-kickback.md
+++ b/docs/tutorials/pay-a-reseller-a-kickback.md
@@ -32,7 +32,7 @@ This lesson takes about 5 minutes.
   - the export under `~/tally-tutorial/2026-07-group`;
   - `ACME_ID`, `ACME_1_ID`, `ACME_2_ID` and `ACME_3_ID` in the shell.
 
-- `jq` 1.8.1 (`jq --version`).
+- `jq` on the path, which the `make check-tools` of lesson 1 called.
 
 If you closed that shell, restore it with this block:
 

--- a/docs/tutorials/set-up-your-local-tally.md
+++ b/docs/tutorials/set-up-your-local-tally.md
@@ -22,29 +22,23 @@ This lesson takes about 30 minutes, most of it `make up` moving images.
 
 ## Before you start
 
-- macOS 15.7.4 with Docker Desktop 4.86.0 running, given 6 CPUs and 8 GB of
-  memory. `docker version` prints the Docker Desktop version on its `Server:`
-  line, and this prints what the engine was given:
-
-  ```sh
-  docker info --format '{{.NCPU}} CPUs, {{.MemTotal}} bytes'
-  ```
-
-  ```text
-  6 CPUs, 8322072576 bytes
-  ```
-
-  The lessons are written for macOS with Docker Desktop, the platform the
-  `Makefile` and `deploy/kind/kind.yaml` assume.
-- `git` 2.51.0 (`git --version`), `kind` v0.32.0 (`kind version`), `kubectl`
-  v1.36.1 (`kubectl version --client`) and Go 1.26 or newer (`go version`) on
-  the path. The run had `go1.26.1` installed, and the first `go run` inside the
-  repository downloads `go1.27.1`, the toolchain `go.mod` names.
-- `jq` 1.8.1 (`jq --version`) and `curl` 8.7.1 (`curl --version`), the one
-  macOS ships.
-- No kind cluster named `tally` on the machine. `kind get clusters` printed
-  `No kind clusters found.` on the run. If it prints `tally`, tear that cluster
-  down with the `make down` of lesson 5 first.
+- macOS with Docker Desktop running, given enough of the machine to run the
+  whole stack on one node. The lessons are written for macOS with Docker
+  Desktop, the platform the `Makefile` and `deploy/kind/kind.yaml` assume.
+- `git`, `kind`, `kubectl`, Go, `jq` and `curl` on the path, and `docker` with
+  its `compose` plugin. No version is named here. The clone below carries
+  `make check-tools`, which calls every one of them, prints what each answered
+  and what the Docker engine was given, and ends on the ones that are missing
+  or answering an error. The next section runs it, before `make up`: it touches
+  no cluster, and a tool that is not there is cheaper to find there than half
+  an hour into `make up`.
+- The Go on the path has to satisfy the `go` line of `go.mod`, which is what
+  `make check-tools` compares it against. That Go downloads the toolchain the
+  `toolchain` line names on its first `go run` inside the repository, a
+  download this lesson shows.
+- No kind cluster named `tally` on the machine. `kind get clusters` prints
+  `No kind clusters found.` when there is none. If it prints `tally`, tear that
+  cluster down with the `make down` of lesson 5 first.
 - 13 GB of free disk for Docker Desktop, measured with `docker system df`
   across images, volumes and build cache. The eight images the stack runs come
   to 3.3 GB and are held twice from here on, once by Docker and once inside the
@@ -71,21 +65,20 @@ This lesson takes about 30 minutes, most of it `make up` moving images.
    Resolving deltas: 100% (1866/1866), done.
    ```
 
-   The object counts and the transfer speed are your own.
+   The object counts and the transfer speed are your own. Every command from
+   here on runs from this directory, the repository root.
 
-2. Read the commit you are on:
+2. Check the tools of Before you start:
 
    ```sh
-   git rev-parse --short HEAD
+   make check-tools
    ```
 
-   ```text
-   789d782
-   ```
-
-   A newer commit is fine. Every output this page shows comes from a run at
-   `789d782`. Every command from here on runs from this directory, the
-   repository root.
+   Every line has to read `ok`. A `missing` line names a tool that is not on
+   the path and a `broken` one a tool that is there and answering an error, and
+   both are to be settled before the next section: `make up` reaches the same
+   tool minutes in and stops with a half-created cluster behind it. A `warn`
+   line for the Docker engine costs time rather than the run.
 
 ## Create the cluster and bring the stack up
 
@@ -131,11 +124,8 @@ This lesson takes about 30 minutes, most of it `make up` moving images.
    Image: "busybox:1.37" with ID "sha256:6df9636795d37473994366014c25264edeb6c00d7a57188ff62d5a94276b4297" not yet present on node "tally-control-plane", loading...
    ```
 
-   The run behind this page fetched three of the eight and copied the other
-   five, `make up` took seventeen minutes end to end, and every pod was ready
-   two minutes after the overlay went on. Which of the eight are fetched is
-   your machine's, and a second `make up` moves none of them: an image the node
-   already carries is skipped.
+   Which of the eight are fetched is your machine's, and a second `make up`
+   moves none of them: an image the node already carries is skipped.
 
 3. Let it wait if a readiness wait expires. One is given five minutes, and an
    expired one is repeated rather than ending the run:

--- a/docs/tutorials/simulate-a-month-of-openstack.md
+++ b/docs/tutorials/simulate-a-month-of-openstack.md
@@ -132,10 +132,9 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
 
    `factor` 744, `total` 15727, `held` 84, `period_from` `2026-07-01T00:00:00Z`
    and `period_to` `2026-08-01T00:00:00Z` have to match. `virtual_now` and
-   `published` are your own and grow between the two reads: on the run they
-   stood at 430 and then at 902 notifications, twelve virtual hours apart.
-   `holding` is false while the month publishes. Connection refused on 8091
-   means the simulator is not running, and
+   `published` are your own and grow between the two reads, which lie twelve
+   virtual hours apart. `holding` is false while the month publishes.
+   Connection refused on 8091 means the simulator is not running, and
    `docker compose -f deploy/compose/compose.yaml ps` shows the three
    containers while
    `docker compose -f deploy/compose/compose.yaml logs simulator` says why it
@@ -164,10 +163,10 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    ```
 
    The counts are your own. They are the resources the collector has delivered
-   at the moment of the call, 15 instances on the run and 20 a minute later.
-   The five resource types are the month's. An empty `items` list two minutes
-   after the start means the collector has delivered nothing yet, which the
-   counter read of the step "Wait for the collector to deliver" diagnoses.
+   at the moment of the call, and they grow while the month goes out. The five
+   resource types are the month's. An empty `items` list two minutes after the
+   start means the collector has delivered nothing yet, which the counter read
+   of the step "Wait for the collector to deliver" diagnoses.
 
 2. Read one row of the fleet:
 
@@ -239,11 +238,11 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    consumed 1728 skipped 13915 unparseable 0 depth 0
    ```
 
-   Repeat the read until `depth` reads 0, which on the run was three minutes
-   after the month went out. The four numbers have to match. 1728 is the
-   month's 1812 billable notifications minus the 84 held ones, 13915 is the
-   notifications the mapping claims nothing for, and the depth is the outbox
-   the collector drains into the Reporting API.
+   Repeat the read until `depth` reads 0, about three minutes after the month
+   went out. The four numbers have to match. 1728 is the month's 1812 billable
+   notifications minus the 84 held ones, 13915 is the notifications the mapping
+   claims nothing for, and the depth is the outbox the collector drains into
+   the Reporting API.
 
 2. Read what the Reporting API took:
 
@@ -309,7 +308,7 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    667 has to match, the instances of the month that pushed traffic. A smaller
    count means the simulator is still pushing the month's series, which it goes
    on doing after the last notification is out; repeat the read until it stands
-   at 667, which took another minute on the run. The series carry July 2026
+   at 667, which takes about another minute. The series carry July 2026
    timestamps, which is why the query is asked at the end of the month with
    `time` and over a window that spans the month, and why lesson 4 sets the
    dashboards' time range to July.

--- a/docs/tutorials/tear-down-your-local-tally.md
+++ b/docs/tutorials/tear-down-your-local-tally.md
@@ -158,8 +158,7 @@ This lesson takes about 5 minutes.
    ```
 
    The four `:dev` images are what `make up` built, and their names have to
-   match. The ids, the sizes and the column layout are Docker's own, and these
-   columns are the ones the run's Docker Desktop 4.86.0 prints. Beside the
+   match. The ids, the sizes and the column layout are Docker's own. Beside the
    images stay Docker's build cache from the image builds, which
    `docker builder prune` removes, the Go build and module caches under your
    home directory, and the clone.

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -25,7 +25,7 @@ This lesson takes about 5 minutes.
   simulator stack holding its 84 notifications, the month of July 2026 in the
   reporting database, and one completed run of that month in the engine
   database.
-- A browser. The run behind this page used Firefox.
+- A browser.
 - `tally-ca.crt` at the repository root, for the `curl` calls beside the
   browser. A new shell writes the file again with:
 
@@ -106,10 +106,9 @@ This lesson takes about 5 minutes.
    panel that reads an `openstack_*` or a `ceilometer_*` series, because the
    simulator pushed those at simulated time, inside July 2026. `Last 3 hours`
    fits every panel that reads a `tally_` series, because those were scraped
-   off the Reporting API at the wall clock while the month went out, on the run
-   between 12:37 and 12:43 UTC. The dashboards open on `Last 6 hours`
-   refreshing every minute. The next step names which panels are which per
-   dashboard.
+   off the Reporting API at the wall clock while the month went out, in the few
+   minutes lesson 2 took. The dashboards open on `Last 6 hours` refreshing
+   every minute. The next step names which panels are which per dashboard.
 
    Every dashboard file carries `"timezone": "utc"`, so both ranges are read in
    UTC and no time zone setting is needed.
@@ -188,7 +187,7 @@ two time ranges, or the `cloud` variable is not on `os-sim`.
    }
    ```
 
-   This one alert has to be there, and on the run no other rule fired.
+   This one alert has to be there, and nothing else should be firing.
    `TallyScrapeTargetDown` fires about five minutes after `make up` for the
    `ceilometer` job, whose target is a placeholder for an exporter that runs
    beside a real control plane, and that is the designed dev state rather than
@@ -249,9 +248,9 @@ two time ranges, or the `cloud` variable is not on `os-sim`.
    {"name":"TallyExporterServiceSilent","state":"inactive","lastError":""}
    ```
 
-   Every `lastError` is empty on the run. A non-empty one names the query that
-   failed, and `state` tells `firing` from `inactive`.
-   `tally:current_resources:sum` is a recording rule and carries no state.
+   Every `lastError` is empty. A non-empty one names the query that failed, and
+   `state` tells `firing` from `inactive`. `tally:current_resources:sum` is a
+   recording rule and carries no state.
 
 ## What you learned
 

--- a/internal/refdoc/maketargets_test.go
+++ b/internal/refdoc/maketargets_test.go
@@ -10,7 +10,7 @@ import (
 // noticed here.
 const (
 	realMakefile    = "../../Makefile"
-	realMakeTargets = 15
+	realMakeTargets = 16
 )
 
 func TestMakeTargets(t *testing.T) {
@@ -165,7 +165,7 @@ func TestMakeTargetsReportsAHelpCommentWithoutATarget(t *testing.T) {
 
 func TestMakeTargetsRendersTheTargetsOfThisRepository(t *testing.T) {
 	const (
-		firstRow = "| `up` | create the kind cluster, install the add-ons, and deploy the dev overlay |"
+		firstRow = "| `check-tools` | check that the tools the dev stack and the tutorials need answer |"
 		lastRow  = "| `docs-build` | build the documentation site; a dead internal link fails the build |"
 	)
 


### PR DESCRIPTION
## What this changes

The `Before you start` of [Set up your local Tally](docs/tutorials/set-up-your-local-tally.md) asked for macOS 15.7.4, Docker Desktop 4.86.0, git 2.51.0, kind v0.32.0, kubectl v1.36.1, jq 1.8.1 and curl 8.7.1, and five later lessons repeated the jq line. Those were the versions of the machine the tutorials were captured on, pinned nowhere and checked by nobody, so they could only age into telling a reader whose machine works that their machine is wrong.

## `make check-tools`

A new target takes their place. It runs one probe per tool, `git`, `docker`, `docker compose`, `kind`, `kubectl`, `jq`, `curl` and `go`, and prints what each answered:

```
==> the tools the dev stack, the simulator stack and the tutorials are driven with
ok       git             git version 2.51.0
ok       docker          engine 29.7.2
...
ok       go              go1.27.1, at or above the go 1.26.0 of go.mod
ok       docker size     6 CPUs and 8 GB
```

- `missing` is a tool that is not on the path, which the probe tells from exit 127.
- `broken` carries the error of a tool that is installed and failing, which is what a Docker whose engine is not running does.
- The one version compared is the Go on the path against the `go` line of `go.mod`, read out of the file rather than pinned a second time in the `Makefile`.
- What the Docker engine was given is printed beside the tools and warns, rather than fails, under `DOCKER_MIN_CPUS` and `DOCKER_MIN_MEMORY_GB`.
- Nothing it does touches a cluster, so it runs before `make up`, where a missing tool is cheapest to find. Node is left alone: only `docs` and `docs-build` need it.

Tested by hand against all four outcomes: everything present, a stripped `PATH`, a stub that answers with an error, and a stub Go under the minimum.

## The capture run leaves the visible pages

Lesson 1 runs the target as the second step of `Get the code`, in place of the `git rev-parse --short HEAD` step. That step had the reader print a commit hash to compare with the one the page was captured at, which is the page's own provenance and nothing the reader can act on. The sentences of the same kind go with it: the run that fetched three of the eight images, the machine a run took a second on, the Firefox the browser step used, the Docker Desktop version behind a column layout, and the `on the run` values, which now read as what to expect. The `<!-- Shown output captured on ... -->` comment keeps all of it, and the review checklist of [Writing and previewing documentation](docs/contributing/writing-documentation.md) now says that is where it stays.

## Handbook

[The dev stack](docs/contributing/dev-stack.md) gains a `What the machine needs` section, saying what the tools are and why no version is asserted; the two Docker floors join its variable list; the make-target table is regenerated, and `internal/refdoc` counts 16 targets.

## Checks

`go test ./docs/... ./internal/refdoc/...`, `go vet` and `make docs-build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPSBfa8JxGAJdEgMTBzn5X