### PR TITLE
Make the simulator-up output readable and take the tear-down lesson out of the core track

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,13 +373,24 @@ simulator-up:
 	@echo '  https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics  OTLP endpoint the series are pushed to'
 	@echo '  https://vm.tally.127-0-0-1.nip.io:8443/targets       scrape targets'
 	@echo
-	@echo "Finish the month at once with:"
+	@# The four hints below carry one shape: a line naming what the hint does,
+	@# then the command or the path indented under it, with a blank line between
+	@# them. The registry command is broken over three lines the way
+	@# docs/how-to/simulator/register-simulated-projects.md writes it, because
+	@# one line of it runs past the width of a terminal and wraps mid-token.
+	@echo 'Finish the month at once:'
 	@echo "  curl -X PUT -d '{\"factor\": 0}' http://127.0.0.1:8091/clock"
-	@echo "Release the held-back notifications of a run with SIM_FAULTS=held-back with:"
-	@echo "  curl -X POST http://127.0.0.1:8091/release"
-	@echo "Inspect the registry with the admin token in deploy/compose/.env:"
-	@echo "  curl --cacert tally-ca.crt -H \"Authorization: Bearer \$$(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)\" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=$(SIM_CLOUD)'"
-	@echo 'Reconcile the cloud the run serves: docs/how-to/simulator/reconcile-the-simulated-cloud.md'
+	@echo
+	@echo 'Release the notifications a run with SIM_FAULTS=held-back keeps back:'
+	@echo '  curl -X POST http://127.0.0.1:8091/release'
+	@echo
+	@echo 'Inspect the registry a run with SIM_REGISTER_PROJECTS=true registered into:'
+	@echo '  curl --cacert tally-ca.crt \'
+	@echo '    -H "Authorization: Bearer $$(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" \'
+	@echo "    'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=$(SIM_CLOUD)'"
+	@echo
+	@echo 'Reconcile the cloud the run serves:'
+	@echo '  docs/how-to/simulator/reconcile-the-simulated-cloud.md'
 
 # Dropping the volumes empties the outbox and the broker's queue, so the next
 # `simulator-up` starts from nothing rather than delivering what the last run

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -22,8 +22,7 @@
             { "text": "Set up your local Tally", "link": "/tutorials/set-up-your-local-tally" },
             { "text": "Simulate a month of OpenStack", "link": "/tutorials/simulate-a-month-of-openstack" },
             { "text": "Meter and rate your first month", "link": "/tutorials/meter-and-rate-your-first-month" },
-            { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" },
-            { "text": "Tear down your local Tally", "link": "/tutorials/tear-down-your-local-tally" }
+            { "text": "Watch the month in Grafana", "link": "/tutorials/watch-the-month-in-grafana" }
           ]
         },
         {
@@ -35,7 +34,8 @@
             { "text": "Finalize the month and export it", "link": "/tutorials/finalize-the-month-and-export-it" },
             { "text": "Book the late events as a credit note", "link": "/tutorials/book-the-late-events-as-a-credit-note" }
           ]
-        }
+        },
+        { "text": "Tear down your local Tally", "link": "/tutorials/tear-down-your-local-tally" }
       ]
     }
   ],

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -43,15 +43,12 @@ system you built yourself, and a name for each part of it.
    four dashboards against the simulated cloud and the simulated month, find
    the one alert the dev stack fires by design, and take the state the next
    track continues from.
-5. [Tear down your local Tally](/tutorials/tear-down-your-local-tally): stop the
-   stack, delete the cluster and remove what the lessons wrote.
-   Assumes Set up your local Tally, or any later lesson.
 
-The fifth lesson is where the track ends when you want a clean machine. A
-reader going on to the billing track does it after that track's last lesson,
-because the billing track starts with
+The fourth lesson is where the core track ends, and the machine stays up: the
+billing track starts with
 [Discount a customer group](/tutorials/discount-a-customer-group) and continues
-from the state the fourth lesson leaves behind.
+from the state that lesson leaves behind. Tearing the machine down is a lesson
+of its own, below both tracks.
 
 ### Billing track
 
@@ -78,8 +75,21 @@ from the state the fourth lesson leaves behind.
 
 The fifth lesson is where the billing track ends, and the state it leaves is
 written out on that page.
-[Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
-back to a clean machine.
+
+### Teardown
+
+[Tear down your local Tally](/tutorials/tear-down-your-local-tally): stop the
+stack, delete the cluster and remove what the lessons wrote. Assumes Set up
+your local Tally, or any later lesson.
+
+This lesson belongs to neither track, because it ends the cluster and the
+compose stack both of them work on. Run it after the last lesson you want:
+after [Watch the month in Grafana](/tutorials/watch-the-month-in-grafana) if the
+core track is where you stop, and after
+[Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note)
+if you go on through the billing track. Running it between the two tracks leaves
+nothing for the billing track to continue from, and starting over means the core
+track again from lesson 1.
 
 ## The simulated cloud
 

--- a/docs/tutorials/set-up-your-local-tally.md
+++ b/docs/tutorials/set-up-your-local-tally.md
@@ -38,7 +38,8 @@ This lesson takes about 30 minutes, most of it `make up` moving images.
   download this lesson shows.
 - No kind cluster named `tally` on the machine. `kind get clusters` prints
   `No kind clusters found.` when there is none. If it prints `tally`, tear that
-  cluster down with the `make down` of lesson 5 first.
+  cluster down with the `make down` of
+  [Tear down your local Tally](/tutorials/tear-down-your-local-tally) first.
 - 13 GB of free disk for Docker Desktop, measured with `docker system df`
   across images, volumes and build cache. The eight images the stack runs come
   to 3.3 GB and are held twice from here on, once by Docker and once inside the
@@ -196,8 +197,9 @@ This lesson takes about 30 minutes, most of it `make up` moving images.
 
    `==> kind cluster tally already exists` as the first line of a first
    `make up` means a cluster from an earlier run of this track is still on the
-   machine. Tear it down with the `make down` of lesson 5 and start over. On a
-   repeated call after a timeout that line is the expected one.
+   machine. Tear it down with the `make down` of
+   [Tear down your local Tally](/tutorials/tear-down-your-local-tally) and start
+   over. On a repeated call after a timeout that line is the expected one.
 
 6. Read the pods once `make up` has printed its block:
 

--- a/docs/tutorials/simulate-a-month-of-openstack.md
+++ b/docs/tutorials/simulate-a-month-of-openstack.md
@@ -83,19 +83,25 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
      https://otlp.tally.127-0-0-1.nip.io:8443/v1/metrics  OTLP endpoint the series are pushed to
      https://vm.tally.127-0-0-1.nip.io:8443/targets       scrape targets
 
-   Finish the month at once with:
+   Finish the month at once:
      curl -X PUT -d '{"factor": 0}' http://127.0.0.1:8091/clock
-   Release the held-back notifications of a run with SIM_FAULTS=held-back with:
+
+   Release the notifications a run with SIM_FAULTS=held-back keeps back:
      curl -X POST http://127.0.0.1:8091/release
-   Inspect the registry with the admin token in deploy/compose/.env:
-     curl --cacert tally-ca.crt -H "Authorization: Bearer $(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" 'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim'
-   Reconcile the cloud the run serves: docs/how-to/simulator/reconcile-the-simulated-cloud.md
+
+   Inspect the registry a run with SIM_REGISTER_PROJECTS=true registered into:
+     curl --cacert tally-ca.crt \
+       -H "Authorization: Bearer $(grep TALLY_SIM_API_TOKEN deploy/compose/.env | cut -d= -f2)" \
+       'https://api.tally.127-0-0-1.nip.io:8443/api/v1/projects?cloud=os-sim'
+
+   Reconcile the cloud the run serves:
+     docs/how-to/simulator/reconcile-the-simulated-cloud.md
    ```
 
-   The seven URLs have to match. The four hint lines below them are printed on
-   every run. This track follows the first of them, the `PUT /clock` of a later
-   step, and never the second: the `POST /release` line is what lets the held
-   share out, which the billing track does.
+   The seven URLs have to match. The four hints below them are printed on every
+   run. This track follows the first of them, the `PUT /clock` of a later step,
+   and never the second: the `POST /release` hint is what lets the held share
+   out, which the billing track does.
 
    Three containers now run beside the cluster. The month of July 2026 of seed
    1 on the cloud `os-sim`, with its six tenants, goes onto the bus at factor

--- a/docs/tutorials/simulate-a-month-of-openstack.md
+++ b/docs/tutorials/simulate-a-month-of-openstack.md
@@ -155,7 +155,7 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    ```
 
    ```json
-   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":15,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":25,"resource_type":"volume"}]}
+   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":15,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":25,"resource_type":"volume"}]}
    ```
 
    A minute later:
@@ -165,7 +165,7 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    ```
 
    ```json
-   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":20,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":29,"resource_type":"volume"}]}
+   {"items":[{"cloud":"os-sim","count":13,"resource_type":"floating_ip"},{"cloud":"os-sim","count":9,"resource_type":"image"},{"cloud":"os-sim","count":20,"resource_type":"instance"},{"cloud":"os-sim","count":2,"resource_type":"loadbalancer"},{"cloud":"os-sim","count":29,"resource_type":"volume"}]}
    ```
 
    The counts are your own. They are the resources the collector has delivered
@@ -181,7 +181,7 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    ```
 
    ```json
-   {"items":[{"cloud":"os-sim","created_at":"2026-07-01T03:17:02Z","deleted_at":null,"last_event_at":"2026-07-02T05:36:15Z","last_event_type":"compute.instance.power_off","last_payload":{"provider":{"oslo_event_type":"compute.instance.power_off.end"},"state":"shutoff"},"platform":"openstack","project_id":"d5a8024946ddf673277b9e2490643a2c","resource_id":"079faae9-9d39-426f-a963-769cb12aa629","resource_type":"instance","size":{"disk_gb":20,"flavor":"m1.small","ram_gb":2,"vcpus":1},"state":"shutoff"}],"next_cursor":"WyJvcy1zaW0iLCJpbnN0YW5jZSIsIjA3OWZhYWU5LTlkMzktNDI2Zi1hOTYzLTc2OWNiMTJhYTYyOSJd"}
+   {"items":[{"cloud":"os-sim","created_at":"2026-07-01T03:17:02Z","deleted_at":null,"last_event_at":"2026-07-02T05:36:15Z","last_event_type":"compute.instance.power_off","last_payload":{"provider":{"oslo_event_type":"compute.instance.power_off.end"},"state":"shutoff"},"platform":"openstack","project_id":"d5a8024946ddf673277b9e2490643a2c","resource_id":"079faae9-9d39-426f-a963-769cb12aa629","resource_type":"instance","size":{"disk_gb":20,"flavor":"m1.small","ram_gb":2,"vcpus":1},"state":"shutoff"}],"next_cursor":"WyJvcy1zaW0iLCJpbnN0YW5jZSIsIjA3OWZhYWU5LTlkMzktNDI2Zi1hOTYzLTc2OWNiMTJhYTYyOSJd"}
    ```
 
    That is one row of the projection. Its `state` is `shutoff`, the state the
@@ -199,7 +199,7 @@ says. `make simulator-up` writes `tally-ca.crt` again if the file is missing.
    ```
 
    ```json
-   {"virtual_now":"2026-07-02T13:14:44Z","factor":0,"published":1174,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
+   {"virtual_now":"2026-07-02T13:14:44Z","factor":0,"published":1174,"total":15727,"held":84,"holding":false,"period_from":"2026-07-01T00:00:00Z","period_to":"2026-08-01T00:00:00Z"}
    ```
 
    The route rebases the clock on the virtual instant it has reached and

--- a/docs/tutorials/tear-down-your-local-tally.md
+++ b/docs/tutorials/tear-down-your-local-tally.md
@@ -1,12 +1,24 @@
 ---
 title: Tear down your local Tally
-description: Stop the simulator stack, delete the kind cluster, and remove the files and the shell variables the core track wrote.
+description: Stop the simulator stack, delete the kind cluster, and remove the files and the shell variables the lessons wrote, after the last lesson you want to run.
 quadrant: tutorial
 audience: all
 ---
 <!-- Shown output captured on 2026-09-07 from commit 789d782 with kind v0.32.0, kubectl v1.36.1, Docker Desktop 4.86.0, Go 1.27.1 on macOS 15.7.4. -->
 
 # Tear down your local Tally
+
+Do this lesson last. It belongs to neither track: it ends the cluster and the
+compose stack every other lesson works on, and nothing here can be undone. The
+billing track continues from the state
+[Watch the month in Grafana](/tutorials/watch-the-month-in-grafana) leaves
+behind, so a reader going on to it, through
+[Discount a customer group](/tutorials/discount-a-customer-group) and the four
+lessons after it, runs this one after that track's last lesson,
+[Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note).
+Tearing down between the two tracks leaves the billing track nothing to
+continue from, and the way back is the core track again from
+[Set up your local Tally](/tutorials/set-up-your-local-tally).
 
 In this lesson you take the machine back to where lesson 1 started. The
 simulator stack goes with its broker and its outbox, and the kind cluster goes
@@ -17,17 +29,14 @@ databases, because that is where they live. You remove the CA file
 `~/tally-tutorial` by hand.
 
 What stays is the four `tally-*:dev` images in Docker, the Go build and module
-caches under your home directory, and the clone. A reader going on to the
-billing track, which starts with
-[Discount a customer group](/tutorials/discount-a-customer-group), does this
-lesson after its last lesson,
-[Book the late events as a credit note](/tutorials/book-the-late-events-as-a-credit-note),
-because the billing track continues from the state lesson 4 leaves behind.
+caches under your home directory, and the clone.
 
 This lesson takes about 5 minutes.
 
 ## Before you start
 
+- Every lesson you still want to run, done. This one leaves no environment for
+  a later lesson to work on.
 - The state lesson 1 leaves, or the state any later lesson leaves: a cluster
   from `make up`, and whatever the later lessons added to it. A step that finds
   nothing to remove says so and changes nothing.

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -298,8 +298,8 @@ lesson of the billing track, which continues from the state this lesson leaves
 behind.
 
 [Tear down your local Tally](/tutorials/tear-down-your-local-tally) is the way
-back to a clean machine. A reader going on to the billing track does lesson 5
-after that track's last lesson.
+back to a clean machine, and it belongs to neither track: a reader going on to
+the billing track runs it after that track's last lesson rather than here.
 
 This is the state this track leaves behind:
 

--- a/docs/tutorials/watch-the-month-in-grafana.md
+++ b/docs/tutorials/watch-the-month-in-grafana.md
@@ -115,6 +115,29 @@ This lesson takes about 5 minutes.
 
 ## Read the four dashboards
 
+The four read one store from four angles, and each of them narrows to what the
+`cloud` variable is set to. What you see on them:
+
+- `Tally / Fleet Overview`, the fleet the events built. It counts the resources
+  the projection holds by type and state, draws the same counts as a trend, and
+  says how many clouds report; two of its panels read the pushed inventory
+  instead, the number of tenants and the ten with the most instances.
+- `Tally / Ingestion Health`, the way in. It draws the events ingested per
+  cloud and source, the duplicates dropped and the items rejected, the
+  collector's buffer and its oldest buffered event, the projection replays, and
+  whether each scrape target answers.
+- `Tally / Project Drilldown`, one tenant at a time. It counts that tenant's
+  servers, volumes, floating IPs, routers, images and load balancers, sums the
+  GB its volumes hold, and reads its usage of the three nova quotas. Its last
+  panel is the cloud's ingest split by event type, the one panel here that does
+  not narrow to the tenant.
+- `Tally / Reconciliation Drift`, what a sync against the cloud's own API
+  changed. It draws the resources reconciled by action, the sync errors, and
+  the sync runs by status, beside a text panel on how to read the three.
+
+Which panels carry a value in this lesson and which stay empty is what the four
+steps below say, and each of them names the time range its panels need.
+
 1. `Tally / Fleet Overview`. With `Last 3 hours`, `Resources by type and state`
    shows 37 instances `active`, 630 `deleted` and 1 `shelved`, 16 volumes
    `available`, 12 `in-use` and 141 `deleted`, 9 floating IPs `active` and 7


### PR DESCRIPTION
Four corrections to what the dev stack prints and what the tutorials show, found while reading the output of `make simulator-up` and walking the tutorial tracks. No behaviour of the stack changes; the Makefile change is output only.

## The change set, in commit order

- **`476664d` Print the hints of simulator-up one block at a time** — `Makefile`, `docs/tutorials/simulate-a-month-of-openstack.md`. The target closed with four hints in seven unbroken lines, the fourth shaped unlike the three above it, and the registry `curl` on one line a terminal wraps mid-token. Each hint now carries one shape: a line naming what it does, the command or the path indented under it, a blank line to the next; the registry call is broken over three lines the way `docs/how-to/simulator/register-simulated-projects.md` writes it. That hint's label also promised "the admin token in deploy/compose/.env", which the default `SIM_REGISTER_PROJECTS=false` does not write — the variable is there and empty and the call answers 401 — so it names the switch now, the way the release hint names `SIM_FAULTS=held-back`. The transcript in lesson 2 moves with the output.
- **`2987cad` Strip the backspaces from four captured JSON lines** — `docs/tutorials/simulate-a-month-of-openstack.md`. Four `json` blocks carried two `0x08` characters between the indent and the opening brace, left by the terminal capture. VitePress renders them as two boxes ahead of the JSON, where they read as part of the answer the reader is told to match. A scan of the tracked tree for control characters, NBSP, soft hyphens, BOMs and zero-width characters finds nothing else.
- **`8539c2f` Say what the four Grafana dashboards show** — `docs/tutorials/watch-the-month-in-grafana.md`. "Read the four dashboards" went straight into the expected values, panel by panel, without saying what any of the four dashboards is for. A block ahead of the steps names each one and the panels it carries, following the expressions in `docs/reference/observability/dashboards.md` — which is also where the note comes from that the last panel of the drilldown reads the cloud rather than the selected tenant.
- **`38ffe64` Take the tear-down lesson out of the core track** — `docs/tutorials/index.md`, `docs/.vitepress/sidebar.json`, `docs/tutorials/tear-down-your-local-tally.md`, `docs/tutorials/set-up-your-local-tally.md`, `docs/tutorials/watch-the-month-in-grafana.md`. See below.

## The trap the last commit closes

The core track listed `Tear down your local Tally` as its fifth lesson, while the billing track continues from the state the fourth one leaves behind. A reader who took the core track in order deleted the cluster and the compose stack, and then had nothing for `Discount a customer group` to work on. The only warning was one sentence in the second paragraph of the tear-down page, behind the sentence about the images that stay.

The lesson now stands in a section of its own below both tracks, in the index and in the sidebar, with the rule written out: after `Watch the month in Grafana` if the core track is where you stop, after `Book the late events as a credit note` if you go on. The page opens with it and `Before you start` carries it as its first item. The core track ends at its fourth lesson, so the three places that spoke of "the `make down` of lesson 5" name the lesson and link to it instead.

## Checks

`go test ./docs/` passes, which is what pins that every page is reachable from `docs/.vitepress/sidebar.json` after the entry moved out of the core-track group. `make docs-build` passes, dead internal links included. The reshaped `simulator-up` banner was rendered from the recipe itself, so the transcript in lesson 2 is the output and not a transcription.
