### PR TITLE
Improve the demo console: dark mode, sortable tables, fleet filters and a readable bill

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,21 +27,152 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` | API: the project, its relations, the projects a traversal reaches, its summary over the current month. Engine: one row per statement of the project. |
-| `/resources` | API: one page of resources, filtered by `cloud`, `project_id`, `resource_type`, `state`, `status`, `cursor`. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the current month. Engine: one row per statement of the project. |
+| `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console keeps the rows that existed in the window `from` and `to` or at the instant `at`, now by default, and prints each one's lifetime in hours. Each row links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
 | `/run?id=` | Engine: the run, its statements, its correction deltas. |
-| `/statement?run=&key=` | Engine: one statement document rendered as a bill. |
+| `/statement?run=&key=` | Engine: one statement document rendered as a bill: its head, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. |
 | `/static/console.css` | The embedded stylesheet, the only asset the pages load. |
+| `/theme` | Nothing. The one route that is not a page: it takes the theme form's POST, keeps the choice in a cookie, and sends the viewer back. |
 
 Every identifier travels in a query parameter rather than in a path segment,
 because a cloud name, a resource id and a statement key may each carry a slash.
 
+A resource names its project by cloud and external id, not by the id the API
+assigns, so the project links on the resource pages carry that pair. The
+project page resolves it through the project list filtered by both, an exact
+match on each, and a pair nothing is registered under is answered 404.
+
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a
 cursor on its own.
+
+## Sorting and filtering
+
+Every listing table can be sorted by a column and filtered by a text, and both
+happen on the console's side of the wire. The console ships no JavaScript, so a
+heading is a link that reloads the page with the order in the query string, and
+the filter box above a table is a form that reloads it with the text. Two
+parameters carry the state of one table, named after the table so that the
+tables of one page keep their own:
+
+| Parameter | Value |
+| --- | --- |
+| `<table>.sort` | The key of a column, which is its heading with spaces as underscores: `resource_type`. A leading hyphen sorts descending: `-count`. A key no column carries leaves the rows in the order they were read. |
+| `<table>.q` | A text. A row stays when any of its cells contains the text, compared without regard to case. Whitespace around the text is dropped. |
+
+So `/?stats.sort=-count&stats.q=os-sim` shows the resource counts of `os-sim`
+with the largest first.
+
+The first click on a heading sorts text ascending and a number descending, and
+the next click flips the direction. Text sorts by its lower-cased form; a
+number sorts by its value, so 10 comes after 2. A column that draws a bar
+neither sorts nor filters. A filtered table says how many of its rows match,
+and one the filter emptied says so in place of the rows. The filter form
+carries every other parameter of the page along as hidden inputs, so applying
+a filter keeps the page's identifiers, its cursor, and the order and filter of
+every other table.
+
+The tables and their names per page:
+
+| Page | Tables |
+| --- | --- |
+| `/` | `stats`, `events`, `rejected`, `periods`, `runs` |
+| `/projects` | `projects` |
+| `/project` | `relations`, `related`, `activity`, `statements` |
+| `/resources` | `resources` |
+| `/resource` | `segments`, `events` |
+| `/pricing` | `models` |
+| `/catalog` | `dimensions` |
+| `/run` | `statements`, `deltas` |
+| `/statement` | `adjustments`; `items` and `rc-<n>`, the summaries of the line items and of the n-th related cost; `li-<n>` and `rc-<n>-li-<n>`, the metric tables of the items, which sort and carry no filter |
+
+A paged listing, `/projects` and `/resources`, is sorted and filtered within
+the page the API answered, which its row count says, and its next link carries
+both parameters along. The timeline of a resource page draws every segment
+whatever the segment table is filtered to.
+
+A statement is rendered in sections, the project's own line items and then one
+per related cost. A section opens with a summary table of its items, resource
+type, resource, description, hours and total, sorted by total descending until
+the viewer sorts it otherwise. The resource of a row leads to the item's detail
+block below, and the blocks follow the summary's order and filter, so filtering
+the summary to one resource shows that resource's detail alone. Every block
+starts folded. The resource of a summary row leads to its block unfolded: the
+link names the block in `open` and in its fragment, so the page comes back
+with that block open and scrolled to, and any other block unfolds by hand. A
+block's heading links the resource's page, and its table holds one row per
+metric of every period, with the period's total as a row of its own. A description that
+only repeats the item's type and id is left out. A value of exactly zero is
+printed in the muted colour, so the amounts that are not zero stand out.
+
+## The fleet over a window and at an instant
+
+The resource list is read under one status and shown over a window or at an
+instant. The status is the API's own filter, chosen with the switch above the
+table: `active` serves the rows whose state is not deleted and is the default,
+`deleted` serves those alone, and `all` serves both. A `status` that is none of
+the three is answered 400. Switching the status drops the cursor, because a
+cursor positions a walk through one status and means nothing in another. A
+deleted resource is only on the page when the status admits it, so looking
+back starts with switching the status to `all`.
+
+The window and the instant are the console's filters, applied to the rows the
+API served. Each of `from`, `to` and `at` is read as RFC 3339 or as the form
+the inputs write, `2026-03-15T12:00`, which carries no zone and is read as UTC;
+one that does not parse is answered 400.
+
+The window is `from` and `to`, half-open: a resource existed in it when it was
+created before `to` and not deleted at or before `from`. Either bound may be
+left out, which leaves the window open on that side, and a `to` that is not
+after `from` is answered 400. The window presets are the last 24 hours, the
+last 7 days, this month, last month, and all, which is no window.
+
+The instant is `at`: a resource existed at it when it was created at or before
+it and not deleted at or before it; a resource whose history shows no create
+has no creation time and is taken to have existed all along. With neither a
+window nor an instant the page shows what exists now, so it opens on what runs
+right now. With a window and no instant it shows everything that lived in the
+window. With an instant, inside a window or not, it shows what existed at that
+instant. The instant presets are now, offered while there is no window, 24
+hours ago, 7 days ago, the start of this month, the start of last month, and
+clear, offered while an instant is pinned inside a window. The instant input
+stays empty while nothing is pinned, so applying a window does not pin the
+instant to now on the way.
+
+The page asks the API for 1000 rows, the most one page carries, so that the
+filters are applied to as much of the fleet as one call holds; the fleet of the
+simulated month fits. A page the API followed with a cursor, or one reached by
+a cursor, counts its rows as one page, and its next link carries the status,
+the window and the instant along. The line above the table says how many of
+the rows the API served the filters kept, and a page the filters emptied says
+so in place of the rows.
+
+Every row prints its lifetime in hours at two places: from its creation to
+its deletion, or to now for a resource still there, whatever the window and
+the instant are. A resource whose history starts without a create has no
+creation time, which the API leaves null and the fold reports as
+`history_starts_without_create`; the row prints `unknown` for its creation and
+its lifetime, and the line above the table counts such rows. The resource page
+names the event such a history starts with and counts the lifetime from it,
+which is where the fold starts the intervals a run bills. The last payload of
+a row is folded under a line that counts its keys, so the listing stays one
+line per row until a payload is opened.
+
+## Theme
+
+The pages follow the operating system's light or dark setting on their own. The
+form at the right end of the navigation bar pins one side: it posts `theme` as
+`light`, `dark` or `auto` to `/theme`, together with `back`, the path of the
+page it stands on. `light` and `dark` are kept in the cookie `theme` for a
+year, and `auto` deletes it. The console answers 303 to `back`, or to `/` when
+`back` is not a path of the console, so the form cannot send the viewer
+elsewhere. A page renders the cookie's value as the `data-theme` attribute of
+its root element, which the stylesheet reads, and a request without the cookie
+renders no attribute. A `theme` that is none of the three is answered 400 on
+the error page, and a GET of `/theme` 405.
 
 Every page ends with a provenance panel naming the reads it was built from: each
 Reporting API request as its method and path with the query string, and each
@@ -53,7 +184,7 @@ that is missing or unreadable, 404 for a lookup that found nothing and for an
 API 404, 502 for a Reporting API call that failed or that the API refused the
 token for, and 503 for an engine query that failed or a stored document that
 does not decode. A path the console has no page for is answered 404 on that same
-error page.
+error page, and a route asked with a method it does not answer 405.
 
 Amounts are rendered at two decimal places and quantities at four, the scales
 the engine rounds them to. A catalog price is rendered with the digits the

--- a/internal/console/httpui/bill.go
+++ b/internal/console/httpui/bill.go
@@ -1,0 +1,187 @@
+package httpui
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/engine/statements"
+)
+
+// A statement is rendered as a bill in sections: the project's own line items,
+// then one section per related cost. A section opens with a summary table of
+// its items, sorted by total descending unless the viewer sorts it otherwise,
+// whose rows lead to the item's detail block below. The details follow the
+// summary's order and filter, so filtering the summary to one resource shows
+// that resource's detail alone. A detail block is a details element that
+// starts folded and holds one row per metric of every period, with the
+// period's total as a row of its own. The resource of a summary row leads to
+// its block unfolded: the link names the block in the open parameter and in
+// its fragment, so the page comes back with that block open and the browser
+// scrolls to it.
+const (
+	// openParameter names the detail block the page renders unfolded.
+	openParameter = "open"
+	// periodTotal is the key the engine writes a period's total under, beside
+	// the metrics, in the cost map of the period.
+	periodTotal = "total"
+	// itemsTable is the summary table of the statement's own line items, and
+	// itemAnchor the prefix of their detail blocks. A related cost's summary
+	// and blocks carry its index, so every table of the page has a name of its
+	// own for its sort and filter parameters.
+	itemsTable = "items"
+	itemAnchor = "li"
+)
+
+// billSection is one section of the bill: the summary of its items and, for
+// a related cost, what the section is about.
+type billSection struct {
+	Currency string
+	Summary  listing[itemRow]
+	Related  *statements.RelatedCost
+}
+
+// itemRow is one line item, in the summary table and as the detail block the
+// summary row leads to.
+type itemRow struct {
+	Anchor string
+	// OpenLink is the page with this block unfolded and scrolled to.
+	OpenLink     string
+	ResourceType string
+	ResourceID   string
+	// Description is what the engine wrote about the item beyond its type and
+	// id, the flavour for example, and empty when it only repeats them.
+	Description string
+	Hours       decimal.Decimal
+	Total       decimal.Decimal
+	// Open is whether the detail block is rendered unfolded, which the open
+	// parameter decides for one block at a time.
+	Open         bool
+	ResourceLink string
+	Metrics      listing[metricRow]
+}
+
+// metricRow is one metric of one period of an item, or the period's total,
+// which carries no usage.
+type metricRow struct {
+	State    string
+	Hours    decimal.Decimal
+	Metric   string
+	Usage    decimal.Decimal
+	Cost     decimal.Decimal
+	Modifier decimal.Decimal
+	Subtotal bool
+}
+
+// itemColumns is the summary table of a section.
+var itemColumns = []column[itemRow]{
+	textCol("resource type", func(r itemRow) string { return r.ResourceType }),
+	textCol("resource", func(r itemRow) string { return r.ResourceID }),
+	textCol("description", func(r itemRow) string { return r.Description }),
+	numberCol("hours", func(r itemRow) decimal.Decimal { return r.Hours }),
+	numberCol("total", func(r itemRow) decimal.Decimal { return r.Total }),
+}
+
+// metricColumns is the detail table of an item.
+var metricColumns = []column[metricRow]{
+	textCol("state", func(r metricRow) string { return r.State }),
+	numberCol("hours", func(r metricRow) decimal.Decimal { return r.Hours }),
+	textCol("metric", func(r metricRow) string { return r.Metric }),
+	numberCol("usage", func(r metricRow) decimal.Decimal { return r.Usage }),
+	numberCol("cost", func(r metricRow) decimal.Decimal { return r.Cost }),
+	numberCol("state modifier", func(r metricRow) decimal.Decimal { return r.Modifier }),
+}
+
+// buildBillSection lays one section out. The table name is what the summary's
+// sort and filter parameters carry, and the anchor prefix is what the detail
+// blocks are addressed by, the index of the item appended. The cloud is what
+// the resource links are built with, and no link is built without it, which
+// is a statement whose key the page could not read.
+func buildBillSection(
+	r *http.Request, table, anchor, cloud, currency string, items []statements.LineItem,
+) billSection {
+	rows := make([]itemRow, 0, len(items))
+	for index, item := range items {
+		rows = append(rows, buildItemRow(r, fmt.Sprintf("%s-%d", anchor, index), cloud, item))
+	}
+	return billSection{
+		Currency: currency,
+		Summary:  tabulateBy(r, table, itemColumns, rows, descending+"total"),
+	}
+}
+
+// buildItemRow lays one item out, summary and detail alike.
+func buildItemRow(r *http.Request, anchor, cloud string, item statements.LineItem) itemRow {
+	values := r.URL.Query()
+	opened := maps.Clone(values)
+	opened.Set(openParameter, anchor)
+	row := itemRow{
+		Anchor:       anchor,
+		OpenLink:     href(r.URL.Path, opened) + "#" + anchor,
+		ResourceType: item.ResourceType,
+		ResourceID:   item.ResourceID,
+		Total:        item.Total.Decimal,
+		Open:         values.Get(openParameter) == anchor,
+	}
+	if item.Description != item.ResourceType+" "+item.ResourceID {
+		row.Description = item.Description
+	}
+	if cloud != "" {
+		row.ResourceLink = link("/resource", "cloud", cloud, "type", item.ResourceType, "id", item.ResourceID)
+	}
+
+	var metrics []metricRow
+	for _, period := range item.Periods {
+		row.Hours = row.Hours.Add(period.Hours.Decimal)
+		metrics = append(metrics, metricRows(period)...)
+	}
+	row.Metrics = tabulate(r, anchor, metricColumns, metrics)
+	return row
+}
+
+// metricRows flattens one period: one row per metric the period carries usage
+// or cost for, in the order of their names, then the period's total. The total
+// is the one the engine wrote where it wrote one, and the metrics' sum where
+// it did not.
+func metricRows(period statements.Period) []metricRow {
+	names := map[string]struct{}{}
+	for name := range period.Usage {
+		names[name] = struct{}{}
+	}
+	for name := range period.Cost {
+		if name != periodTotal {
+			names[name] = struct{}{}
+		}
+	}
+
+	rows := make([]metricRow, 0, len(names)+1)
+	sum := decimal.Zero
+	for _, name := range slices.Sorted(maps.Keys(names)) {
+		cost := period.Cost[name].Decimal
+		sum = sum.Add(cost)
+		rows = append(rows, metricRow{
+			State:    period.State,
+			Hours:    period.Hours.Decimal,
+			Metric:   name,
+			Usage:    period.Usage[name].Decimal,
+			Cost:     cost,
+			Modifier: period.StateModifier.Decimal,
+		})
+	}
+
+	total := sum
+	if written, ok := period.Cost[periodTotal]; ok {
+		total = written.Decimal
+	}
+	return append(rows, metricRow{
+		State:    period.State,
+		Hours:    period.Hours.Decimal,
+		Metric:   periodTotal,
+		Cost:     total,
+		Modifier: period.StateModifier.Decimal,
+		Subtotal: true,
+	})
+}

--- a/internal/console/httpui/errors.go
+++ b/internal/console/httpui/errors.go
@@ -77,6 +77,19 @@ func (e documentError) Unwrap() error { return e.err }
 // documentFailed tags err as a stored document that could not be read.
 func documentFailed(err error) error { return documentError{err: err} }
 
+// lookupError tags a pair nothing is registered under: a cloud and external
+// id the project list, filtered by both, answered with no project for.
+type lookupError struct{ err error }
+
+// Error names the pair that was looked up.
+func (e lookupError) Error() string { return e.err.Error() }
+
+// Unwrap exposes the wrapped error.
+func (e lookupError) Unwrap() error { return e.err }
+
+// nothingRegistered tags err as a lookup that found nothing.
+func nothingRegistered(err error) error { return lookupError{err: err} }
+
 // failFrom answers a failed page by what the error is tagged as. The tag
 // decides the status and the heading; the error itself, wrapped as the handler
 // wrapped it, is what the page and the log carry.
@@ -103,6 +116,12 @@ func (h *handlers) failFrom(w http.ResponseWriter, r *http.Request, err error, s
 			}
 		}
 		h.fail(w, r, http.StatusBadGateway, "the Reporting API call failed", err, src)
+		return
+	}
+
+	var fromLookup lookupError
+	if errors.As(err, &fromLookup) {
+		h.fail(w, r, http.StatusNotFound, "the Reporting API registers nothing under that pair", err, src)
 		return
 	}
 
@@ -154,7 +173,7 @@ func (h *handlers) fail(
 	}
 
 	var body bytes.Buffer
-	p := page{Title: heading, Sources: src, Data: errorData{Message: err.Error()}}
+	p := page{Title: heading, Sources: src, Data: errorData{Message: err.Error()}}.forRequest(r)
 	// The error page is what every other page falls back to, so it cannot fall
 	// back to itself. What is left when it fails is the status and one line.
 	if execErr := tpl.ExecuteTemplate(&body, "layout", p); execErr != nil {

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -1,0 +1,447 @@
+package httpui
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+)
+
+// The resources page lists the part of the fleet the Reporting API serves
+// under one status, and of those rows the ones that existed over a window or
+// at an instant. The status is the API's own filter, active by default. The
+// window and the instant are the console's, applied to the rows the API
+// served.
+//
+// The window is from and to, a half-open span: a resource existed in it when
+// it was created before to and not deleted at or before from. The instant is
+// at: a resource existed at it when it was created at or before it and not
+// deleted at or before it. Without a window and without an instant the page
+// shows what exists now, so it opens on what runs right now. With a window and
+// no instant it shows everything that lived in the window. With an instant,
+// whether inside a window or not, it shows what existed at that instant.
+//
+// A deleted resource is only on the page when the status admits it, so
+// looking back starts with switching the status to all. Every row carries the
+// resource's lifetime in hours, from its creation to its deletion or to now,
+// and folds its last payload.
+const (
+	// resourcePageLimit is how many rows the page asks the API for, the most
+	// the API serves in one page. The filters run on the rows the page holds,
+	// so a page that holds the whole fleet filters the whole fleet, and the
+	// fleet of the simulated month fits.
+	resourcePageLimit = 1000
+	// secondsPerHour turns a lifetime in seconds into the hours a bill
+	// counts in.
+	secondsPerHour = 3600
+	// atLayout is how the datetime-local inputs write and read an instant:
+	// to the minute, without a zone, and read as UTC here.
+	atLayout = "2006-01-02T15:04"
+	// The query parameters of the fleet controls.
+	statusParameter = "status"
+	fromParameter   = "from"
+	toParameter     = "to"
+	atParameter     = "at"
+	// resourceTable is the name the resource listing's sort and filter
+	// parameters carry.
+	resourceTable = "resources"
+)
+
+// statuses are the parts of the fleet the API serves, in the order the switch
+// prints them. The first is the API's default and the page's.
+var statuses = []string{"active", "deleted", "all"}
+
+// fleetState is what the request says about the fleet: which part of it, over
+// which window, and at which instant. A nil bound is a window open on that
+// side, and Pinned is false while no instant was named, which is now when
+// there is no window either.
+type fleetState struct {
+	Status string
+	From   *time.Time
+	To     *time.Time
+	At     time.Time
+	Pinned bool
+}
+
+// windowed reports whether either bound of the window is set.
+func (s fleetState) windowed() bool {
+	return s.From != nil || s.To != nil
+}
+
+// readFleet reads the status, the window and the instant, each falling back
+// to its default when absent. A status the API does not serve, a bound or an
+// instant that does not parse, and a window that ends before it starts are
+// refused the way any unreadable parameter is.
+func readFleet(r *http.Request, now time.Time) (fleetState, error) {
+	query := r.URL.Query()
+	state := fleetState{Status: statuses[0], At: now}
+
+	if status := query.Get(statusParameter); status != "" {
+		if !slices.Contains(statuses, status) {
+			return fleetState{}, &paramError{name: statusParameter, reason: "is not active, deleted or all"}
+		}
+		state.Status = status
+	}
+
+	var err error
+	if state.From, err = optionalInstant(query, fromParameter); err != nil {
+		return fleetState{}, err
+	}
+	if state.To, err = optionalInstant(query, toParameter); err != nil {
+		return fleetState{}, err
+	}
+	if state.From != nil && state.To != nil && !state.To.After(*state.From) {
+		return fleetState{}, &paramError{name: toParameter, reason: "is not after from"}
+	}
+
+	if at := query.Get(atParameter); at != "" {
+		parsed, err := parseInstant(at)
+		if err != nil {
+			return fleetState{}, &paramError{name: atParameter, reason: "is not an instant: " + err.Error()}
+		}
+		state.At, state.Pinned = parsed, true
+	}
+	return state, nil
+}
+
+// optionalInstant reads a bound of the window, nil when it is not there.
+func optionalInstant(query url.Values, name string) (*time.Time, error) {
+	text := query.Get(name)
+	if text == "" {
+		return nil, nil
+	}
+	parsed, err := parseInstant(text)
+	if err != nil {
+		return nil, &paramError{name: name, reason: "is not an instant: " + err.Error()}
+	}
+	return &parsed, nil
+}
+
+// parseInstant reads an instant as RFC 3339, the form a preset link carries,
+// or as the form the datetime-local inputs write, which carries no zone and is
+// read as UTC because every instant the console prints is UTC.
+func parseInstant(text string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, text); err == nil {
+		return t.UTC(), nil
+	}
+	return time.ParseInLocation(atLayout, text, time.UTC)
+}
+
+// keep reports whether a row is shown: inside the window where one is set,
+// and existing at the instant where one is pinned, or at now when neither is
+// there.
+func keep(resource httpapi.Resource, state fleetState, now time.Time) bool {
+	if state.From != nil && resource.DeletedAt != nil && !resource.DeletedAt.After(*state.From) {
+		return false
+	}
+	if state.To != nil && resource.CreatedAt != nil && !resource.CreatedAt.Before(*state.To) {
+		return false
+	}
+	switch {
+	case state.Pinned:
+		return existedAt(resource, state.At)
+	case state.windowed():
+		return true
+	default:
+		return existedAt(resource, now)
+	}
+}
+
+// existedAt reports whether a resource existed at an instant: created at or
+// before it, and not deleted at or before it. A resource whose history shows
+// no create has no created_at and is taken to have existed all along.
+func existedAt(resource httpapi.Resource, at time.Time) bool {
+	if resource.CreatedAt != nil && resource.CreatedAt.After(at) {
+		return false
+	}
+	return resource.DeletedAt == nil || resource.DeletedAt.After(at)
+}
+
+// lifetimeHours is how long a resource has lived, from its creation to its
+// deletion or to now for one still there, in hours at the two places the
+// bills carry hours at. A resource whose history shows no create has no
+// creation time, and reports that its lifetime is unknown.
+func lifetimeHours(resource httpapi.Resource, now time.Time) (decimal.Decimal, bool) {
+	if resource.CreatedAt == nil {
+		return decimal.Zero, false
+	}
+	return hoursBetween(*resource.CreatedAt, lifetimeEnd(resource, now)), true
+}
+
+// lifetimeEnd is where a lifetime stops: the deletion, or now for a resource
+// still there.
+func lifetimeEnd(resource httpapi.Resource, now time.Time) time.Time {
+	if resource.DeletedAt != nil {
+		return *resource.DeletedAt
+	}
+	return now
+}
+
+// hoursBetween is the span of two instants in hours at two places, and zero
+// for an end before its start.
+func hoursBetween(start, end time.Time) decimal.Decimal {
+	seconds := int64(end.Sub(start) / time.Second)
+	if seconds < 0 {
+		seconds = 0
+	}
+	return money.Round2(money.Div(decimal.NewFromInt(seconds), decimal.NewFromInt(secondsPerHour)))
+}
+
+// lifecycleTimes is what a resource page prints for the creation and the
+// lifetime of one resource. A history that starts without a create has no
+// creation time; the page then names the event the history starts with and
+// counts the lifetime from it, because that is where the fold starts the
+// intervals a run bills.
+func lifecycleTimes(lifecycle httpapi.Lifecycle, now time.Time) (created, lifetime string) {
+	resource := lifecycle.Resource
+	end := lifetimeEnd(resource, now)
+	if resource.CreatedAt != nil {
+		return stamp(*resource.CreatedAt), amount(hoursBetween(*resource.CreatedAt, end)) + " hours"
+	}
+
+	first, ok := firstEvent(lifecycle.Events)
+	if !ok {
+		return unknown, unknown
+	}
+	return fmt.Sprintf("%s, the history starts with %s at %s", unknown, first.EventType, stamp(first.Timestamp)),
+		amount(hoursBetween(first.Timestamp, end)) + " hours since the first event"
+}
+
+// firstEvent is the earliest event of a history. The API serves a history in
+// order, but the page reads the timestamps rather than trusting the order.
+func firstEvent(events []httpapi.StoredEvent) (httpapi.StoredEvent, bool) {
+	if len(events) == 0 {
+		return httpapi.StoredEvent{}, false
+	}
+	first := events[0]
+	for _, event := range events[1:] {
+		if event.Timestamp.Before(first.Timestamp) {
+			first = event
+		}
+	}
+	return first, true
+}
+
+// unknownText is the line the resources page adds for the rows whose history
+// starts without a create, and nothing when there is none.
+func unknownText(rows int) string {
+	switch rows {
+	case 0:
+		return ""
+	case 1:
+		return "1 row has no creation and no lifetime, because its history starts without a create"
+	default:
+		return fmt.Sprintf(
+			"%d rows have no creation and no lifetime, because their histories start without a create", rows)
+	}
+}
+
+// payloadSummary is what the folded payload of a row says: how many keys the
+// payload carries, or nothing for a payload that is not there or empty, which
+// the row prints as absent instead.
+func payloadSummary(payload *map[string]interface{}) string {
+	if payload == nil || len(*payload) == 0 {
+		return ""
+	}
+	if len(*payload) == 1 {
+		return "1 key"
+	}
+	return fmt.Sprintf("%d keys", len(*payload))
+}
+
+// choice is one option of a control: what it says, where it leads, and
+// whether it is the one in effect.
+type choice struct {
+	Label   string
+	Link    string
+	Current bool
+}
+
+// fleetView is what the template renders above the resource table: the status
+// switch, the three inputs with the hidden fields their form carries, the
+// presets of the window and of the instant, and what the filters left of the
+// page.
+type fleetView struct {
+	Path          string
+	Hidden        []field
+	Switch        []choice
+	From          string
+	To            string
+	At            string
+	WindowPresets []choice
+	Presets       []choice
+	Count         string
+	// Empty is what the table says when the filters left nothing of a page
+	// that held rows; a page the API served empty says what it always said.
+	Empty string
+	// Unknown counts the rows kept whose history starts without a create,
+	// and is empty when there is none.
+	Unknown string
+}
+
+// buildFleetView lays the controls out for one request. The status links drop
+// the cursor, because a cursor positions a walk through one status and means
+// nothing in another; the window and the instant keep it, because they filter
+// the page the cursor named. The instant input is left empty while nothing is
+// pinned, so that applying a window does not pin the instant to now on the
+// way.
+func buildFleetView(
+	r *http.Request, state fleetState, now time.Time, kept, total, unknown int, paged bool,
+) fleetView {
+	values := r.URL.Query()
+	view := fleetView{
+		Path:    r.URL.Path,
+		From:    inputValue(state.From),
+		To:      inputValue(state.To),
+		Unknown: unknownText(unknown),
+	}
+	if state.Pinned {
+		view.At = state.At.UTC().Format(atLayout)
+	}
+
+	own := []string{fromParameter, toParameter, atParameter}
+	for _, key := range slices.Sorted(maps.Keys(values)) {
+		if slices.Contains(own, key) {
+			continue
+		}
+		for _, value := range values[key] {
+			if value != "" {
+				view.Hidden = append(view.Hidden, field{Name: key, Value: value})
+			}
+		}
+	}
+
+	for _, status := range statuses {
+		linked := maps.Clone(values)
+		linked.Del("cursor")
+		linked.Set(statusParameter, status)
+		if status == statuses[0] {
+			linked.Del(statusParameter)
+		}
+		view.Switch = append(view.Switch, choice{
+			Label: status, Link: href(r.URL.Path, linked), Current: status == state.Status,
+		})
+	}
+
+	view.WindowPresets = windowPresets(r.URL.Path, values, state, now)
+	view.Presets = instantPresets(r.URL.Path, values, state, now)
+	view.Count = fleetCount(state, kept, total, paged)
+	if total > 0 && kept == 0 {
+		view.Empty = "no resource of this page " + existence(state, 1)
+	}
+	return view
+}
+
+// inputValue is what a datetime-local input shows for a bound: the bound, or
+// nothing for a side the window is open on.
+func inputValue(bound *time.Time) string {
+	if bound == nil {
+		return ""
+	}
+	return bound.UTC().Format(atLayout)
+}
+
+// windowPresets are the windows one click away, four spans behind now that a
+// demo month is read over, and all, which is no window at all.
+func windowPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
+	monthStart := firstOfThisMonthUTC(now)
+	spans := []struct {
+		label    string
+		from, to time.Time
+	}{
+		{"last 24 hours", now.Add(-24 * time.Hour), now},
+		{"last 7 days", now.Add(-7 * 24 * time.Hour), now},
+		{"this month", monthStart, monthStart.AddDate(0, 1, 0)},
+		{"last month", monthStart.AddDate(0, -1, 0), monthStart},
+	}
+
+	var list []choice
+	for _, span := range spans {
+		linked := maps.Clone(values)
+		linked.Set(fromParameter, stamp(span.from))
+		linked.Set(toParameter, stamp(span.to))
+		list = append(list, choice{
+			Label:   span.label,
+			Link:    href(path, linked),
+			Current: state.From != nil && state.To != nil && state.From.Equal(span.from) && state.To.Equal(span.to),
+		})
+	}
+
+	linked := maps.Clone(values)
+	linked.Del(fromParameter)
+	linked.Del(toParameter)
+	return append(list, choice{Label: "all", Link: href(path, linked), Current: !state.windowed()})
+}
+
+// instantPresets are the instants one click away: now, which is no parameter
+// at all and is offered while there is no window, four points behind it, and
+// clear, which unpins the instant inside a window.
+func instantPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
+	monthStart := firstOfThisMonthUTC(now)
+	points := []struct {
+		label string
+		at    time.Time
+	}{
+		{"24 hours ago", now.Add(-24 * time.Hour)},
+		{"7 days ago", now.Add(-7 * 24 * time.Hour)},
+		{"start of this month", monthStart},
+		{"start of last month", monthStart.AddDate(0, -1, 0)},
+	}
+
+	unpinned := maps.Clone(values)
+	unpinned.Del(atParameter)
+	var list []choice
+	if !state.windowed() {
+		list = append(list, choice{Label: "now", Link: href(path, unpinned), Current: !state.Pinned})
+	}
+	for _, point := range points {
+		linked := maps.Clone(values)
+		linked.Set(atParameter, stamp(point.at))
+		list = append(list, choice{
+			Label:   point.label,
+			Link:    href(path, linked),
+			Current: state.Pinned && state.At.Equal(point.at),
+		})
+	}
+	if state.windowed() && state.Pinned {
+		list = append(list, choice{Label: "clear", Link: href(path, unpinned)})
+	}
+	return list
+}
+
+// fleetCount says what the filters left of the page: how many of the rows the
+// API served existed at the instant or in the window.
+func fleetCount(state fleetState, kept, total int, paged bool) string {
+	scope := ""
+	if paged {
+		scope = " on this page"
+	}
+	return fmt.Sprintf("%d of %s%s %s", kept, rowsText(total), scope, existence(state, kept))
+}
+
+// existence is the tail of a sentence about the filters: what the subject did
+// at the instant or in the window, in the tense the filter calls for and in
+// the number the subject has.
+func existence(state fleetState, subjects int) string {
+	switch {
+	case state.Pinned:
+		return "existed at " + stamp(state.At)
+	case state.From != nil && state.To != nil:
+		return "existed between " + stamp(*state.From) + " and " + stamp(*state.To)
+	case state.From != nil:
+		return "existed since " + stamp(*state.From)
+	case state.To != nil:
+		return "existed before " + stamp(*state.To)
+	case subjects == 1:
+		return "exists now"
+	default:
+		return "exist now"
+	}
+}

--- a/internal/console/httpui/fleet_test.go
+++ b/internal/console/httpui/fleet_test.go
@@ -1,0 +1,183 @@
+package httpui
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+)
+
+func TestReadFleet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to the active fleet now", func(t *testing.T) {
+		t.Parallel()
+
+		state, err := readFleet(httptest.NewRequest("GET", "/resources", nil), testNow)
+		if err != nil {
+			t.Fatalf("readFleet() error = %v", err)
+		}
+		if state.Status != "active" || !state.At.Equal(testNow) || state.Pinned {
+			t.Errorf("state = %+v, want active at now, not pinned", state)
+		}
+	})
+
+	t.Run("reads both forms of an instant as UTC", func(t *testing.T) {
+		t.Parallel()
+
+		want := time.Date(2026, 3, 3, 0, 30, 0, 0, time.UTC)
+		for _, at := range []string{"2026-03-03T00:30:00Z", "2026-03-03T01:30:00%2B01:00", "2026-03-03T00:30"} {
+			state, err := readFleet(httptest.NewRequest("GET", "/resources?at="+at, nil), testNow)
+			if err != nil {
+				t.Fatalf("readFleet(%s) error = %v", at, err)
+			}
+			if !state.At.Equal(want) || !state.Pinned || state.At.Location() != time.UTC {
+				t.Errorf("readFleet(%s) = %v in %v, want %v pinned in UTC", at, state.At, state.At.Location(), want)
+			}
+		}
+	})
+
+	t.Run("refuses what it cannot read", func(t *testing.T) {
+		t.Parallel()
+
+		for _, query := range []string{"status=zombie", "at=yesterday", "at=2026-13-01T00:00"} {
+			if _, err := readFleet(httptest.NewRequest("GET", "/resources?"+query, nil), testNow); err == nil {
+				t.Errorf("readFleet(%s) accepted it", query)
+			}
+		}
+	})
+}
+
+func TestExistedAt(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	deleted := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	between := time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)
+	before := created.Add(-time.Hour)
+
+	cases := []struct {
+		name     string
+		resource httpapi.Resource
+		at       time.Time
+		want     bool
+	}{
+		{"alive and created before", httpapi.Resource{CreatedAt: &created}, between, true},
+		{"alive and created at the instant", httpapi.Resource{CreatedAt: &created}, created, true},
+		{"not yet created", httpapi.Resource{CreatedAt: &created}, before, false},
+		{"deleted after the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, between, true},
+		{"deleted at the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, deleted, false},
+		{"deleted before the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, deleted.Add(time.Hour), false},
+		{"a history without a create", httpapi.Resource{}, before, true},
+		{"a history without a create that ended", httpapi.Resource{DeletedAt: &deleted}, deleted.Add(time.Hour), false},
+	}
+	for _, tc := range cases {
+		if got := existedAt(tc.resource, tc.at); got != tc.want {
+			t.Errorf("%s: existedAt() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestScale(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	deleted := time.Date(2026, 3, 8, 0, 0, 0, 0, time.UTC)
+
+	sc := newScale(created, deleted, 100)
+	if got := sc.x(created.Add(-time.Hour)); got != 0 {
+		t.Errorf("before the start = %d, want 0", got)
+	}
+	if got := sc.x(deleted.Add(time.Hour)); got != 100 {
+		t.Errorf("after the end = %d, want 100", got)
+	}
+	if got := sc.x(created.Add(7 * 12 * time.Hour)); got != 50 {
+		t.Errorf("halfway = %d, want 50", got)
+	}
+	if got := newScale(created, created, 100).x(created); got != 0 {
+		t.Errorf("an empty span = %d, want 0", got)
+	}
+}
+
+func TestLifetimeHours(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	deleted := created.Add(90 * time.Minute)
+
+	hours, lived := lifetimeHours(httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, testNow)
+	if !lived || hours.String() != "1.5" {
+		t.Errorf("a deleted resource = %s, %v, want 1.5 hours", hours, lived)
+	}
+
+	hours, lived = lifetimeHours(httpapi.Resource{CreatedAt: &created}, testNow)
+	if !lived || hours.String() != "348" {
+		t.Errorf("a resource still there = %s, %v, want 348 hours to now", hours, lived)
+	}
+
+	if _, lived = lifetimeHours(httpapi.Resource{}, testNow); lived {
+		t.Error("a history without a create has a lifetime")
+	}
+
+	later := testNow.Add(time.Hour)
+	if hours, _ = lifetimeHours(httpapi.Resource{CreatedAt: &later}, testNow); !hours.IsZero() {
+		t.Errorf("a creation after now = %s, want 0", hours)
+	}
+}
+
+func TestPayloadSummary(t *testing.T) {
+	t.Parallel()
+
+	if got := payloadSummary(nil); got != "" {
+		t.Errorf("no payload = %q", got)
+	}
+	if got := payloadSummary(&map[string]interface{}{}); got != "" {
+		t.Errorf("an empty payload = %q", got)
+	}
+	if got := payloadSummary(&map[string]interface{}{"a": 1}); got != "1 key" {
+		t.Errorf("one key = %q", got)
+	}
+	if got := payloadSummary(&map[string]interface{}{"a": 1, "b": 2}); got != "2 keys" {
+		t.Errorf("two keys = %q", got)
+	}
+}
+
+func TestKeep(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)
+	deleted := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	gone := httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}
+	alive := httpapi.Resource{CreatedAt: &created}
+	at := func(day int) time.Time { return time.Date(2026, 3, day, 0, 0, 0, 0, time.UTC) }
+	window := func(from, to int) fleetState {
+		f, t := at(from), at(to)
+		return fleetState{From: &f, To: &t}
+	}
+
+	cases := []struct {
+		name     string
+		resource httpapi.Resource
+		state    fleetState
+		want     bool
+	}{
+		{"nothing set keeps what exists now", alive, fleetState{At: testNow}, true},
+		{"nothing set drops what is gone now", gone, fleetState{At: testNow}, false},
+		{"a window keeps what lived in it", gone, window(5, 8), true},
+		{"a window keeps what began in it", gone, window(1, 5), true},
+		{"a window keeps what ended in it", gone, window(8, 12), true},
+		{"a window keeps what outlives it", alive, window(5, 8), true},
+		{"a window drops what ended at its start", gone, window(10, 12), false},
+		{"a window drops what began at its end", gone, window(1, 3), false},
+		{"a window open at the end keeps what began after the start", gone, fleetState{From: pointerTo(at(5))}, true},
+		{"a window open at the start drops what began at the end", gone, fleetState{To: pointerTo(at(3))}, false},
+		{"an instant inside a window narrows to it", gone, fleetState{From: pointerTo(at(1)), To: pointerTo(at(12)), At: at(11), Pinned: true}, false},
+		{"an instant alone keeps what existed at it", gone, fleetState{At: at(5), Pinned: true}, true},
+	}
+	for _, tc := range cases {
+		if got := keep(tc.resource, tc.state, testNow); got != tc.want {
+			t.Errorf("%s: keep() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/console/httpui/funcs.go
+++ b/internal/console/httpui/funcs.go
@@ -13,26 +13,53 @@ import (
 
 // absent is what a template prints where a value is not there: a timestamp
 // that was never written, a payload nothing stored, a modifier map a catalog
-// entry left out.
-const absent = "none"
+// entry left out. unknown is what it prints where a value exists but the
+// console cannot know it: the creation of a resource whose history starts
+// without a create, and the lifetime that would follow from it.
+const (
+	absent  = "none"
+	unknown = "unknown"
+)
 
 // funcMap is what every page is parsed with. A number reaches a page as a
 // decimal and becomes text here, at the scale its kind is rendered at, so no
 // page decides on its own how many places an amount carries.
 func funcMap() template.FuncMap {
 	return template.FuncMap{
-		"amount":     amount,
-		"quantity":   quantity,
-		"rate":       rate,
-		"price":      price,
-		"stamp":      stamp,
-		"optStamp":   optStamp,
-		"zeroStamp":  zeroStamp,
-		"idText":     idText,
-		"optString":  optString,
-		"pretty":     pretty,
-		"stateClass": stateClass,
+		"amount":       amount,
+		"quantity":     quantity,
+		"rate":         rate,
+		"price":        price,
+		"stamp":        stamp,
+		"optStamp":     optStamp,
+		"unknownStamp": unknownStamp,
+		"zeroStamp":    zeroStamp,
+		"idText":       idText,
+		"optString":    optString,
+		"pretty":       pretty,
+		"stateClass":   stateClass,
+		"emptyText":    emptyText,
+		"zeroClass":    zeroClass,
 	}
+}
+
+// zeroClass is the class a cell of exactly zero is muted with, appended to the
+// cell's other classes, and nothing for any other value. A bill of a simulated
+// month is mostly zeros, and the few real amounts have to stand out of them.
+func zeroClass(d decimal.Decimal) string {
+	if d.IsZero() {
+		return " zero"
+	}
+	return ""
+}
+
+// emptyText is what a table without rows says. A table the filter emptied says
+// so; a table that had nothing to filter says what the page says about it.
+func emptyText(view tableView, otherwise string) string {
+	if view.Query != "" && view.Total > 0 {
+		return "no row matches the filter"
+	}
+	return otherwise
 }
 
 // amount renders money at the two places every monetary value is rounded to.
@@ -69,6 +96,15 @@ func stamp(t time.Time) string {
 func optStamp(t *time.Time) string {
 	if t == nil {
 		return absent
+	}
+	return stamp(*t)
+}
+
+// unknownStamp renders an instant the API leaves null because it does not
+// know it, the creation of a resource whose history starts without a create.
+func unknownStamp(t *time.Time) string {
+	if t == nil {
+		return unknown
 	}
 	return stamp(*t)
 }

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -79,9 +79,10 @@ func (f *fakeAPI) ListProjects(
 ) (httpapi.ProjectList, reporting.Request, error) {
 	f.projectsQuery = q
 	return f.projects, apiRequest("/api/v1/projects", url.Values{
-		"platform": nonEmpty(q.Platform),
-		"cloud":    nonEmpty(q.Cloud),
-		"cursor":   nonEmpty(q.Cursor),
+		"platform":    nonEmpty(q.Platform),
+		"cloud":       nonEmpty(q.Cloud),
+		"external_id": nonEmpty(q.ExternalID),
+		"cursor":      nonEmpty(q.Cursor),
 	}), f.projectsErr
 }
 
@@ -121,6 +122,7 @@ func (f *fakeAPI) ListResources(
 		"state":         nonEmpty(q.State),
 		"status":        nonEmpty(q.Status),
 		"cursor":        nonEmpty(q.Cursor),
+		"limit":         nonEmpty(strconv.Itoa(q.Limit)),
 	}), f.resourcesErr
 }
 
@@ -1166,7 +1168,7 @@ func TestStatementPage(t *testing.T) {
 		if status != http.StatusOK {
 			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
 		}
-		if !strings.Contains(body, "Related cost of p-2") {
+		if !strings.Contains(body, "Related cost of <code>p-2</code>") {
 			t.Errorf("the bill does not name the attributed project:\n%s", body)
 		}
 		for _, want := range []string{"12.00", "vm-2", "24.00"} {
@@ -1432,11 +1434,1098 @@ func TestResourcePage(t *testing.T) {
 		handler, _ := serve(t, api, fullStore(t), testNow)
 
 		_, body, _ := get(t, handler, resourcePath)
-		if got := strings.Count(body, "<dd>none</dd>"); got != 2 {
-			t.Errorf("the page renders %d absent timestamps, want 2:\n%s", got, body)
+		if got := strings.Count(body, "<dd>none</dd>"); got != 1 {
+			t.Errorf("the page renders %d absent timestamps, want the deletion alone:\n%s", got, body)
+		}
+		if !strings.Contains(body, "<dt>created</dt><dd>unknown, the history starts with") {
+			t.Error("the page does not say the creation is unknown")
 		}
 		if !strings.Contains(body, "<pre>none</pre>") {
 			t.Error("the page does not render the absent payload")
+		}
+	})
+}
+
+// post sends one form to the console and reads the whole answer, cookies
+// included.
+func post(t *testing.T, handler http.Handler, path string, form url.Values) *http.Response {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	result := recorder.Result()
+	t.Cleanup(func() { _ = result.Body.Close() })
+	return result
+}
+
+// getWithCookie asks for one page as a viewer who chose a theme.
+func getWithCookie(t *testing.T, handler http.Handler, path, theme string) string {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	request.AddCookie(&http.Cookie{Name: themeCookie, Value: theme})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	result := recorder.Result()
+	defer func() { _ = result.Body.Close() }()
+	read, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("reading the answer of %s: %v", path, err)
+	}
+	return string(read)
+}
+
+// themeCookieOf finds the theme cookie an answer set.
+func themeCookieOf(t *testing.T, result *http.Response) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range result.Cookies() {
+		if cookie.Name == themeCookie {
+			return cookie
+		}
+	}
+	t.Fatal("the answer set no theme cookie")
+	return nil
+}
+
+func TestTheme(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a page without a cookie follows the system", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/projects?platform=openstack")
+		if strings.Contains(body, "data-theme") {
+			t.Error("the page pins a theme nobody chose")
+		}
+		if !strings.Contains(body, `value="auto" aria-pressed="true"`) {
+			t.Error("the auto button is not pressed")
+		}
+		if !strings.Contains(body, `name="back" value="/projects?platform=openstack"`) {
+			t.Errorf("the form does not carry the page it stands on:\n%s", body)
+		}
+	})
+
+	t.Run("a choice is kept in a cookie and the viewer goes back", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		result := post(t, handler, themeRoute, url.Values{"theme": {"dark"}, "back": {"/pricing?models.sort=version"}})
+		if result.StatusCode != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusSeeOther)
+		}
+		if location := result.Header.Get("Location"); location != "/pricing?models.sort=version" {
+			t.Errorf("location = %q, want the page the form was on", location)
+		}
+		cookie := themeCookieOf(t, result)
+		if cookie.Value != "dark" || cookie.MaxAge != themeCookieAge || cookie.Path != "/" {
+			t.Errorf("cookie = %s, want dark for a year on /", cookie)
+		}
+	})
+
+	t.Run("the page renders the choice", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		body := getWithCookie(t, handler, "/", "dark")
+		if !strings.Contains(body, `<html lang="en" data-theme="dark">`) {
+			t.Error("the page does not carry the chosen theme")
+		}
+		if !strings.Contains(body, `value="dark" aria-pressed="true"`) {
+			t.Error("the dark button is not pressed")
+		}
+		if strings.Contains(body, `value="auto" aria-pressed="true"`) {
+			t.Error("the auto button is still pressed")
+		}
+
+		body = getWithCookie(t, handler, "/nowhere", "light")
+		if !strings.Contains(body, `data-theme="light"`) {
+			t.Error("the error page ignores the chosen theme")
+		}
+	})
+
+	t.Run("a cookie holding nonsense is no choice", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		if body := getWithCookie(t, handler, "/", "purple"); strings.Contains(body, "data-theme") {
+			t.Error("the page pins a theme the stylesheet does not know")
+		}
+	})
+
+	t.Run("auto deletes the cookie", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		result := post(t, handler, themeRoute, url.Values{"theme": {"auto"}, "back": {"/"}})
+		if result.StatusCode != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusSeeOther)
+		}
+		if cookie := themeCookieOf(t, result); cookie.MaxAge >= 0 || cookie.Value != "" {
+			t.Errorf("cookie = %s, want it deleted", cookie)
+		}
+	})
+
+	t.Run("a back path off the console lands on the front page", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		for _, back := range []string{"https://example.com/", "//example.com/", "", "pricing"} {
+			result := post(t, handler, themeRoute, url.Values{"theme": {"light"}, "back": {back}})
+			if location := result.Header.Get("Location"); location != "/" {
+				t.Errorf("back=%q sent the viewer to %q", back, location)
+			}
+		}
+	})
+
+	t.Run("a choice that is none of the three is refused", func(t *testing.T) {
+		t.Parallel()
+
+		handler, logged := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		result := post(t, handler, themeRoute, url.Values{"theme": {"purple"}, "back": {"/"}})
+		if result.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", result.StatusCode, http.StatusBadRequest)
+		}
+		if len(result.Cookies()) != 0 {
+			t.Error("a refused choice set a cookie")
+		}
+		if !strings.Contains(logged.String(), "is not auto, light or dark") {
+			t.Errorf("the log does not name the choice:\n%s", logged.String())
+		}
+	})
+
+	t.Run("fetching the route lands on the error page", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, contentType := get(t, handler, themeRoute)
+		if status != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want %d", status, http.StatusMethodNotAllowed)
+		}
+		if contentType != htmlContentType || !strings.Contains(body, "does not answer GET") {
+			t.Errorf("the answer is not the error page:\n%s", body)
+		}
+	})
+}
+
+func TestTablesOnPages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the overview sorts a table by a number", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/?stats.sort=count")
+		volume, instance := strings.Index(body, "<td>volume</td>"), strings.Index(body, "<td>instance</td>")
+		if volume < 0 || instance < 0 || volume > instance {
+			t.Errorf("the count of one comes after the count of three:\n%s", body)
+		}
+		if !strings.Contains(body, `<th class="number" aria-sort="ascending"><a href="/?stats.sort=-count">count</a></th>`) {
+			t.Errorf("the sorted heading does not say so, does not flip, or is not aligned over its numbers:\n%s", body)
+		}
+		if !strings.Contains(body, `<th class="number"><a href="/?events.sort=-count&amp;stats.sort=count">count</a></th>`) {
+			t.Errorf("the heading of another table drops the state of this one:\n%s", body)
+		}
+		if !strings.Contains(body, `<th><a href="/?stats.sort=cloud">cloud</a></th>`) {
+			t.Error("a text heading is aligned as a number")
+		}
+	})
+
+	t.Run("the overview filters one table and leaves the others", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/?stats.q=VOLUME")
+		if strings.Contains(body, `<td class="number">3</td>`) {
+			t.Error("the row of the instances survived the filter")
+		}
+		if !strings.Contains(body, "1 of 2 rows match") {
+			t.Error("the count does not say what matched")
+		}
+		if !strings.Contains(body, `href="/"`) {
+			t.Error("the filter cannot be cleared")
+		}
+		if !strings.Contains(body, "instance.create.end") {
+			t.Error("the filter of the counts emptied the events")
+		}
+		if !strings.Contains(body, `<input type="hidden" name="stats.q" value="VOLUME">`) {
+			t.Error("the form of another table drops the filter of this one")
+		}
+	})
+
+	t.Run("a filter that matches nothing says so", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/?runs.q=nomatch")
+		if !strings.Contains(body, "0 of 1 row match") || !strings.Contains(body, "no row matches the filter") {
+			t.Errorf("the emptied table does not say so:\n%s", body)
+		}
+		if strings.Contains(body, "no run has been recorded") {
+			t.Error("the emptied table claims nothing was recorded")
+		}
+	})
+
+	t.Run("the next link carries the table state", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.projects.NextCursor = pointerTo("abc")
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/projects?cloud=os-sim&projects.sort=-name&projects.q=p")
+		if !strings.Contains(body, `href="/projects?cloud=os-sim&amp;cursor=abc&amp;projects.q=p&amp;projects.sort=-name"`) {
+			t.Errorf("the next link drops the filter or the order:\n%s", body)
+		}
+		if !strings.Contains(body, "1 row on this page") {
+			t.Error("the count does not say it counts one page")
+		}
+	})
+
+	t.Run("the form carries the page's own identifier", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/catalog?version=2026-03&dimensions.q=vcpus")
+		if !strings.Contains(body, `<input type="hidden" name="version" value="2026-03">`) {
+			t.Error("the filter form drops the catalog version")
+		}
+		if !strings.Contains(body, `action="/catalog"`) || !strings.Contains(body, `name="dimensions.q" value="vcpus"`) {
+			t.Errorf("the filter form is not the catalog's:\n%s", body)
+		}
+		if strings.Contains(body, "ram_gb") {
+			t.Error("a metric the filter does not name survived")
+		}
+	})
+
+	t.Run("the timeline draws every segment whatever the table shows", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resource?cloud=os-sim&type=instance&id=vm-1&segments.q=nomatch")
+		if !strings.Contains(body, "metered and rated") {
+			t.Error("the filter of the segment table emptied the timeline")
+		}
+		if !strings.Contains(body, "no row matches the filter") {
+			t.Error("the emptied segment table does not say so")
+		}
+	})
+
+	t.Run("every table of every page carries its form", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		for _, path := range pagePaths() {
+			_, body, _ := get(t, handler, path)
+			tables := strings.Count(body, "<table>")
+			forms := strings.Count(body, `<form class="tools"`)
+			// A statement's forms are its summary tables, one per section: the
+			// metric tables inside the items sort and carry no form.
+			if strings.HasPrefix(path, "/statement") {
+				tables = strings.Count(body, "<h2>Adjustments</h2>") +
+					strings.Count(body, "<h2>Line items</h2>") + strings.Count(body, "<h2>Related cost of")
+			}
+			if forms != tables {
+				t.Errorf("%s: %d tables and %d filter forms", path, tables, forms)
+			}
+		}
+	})
+}
+
+func TestProjectByPair(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the resource pages link the project by its pair", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		want := `<a href="/project?cloud=os-sim&amp;external_id=p-1">p-1</a>`
+		for _, path := range []string{"/resources", "/resource?cloud=os-sim&type=instance&id=vm-1"} {
+			if _, body, _ := get(t, handler, path); !strings.Contains(body, want) {
+				t.Errorf("%s does not link the project:\n%s", path, body)
+			}
+		}
+	})
+
+	t.Run("a resource without a project gets no link", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.Items[0].ProjectId = ""
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		if _, body, _ := get(t, handler, "/resources"); strings.Contains(body, "/project?cloud=os-sim") {
+			t.Error("the page links a project the resource does not name")
+		}
+	})
+
+	t.Run("the pair resolves to the project", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/project?cloud=os-sim&external_id=p-1")
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		if !strings.Contains(body, "Project the first project") {
+			t.Error("the page is not the project's")
+		}
+		if got := api.projectsQuery; got.Cloud != "os-sim" || got.ExternalID != "p-1" || got.Platform != "" {
+			t.Errorf("the list was asked with %+v, want the cloud and the external id alone", got)
+		}
+		if !strings.Contains(body, "GET /api/v1/projects?cloud=os-sim&amp;external_id=p-1") {
+			t.Error("the provenance panel does not list the lookup")
+		}
+	})
+
+	t.Run("the id wins over the pair", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, _, _ := get(t, handler, "/project?id="+testProjectID.String()+"&cloud=other&external_id=p-9")
+		if status != http.StatusOK {
+			t.Errorf("status = %d, want %d", status, http.StatusOK)
+		}
+		if api.projectsQuery.ExternalID != "" {
+			t.Error("the list was asked although the id was there")
+		}
+	})
+
+	t.Run("a pair nothing is registered under is 404", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.projects.Items = nil
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/project?cloud=os-sim&external_id=p-9")
+		if status != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", status, http.StatusNotFound)
+		}
+		if !strings.Contains(body, "the cloud os-sim and the external id p-9") {
+			t.Errorf("the error page does not name the pair:\n%s", body)
+		}
+	})
+
+	t.Run("a project of another pair does not stand in", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.projects.Items[0].ExternalId = "p-10"
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		if status, _, _ := get(t, handler, "/project?cloud=os-sim&external_id=p-1"); status != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", status, http.StatusNotFound)
+		}
+	})
+
+	t.Run("the pair needs its cloud", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/project?external_id=p-1")
+		if status != http.StatusBadRequest || !strings.Contains(body, "the parameter cloud is missing") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+	})
+}
+
+func TestFleet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the page opens on the active fleet now", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources")
+		if api.resourcesQuery.Status != "active" || api.resourcesQuery.Limit != resourcePageLimit {
+			t.Errorf("the API was asked with %+v, want the active fleet in the widest page", api.resourcesQuery)
+		}
+		for _, want := range []string{
+			`aria-current="true">active</a>`,
+			`aria-current="true">now</a>`,
+			`aria-current="true">all</a>`,
+			`name="at" value=""`,
+			"1 of 1 row exists now",
+			`<th class="number"><a href="/resources?resources.sort=-lifetime_hours">lifetime hours</a></th>`,
+			`<td class="number">348.00</td>`,
+			`<details class="cell"><summary>1 key</summary><pre>{`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, "on this page") {
+			t.Error("a fleet that fits one page is called a page")
+		}
+	})
+
+	t.Run("a status is passed to the API and the switch drops the cursor", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=deleted&cursor=abc")
+		if api.resourcesQuery.Status != "deleted" || api.resourcesQuery.Cursor != "abc" {
+			t.Errorf("the API was asked with %+v", api.resourcesQuery)
+		}
+		for _, want := range []string{
+			`<a href="/resources">active</a>`,
+			`<a href="/resources?status=deleted" aria-current="true">deleted</a>`,
+			`<a href="/resources?status=all">all</a>`,
+			`<input type="hidden" name="cursor" value="abc">`,
+			`<input type="hidden" name="status" value="deleted">`,
+			"1 row on this page",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("an unknown status is refused", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/resources?status=zombie")
+		if status != http.StatusBadRequest || !strings.Contains(body, "is not active, deleted or all") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+	})
+
+	t.Run("the instant hides what was not yet there", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?at=2026-02-01T00:00:00Z")
+		if strings.Contains(body, ">vm-1</a>") {
+			t.Error("a resource created after the instant is on the page")
+		}
+		for _, want := range []string{
+			"0 of 1 row existed at 2026-02-01T00:00:00Z",
+			"no resource of this page existed at 2026-02-01T00:00:00Z",
+			`name="at" value="2026-02-01T00:00"`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+		if api.resourcesQuery.Status != "active" {
+			t.Error("the instant changed what the API was asked for")
+		}
+	})
+
+	t.Run("a deleted resource is shown while it lived", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		deleted := testPeriod.Add(4 * 24 * time.Hour)
+		api.resources.Items[0].DeletedAt = &deleted
+		api.resources.Items[0].State = "deleted"
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&at=2026-03-03T00:00")
+		for _, want := range []string{
+			">vm-1</a>",
+			"1 of 1 row existed at 2026-03-03T00:00:00Z",
+			`<td class="number">96.00</td>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+
+		_, body, _ = get(t, handler, "/resources?status=all")
+		if strings.Contains(body, ">vm-1</a>") || !strings.Contains(body, "0 of 1 row exist now") {
+			t.Errorf("a deleted resource is on the page now:\n%s", body)
+		}
+	})
+
+	t.Run("an unreadable instant is refused", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/resources?at=yesterday")
+		if status != http.StatusBadRequest || !strings.Contains(body, "the parameter at is not an instant") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+	})
+
+	t.Run("the presets and the form carry the rest of the page", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&resources.sort=state&cursor=abc")
+		for _, want := range []string{
+			`<a href="/resources?at=2026-03-08T12%3A00%3A00Z&amp;cursor=abc&amp;resources.sort=state&amp;status=all">7 days ago</a>`,
+			`<a href="/resources?at=2026-03-01T00%3A00%3A00Z&amp;cursor=abc&amp;resources.sort=state&amp;status=all">start of this month</a>`,
+			`<a href="/resources?at=2026-02-01T00%3A00%3A00Z&amp;cursor=abc&amp;resources.sort=state&amp;status=all">start of last month</a>`,
+			`<a href="/resources?resources.sort=state&amp;status=deleted">deleted</a>`,
+			`<input type="hidden" name="resources.sort" value="state">`,
+			`<input type="hidden" name="status" value="all">`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(fleetForm(t, body), `type="hidden" name="at"`) {
+			t.Error("the fleet form carries its own input hidden")
+		}
+	})
+
+	t.Run("a preset in effect is marked", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?at=2026-03-08T12:00:00Z")
+		if !strings.Contains(body, `aria-current="true">7 days ago</a>`) {
+			t.Error("the preset in effect is not marked")
+		}
+		if strings.Contains(body, `aria-current="true">now</a>`) {
+			t.Error("now is marked although the instant is pinned")
+		}
+	})
+
+	t.Run("the next link keeps the status and the instant", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.NextCursor = pointerTo("abc")
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&at=2026-03-03T00:00:00Z")
+		if !strings.Contains(body, `href="/resources?at=2026-03-03T00%3A00%3A00Z&amp;cursor=abc&amp;status=all"`) {
+			t.Errorf("the next link drops the status or the instant:\n%s", body)
+		}
+		if !strings.Contains(body, "on this page") {
+			t.Error("a page the API followed is not called a page")
+		}
+	})
+
+	t.Run("a project list that fits one page is not called a page", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		if _, body, _ := get(t, handler, "/projects"); strings.Contains(body, "on this page") {
+			t.Error("the whole registry is called a page")
+		}
+	})
+}
+
+// fleetForm cuts the fleet form out of a page, so a test can tell its hidden
+// fields from the table filter's, which carries the window and the instant on
+// purpose.
+func fleetForm(t *testing.T, body string) string {
+	t.Helper()
+
+	start := strings.Index(body, `<form class="tools fleet"`)
+	if start < 0 {
+		t.Fatalf("the page carries no fleet form:\n%s", body)
+	}
+	end := strings.Index(body[start:], "</form>")
+	if end < 0 {
+		t.Fatalf("the fleet form does not end:\n%s", body)
+	}
+	return body[start : start+end]
+}
+
+// twoResources is the fleet the window tests read: the fixture's vm-1, alive
+// since the first of March, beside vm-2, which lived from the third to the
+// tenth.
+func twoResources(t *testing.T) *fakeAPI {
+	t.Helper()
+
+	api := fullAPI(t)
+	second := api.resources.Items[0]
+	created := testPeriod.Add(2 * 24 * time.Hour)
+	deleted := testPeriod.Add(9 * 24 * time.Hour)
+	second.ResourceId, second.CreatedAt, second.DeletedAt, second.State = "vm-2", &created, &deleted, "deleted"
+	api.resources.Items = append(api.resources.Items, second)
+	return api
+}
+
+func TestFleetWindow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a window keeps what lived in it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&from=2026-03-02T00:00&to=2026-03-08T00:00")
+		for _, want := range []string{
+			">vm-1</a>",
+			">vm-2</a>",
+			"2 of 2 rows existed between 2026-03-02T00:00:00Z and 2026-03-08T00:00:00Z",
+			`name="from" value="2026-03-02T00:00"`,
+			`name="to" value="2026-03-08T00:00"`,
+			`name="at" value=""`,
+			// vm-2 lived a week whatever the window is.
+			`<td class="number">168.00</td>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, `>now</a>`) {
+			t.Error("a window offers the instant now")
+		}
+	})
+
+	t.Run("a window drops what ended before it or began after it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&from=2026-03-11T00:00:00Z&to=2026-03-12T00:00:00Z")
+		if strings.Contains(body, ">vm-2</a>") || !strings.Contains(body, ">vm-1</a>") {
+			t.Errorf("the window after vm-2 ended keeps the wrong rows:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, "/resources?status=all&from=2026-02-01T00:00:00Z&to=2026-02-15T00:00:00Z")
+		if strings.Contains(body, ">vm-1</a>") ||
+			!strings.Contains(body, "no resource of this page existed between 2026-02-01T00:00:00Z and 2026-02-15T00:00:00Z") {
+			t.Errorf("the window before anything began keeps a row or does not say so:\n%s", body)
+		}
+	})
+
+	t.Run("an instant inside a window narrows to it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&from=2026-03-02T00:00:00Z&to=2026-03-08T00:00:00Z&at=2026-03-05T00:00:00Z")
+		for _, want := range []string{
+			">vm-1</a>", ">vm-2</a>",
+			"2 of 2 rows existed at 2026-03-05T00:00:00Z",
+			`>clear</a>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+
+		_, body, _ = get(t, handler, "/resources?status=all&from=2026-03-02T00:00:00Z&to=2026-03-08T00:00:00Z&at=2026-03-11T00:00:00Z")
+		if strings.Contains(body, ">vm-2</a>") || !strings.Contains(body, "1 of 2 rows existed at 2026-03-11T00:00:00Z") {
+			t.Errorf("an instant after vm-2 ended keeps it:\n%s", body)
+		}
+	})
+
+	t.Run("a window open on one side filters on that side", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&from=2026-03-05T00:00:00Z")
+		for _, want := range []string{
+			"2 of 2 rows existed since 2026-03-05T00:00:00Z",
+			`name="to" value=""`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+
+		_, body, _ = get(t, handler, "/resources?status=all&to=2026-03-02T00:00:00Z")
+		if !strings.Contains(body, "1 of 2 rows existed before 2026-03-02T00:00:00Z") {
+			t.Errorf("an open start keeps the wrong rows:\n%s", body)
+		}
+	})
+
+	t.Run("a window that ends before it starts is refused", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/resources?from=2026-03-08T00:00&to=2026-03-02T00:00")
+		if status != http.StatusBadRequest || !strings.Contains(body, "the parameter to is not after from") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+		status, body, _ = get(t, handler, "/resources?from=soon")
+		if status != http.StatusBadRequest || !strings.Contains(body, "the parameter from is not an instant") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+	})
+
+	t.Run("the window presets carry the page and mark the one in effect", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&resources.q=vm")
+		for _, want := range []string{
+			`<a href="/resources?from=2026-03-01T00%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-04-01T00%3A00%3A00Z">this month</a>`,
+			`<a href="/resources?from=2026-02-01T00%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-03-01T00%3A00%3A00Z">last month</a>`,
+			`<a href="/resources?from=2026-03-08T12%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-03-15T12%3A00%3A00Z">last 7 days</a>`,
+			`<a href="/resources?resources.q=vm&amp;status=all" aria-current="true">all</a>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+
+		_, body, _ = get(t, handler, "/resources?from=2026-03-01T00:00:00Z&to=2026-04-01T00:00:00Z")
+		if !strings.Contains(body, `aria-current="true">this month</a>`) {
+			t.Error("the window in effect is not marked")
+		}
+		if !strings.Contains(body, `<a href="/resources">all</a>`) {
+			t.Error("all does not clear the window")
+		}
+		form := fleetForm(t, body)
+		if strings.Contains(form, `type="hidden" name="from"`) || strings.Contains(form, `type="hidden" name="to"`) {
+			t.Error("the fleet form carries its own inputs hidden")
+		}
+	})
+
+	t.Run("the next link keeps the window", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.NextCursor = pointerTo("abc")
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?from=2026-03-01T00:00:00Z&to=2026-04-01T00:00:00Z")
+		if !strings.Contains(body, `href="/resources?cursor=abc&amp;from=2026-03-01T00%3A00%3A00Z&amp;to=2026-04-01T00%3A00%3A00Z"`) {
+			t.Errorf("the next link drops the window:\n%s", body)
+		}
+	})
+}
+
+// billDocument is a statement of two items, one that cost something and one
+// that cost nothing, whose description only repeats its type and id.
+func billDocument(t *testing.T) []byte {
+	t.Helper()
+
+	period := func(state, hours, vcpus, cost, modifier string) statements.Period {
+		return statements.Period{
+			State: state,
+			Hours: money.NewAmount(mustDecimal(t, hours)),
+			Usage: map[string]money.Quantity{"vcpus": money.NewQuantity(mustDecimal(t, vcpus))},
+			Cost: map[string]money.Amount{
+				"vcpus": money.NewAmount(mustDecimal(t, cost)),
+				"total": money.NewAmount(mustDecimal(t, cost)),
+			},
+			StateModifier: money.NewQuantity(mustDecimal(t, modifier)),
+		}
+	}
+	document := statements.Document{
+		BillingPeriod: statements.BillingPeriod{From: "2026-03-01T00:00:00Z", To: "2026-04-01T00:00:00Z"},
+		ProjectID:     "p-1",
+		Platform:      "openstack",
+		LineItems: []statements.LineItem{
+			{
+				ResourceType: "instance", ResourceID: "vm-3", Platform: "openstack",
+				Description: "instance vm-3",
+				Periods:     []statements.Period{period("shelved", "10", "2", "0", "0")},
+				Total:       money.NewAmount(mustDecimal(t, "0")),
+			},
+			{
+				ResourceType: "instance", ResourceID: "vm-4", Platform: "openstack",
+				Description: "m1.small instance",
+				Periods: []statements.Period{
+					period("active", "24", "2", "12", "1"),
+					period("shutoff", "6", "2", "1.5", "0.5"),
+				},
+				Total: money.NewAmount(mustDecimal(t, "13.5")),
+			},
+		},
+		Total:    money.NewAmount(mustDecimal(t, "13.5")),
+		Currency: "EUR",
+	}
+
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("building the statement document: %v", err)
+	}
+	return raw
+}
+
+func TestBill(t *testing.T) {
+	t.Parallel()
+
+	statementPath := "/statement?run=" + testRunID.String() + "&key=" + url.QueryEscape(testKey)
+
+	billStore := func(t *testing.T) *fakeStore {
+		t.Helper()
+
+		engine := fullStore(t)
+		engine.statement = store.Statement{Document: billDocument(t), Total: mustDecimal(t, "13.5"), Currency: "EUR"}
+		return engine
+	}
+
+	t.Run("the summary opens sorted by total and leads to the items", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath)
+		for _, want := range []string{
+			`<th class="number" aria-sort="descending"><a href="/statement?items.sort=total&amp;key=os-sim%2Fp-1&amp;run=` +
+				testRunID.String() + `">total</a></th>`,
+			`<td><a href="/statement?key=os-sim%2Fp-1&amp;open=li-1&amp;run=` + testRunID.String() +
+				`#li-1"><code>vm-4</code></a></td>`,
+			`<td>m1.small instance</td>`,
+			`<td class="number">30.00</td>`,
+			`<td class="number">13.50 EUR</td>`,
+			`<td class="number zero">0.00 EUR</td>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the summary lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Index(body, `<code>vm-4</code>`) > strings.Index(body, `<code>vm-3</code>`) {
+			t.Error("the item that cost something is not first")
+		}
+	})
+
+	t.Run("every block starts folded and the link opens one", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath)
+		if strings.Contains(body, " open>") {
+			t.Errorf("a block starts unfolded:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, statementPath+"&open=li-1")
+		for _, want := range []string{
+			`<details class="item" id="li-1" open>`,
+			`<details class="item" id="li-0">`,
+			`<input type="hidden" name="open" value="li-1">`,
+			`<summary><span>instance <code>vm-4</code></span> <span class="muted">m1.small instance</span><span class="total">13.50 EUR</span></summary>`,
+			`<summary><span>instance <code>vm-3</code></span><span class="total zero">0.00 EUR</span></summary>`,
+			`<a href="/resource?cloud=os-sim&amp;id=vm-4&amp;type=instance">the resource's page</a>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the blocks lack %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, "<dt>description</dt>") || strings.Contains(body, "instance vm-3</span>") {
+			t.Error("a description that repeats the heading is printed")
+		}
+	})
+
+	t.Run("a period is one row per metric and a total", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath)
+		for _, want := range []string{
+			"<tr>\n<td>active</td>\n<td class=\"number\">24.00</td>\n<td>vcpus</td>\n" +
+				"<td class=\"number\">2.0000</td>\n<td class=\"number\">12.00</td>\n<td class=\"number\">1.0000</td>\n</tr>",
+			"<tr class=\"subtotal\">\n<td>active</td>\n<td class=\"number\">24.00</td>\n<td>total</td>\n" +
+				"<td class=\"number zero\"></td>\n<td class=\"number\">12.00</td>\n<td class=\"number\">1.0000</td>\n</tr>",
+			`<td class="number zero">0.00</td>`,
+			`<th class="number"><a href="/statement?key=os-sim%2Fp-1&amp;li-1.sort=-cost&amp;run=` +
+				testRunID.String() + `">cost</a></th>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the metric rows lack %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a metric table sorts on its own", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath+"&li-1.sort=cost")
+		block := body[strings.Index(body, `id="li-1"`):]
+		if strings.Index(block, "1.50") > strings.Index(block, "12.00") {
+			t.Errorf("the cheapest row is not first:\n%s", block)
+		}
+	})
+
+	t.Run("filtering the summary filters the blocks", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath+"&items.q=vm-4")
+		if strings.Count(body, "<details") != 1 || !strings.Contains(body, `id="li-1"`) {
+			t.Errorf("the blocks do not follow the filter:\n%s", body)
+		}
+		if !strings.Contains(body, "1 of 2 rows match") {
+			t.Error("the summary does not count the filter")
+		}
+	})
+
+	t.Run("the golden statement flattens its periods", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, statementPath)
+		for _, want := range []string{
+			`<td class="number">744.00</td>`,
+			"<td>disk_gb</td>\n<td class=\"number\">80.0000</td>\n<td class=\"number\">19.20</td>",
+			"<td>total</td>\n<td class=\"number zero\"></td>\n<td class=\"number\">49.62</td>",
+			`<details class="item" id="li-0">`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the golden bill lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Count(body, `<tr class="subtotal">`) != 3 {
+			t.Errorf("the golden bill carries %d period totals, want 3", strings.Count(body, `<tr class="subtotal">`))
+		}
+	})
+
+	t.Run("a related cost is a section of its own", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.statement = store.Statement{Document: relatedCostDocument(t), Total: mustDecimal(t, "12.00"), Currency: "EUR"}
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, statementPath)
+		for _, want := range []string{
+			"<p>this section holds no line item</p>",
+			`open=rc-0-li-0&amp;run=` + testRunID.String() + `#rc-0-li-0"><code>vm-2</code></a></td>`,
+			`<details class="item" id="rc-0-li-0">`,
+			`name="rc-0.q"`,
+			`rc-0.sort=total`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the related section lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a key the page cannot read links no resource", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/statement?run="+testRunID.String()+"&key=nokey")
+		if strings.Contains(body, "the resource's page") {
+			t.Error("a statement without a cloud links a resource")
+		}
+	})
+}
+
+func TestHistoryWithoutCreate(t *testing.T) {
+	t.Parallel()
+
+	// orphan is the fixture's resource without a creation, the way the API
+	// serves a history that starts without a create.
+	orphan := func(t *testing.T) *fakeAPI {
+		t.Helper()
+
+		api := fullAPI(t)
+		api.resources.Items[0].CreatedAt = nil
+		api.lifecycle.Resource.CreatedAt = nil
+		api.lifecycle.Warnings = []string{"history_starts_without_create"}
+		return api
+	}
+
+	t.Run("the listing says the creation and the lifetime are unknown", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, orphan(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources")
+		for _, want := range []string{
+			"<td>unknown</td>\n<td>none</td>\n<td class=\"number\">unknown</td>",
+			"1 row has no creation and no lifetime, because its history starts without a create</p>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the listing lacks %q:\n%s", want, body)
+			}
+		}
+
+		handler, _ = serve(t, fullAPI(t), fullStore(t), testNow)
+		if _, body, _ = get(t, handler, "/resources"); strings.Contains(body, "no creation") {
+			t.Error("a fleet with every creation known is told about unknown ones")
+		}
+	})
+
+	t.Run("the resource page names the first event and counts from it", func(t *testing.T) {
+		t.Parallel()
+
+		api := orphan(t)
+		later := api.lifecycle.Events[0]
+		later.EventType, later.Timestamp = "instance.power_on", testPeriod.Add(48*time.Hour)
+		// The later event is served first, and the page still finds the earliest.
+		api.lifecycle.Events = []httpapi.StoredEvent{later, api.lifecycle.Events[0]}
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resource?cloud=os-sim&type=instance&id=vm-1")
+		for _, want := range []string{
+			"<dt>created</dt><dd>unknown, the history starts with instance.create.end at 2026-03-01T00:00:00Z</dd>",
+			"<dt>lifetime</dt><dd>348.00 hours since the first event</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a resource with a creation counts from it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resource?cloud=os-sim&type=instance&id=vm-1")
+		for _, want := range []string{
+			"<dt>created</dt><dd>2026-03-01T00:00:00Z</dd>",
+			"<dt>lifetime</dt><dd>348.00 hours</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a history without any event is unknown throughout", func(t *testing.T) {
+		t.Parallel()
+
+		api := orphan(t)
+		api.lifecycle.Events = nil
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resource?cloud=os-sim&type=instance&id=vm-1")
+		if !strings.Contains(body, "<dt>created</dt><dd>unknown</dd>") ||
+			!strings.Contains(body, "<dt>lifetime</dt><dd>unknown</dd>") {
+			t.Errorf("the page guesses at a history it does not have:\n%s", body)
 		}
 	})
 }

--- a/internal/console/httpui/overview.go
+++ b/internal/console/httpui/overview.go
@@ -23,14 +23,52 @@ const (
 // overviewData is the front page: what the API counts, what the ingest path
 // refused, and what the engine has run.
 type overviewData struct {
-	Stats    []statRow
-	Events   []httpapi.EventStatsItem
-	Rejected []httpapi.DeadLetteredEvent
-	Periods  []store.Period
-	Runs     []runRow
+	Stats    listing[statRow]
+	Events   listing[httpapi.EventStatsItem]
+	Rejected listing[httpapi.DeadLetteredEvent]
+	Periods  listing[store.Period]
+	Runs     listing[runRow]
 	From     time.Time
 	To       time.Time
 }
+
+// The columns of the overview's tables. The share bar of the counts draws the
+// count and is sorted through it.
+var (
+	statColumns = []column[statRow]{
+		textCol("cloud", func(r statRow) string { return r.Cloud }),
+		textCol("resource type", func(r statRow) string { return r.ResourceType }),
+		textCol("state", func(r statRow) string { return r.State }),
+		countCol("count", func(r statRow) int64 { return r.Count }),
+		plainCol[statRow]("share"),
+	}
+	eventColumns = []column[httpapi.EventStatsItem]{
+		textCol("bucket", func(r httpapi.EventStatsItem) string { return stamp(r.Bucket) }),
+		textCol("cloud", func(r httpapi.EventStatsItem) string { return r.Cloud }),
+		textCol("event type", func(r httpapi.EventStatsItem) string { return r.EventType }),
+		countCol("count", func(r httpapi.EventStatsItem) int64 { return r.Count }),
+	}
+	rejectedColumns = []column[httpapi.DeadLetteredEvent]{
+		textCol("received at", func(r httpapi.DeadLetteredEvent) string { return stamp(r.ReceivedAt) }),
+		textCol("reason", func(r httpapi.DeadLetteredEvent) string { return r.Reason }),
+	}
+	periodColumns = []column[store.Period]{
+		textCol("from", func(r store.Period) string { return stamp(r.From) }),
+		textCol("to", func(r store.Period) string { return stamp(r.To) }),
+		textCol("status", func(r store.Period) string { return r.Status }),
+		textCol("finalized by", func(r store.Period) string { return idText(r.FinalizedRunID) }),
+		textCol("finalized at", func(r store.Period) string { return zeroStamp(r.FinalizedAt) }),
+	}
+	runColumns = []column[runRow]{
+		textCol("run", func(r runRow) string { return r.Run.ID.String() }),
+		textCol("period", func(r runRow) string { return stamp(r.Run.PeriodFrom) }),
+		textCol("kind", func(r runRow) string { return r.Run.Kind }),
+		textCol("status", func(r runRow) string { return r.Run.Status }),
+		textCol("pricing", func(r runRow) string { return r.Run.PricingVersion }),
+		textCol("started", func(r runRow) string { return zeroStamp(r.Run.StartedAt) }),
+		textCol("completed", func(r runRow) string { return zeroStamp(r.Run.CompletedAt) }),
+	}
+)
 
 // statRow is one counted group with the bar it is drawn as.
 type statRow struct {
@@ -93,11 +131,11 @@ func (h *handlers) overview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := overviewData{
-		Stats:    statRows(stats.Items),
-		Events:   events.Items,
-		Rejected: rejected.Items,
-		Periods:  periods,
-		Runs:     runRows(runs),
+		Stats:    tabulate(r, "stats", statColumns, statRows(stats.Items)),
+		Events:   tabulate(r, "events", eventColumns, events.Items),
+		Rejected: tabulate(r, "rejected", rejectedColumns, rejected.Items),
+		Periods:  tabulate(r, "periods", periodColumns, periods),
+		Runs:     tabulate(r, "runs", runColumns, runRows(runs)),
 		From:     from,
 		To:       to,
 	}

--- a/internal/console/httpui/pricing.go
+++ b/internal/console/httpui/pricing.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -15,7 +16,15 @@ import (
 
 // pricingData is the list of imported catalog versions.
 type pricingData struct {
-	Models []pricingRow
+	Models listing[pricingRow]
+}
+
+// modelColumns is the version listing.
+var modelColumns = []column[pricingRow]{
+	textCol("version", func(r pricingRow) string { return r.Model.Version }),
+	textCol("valid from", func(r pricingRow) string { return stamp(r.Model.ValidFrom) }),
+	textCol("currency", func(r pricingRow) string { return r.Model.Currency }),
+	textCol("imported", func(r pricingRow) string { return stamp(r.Model.ImportedAt) }),
 }
 
 // pricingRow is one version and the catalog it opens.
@@ -30,7 +39,19 @@ type catalogData struct {
 	ValidFrom  time.Time
 	Currency   string
 	ImportedAt time.Time
-	Rows       []dimensionRow
+	Rows       listing[dimensionRow]
+}
+
+// dimensionColumns is the catalog table. The modifier columns are searched as
+// the text they print, so a filter finds a state or a flavour inside them.
+var dimensionColumns = []column[dimensionRow]{
+	textCol("platform", func(r dimensionRow) string { return r.Platform }),
+	textCol("resource type", func(r dimensionRow) string { return r.ResourceType }),
+	textCol("metric", func(r dimensionRow) string { return r.Metric }),
+	textCol("type", func(r dimensionRow) string { return r.Type }),
+	numberCol("price", func(r dimensionRow) decimal.Decimal { return r.Price }),
+	textCol("state modifiers", func(r dimensionRow) string { return modifierText(r.StateModifiers) }),
+	textCol("type modifiers", func(r dimensionRow) string { return modifierText(r.TypeModifiers) }),
 }
 
 // dimensionRow is one priced metric of one resource type with the modifiers of
@@ -70,7 +91,7 @@ func (h *handlers) pricing(w http.ResponseWriter, r *http.Request) {
 	h.render(w, r, "pricing", page{
 		Title:   "Pricing",
 		Sources: src,
-		Data:    pricingData{Models: rows},
+		Data:    pricingData{Models: tabulate(r, "models", modelColumns, rows)},
 	})
 }
 
@@ -104,7 +125,7 @@ func (h *handlers) catalog(w http.ResponseWriter, r *http.Request) {
 		ValidFrom:  stored.ValidFrom,
 		Currency:   stored.Currency,
 		ImportedAt: stored.ImportedAt,
-		Rows:       dimensionRows(model),
+		Rows:       tabulate(r, "dimensions", dimensionColumns, dimensionRows(model)),
 	}
 	h.render(w, r, "catalog", page{
 		Title:   "Catalog " + stored.Version,
@@ -146,6 +167,16 @@ func dimensionPrice(dimension pricing.Dimension) decimal.Decimal {
 		return dimension.PricePerUnit
 	}
 	return dimension.PricePerUnitHour
+}
+
+// modifierText is a modifier list as one line of text, key and factor each,
+// which is what the filter of the catalog table matches against.
+func modifierText(list []modifier) string {
+	parts := make([]string, 0, len(list))
+	for _, m := range list {
+		parts = append(parts, m.Key+": "+price(m.Value))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // modifiers sorts a modifier map by key. An entry that sets none renders as

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -1,8 +1,13 @@
 package httpui
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/console/reporting"
 	"github.com/b42labs/tally/internal/console/store"
@@ -12,8 +17,17 @@ import (
 
 // projectsData is one page of the registry with the link to the next one.
 type projectsData struct {
-	Items    []projectRow
+	Items    listing[projectRow]
 	NextLink string
+}
+
+// projectColumns is the registry listing.
+var projectColumns = []column[projectRow]{
+	textCol("cloud", func(r projectRow) string { return r.Project.Cloud }),
+	textCol("external id", func(r projectRow) string { return r.Project.ExternalId }),
+	textCol("name", func(r projectRow) string { return optString(r.Project.Name, r.Project.ExternalId) }),
+	textCol("platform", func(r projectRow) string { return r.Project.Platform }),
+	textCol("registered", func(r projectRow) string { return stamp(r.Project.CreatedAt) }),
 }
 
 // projectRow is one registered project and its own page.
@@ -26,14 +40,46 @@ type projectRow struct {
 // ran this month, and what every run billed it.
 type projectData struct {
 	Project    httpapi.Project
-	Relations  []httpapi.Relation
-	Related    []relatedRow
-	Activity   []httpapi.ProjectActivity
+	Relations  listing[httpapi.Relation]
+	Related    listing[relatedRow]
+	Activity   listing[httpapi.ProjectActivity]
 	From       time.Time
 	To         time.Time
 	Key        string
-	Statements []projectStatementRow
+	Statements listing[projectStatementRow]
 }
+
+// The columns of a project page's tables.
+var (
+	relationColumns = []column[httpapi.Relation]{
+		textCol("relation type", func(r httpapi.Relation) string { return r.RelationType }),
+		textCol("source", func(r httpapi.Relation) string { return r.SourceId.String() }),
+		textCol("target", func(r httpapi.Relation) string { return r.TargetId.String() }),
+		textCol("valid from", func(r httpapi.Relation) string { return stamp(r.ValidFrom) }),
+		textCol("valid to", func(r httpapi.Relation) string { return optStamp(r.ValidTo) }),
+	}
+	relatedColumns = []column[relatedRow]{
+		textCol("project", func(r relatedRow) string {
+			return optString(r.Related.Project.Name, r.Related.Project.ExternalId)
+		}),
+		textCol("cloud", func(r relatedRow) string { return r.Related.Project.Cloud }),
+		textCol("relation type", func(r relatedRow) string { return r.Related.RelationType }),
+		countCol("depth", func(r relatedRow) int64 { return int64(r.Related.Depth) }),
+	}
+	activityColumns = []column[httpapi.ProjectActivity]{
+		textCol("resource type", func(r httpapi.ProjectActivity) string { return r.ResourceType }),
+		countCol("created", func(r httpapi.ProjectActivity) int64 { return int64(r.Created) }),
+		countCol("deleted", func(r httpapi.ProjectActivity) int64 { return int64(r.Deleted) }),
+		countCol("active now", func(r httpapi.ProjectActivity) int64 { return int64(r.ActiveNow) }),
+		countCol("minutes", func(r httpapi.ProjectActivity) int64 { return r.TotalMinutes }),
+	}
+	projectStatementColumns = []column[projectStatementRow]{
+		textCol("period", func(r projectStatementRow) string { return stamp(r.Row.PeriodFrom) }),
+		textCol("run kind", func(r projectStatementRow) string { return r.Row.Kind }),
+		textCol("run status", func(r projectStatementRow) string { return r.Row.Status }),
+		numberCol("total", func(r projectStatementRow) decimal.Decimal { return r.Row.Total }),
+	}
+)
 
 // relatedRow is one project a traversal reached and its own page.
 type relatedRow struct {
@@ -73,22 +119,25 @@ func (h *handlers) projects(w http.ResponseWriter, r *http.Request) {
 		rows = append(rows, projectRow{Project: project, Link: link("/project", "id", project.Id.String())})
 	}
 
-	data := projectsData{Items: rows}
+	data := projectsData{Items: tabulate(r, "projects", projectColumns, rows)}
+	if list.NextCursor != nil || query.Cursor != "" {
+		data.Items = data.Items.paged()
+	}
 	if list.NextCursor != nil {
-		data.NextLink = link("/projects",
-			"platform", query.Platform, "cloud", query.Cloud, "cursor", *list.NextCursor)
+		data.NextLink = nextLink(r, *list.NextCursor)
 	}
 	h.render(w, r, "projects", page{Title: "Projects", Sources: src, Data: data})
 }
 
-// project shows one project. The statements are read under the key the engine
-// stores them by, which is the pair of cloud and external id rather than the
-// id the API addresses the project with.
+// project shows one project. It is addressed by the id the API assigns, or by
+// the pair a resource names its project with, cloud and external id, which the
+// registry resolves to that id first. The statements are read under the key
+// the engine stores them by, which is that same pair.
 func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var src sources
 
-	id, err := uuidParameter(r, "id")
+	id, err := h.projectID(ctx, r, &src)
 	if err != nil {
 		h.failFrom(w, r, err, src)
 		return
@@ -150,19 +199,61 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	data := projectData{
 		Project:    project,
-		Relations:  relations.Items,
-		Related:    reached,
-		Activity:   summary.ResourceTypes,
+		Relations:  tabulate(r, "relations", relationColumns, relations.Items),
+		Related:    tabulate(r, "related", relatedColumns, reached),
+		Activity:   tabulate(r, "activity", activityColumns, summary.ResourceTypes),
 		From:       from,
 		To:         to,
 		Key:        key,
-		Statements: rows,
+		Statements: tabulate(r, "statements", projectStatementColumns, rows),
 	}
 	h.render(w, r, "project", page{
 		Title:   "Project " + optString(project.Name, project.ExternalId),
 		Sources: src,
 		Data:    data,
 	})
+}
+
+// projectID reads which project the page is about: the id parameter when it
+// is there, and otherwise the project registered under the cloud and
+// external_id parameters, which is how a resource names its project. The pair
+// is looked up through the project list filtered by both, and the answer is
+// checked for an exact match on each, so a project of another pair never stands
+// in. A pair nothing is registered under fails the way an unknown id does.
+func (h *handlers) projectID(ctx context.Context, r *http.Request, src *sources) (uuid.UUID, error) {
+	query := r.URL.Query()
+	if query.Get("id") != "" || query.Get("external_id") == "" {
+		return uuidParameter(r, "id")
+	}
+
+	cloud, err := stringParameter(r, "cloud")
+	if err != nil {
+		return uuid.Nil, err
+	}
+	externalID := query.Get("external_id")
+
+	list, request, err := h.api.ListProjects(ctx, reporting.ProjectsQuery{Cloud: cloud, ExternalID: externalID})
+	src.api(request)
+	if err != nil {
+		return uuid.Nil, apiFailed(err)
+	}
+	for _, project := range list.Items {
+		if project.Cloud == cloud && project.ExternalId == externalID {
+			return project.Id, nil
+		}
+	}
+	return uuid.Nil, nothingRegistered(
+		fmt.Errorf("no project is registered under the cloud %s and the external id %s", cloud, externalID))
+}
+
+// projectLink is the page of the project a resource names, addressed by the
+// pair the resource carries rather than by the id the API assigns, which the
+// project page resolves. A resource that names no project gets no link.
+func projectLink(cloud, externalID string) string {
+	if externalID == "" {
+		return ""
+	}
+	return link("/project", "cloud", cloud, "external_id", externalID)
 }
 
 // firstOfThisMonthUTC is the start of the month now falls in. The summary

--- a/internal/console/httpui/render.go
+++ b/internal/console/httpui/render.go
@@ -64,11 +64,23 @@ func parsePages() (map[string]*template.Template, error) {
 }
 
 // page is what a template is executed with: the heading the layout prints,
-// where the page's numbers came from, and the page's own data.
+// where the page's numbers came from, and the page's own data. Theme and Back
+// are filled in by render and fail, because they come from the request rather
+// than from the handler: the theme the viewer chose, and the path the theme
+// form sends the viewer back to, which is the page it stands on.
 type page struct {
 	Title   string
 	Sources []Source
 	Data    any
+	Theme   string
+	Back    string
+}
+
+// forRequest fills in what the layout takes from the request.
+func (p page) forRequest(r *http.Request) page {
+	p.Theme = themeFrom(r)
+	p.Back = r.URL.RequestURI()
+	return p
 }
 
 // render writes one page. The template is executed into a buffer first: a
@@ -86,7 +98,7 @@ func (h *handlers) render(w http.ResponseWriter, r *http.Request, name string, p
 	}
 
 	var body bytes.Buffer
-	if err := tpl.ExecuteTemplate(&body, "layout", p); err != nil {
+	if err := tpl.ExecuteTemplate(&body, "layout", p.forRequest(r)); err != nil {
 		h.fail(w, r, http.StatusServiceUnavailable, "the page could not be rendered",
 			fmt.Errorf("rendering the page %s: %w", name, err), p.Sources)
 		return

--- a/internal/console/httpui/resources.go
+++ b/internal/console/httpui/resources.go
@@ -4,46 +4,105 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/console/reporting"
 	"github.com/b42labs/tally/internal/console/store"
 	"github.com/b42labs/tally/internal/reporting/httpapi"
 )
 
-// resourcesData is one page of the projection with the link to the next one.
+// resourcesData is one page of the projection: the fleet controls above it,
+// the rows the instant left of it, and the link to the next page.
 type resourcesData struct {
-	Items    []resourceRow
+	Fleet    fleetView
+	Items    listing[resourceRow]
 	NextLink string
 }
 
-// resourceRow is one resource and its own page.
+// resourceColumns is the projection listing. The payload column is searched
+// as the text the page prints it as, so a filter finds a value inside it.
+var resourceColumns = []column[resourceRow]{
+	textCol("cloud", func(r resourceRow) string { return r.Resource.Cloud }),
+	textCol("platform", func(r resourceRow) string { return r.Resource.Platform }),
+	textCol("project", func(r resourceRow) string { return r.Resource.ProjectId }),
+	textCol("resource type", func(r resourceRow) string { return r.Resource.ResourceType }),
+	textCol("resource", func(r resourceRow) string { return r.Resource.ResourceId }),
+	textCol("state", func(r resourceRow) string { return r.Resource.State }),
+	textCol("created", func(r resourceRow) string { return unknownStamp(r.Resource.CreatedAt) }),
+	textCol("deleted", func(r resourceRow) string { return optStamp(r.Resource.DeletedAt) }),
+	numberCol("lifetime hours", func(r resourceRow) decimal.Decimal { return r.Lifetime }),
+	textCol("last payload", func(r resourceRow) string { return pretty(r.Resource.LastPayload) }),
+}
+
+// resourceRow is one resource, its own page, the page of its project, how
+// long it has lived, and what its folded payload says.
 type resourceRow struct {
-	Resource httpapi.Resource
-	Link     string
+	Resource    httpapi.Resource
+	Link        string
+	ProjectLink string
+	// Lifetime is the resource's hours from creation to deletion or to now,
+	// and Lived is false for a resource whose history shows no create.
+	Lifetime       decimal.Decimal
+	Lived          bool
+	PayloadSummary string
 }
 
 // resourceData is one resource from both sides: what its events made of it, and
 // what a run metered and rated it at.
 type resourceData struct {
-	Cloud    string
-	Type     string
-	ID       string
-	Resource httpapi.Resource
+	Cloud       string
+	Type        string
+	ID          string
+	Resource    httpapi.Resource
+	ProjectLink string
+	// Created and Lifetime are the two lines the head prints for a history
+	// with or without a create.
+	Created  string
+	Lifetime string
 	Warnings []string
-	Events   []httpapi.StoredEvent
+	Events   listing[httpapi.StoredEvent]
 	Timeline timeline
 	// Metered is false for a resource no run holds usage for, which every
 	// resource is until the first run of its period has passed over it.
 	Metered     bool
 	Run         store.Run
-	Segments    []store.Segment
+	Segments    listing[store.Segment]
 	CatalogLink string
 }
 
-// resources lists one page of the projection.
+// The columns of a resource page's tables.
+var (
+	segmentColumns = []column[store.Segment]{
+		textCol("state", func(r store.Segment) string { return r.State }),
+		textCol("from", func(r store.Segment) string { return stamp(r.From) }),
+		textCol("to", func(r store.Segment) string { return stamp(r.To) }),
+		countCol("seconds", func(r store.Segment) int64 { return r.Seconds }),
+		textCol("dimension", func(r store.Segment) string { return r.Dimension }),
+		numberCol("amount", func(r store.Segment) decimal.Decimal { return r.Amount }),
+		textCol("currency", func(r store.Segment) string { return r.Currency }),
+	}
+	storedEventColumns = []column[httpapi.StoredEvent]{
+		textCol("timestamp", func(r httpapi.StoredEvent) string { return stamp(r.Timestamp) }),
+		textCol("event type", func(r httpapi.StoredEvent) string { return r.EventType }),
+		textCol("source", func(r httpapi.StoredEvent) string { return r.Source }),
+		textCol("project", func(r httpapi.StoredEvent) string { return r.ProjectId }),
+	}
+)
+
+// resources lists one page of the projection under the status the viewer
+// chose, and of that page the rows that existed in the window or at the
+// instant. The page is the widest the API serves, so the filters are applied
+// to as much of the fleet as one call can hold.
 func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var src sources
+
+	now := h.now()
+	fleet, err := readFleet(r, now)
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
 
 	parameters := r.URL.Query()
 	query := reporting.ResourcesQuery{
@@ -51,8 +110,9 @@ func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 		ProjectID:    parameters.Get("project_id"),
 		ResourceType: parameters.Get("resource_type"),
 		State:        parameters.Get("state"),
-		Status:       parameters.Get("status"),
+		Status:       fleet.Status,
 		Cursor:       parameters.Get("cursor"),
+		Limit:        resourcePageLimit,
 	}
 
 	list, request, err := h.api.ListResources(ctx, query)
@@ -63,23 +123,38 @@ func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows := make([]resourceRow, 0, len(list.Items))
+	unknown := 0
 	for _, resource := range list.Items {
+		if !keep(resource, fleet, now) {
+			continue
+		}
+		lifetime, lived := lifetimeHours(resource, now)
+		if !lived {
+			unknown++
+		}
 		rows = append(rows, resourceRow{
 			Resource: resource,
 			Link: link("/resource",
 				"cloud", resource.Cloud, "type", resource.ResourceType, "id", resource.ResourceId),
+			ProjectLink:    projectLink(resource.Cloud, resource.ProjectId),
+			Lifetime:       lifetime,
+			Lived:          lived,
+			PayloadSummary: payloadSummary(resource.LastPayload),
 		})
 	}
 
-	data := resourcesData{Items: rows}
+	// A page is one of several only when the API said so, or when it was
+	// reached by a cursor: a fleet that fits one page is the whole fleet.
+	paged := list.NextCursor != nil || query.Cursor != ""
+	data := resourcesData{
+		Fleet: buildFleetView(r, fleet, now, len(rows), len(list.Items), unknown, paged),
+		Items: tabulate(r, resourceTable, resourceColumns, rows),
+	}
+	if paged {
+		data.Items = data.Items.paged()
+	}
 	if list.NextCursor != nil {
-		data.NextLink = link("/resources",
-			"cloud", query.Cloud,
-			"project_id", query.ProjectID,
-			"resource_type", query.ResourceType,
-			"state", query.State,
-			"status", query.Status,
-			"cursor", *list.NextCursor)
+		data.NextLink = nextLink(r, *list.NextCursor)
 	}
 	h.render(w, r, "resources", page{Title: "Resources", Sources: src, Data: data})
 }
@@ -136,14 +211,16 @@ func (h *handlers) resource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := resourceData{
-		Cloud:    cloud,
-		Type:     resourceType,
-		ID:       resourceID,
-		Resource: lifecycle.Resource,
-		Warnings: lifecycle.Warnings,
-		Events:   lifecycle.Events,
-		Metered:  metered,
+		Cloud:       cloud,
+		Type:        resourceType,
+		ID:          resourceID,
+		Resource:    lifecycle.Resource,
+		ProjectLink: projectLink(lifecycle.Resource.Cloud, lifecycle.Resource.ProjectId),
+		Warnings:    lifecycle.Warnings,
+		Events:      tabulate(r, "events", storedEventColumns, lifecycle.Events),
+		Metered:     metered,
 	}
+	data.Created, data.Lifetime = lifecycleTimes(lifecycle, h.now())
 
 	var groups []segmentGroup
 	if metered {
@@ -163,7 +240,7 @@ func (h *handlers) resource(w http.ResponseWriter, r *http.Request) {
 
 		groups = groupSegments(segments)
 		data.Run = run
-		data.Segments = segments
+		data.Segments = tabulate(r, "segments", segmentColumns, segments)
 		if run.PricingVersion != "" {
 			data.CatalogLink = link("/catalog", "version", run.PricingVersion)
 		}

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -5,16 +5,21 @@
 // page carries a script element or an event handler attribute, and it loads
 // exactly one asset, /static/console.css. What a viewer sees is what the
 // handler rendered, and a page that shows a number read that number itself.
+// Sorting and filtering a table are links and a form that reload the page
+// with the table's state in the query string, and the theme is a form that
+// posts the choice to /theme, the one route that is not a page: it keeps the
+// choice in a cookie and sends the viewer back.
 //
 // Every identifier travels in a query parameter rather than in a path segment.
 // A cloud name, a resource id and a statement key may each carry a slash, and a
 // path segment would either split such an identifier in two or hide it behind
 // an escape that a proxy in front of the console is free to normalize away.
 //
-// Nothing here writes. The pages read the Reporting API for projects,
-// resources, lifecycles, stats and refused events, and the engine database for
-// everything monetary. A failure of either side reaches the viewer as one error
-// page naming what failed, and the same wrapped error goes to the log.
+// Nothing here writes to either side. The pages read the Reporting API for
+// projects, resources, lifecycles, stats and refused events, and the engine
+// database for everything monetary. A failure of either side reaches the
+// viewer as one error page naming what failed, and the same wrapped error goes
+// to the log.
 package httpui
 
 import (
@@ -135,7 +140,9 @@ func NewRouter(opts Options) (http.Handler, error) {
 	r.Get("/run", h.run)
 	r.Get("/statement", h.statement)
 	r.Get("/static/console.css", h.stylesheet)
+	r.Post(themeRoute, h.theme)
 	r.NotFound(h.notFound)
+	r.MethodNotAllowed(h.methodNotAllowed)
 
 	return r, nil
 }
@@ -158,6 +165,14 @@ func (h *handlers) stylesheet(w http.ResponseWriter, r *http.Request) {
 func (h *handlers) notFound(w http.ResponseWriter, r *http.Request) {
 	h.fail(w, r, http.StatusNotFound, "no such page",
 		fmt.Errorf("the path %s is not part of the console", r.URL.Path), nil)
+}
+
+// methodNotAllowed answers a route asked with the wrong method, which is the
+// theme route fetched rather than posted. It lands on the error page for the
+// reason notFound does.
+func (h *handlers) methodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	h.fail(w, r, http.StatusMethodNotAllowed, "the method is not allowed",
+		fmt.Errorf("the path %s does not answer %s", r.URL.Path, r.Method), nil)
 }
 
 // link builds one href. The pairs are parameter names and values, encoded once

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/adjustments"
 	"github.com/b42labs/tally/internal/engine/statements"
 )
 
@@ -19,9 +20,29 @@ type runData struct {
 	Run          store.Run
 	CorrectsLink string
 	CatalogLink  string
-	Statements   []statementBar
-	Deltas       []store.Delta
+	Statements   listing[statementBar]
+	Deltas       listing[store.Delta]
 }
+
+// The columns of a run page's tables. The share bar draws the total and is
+// sorted through it.
+var (
+	statementColumns = []column[statementBar]{
+		textCol("project", func(r statementBar) string { return r.Row.Key }),
+		numberCol("total", func(r statementBar) decimal.Decimal { return r.Row.Total }),
+		plainCol[statementBar]("share"),
+	}
+	deltaColumns = []column[store.Delta]{
+		textCol("cloud", func(r store.Delta) string { return r.Cloud }),
+		textCol("project", func(r store.Delta) string { return r.ProjectID }),
+		textCol("resource type", func(r store.Delta) string { return r.ResourceType }),
+		textCol("resource", func(r store.Delta) string { return r.ResourceID }),
+		textCol("dimension", func(r store.Delta) string { return r.Dimension }),
+		numberCol("old", func(r store.Delta) decimal.Decimal { return r.OldAmount }),
+		numberCol("new", func(r store.Delta) decimal.Decimal { return r.NewAmount }),
+		numberCol("delta", func(r store.Delta) decimal.Decimal { return r.Delta }),
+	}
+)
 
 // statementBar is one project's total of a run, drawn against the largest total
 // the run produced.
@@ -31,14 +52,31 @@ type statementBar struct {
 	Link  string
 }
 
-// statementData is one stored statement document rendered as the bill it is.
+// statementData is one stored statement document rendered as the bill it is:
+// its head, its adjustments, its own line items as one section, and one
+// section per related cost.
 type statementData struct {
-	Key      string
-	Cloud    string
-	Project  string
-	RunID    uuid.UUID
-	RunLink  string
-	Document statements.Document
+	Key         string
+	Cloud       string
+	Project     string
+	RunID       uuid.UUID
+	RunLink     string
+	Document    statements.Document
+	Adjustments listing[adjustments.Line]
+	Items       billSection
+	Related     []billSection
+}
+
+// adjustmentColumns is the adjustments table of a statement.
+var adjustmentColumns = []column[adjustments.Line]{
+	textCol("type", func(r adjustments.Line) string { return r.Type }),
+	textCol("relation type", func(r adjustments.Line) string { return r.RelationType }),
+	textCol("target", func(r adjustments.Line) string { return r.RelationTarget }),
+	textCol("scope", func(r adjustments.Line) string { return r.Scope }),
+	textCol("description", func(r adjustments.Line) string { return r.Description }),
+	numberCol("rate", func(r adjustments.Line) decimal.Decimal { return r.Rate.Decimal }),
+	numberCol("base", func(r adjustments.Line) decimal.Decimal { return r.Base.Decimal }),
+	numberCol("amount", func(r adjustments.Line) decimal.Decimal { return r.Amount.Decimal }),
 }
 
 // run shows what one metering run produced. The deltas of a correction run are
@@ -74,7 +112,11 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := runData{Run: run, Statements: statementBars(id, billed), Deltas: deltas}
+	data := runData{
+		Run:        run,
+		Statements: tabulate(r, "statements", statementColumns, statementBars(id, billed)),
+		Deltas:     tabulate(r, "deltas", deltaColumns, deltas),
+	}
 	if run.CorrectsRunID != uuid.Nil {
 		data.CorrectsLink = link("/run", "id", run.CorrectsRunID.String())
 	}
@@ -120,17 +162,29 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := statementData{
-		Key:      key,
-		Cloud:    absent,
-		Project:  key,
-		RunID:    runID,
-		RunLink:  link("/run", "id", runID.String()),
-		Document: document,
+		Key:         key,
+		Cloud:       absent,
+		Project:     key,
+		RunID:       runID,
+		RunLink:     link("/run", "id", runID.String()),
+		Document:    document,
+		Adjustments: tabulate(r, "adjustments", adjustmentColumns, document.Adjustments),
 	}
 	// A key this cannot read is shown as it is stored: the page is about that
 	// stored row, and a guessed pair would name one nothing was stored under.
+	// The resource links need the cloud, and a key without one links nothing.
+	linkCloud := ""
 	if cloud, project, keyErr := statements.ParseKey(key); keyErr == nil {
-		data.Cloud, data.Project = cloud, project
+		data.Cloud, data.Project, linkCloud = cloud, project, cloud
+	}
+
+	data.Items = buildBillSection(r, itemsTable, itemAnchor, linkCloud, document.Currency, document.LineItems)
+	for index := range document.RelatedCosts {
+		related := &document.RelatedCosts[index]
+		prefix := fmt.Sprintf("rc-%d", index)
+		section := buildBillSection(r, prefix, prefix+"-"+itemAnchor, linkCloud, document.Currency, related.LineItems)
+		section.Related = related
+		data.Related = append(data.Related, section)
 	}
 
 	h.render(w, r, "statement", page{

--- a/internal/console/httpui/static/console.css
+++ b/internal/console/httpui/static/console.css
@@ -1,20 +1,42 @@
 /* The console's only asset. No font, no image, no second stylesheet: a page
-   loads this file and nothing else. */
+   loads this file and nothing else.
+
+   Every colour is a token with a light and a dark value. The page follows the
+   operating system's setting on its own, and a data-theme attribute on the
+   root element, set from the viewer's cookie, pins it to one side. */
 
 :root {
-  --ink: #1b1e22;
-  --muted: #5b6570;
-  --line: #d6dae0;
-  --panel: #f4f6f8;
-  --accent: #2f5d8a;
-  --warn: #8a3b2f;
+  color-scheme: light dark;
+  --paper: light-dark(#ffffff, #15181c);
+  --ink: light-dark(#1b1e22, #e4e8ec);
+  --muted: light-dark(#5b6570, #98a3ae);
+  --line: light-dark(#d6dae0, #2f363e);
+  --panel: light-dark(#f4f6f8, #1e2329);
+  --stripe: light-dark(#f9fafb, #191d22);
+  --accent: light-dark(#2f5d8a, #86b6e6);
+  --warn: light-dark(#8a3b2f, #e59283);
+  --label: #ffffff;
+  --lane: light-dark(#9aa4b0, #6b7683);
+  --state-running: light-dark(#2f7d4f, #3f9a63);
+  --state-available: light-dark(#4a8fbd, #5aa2d1);
+  --state-stopped: light-dark(#a4761f, #b98a2b);
+  --state-paused: light-dark(#6f5aa8, #8874c0);
+  --state-deleted: light-dark(#8a3b2f, #b0503f);
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 body {
   max-width: 74rem;
   margin: 0 auto;
   padding: 1.5rem;
-  background: #ffffff;
+  background: var(--paper);
   color: var(--ink);
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
   font-size: 15px;
@@ -23,6 +45,8 @@ body {
 
 nav {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 1rem;
   padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--line);
@@ -32,6 +56,10 @@ nav a {
   color: var(--accent);
   font-weight: 600;
   text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
 }
 
 a {
@@ -53,6 +81,167 @@ h3 {
   margin: 1rem 0 0.5rem;
 }
 
+/* Controls share one look: the theme buttons, the filter box and its button. */
+button,
+input[type="search"],
+input[type="datetime-local"] {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+button:focus-visible,
+input[type="search"]:focus-visible,
+input[type="datetime-local"]:focus-visible,
+th a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+input[type="search"],
+input[type="datetime-local"] {
+  background: var(--paper);
+}
+
+input[type="search"] {
+  min-width: 14rem;
+}
+
+/* The fleet switch is three links drawn as one control, the way the theme
+   buttons are, and the presets are plain links with the current one in bold. */
+.switch {
+  display: inline-flex;
+}
+
+.switch a {
+  margin-left: -1px;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.switch a:first-child {
+  margin-left: 0;
+  border-radius: 3px 0 0 3px;
+}
+
+.switch a:last-child {
+  border-radius: 0 3px 3px 0;
+}
+
+.switch a:hover {
+  border-color: var(--accent);
+}
+
+.switch a[aria-current="true"] {
+  position: relative;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--paper);
+}
+
+p.presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+}
+
+p.presets span {
+  color: var(--muted);
+}
+
+p.presets span + a,
+p.presets a + span {
+  margin-left: 0.4rem;
+}
+
+p.presets a[aria-current="true"] {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+p.axis {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+/* The theme switch sits at the right end of the navigation, as one control of
+   three pressed-or-not buttons. */
+form.theme {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+form.theme span {
+  margin-right: 0.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+form.theme button {
+  margin-left: -1px;
+  border-radius: 0;
+}
+
+form.theme button:first-of-type {
+  margin-left: 0;
+  border-radius: 3px 0 0 3px;
+}
+
+form.theme button:last-of-type {
+  border-radius: 0 3px 3px 0;
+}
+
+form.theme button[aria-pressed="true"] {
+  position: relative;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--paper);
+}
+
+/* The filter form above a table. */
+form.tools {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+form.tools label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+form.tools .count {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
 table {
   width: 100%;
   margin: 0.5rem 0 1rem;
@@ -68,15 +257,139 @@ td {
 }
 
 th {
+  position: sticky;
+  top: 0;
   background: var(--panel);
+  box-shadow: 0 1px 0 var(--line);
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
+/* A heading that sorts is a link in the heading's own colour, and the heading
+   the table is sorted by carries the direction. */
+th a {
+  color: inherit;
+  text-decoration: none;
+}
+
+th a:hover {
+  text-decoration: underline;
+}
+
+th[aria-sort] a {
+  color: var(--accent);
+}
+
+th[aria-sort="ascending"] a::after {
+  content: " \25B2";
+  font-size: 0.7em;
+}
+
+th[aria-sort="descending"] a::after {
+  content: " \25BC";
+  font-size: 0.7em;
+}
+
+/* Every other row is tinted, so the eye keeps its row across a wide table,
+   and the row under the pointer is tinted more. */
+tbody tr:nth-child(even) {
+  background: var(--stripe);
+}
+
+tbody tr:hover {
+  background: var(--panel);
+}
+
+/* A numeric column is as narrow as its numbers, right-aligned under a heading
+   aligned the same way, so a value stands under the name it belongs to and
+   next to the values it compares with. */
+th.number,
 td.number {
   text-align: right;
+  white-space: nowrap;
   font-variant-numeric: tabular-nums;
+}
+
+th.number {
+  width: 1%;
+  padding-left: 1.25rem;
+}
+
+td.number {
+  padding-left: 1.25rem;
+}
+
+/* An identifier is set in a monospace face, so it stands apart from prose and
+   two of them compare character by character. */
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+}
+
+/* A value of exactly zero steps back, so the amounts that are not zero stand
+   out of a bill that is mostly zeros. */
+.zero {
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+/* A period's total closes the period's rows. */
+tr.subtotal td {
+  font-weight: 600;
+  border-bottom: 2px solid var(--line);
+}
+
+/* A line item of a bill is a block that folds. Its summary line names the
+   item and carries its total at the right end. */
+details.item {
+  margin: 0.75rem 0;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  scroll-margin-top: 1rem;
+}
+
+/* The block the page was scrolled to is outlined, so the reader lands on it. */
+details.item:target {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+details.item > summary {
+  padding: 0.5rem 0.75rem;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+details.item > summary:hover {
+  color: var(--accent);
+}
+
+details.item > summary .total {
+  float: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+details.item > summary .muted {
+  margin-left: 0.5rem;
+}
+
+details.item[open] > summary {
+  border-bottom: 1px solid var(--line);
+}
+
+details.item > p {
+  margin: 0.5rem 0.75rem 0;
+  font-size: 0.85rem;
+}
+
+details.item > table {
+  width: calc(100% - 1.5rem);
+  margin: 0.5rem 0.75rem 0.75rem;
 }
 
 pre {
@@ -136,6 +449,24 @@ svg {
   margin: 0.5rem 0 1rem;
 }
 
+/* A drawing inside a cell keeps the row at the row's height. */
+td svg {
+  margin: 0;
+}
+
+/* A document inside a cell folds, so a listing stays one line per row until
+   the reader opens the one they are after. */
+details.cell > summary {
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+details.cell > pre {
+  margin-top: 0.35rem;
+  min-width: 24rem;
+}
+
 svg text {
   fill: var(--ink);
   font-family: system-ui, sans-serif;
@@ -143,7 +474,7 @@ svg text {
 }
 
 svg text.label {
-  fill: #ffffff;
+  fill: var(--label);
 }
 
 svg text.axis {
@@ -157,30 +488,30 @@ svg text.axis {
 
 /* A timeline lane whose state has no colour of its own. */
 .lane {
-  fill: #9aa4b0;
+  fill: var(--lane);
 }
 
 .state-active,
 .state-in-use {
-  fill: #2f7d4f;
+  fill: var(--state-running);
 }
 
 .state-available {
-  fill: #4a8fbd;
+  fill: var(--state-available);
 }
 
 .state-shutoff,
 .state-suspended {
-  fill: #a4761f;
+  fill: var(--state-stopped);
 }
 
 .state-paused,
 .state-hibernated {
-  fill: #6f5aa8;
+  fill: var(--state-paused);
 }
 
 .state-deleted {
-  fill: #8a3b2f;
+  fill: var(--state-deleted);
 }
 
 /* An interval that has not ended is drawn to the edge of the picture, which is

--- a/internal/console/httpui/svg.go
+++ b/internal/console/httpui/svg.go
@@ -56,12 +56,44 @@ type segmentGroup struct {
 	Amount decimal.Decimal
 }
 
-// buildTimeline lays both lanes out over one window: the earliest start of
-// either lane to the latest end. An interval that is still open ends at now.
+// scale maps instants onto the user units of one picture, from its start at
+// the left edge to its end at the right one. An instant outside the span is
+// drawn at the edge it lies beyond.
 //
 // The geometry is integer seconds and integer user units from end to end. A
 // picture is not money, but a float here would make the same page render
 // differently on two machines for no gain at all.
+type scale struct {
+	start   time.Time
+	seconds int64
+	width   int64
+}
+
+// newScale spans start to end over width units. A span shorter than a second,
+// and one that is empty because everything happened at one instant, still has
+// to divide.
+func newScale(start, end time.Time, width int64) scale {
+	seconds := int64(end.Sub(start) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return scale{start: start, seconds: seconds, width: width}
+}
+
+// x is where an instant falls.
+func (s scale) x(t time.Time) int64 {
+	seconds := int64(t.Sub(s.start) / time.Second)
+	if seconds < 0 {
+		return 0
+	}
+	if seconds > s.seconds {
+		return s.width
+	}
+	return seconds * s.width / s.seconds
+}
+
+// buildTimeline lays both lanes out over one window: the earliest start of
+// either lane to the latest end. An interval that is still open ends at now.
 func buildTimeline(intervals []httpapi.LifecycleInterval, groups []segmentGroup, now time.Time) timeline {
 	line := timeline{Width: chartWidth}
 
@@ -70,16 +102,8 @@ func buildTimeline(intervals []httpapi.LifecycleInterval, groups []segmentGroup,
 		return line
 	}
 	line.Start, line.End = start, end
-
-	// A window shorter than a second, and one that is empty because everything
-	// happened at one instant, still has to divide.
-	spanSeconds := int64(end.Sub(start) / time.Second)
-	if spanSeconds < 1 {
-		spanSeconds = 1
-	}
-	x := func(t time.Time) int64 {
-		return int64(t.Sub(start)/time.Second) * chartWidth / spanSeconds
-	}
+	sc := newScale(start, end, chartWidth)
+	x := sc.x
 
 	for _, interval := range intervals {
 		drawn := lane{X: x(interval.From), Class: stateClass(interval.State), Label: interval.State}

--- a/internal/console/httpui/table.go
+++ b/internal/console/httpui/table.go
@@ -1,0 +1,327 @@
+package httpui
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// A table is sorted and filtered here, on the rows the page already holds. The
+// console ships no JavaScript, so a heading the viewer clicks is a link that
+// reloads the page with the order in its query string, and the filter box is a
+// form that reloads it with the text. Two parameters carry the state of one
+// table, named after the table so that the tables of one page keep their own:
+// <table>.sort holds the key of a column, prefixed with a hyphen for descending,
+// and <table>.q holds the filter text.
+//
+// A listing the Reporting API pages is sorted and filtered within the page it
+// answered, and the link to the next page carries both parameters along.
+const (
+	sortSuffix  = ".sort"
+	querySuffix = ".q"
+	descending  = "-"
+)
+
+// cell is one value of a table as sorting and filtering see it: the text the
+// filter matches, folded to lower case once, and for a numeric column the number
+// the order is decided by.
+type cell struct {
+	text    string
+	number  decimal.Decimal
+	numeric bool
+}
+
+// column is one column of a table: the key its sort parameter names, the
+// heading it prints, and the cell a row shows in it. A column without a Cell is
+// drawn but neither sorted nor searched, a bar for example.
+type column[T any] struct {
+	Key     string
+	Label   string
+	Cell    func(T) cell
+	numeric bool
+}
+
+// columnKey is the label with its spaces as underscores, which is what the
+// sort parameter carries: "resource type" sorts as resource_type.
+func columnKey(label string) string {
+	return strings.ReplaceAll(label, " ", "_")
+}
+
+// textCol declares a column that sorts and filters as text.
+func textCol[T any](label string, get func(T) string) column[T] {
+	return column[T]{
+		Key:   columnKey(label),
+		Label: label,
+		Cell:  func(row T) cell { return cell{text: strings.ToLower(get(row))} },
+	}
+}
+
+// numberCol declares a column that sorts as a number. The first click on its
+// heading sorts descending, because the largest amount is what a viewer looks
+// for first.
+func numberCol[T any](label string, get func(T) decimal.Decimal) column[T] {
+	return column[T]{
+		Key:     columnKey(label),
+		Label:   label,
+		numeric: true,
+		Cell: func(row T) cell {
+			value := get(row)
+			return cell{text: value.String(), number: value, numeric: true}
+		},
+	}
+}
+
+// countCol declares a numeric column over an integer.
+func countCol[T any](label string, get func(T) int64) column[T] {
+	return numberCol(label, func(row T) decimal.Decimal { return decimal.NewFromInt(get(row)) })
+}
+
+// plainCol declares a column that is drawn and nothing else.
+func plainCol[T any](label string) column[T] {
+	return column[T]{Label: label}
+}
+
+// field is one query parameter the filter form carries through as a hidden
+// input, so that filtering a table keeps the page's identifiers, its paging
+// cursor, and the state of every other table.
+type field struct {
+	Name  string
+	Value string
+}
+
+// header is one heading as the template prints it: the label, the link that
+// sorts by the column or nothing for a column that cannot, the direction the
+// table is sorted in when this is the column, as aria-sort spells it, and
+// whether the column holds numbers, which the heading is aligned over.
+type header struct {
+	Label   string
+	Link    string
+	Sort    string
+	Numeric bool
+}
+
+// tableView is what the template renders around a table: the filter form, the
+// headings with their sort links, and how many rows survived the filter.
+type tableView struct {
+	Path      string
+	Query     string
+	QueryName string
+	Hidden    []field
+	ClearLink string
+	Headers   []header
+	Shown     int
+	Total     int
+	// Paged is set for a listing that is one page of a longer list, so the
+	// row count says which rows it counted.
+	Paged bool
+}
+
+// Count is the row count the form prints: how many rows the table holds, and
+// under a filter how many of them match.
+func (v tableView) Count() string {
+	scope := ""
+	if v.Paged {
+		scope = " on this page"
+	}
+	if v.Query == "" {
+		return rowsText(v.Total) + scope
+	}
+	return fmt.Sprintf("%d of %s%s match", v.Shown, rowsText(v.Total), scope)
+}
+
+// rowsText counts rows in words, one row or n rows.
+func rowsText(n int) string {
+	if n == 1 {
+		return "1 row"
+	}
+	return fmt.Sprintf("%d rows", n)
+}
+
+// listing is one table as the page renders it: the rows in the order and under
+// the filter the viewer asked for, and the controls that got them there.
+type listing[T any] struct {
+	Rows  []T
+	Table tableView
+}
+
+// paged marks a listing as one page of a longer list.
+func (l listing[T]) paged() listing[T] {
+	l.Table.Paged = true
+	return l
+}
+
+// tabulate applies what the request says about the table id to rows: the
+// filter first, then the order. The rows are copied, so the caller's slice
+// stays in the order it was read in, which is the order a picture built from
+// the same rows relies on.
+func tabulate[T any](r *http.Request, id string, cols []column[T], rows []T) listing[T] {
+	return tabulateValues(r.URL.Path, r.URL.Query(), id, cols, rows)
+}
+
+// tabulateBy is tabulate with the order a table opens in when the viewer names
+// none: the key of a column, with the hyphen for descending. The order is put
+// into the query the links and the form are built from, so the heading says
+// which way the table is sorted and the filter keeps it.
+func tabulateBy[T any](r *http.Request, id string, cols []column[T], rows []T, defaultSort string) listing[T] {
+	values := r.URL.Query()
+	if values.Get(id+sortSuffix) == "" {
+		values.Set(id+sortSuffix, defaultSort)
+	}
+	return tabulateValues(r.URL.Path, values, id, cols, rows)
+}
+
+// tabulateValues is tabulate over a query a caller has already read or edited.
+func tabulateValues[T any](path string, values url.Values, id string, cols []column[T], rows []T) listing[T] {
+	sortName, queryName := id+sortSuffix, id+querySuffix
+
+	query := strings.TrimSpace(values.Get(queryName))
+	sortKey, desc := strings.CutPrefix(values.Get(sortName), descending)
+
+	kept := filterRows(cols, rows, query)
+	if index := slices.IndexFunc(cols, func(c column[T]) bool { return c.Key == sortKey && c.Cell != nil }); index >= 0 {
+		sortRows(kept, cols[index], desc)
+	}
+
+	view := tableView{
+		Path:      path,
+		Query:     query,
+		QueryName: queryName,
+		Shown:     len(kept),
+		Total:     len(rows),
+	}
+	for _, key := range slices.Sorted(maps.Keys(values)) {
+		if key == queryName {
+			continue
+		}
+		for _, value := range values[key] {
+			if value != "" {
+				view.Hidden = append(view.Hidden, field{Name: key, Value: value})
+			}
+		}
+	}
+	if query != "" {
+		cleared := maps.Clone(values)
+		cleared.Del(queryName)
+		view.ClearLink = href(path, cleared)
+	}
+	for _, col := range cols {
+		view.Headers = append(view.Headers, headerFor(path, values, sortName, col, sortKey, desc))
+	}
+	return listing[T]{Rows: kept, Table: view}
+}
+
+// headerFor builds one heading. The link of the sorted column flips its
+// direction; the link of any other column sorts by it, ascending for text and
+// descending for a number.
+func headerFor[T any](
+	path string, values url.Values, sortName string, col column[T], sortKey string, desc bool,
+) header {
+	head := header{Label: col.Label, Numeric: col.numeric}
+	if col.Cell == nil {
+		return head
+	}
+
+	next := col.Key
+	switch {
+	case col.Key == sortKey && !desc:
+		head.Sort = "ascending"
+		next = descending + col.Key
+	case col.Key == sortKey && desc:
+		head.Sort = "descending"
+	case col.numeric:
+		next = descending + col.Key
+	}
+
+	linked := maps.Clone(values)
+	linked.Set(sortName, next)
+	head.Link = href(path, linked)
+	return head
+}
+
+// filterRows keeps every row with a cell that contains the query, compared in
+// lower case. An empty query keeps every row.
+func filterRows[T any](cols []column[T], rows []T, query string) []T {
+	if query == "" {
+		return slices.Clone(rows)
+	}
+
+	needle := strings.ToLower(query)
+	kept := make([]T, 0, len(rows))
+	for _, row := range rows {
+		for _, col := range cols {
+			if col.Cell != nil && strings.Contains(col.Cell(row).text, needle) {
+				kept = append(kept, row)
+				break
+			}
+		}
+	}
+	return kept
+}
+
+// keyedRow is a row beside the cell it is sorted by, computed once rather than
+// on every comparison.
+type keyedRow[T any] struct {
+	row T
+	key cell
+}
+
+// sortRows orders rows by one column in place. The sort is stable, so rows
+// equal in the column keep the order they were read in.
+func sortRows[T any](rows []T, col column[T], desc bool) {
+	keyed := make([]keyedRow[T], len(rows))
+	for i, row := range rows {
+		keyed[i] = keyedRow[T]{row: row, key: col.Cell(row)}
+	}
+
+	slices.SortStableFunc(keyed, func(a, b keyedRow[T]) int {
+		order := compareCells(a.key, b.key)
+		if desc {
+			return -order
+		}
+		return order
+	})
+
+	for i := range keyed {
+		rows[i] = keyed[i].row
+	}
+}
+
+// compareCells orders two cells of one column: numbers by value, text by its
+// folded form.
+func compareCells(a, b cell) int {
+	if a.numeric && b.numeric {
+		return a.number.Cmp(b.number)
+	}
+	return cmp.Compare(a.text, b.text)
+}
+
+// href encodes an edited query the way link does: every empty value is dropped,
+// and a query with nothing left is no query at all.
+func href(path string, values url.Values) string {
+	clean := url.Values{}
+	for key, list := range values {
+		for _, value := range list {
+			if value != "" {
+				clean.Add(key, value)
+			}
+		}
+	}
+	if len(clean) == 0 {
+		return path
+	}
+	return path + "?" + clean.Encode()
+}
+
+// nextLink is the link to the next page of a listing: the request's own query,
+// filters and table state included, with the cursor the API answered.
+func nextLink(r *http.Request, cursor string) string {
+	values := r.URL.Query()
+	values.Set("cursor", cursor)
+	return href(r.URL.Path, values)
+}

--- a/internal/console/httpui/table_test.go
+++ b/internal/console/httpui/table_test.go
@@ -1,0 +1,288 @@
+package httpui
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// tableRow is what the table tests sort and filter.
+type tableRow struct {
+	Name  string
+	Count int64
+}
+
+// tableColumns is a text column, a number column and a plain one, which is
+// every kind a page declares.
+var tableColumns = []column[tableRow]{
+	textCol("name", func(r tableRow) string { return r.Name }),
+	countCol("row count", func(r tableRow) int64 { return r.Count }),
+	plainCol[tableRow]("share"),
+}
+
+// tableRows is deliberately out of order in both columns, and mixed in case.
+func tableRows() []tableRow {
+	return []tableRow{{Name: "beta", Count: 2}, {Name: "Alpha", Count: 10}, {Name: "gamma", Count: 1}}
+}
+
+// names is the order the rows came out in.
+func names(rows []tableRow) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Name)
+	}
+	return out
+}
+
+// tabulateAt runs the table under one request URL.
+func tabulateAt(target string, rows []tableRow) listing[tableRow] {
+	return tabulate(httptest.NewRequest("GET", target, nil), "t", tableColumns, rows)
+}
+
+func TestTabulate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no state keeps the order as read", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?id=7", tableRows())
+		if want := []string{"beta", "Alpha", "gamma"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+		if got.Table.Count() != "3 rows" {
+			t.Errorf("count = %q, want 3 rows", got.Table.Count())
+		}
+		for _, head := range got.Table.Headers {
+			if head.Sort != "" {
+				t.Errorf("the heading %s says it is sorted %s", head.Label, head.Sort)
+			}
+		}
+		if got.Table.ClearLink != "" {
+			t.Error("a table without a filter offers to clear one")
+		}
+	})
+
+	t.Run("text sorts ascending without regard to case", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.sort=name", tableRows())
+		if want := []string{"Alpha", "beta", "gamma"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+	})
+
+	t.Run("a hyphen sorts descending", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.sort=-row_count", tableRows())
+		if want := []string{"Alpha", "beta", "gamma"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+	})
+
+	t.Run("a number sorts as a number", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.sort=row_count", tableRows())
+		// As text, 10 would come before 2.
+		if want := []string{"gamma", "beta", "Alpha"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+	})
+
+	t.Run("the sorted heading says its direction and flips it", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?id=7&t.sort=name", tableRows())
+		name := got.Table.Headers[0]
+		if name.Sort != "ascending" {
+			t.Errorf("aria-sort = %q, want ascending", name.Sort)
+		}
+		if name.Link != "/page?id=7&t.sort=-name" {
+			t.Errorf("link = %q, want the descending sort beside the id", name.Link)
+		}
+
+		got = tabulateAt("/page?t.sort=-name", tableRows())
+		name = got.Table.Headers[0]
+		if name.Sort != "descending" {
+			t.Errorf("aria-sort = %q, want descending", name.Sort)
+		}
+		if name.Link != "/page?t.sort=name" {
+			t.Errorf("link = %q, want the ascending sort", name.Link)
+		}
+	})
+
+	t.Run("a first click sorts text ascending and a number descending", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page", tableRows())
+		if link := got.Table.Headers[0].Link; link != "/page?t.sort=name" {
+			t.Errorf("text link = %q, want ascending", link)
+		}
+		if link := got.Table.Headers[1].Link; link != "/page?t.sort=-row_count" {
+			t.Errorf("number link = %q, want descending", link)
+		}
+	})
+
+	t.Run("a plain column has no link", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page", tableRows())
+		share := got.Table.Headers[2]
+		if share.Label != "share" || share.Link != "" {
+			t.Errorf("plain heading = %+v, want the label and no link", share)
+		}
+	})
+
+	t.Run("only a number heading is numeric", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page", tableRows())
+		if got.Table.Headers[0].Numeric || !got.Table.Headers[1].Numeric || got.Table.Headers[2].Numeric {
+			t.Errorf("headings = %+v, want the count alone numeric", got.Table.Headers)
+		}
+	})
+
+	t.Run("a key no column carries sorts nothing", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.sort=share", tableRows())
+		if want := []string{"beta", "Alpha", "gamma"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want the order as read", names(got.Rows))
+		}
+	})
+
+	t.Run("the filter matches any cell without regard to case", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?id=7&t.q=ALPHA", tableRows())
+		if want := []string{"Alpha"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+		if got.Table.Count() != "1 of 3 rows match" {
+			t.Errorf("count = %q", got.Table.Count())
+		}
+		if got.Table.ClearLink != "/page?id=7" {
+			t.Errorf("clear link = %q, want the page without the filter", got.Table.ClearLink)
+		}
+		if got.Table.Query != "ALPHA" {
+			t.Errorf("the form shows %q, want the text as typed", got.Table.Query)
+		}
+	})
+
+	t.Run("a number is matched by its text", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.q=10", tableRows())
+		if want := []string{"Alpha"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+	})
+
+	t.Run("the filter is trimmed and then sorted", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?t.q=%20a%20&t.sort=-name", tableRows())
+		if want := []string{"gamma", "beta", "Alpha"}; !slices.Equal(names(got.Rows), want) {
+			t.Errorf("rows = %v, want %v", names(got.Rows), want)
+		}
+	})
+
+	t.Run("the form carries every other parameter and not its own", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page?id=7&t.sort=name&t.q=a&u.q=z&empty=", tableRows())
+		want := []field{{"id", "7"}, {"t.sort", "name"}, {"u.q", "z"}}
+		if !slices.Equal(got.Table.Hidden, want) {
+			t.Errorf("hidden fields = %v, want %v", got.Table.Hidden, want)
+		}
+		if got.Table.QueryName != "t.q" || got.Table.Path != "/page" {
+			t.Errorf("the form posts %s to %s", got.Table.QueryName, got.Table.Path)
+		}
+	})
+
+	t.Run("a paged listing counts the page", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page", tableRows()).paged()
+		if got.Table.Count() != "3 rows on this page" {
+			t.Errorf("count = %q", got.Table.Count())
+		}
+		got = tabulateAt("/page?t.q=a", tableRows()).paged()
+		if got.Table.Count() != "3 of 3 rows on this page match" {
+			t.Errorf("count = %q", got.Table.Count())
+		}
+	})
+
+	t.Run("one row is counted in the singular", func(t *testing.T) {
+		t.Parallel()
+
+		got := tabulateAt("/page", tableRows()[:1])
+		if got.Table.Count() != "1 row" {
+			t.Errorf("count = %q", got.Table.Count())
+		}
+	})
+
+	t.Run("the caller's rows keep their order", func(t *testing.T) {
+		t.Parallel()
+
+		rows := tableRows()
+		tabulateAt("/page?t.sort=name", rows)
+		if want := []string{"beta", "Alpha", "gamma"}; !slices.Equal(names(rows), want) {
+			t.Errorf("the caller's rows = %v, want them untouched", names(rows))
+		}
+	})
+}
+
+func TestEmptyText(t *testing.T) {
+	t.Parallel()
+
+	if got := emptyText(tableView{}, "nothing here"); got != "nothing here" {
+		t.Errorf("without a filter = %q", got)
+	}
+	if got := emptyText(tableView{Query: "x", Total: 0}, "nothing here"); got != "nothing here" {
+		t.Errorf("with a filter over nothing = %q", got)
+	}
+	if got := emptyText(tableView{Query: "x", Total: 3}, "nothing here"); got != "no row matches the filter" {
+		t.Errorf("with a filter that emptied the table = %q", got)
+	}
+}
+
+func TestHref(t *testing.T) {
+	t.Parallel()
+
+	if got := href("/p", url.Values{}); got != "/p" {
+		t.Errorf("no query = %q", got)
+	}
+	if got := href("/p", url.Values{"b": {""}, "a": {"x y"}}); got != "/p?a=x+y" {
+		t.Errorf("an empty value and an encoded one = %q", got)
+	}
+
+	next := nextLink(httptest.NewRequest("GET", "/projects?platform=openstack&projects.q=p", nil), "abc")
+	for _, part := range []string{"platform=openstack", "projects.q=p", "cursor=abc"} {
+		if !strings.Contains(next, part) {
+			t.Errorf("the next link %q drops %s", next, part)
+		}
+	}
+}
+
+func TestBackPath(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"/projects?platform=openstack": "/projects?platform=openstack",
+		"/":                            "/",
+		"":                             "/",
+		"projects":                     "/",
+		"https://example.com/":         "/",
+		"//example.com/":               "/",
+		`/\example.com/`:               "/",
+	}
+	for back, want := range cases {
+		if got := backPath(back); got != want {
+			t.Errorf("backPath(%q) = %q, want %q", back, got, want)
+		}
+	}
+}

--- a/internal/console/httpui/templates/catalog.gohtml
+++ b/internal/console/httpui/templates/catalog.gohtml
@@ -6,10 +6,11 @@
 <dt>imported</dt><dd>{{stamp .ImportedAt}}</dd>
 </dl>
 
+{{template "tableTools" .Rows.Table}}
 <table>
-<thead><tr><th>platform</th><th>resource type</th><th>metric</th><th>type</th><th>price</th><th>state modifiers</th><th>type modifiers</th></tr></thead>
+{{template "tableHead" .Rows.Table}}
 <tbody>
-{{range .Rows}}<tr>
+{{range .Rows.Rows}}<tr>
 <td>{{.Platform}}</td>
 <td>{{.ResourceType}}</td>
 <td>{{.Metric}}</td>
@@ -18,7 +19,7 @@
 <td>{{range .StateModifiers}}{{.Key}}: {{price .Value}}<br>{{else}}none{{end}}</td>
 <td>{{range .TypeModifiers}}{{.Key}}: {{price .Value}}<br>{{else}}none{{end}}</td>
 </tr>
-{{else}}<tr><td colspan="7">this catalog prices nothing</td></tr>
+{{else}}<tr><td colspan="7">{{emptyText .Rows.Table "this catalog prices nothing"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/layout.gohtml
+++ b/internal/console/httpui/templates/layout.gohtml
@@ -1,7 +1,8 @@
 {{define "layout"}}<!DOCTYPE html>
-<html lang="en">
+<html lang="en"{{if .Theme}} data-theme="{{.Theme}}"{{end}}>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>tally console: {{.Title}}</title>
 <link rel="stylesheet" href="/static/console.css">
 </head>
@@ -11,6 +12,13 @@
 <a href="/projects">Projects</a>
 <a href="/resources">Resources</a>
 <a href="/pricing">Pricing</a>
+<form class="theme" method="post" action="/theme">
+<input type="hidden" name="back" value="{{.Back}}">
+<span>theme</span>
+<button name="theme" value="auto"{{if not .Theme}} aria-pressed="true"{{end}}>auto</button>
+<button name="theme" value="light"{{if eq .Theme "light"}} aria-pressed="true"{{end}}>light</button>
+<button name="theme" value="dark"{{if eq .Theme "dark"}} aria-pressed="true"{{end}}>dark</button>
+</form>
 </nav>
 <main>
 <h1>{{.Title}}</h1>
@@ -25,4 +33,22 @@
 </footer>
 </body>
 </html>
+{{end}}
+
+{{/* tableTools is the filter form above a table. Every other parameter of the
+     page rides along as a hidden input, so the filter keeps the page's
+     identifiers, its cursor, and the order and filter of every other table. */}}
+{{define "tableTools"}}<form class="tools" method="get" action="{{.Path}}">
+{{range .Hidden}}<input type="hidden" name="{{.Name}}" value="{{.Value}}">
+{{end}}<label>filter <input type="search" name="{{.QueryName}}" value="{{.Query}}" placeholder="any column"></label>
+<button type="submit">apply</button>
+{{if .Query}}<a href="{{.ClearLink}}">clear</a>{{end}}
+<span class="count">{{.Count}}</span>
+</form>
+{{end}}
+
+{{/* tableHead prints the headings. A heading that can sort is a link, the one
+     the table is sorted by says which way in aria-sort, and the heading of a
+     numeric column is aligned over its numbers. */}}
+{{define "tableHead"}}<thead><tr>{{range .Headers}}{{if .Link}}<th{{if .Numeric}} class="number"{{end}}{{if .Sort}} aria-sort="{{.Sort}}"{{end}}><a href="{{.Link}}">{{.Label}}</a></th>{{else}}<th>{{.Label}}</th>{{end}}{{end}}</tr></thead>
 {{end}}

--- a/internal/console/httpui/templates/overview.gohtml
+++ b/internal/console/httpui/templates/overview.gohtml
@@ -1,42 +1,46 @@
 {{define "content"}}
 <h2>Resources the Reporting API counts</h2>
+{{template "tableTools" .Stats.Table}}
 <table>
-<thead><tr><th>cloud</th><th>resource type</th><th>state</th><th>count</th><th>share</th></tr></thead>
+{{template "tableHead" .Stats.Table}}
 <tbody>
-{{range .Stats}}<tr>
+{{range .Stats.Rows}}<tr>
 <td>{{.Cloud}}</td>
 <td>{{.ResourceType}}</td>
 <td>{{.State}}</td>
 <td class="number">{{.Count}}</td>
 <td><svg width="640" height="14" viewBox="0 0 640 14"><rect class="bar" x="0" y="1" width="{{.Width}}" height="12"></rect></svg></td>
 </tr>
-{{else}}<tr><td colspan="5">no resource is counted</td></tr>
+{{else}}<tr><td colspan="5">{{emptyText .Stats.Table "no resource is counted"}}</td></tr>
 {{end}}</tbody>
 </table>
 
 <h2>Events per hour, {{stamp .From}} to {{stamp .To}}</h2>
+{{template "tableTools" .Events.Table}}
 <table>
-<thead><tr><th>bucket</th><th>cloud</th><th>event type</th><th>count</th></tr></thead>
+{{template "tableHead" .Events.Table}}
 <tbody>
-{{range .Events}}<tr>
+{{range .Events.Rows}}<tr>
 <td>{{stamp .Bucket}}</td>
 <td>{{.Cloud}}</td>
 <td>{{.EventType}}</td>
 <td class="number">{{.Count}}</td>
 </tr>
-{{else}}<tr><td colspan="4">no event reached the window</td></tr>
+{{else}}<tr><td colspan="4">{{emptyText .Events.Table "no event reached the window"}}</td></tr>
 {{end}}</tbody>
 </table>
 
-{{if .Rejected}}
+{{if .Rejected.Table.Total}}
 <h2>The ingest path refused these events</h2>
+{{template "tableTools" .Rejected.Table}}
 <table>
-<thead><tr><th>received at</th><th>reason</th></tr></thead>
+{{template "tableHead" .Rejected.Table}}
 <tbody>
-{{range .Rejected}}<tr>
+{{range .Rejected.Rows}}<tr>
 <td>{{stamp .ReceivedAt}}</td>
 <td>{{.Reason}}</td>
 </tr>
+{{else}}<tr><td colspan="2">{{emptyText .Rejected.Table "nothing was refused"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{else}}
@@ -44,25 +48,27 @@
 {{end}}
 
 <h2>Billing periods</h2>
+{{template "tableTools" .Periods.Table}}
 <table>
-<thead><tr><th>from</th><th>to</th><th>status</th><th>finalized by</th><th>finalized at</th></tr></thead>
+{{template "tableHead" .Periods.Table}}
 <tbody>
-{{range .Periods}}<tr>
+{{range .Periods.Rows}}<tr>
 <td>{{stamp .From}}</td>
 <td>{{stamp .To}}</td>
 <td>{{.Status}}</td>
 <td>{{idText .FinalizedRunID}}</td>
 <td>{{zeroStamp .FinalizedAt}}</td>
 </tr>
-{{else}}<tr><td colspan="5">no period is opened</td></tr>
+{{else}}<tr><td colspan="5">{{emptyText .Periods.Table "no period is opened"}}</td></tr>
 {{end}}</tbody>
 </table>
 
 <h2>Metering runs</h2>
+{{template "tableTools" .Runs.Table}}
 <table>
-<thead><tr><th>run</th><th>period</th><th>kind</th><th>status</th><th>pricing</th><th>started</th><th>completed</th></tr></thead>
+{{template "tableHead" .Runs.Table}}
 <tbody>
-{{range .Runs}}<tr>
+{{range .Runs.Rows}}<tr>
 <td><a href="{{.Link}}">{{.Run.ID}}</a></td>
 <td>{{stamp .Run.PeriodFrom}}</td>
 <td>{{.Run.Kind}}</td>
@@ -71,7 +77,7 @@
 <td>{{zeroStamp .Run.StartedAt}}</td>
 <td>{{zeroStamp .Run.CompletedAt}}</td>
 </tr>
-{{else}}<tr><td colspan="7">no run has been recorded</td></tr>
+{{else}}<tr><td colspan="7">{{emptyText .Runs.Table "no run has been recorded"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/pricing.gohtml
+++ b/internal/console/httpui/templates/pricing.gohtml
@@ -1,14 +1,15 @@
 {{define "content"}}
+{{template "tableTools" .Models.Table}}
 <table>
-<thead><tr><th>version</th><th>valid from</th><th>currency</th><th>imported</th></tr></thead>
+{{template "tableHead" .Models.Table}}
 <tbody>
-{{range .Models}}<tr>
+{{range .Models.Rows}}<tr>
 <td><a href="{{.Link}}">{{.Model.Version}}</a></td>
 <td>{{stamp .Model.ValidFrom}}</td>
 <td>{{.Model.Currency}}</td>
 <td>{{stamp .Model.ImportedAt}}</td>
 </tr>
-{{else}}<tr><td colspan="4">no catalog is imported</td></tr>
+{{else}}<tr><td colspan="4">{{emptyText .Models.Table "no catalog is imported"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -12,60 +12,64 @@
 <pre>{{pretty .Project.Metadata}}</pre>
 
 <h2>Relations</h2>
+{{template "tableTools" .Relations.Table}}
 <table>
-<thead><tr><th>relation type</th><th>source</th><th>target</th><th>valid from</th><th>valid to</th></tr></thead>
+{{template "tableHead" .Relations.Table}}
 <tbody>
-{{range .Relations}}<tr>
+{{range .Relations.Rows}}<tr>
 <td>{{.RelationType}}</td>
 <td>{{.SourceId}}</td>
 <td>{{.TargetId}}</td>
 <td>{{stamp .ValidFrom}}</td>
 <td>{{optStamp .ValidTo}}</td>
 </tr>
-{{else}}<tr><td colspan="5">this project has no relation</td></tr>
+{{else}}<tr><td colspan="5">{{emptyText .Relations.Table "this project has no relation"}}</td></tr>
 {{end}}</tbody>
 </table>
 
 <h2>Related projects</h2>
+{{template "tableTools" .Related.Table}}
 <table>
-<thead><tr><th>project</th><th>cloud</th><th>relation type</th><th>depth</th></tr></thead>
+{{template "tableHead" .Related.Table}}
 <tbody>
-{{range .Related}}<tr>
+{{range .Related.Rows}}<tr>
 <td><a href="{{.Link}}">{{optString .Related.Project.Name .Related.Project.ExternalId}}</a></td>
 <td>{{.Related.Project.Cloud}}</td>
 <td>{{.Related.RelationType}}</td>
 <td class="number">{{.Related.Depth}}</td>
 </tr>
-{{else}}<tr><td colspan="4">no relation reaches another project</td></tr>
+{{else}}<tr><td colspan="4">{{emptyText .Related.Table "no relation reaches another project"}}</td></tr>
 {{end}}</tbody>
 </table>
 
 <h2>What this project ran, {{stamp .From}} to {{stamp .To}}</h2>
+{{template "tableTools" .Activity.Table}}
 <table>
-<thead><tr><th>resource type</th><th>created</th><th>deleted</th><th>active now</th><th>minutes</th></tr></thead>
+{{template "tableHead" .Activity.Table}}
 <tbody>
-{{range .Activity}}<tr>
+{{range .Activity.Rows}}<tr>
 <td>{{.ResourceType}}</td>
 <td class="number">{{.Created}}</td>
 <td class="number">{{.Deleted}}</td>
 <td class="number">{{.ActiveNow}}</td>
 <td class="number">{{.TotalMinutes}}</td>
 </tr>
-{{else}}<tr><td colspan="5">this project ran nothing in this window</td></tr>
+{{else}}<tr><td colspan="5">{{emptyText .Activity.Table "this project ran nothing in this window"}}</td></tr>
 {{end}}</tbody>
 </table>
 
 <h2>Statements</h2>
+{{template "tableTools" .Statements.Table}}
 <table>
-<thead><tr><th>period</th><th>run kind</th><th>run status</th><th>total</th></tr></thead>
+{{template "tableHead" .Statements.Table}}
 <tbody>
-{{range .Statements}}<tr>
+{{range .Statements.Rows}}<tr>
 <td><a href="{{.Link}}">{{stamp .Row.PeriodFrom}}</a></td>
 <td>{{.Row.Kind}}</td>
 <td>{{.Row.Status}}</td>
 <td class="number">{{amount .Row.Total}} {{.Row.Currency}}</td>
 </tr>
-{{else}}<tr><td colspan="4">no run has billed this project</td></tr>
+{{else}}<tr><td colspan="4">{{emptyText .Statements.Table "no run has billed this project"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/projects.gohtml
+++ b/internal/console/httpui/templates/projects.gohtml
@@ -1,15 +1,16 @@
 {{define "content"}}
+{{template "tableTools" .Items.Table}}
 <table>
-<thead><tr><th>cloud</th><th>external id</th><th>name</th><th>platform</th><th>registered</th></tr></thead>
+{{template "tableHead" .Items.Table}}
 <tbody>
-{{range .Items}}<tr>
+{{range .Items.Rows}}<tr>
 <td>{{.Project.Cloud}}</td>
 <td><a href="{{.Link}}">{{.Project.ExternalId}}</a></td>
 <td>{{optString .Project.Name .Project.ExternalId}}</td>
 <td>{{.Project.Platform}}</td>
 <td>{{stamp .Project.CreatedAt}}</td>
 </tr>
-{{else}}<tr><td colspan="5">no project matched</td></tr>
+{{else}}<tr><td colspan="5">{{emptyText .Items.Table "no project matched"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{if .NextLink}}<p><a href="{{.NextLink}}">next page</a></p>{{end}}

--- a/internal/console/httpui/templates/resource.gohtml
+++ b/internal/console/httpui/templates/resource.gohtml
@@ -2,12 +2,13 @@
 <dl>
 <dt>cloud</dt><dd>{{.Resource.Cloud}}</dd>
 <dt>platform</dt><dd>{{.Resource.Platform}}</dd>
-<dt>project</dt><dd>{{.Resource.ProjectId}}</dd>
+<dt>project</dt><dd>{{if .ProjectLink}}<a href="{{.ProjectLink}}">{{.Resource.ProjectId}}</a>{{else}}{{.Resource.ProjectId}}{{end}}</dd>
 <dt>resource type</dt><dd>{{.Resource.ResourceType}}</dd>
 <dt>resource</dt><dd>{{.Resource.ResourceId}}</dd>
 <dt>state</dt><dd>{{.Resource.State}}</dd>
-<dt>created</dt><dd>{{optStamp .Resource.CreatedAt}}</dd>
+<dt>created</dt><dd>{{.Created}}</dd>
 <dt>deleted</dt><dd>{{optStamp .Resource.DeletedAt}}</dd>
+<dt>lifetime</dt><dd>{{.Lifetime}}</dd>
 <dt>last event</dt><dd>{{.Resource.LastEventType}} at {{stamp .Resource.LastEventAt}}</dd>
 </dl>
 
@@ -48,10 +49,11 @@
 <dt>run status</dt><dd>{{.Run.Status}}</dd>
 {{if .CatalogLink}}<dt>pricing</dt><dd><a href="{{.CatalogLink}}">{{.Run.PricingVersion}}</a></dd>{{end}}
 </dl>
+{{template "tableTools" .Segments.Table}}
 <table>
-<thead><tr><th>state</th><th>from</th><th>to</th><th>seconds</th><th>dimension</th><th>amount</th><th>currency</th></tr></thead>
+{{template "tableHead" .Segments.Table}}
 <tbody>
-{{range .Segments}}<tr>
+{{range .Segments.Rows}}<tr>
 <td>{{.State}}</td>
 <td>{{stamp .From}}</td>
 <td>{{stamp .To}}</td>
@@ -60,7 +62,7 @@
 <td class="number">{{amount .Amount}}</td>
 <td>{{.Currency}}</td>
 </tr>
-{{else}}<tr><td colspan="7">this run metered no interval of the resource</td></tr>
+{{else}}<tr><td colspan="7">{{emptyText .Segments.Table "this run metered no interval of the resource"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{else}}
@@ -68,16 +70,17 @@
 {{end}}
 
 <h2>Events</h2>
+{{template "tableTools" .Events.Table}}
 <table>
-<thead><tr><th>timestamp</th><th>event type</th><th>source</th><th>project</th></tr></thead>
+{{template "tableHead" .Events.Table}}
 <tbody>
-{{range .Events}}<tr>
+{{range .Events.Rows}}<tr>
 <td>{{stamp .Timestamp}}</td>
 <td>{{.EventType}}</td>
 <td>{{.Source}}</td>
 <td>{{.ProjectId}}</td>
 </tr>
-{{else}}<tr><td colspan="4">this resource has no event</td></tr>
+{{else}}<tr><td colspan="4">{{emptyText .Events.Table "this resource has no event"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/resources.gohtml
+++ b/internal/console/httpui/templates/resources.gohtml
@@ -1,19 +1,32 @@
 {{define "content"}}
+<form class="tools fleet" method="get" action="{{.Fleet.Path}}">
+{{range .Fleet.Hidden}}<input type="hidden" name="{{.Name}}" value="{{.Value}}">
+{{end}}<span class="switch">{{range .Fleet.Switch}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</span>
+<label>from <input type="datetime-local" name="from" value="{{.Fleet.From}}"></label>
+<label>to <input type="datetime-local" name="to" value="{{.Fleet.To}}"></label>
+<label>at <input type="datetime-local" name="at" value="{{.Fleet.At}}"></label>
+<button type="submit">apply</button>
+<span class="count">{{.Fleet.Count}}</span>
+</form>
+<p class="presets"><span>window</span>{{range .Fleet.WindowPresets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}<span>instant</span>{{range .Fleet.Presets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</p>
+<p class="axis">every instant is UTC; a lifetime runs from the creation to the deletion, or to now{{if .Fleet.Unknown}}; {{.Fleet.Unknown}}{{end}}</p>
+{{template "tableTools" .Items.Table}}
 <table>
-<thead><tr><th>cloud</th><th>platform</th><th>project</th><th>resource type</th><th>resource</th><th>state</th><th>created</th><th>deleted</th><th>last payload</th></tr></thead>
+{{template "tableHead" .Items.Table}}
 <tbody>
-{{range .Items}}<tr>
+{{range .Items.Rows}}<tr>
 <td>{{.Resource.Cloud}}</td>
 <td>{{.Resource.Platform}}</td>
-<td>{{.Resource.ProjectId}}</td>
+<td>{{if .ProjectLink}}<a href="{{.ProjectLink}}">{{.Resource.ProjectId}}</a>{{else}}{{.Resource.ProjectId}}{{end}}</td>
 <td>{{.Resource.ResourceType}}</td>
 <td><a href="{{.Link}}">{{.Resource.ResourceId}}</a></td>
 <td>{{.Resource.State}}</td>
-<td>{{optStamp .Resource.CreatedAt}}</td>
+<td>{{unknownStamp .Resource.CreatedAt}}</td>
 <td>{{optStamp .Resource.DeletedAt}}</td>
-<td><pre>{{pretty .Resource.LastPayload}}</pre></td>
+<td class="number">{{if .Lived}}{{amount .Lifetime}}{{else}}unknown{{end}}</td>
+<td>{{if .PayloadSummary}}<details class="cell"><summary>{{.PayloadSummary}}</summary><pre>{{pretty .Resource.LastPayload}}</pre></details>{{else}}none{{end}}</td>
 </tr>
-{{else}}<tr><td colspan="9">no resource matched</td></tr>
+{{else}}<tr><td colspan="10">{{if .Fleet.Empty}}{{.Fleet.Empty}}{{else}}{{emptyText .Items.Table "no resource matched"}}{{end}}</td></tr>
 {{end}}</tbody>
 </table>
 {{if .NextLink}}<p><a href="{{.NextLink}}">next page</a></p>{{end}}

--- a/internal/console/httpui/templates/run.gohtml
+++ b/internal/console/httpui/templates/run.gohtml
@@ -12,27 +12,30 @@
 </dl>
 
 <h2>Statements</h2>
-{{if .Statements}}
+{{if .Statements.Table.Total}}
+{{template "tableTools" .Statements.Table}}
 <table>
-<thead><tr><th>project</th><th>total</th><th>share</th></tr></thead>
+{{template "tableHead" .Statements.Table}}
 <tbody>
-{{range .Statements}}<tr>
+{{range .Statements.Rows}}<tr>
 <td><a href="{{.Link}}">{{.Row.Key}}</a></td>
 <td class="number">{{amount .Row.Total}} {{.Row.Currency}}</td>
 <td><svg width="640" height="14" viewBox="0 0 640 14"><rect class="bar" x="0" y="1" width="{{.Width}}" height="12"></rect></svg></td>
 </tr>
+{{else}}<tr><td colspan="3">{{emptyText .Statements.Table "this run produced no statement"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{else}}
 <p>this run produced no statement</p>
 {{end}}
 
-{{if .Deltas}}
+{{if .Deltas.Table.Total}}
 <h2>What this run moved</h2>
+{{template "tableTools" .Deltas.Table}}
 <table>
-<thead><tr><th>cloud</th><th>project</th><th>resource type</th><th>resource</th><th>dimension</th><th>old</th><th>new</th><th>delta</th></tr></thead>
+{{template "tableHead" .Deltas.Table}}
 <tbody>
-{{range .Deltas}}<tr>
+{{range .Deltas.Rows}}<tr>
 <td>{{.Cloud}}</td>
 <td>{{.ProjectID}}</td>
 <td>{{.ResourceType}}</td>
@@ -42,6 +45,7 @@
 <td class="number">{{amount .NewAmount}}</td>
 <td class="number">{{amount .Delta}} {{.Currency}}</td>
 </tr>
+{{else}}<tr><td colspan="8">{{emptyText .Deltas.Table "this run moved nothing"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}

--- a/internal/console/httpui/templates/statement.gohtml
+++ b/internal/console/httpui/templates/statement.gohtml
@@ -1,9 +1,9 @@
 {{define "content"}}
 <dl>
 <dt>cloud</dt><dd>{{.Cloud}}</dd>
-<dt>project</dt><dd>{{.Project}}</dd>
+<dt>project</dt><dd><code>{{.Project}}</code></dd>
 <dt>platform</dt><dd>{{.Document.Platform}}</dd>
-<dt>run</dt><dd><a href="{{.RunLink}}">{{.RunID}}</a></dd>
+<dt>run</dt><dd><a href="{{.RunLink}}"><code>{{.RunID}}</code></a></dd>
 <dt>billing period</dt><dd>{{.Document.BillingPeriod.From}} to {{.Document.BillingPeriod.To}}</dd>
 <dt>total</dt><dd>{{amount .Document.Total.Decimal}} {{.Document.Currency}}</dd>
 {{with .Document.BaseCost}}<dt>base cost</dt><dd>{{amount .Decimal}}</dd>{{end}}
@@ -11,61 +11,81 @@
 {{with .Document.KickbackTotal}}<dt>kickback total</dt><dd>{{amount .Decimal}}</dd>{{end}}
 </dl>
 
-{{if .Document.Adjustments}}
+{{if .Adjustments.Table.Total}}
 <h2>Adjustments</h2>
+{{template "tableTools" .Adjustments.Table}}
 <table>
-<thead><tr><th>type</th><th>relation type</th><th>target</th><th>scope</th><th>description</th><th>rate</th><th>base</th><th>amount</th></tr></thead>
+{{template "tableHead" .Adjustments.Table}}
 <tbody>
-{{range .Document.Adjustments}}<tr>
+{{range .Adjustments.Rows}}<tr>
 <td>{{.Type}}</td>
 <td>{{.RelationType}}</td>
-<td>{{.RelationTarget}}</td>
+<td><code>{{.RelationTarget}}</code></td>
 <td>{{.Scope}}</td>
 <td>{{.Description}}</td>
 <td class="number">{{rate .Rate.Decimal}}</td>
 <td class="number">{{amount .Base.Decimal}}</td>
-<td class="number">{{amount .Amount.Decimal}}</td>
+<td class="number{{zeroClass .Amount.Decimal}}">{{amount .Amount.Decimal}}</td>
 </tr>
+{{else}}<tr><td colspan="8">{{emptyText .Adjustments.Table "this statement carries no adjustment"}}</td></tr>
 {{end}}</tbody>
 </table>
 {{end}}
 
 <h2>Line items</h2>
-{{template "lineItems" .Document.LineItems}}
+{{template "billSection" .Items}}
 
-{{range .Document.RelatedCosts}}
-<h2>Related cost of {{.ProjectID}}</h2>
+{{range .Related}}
+<h2>Related cost of <code>{{.Related.ProjectID}}</code></h2>
 <dl>
-<dt>relation type</dt><dd>{{.RelationType}}</dd>
-<dt>project</dt><dd>{{.ProjectID}}</dd>
-<dt>platform</dt><dd>{{.Platform}}</dd>
-<dt>total</dt><dd>{{amount .Total.Decimal}}</dd>
+<dt>relation type</dt><dd>{{.Related.RelationType}}</dd>
+<dt>project</dt><dd><code>{{.Related.ProjectID}}</code></dd>
+<dt>platform</dt><dd>{{.Related.Platform}}</dd>
+<dt>total</dt><dd>{{amount .Related.Total.Decimal}} {{.Currency}}</dd>
 </dl>
-{{template "lineItems" .LineItems}}
+{{template "billSection" .}}
 {{end}}
 {{end}}
 
-{{define "lineItems"}}
-{{range .}}
-<h3>{{.ResourceType}} {{.ResourceID}}</h3>
-<dl>
-<dt>platform</dt><dd>{{.Platform}}</dd>
-<dt>description</dt><dd>{{.Description}}</dd>
-<dt>total</dt><dd>{{amount .Total.Decimal}}</dd>
-</dl>
+{{/* billSection is one section of the bill: the summary table of its items,
+     then the detail block of every item the summary shows, in its order. */}}
+{{define "billSection"}}
+{{if .Summary.Table.Total}}
+{{template "tableTools" .Summary.Table}}
 <table>
-<thead><tr><th>state</th><th>hours</th><th>usage</th><th>cost</th><th>state modifier</th></tr></thead>
+{{template "tableHead" .Summary.Table}}
 <tbody>
-{{range .Periods}}<tr>
-<td>{{.State}}</td>
-<td class="number">{{amount .Hours.Decimal}}</td>
-<td>{{range $metric, $value := .Usage}}{{$metric}}: {{quantity $value.Decimal}}<br>{{end}}</td>
-<td>{{range $dimension, $value := .Cost}}{{$dimension}}: {{amount $value.Decimal}}<br>{{end}}</td>
-<td class="number">{{quantity .StateModifier.Decimal}}</td>
+{{range .Summary.Rows}}<tr>
+<td>{{.ResourceType}}</td>
+<td><a href="{{.OpenLink}}"><code>{{.ResourceID}}</code></a></td>
+<td>{{.Description}}</td>
+<td class="number">{{amount .Hours}}</td>
+<td class="number{{zeroClass .Total}}">{{amount .Total}} {{$.Currency}}</td>
 </tr>
+{{else}}<tr><td colspan="5">{{emptyText .Summary.Table "this section holds no line item"}}</td></tr>
 {{end}}</tbody>
 </table>
+{{range .Summary.Rows}}
+<details class="item" id="{{.Anchor}}"{{if .Open}} open{{end}}>
+<summary><span>{{.ResourceType}} <code>{{.ResourceID}}</code></span>{{if .Description}} <span class="muted">{{.Description}}</span>{{end}}<span class="total{{zeroClass .Total}}">{{amount .Total}} {{$.Currency}}</span></summary>
+{{if .ResourceLink}}<p class="muted"><a href="{{.ResourceLink}}">the resource's page</a></p>{{end}}
+<table>
+{{template "tableHead" .Metrics.Table}}
+<tbody>
+{{range .Metrics.Rows}}<tr{{if .Subtotal}} class="subtotal"{{end}}>
+<td>{{.State}}</td>
+<td class="number">{{amount .Hours}}</td>
+<td>{{.Metric}}</td>
+<td class="number{{zeroClass .Usage}}">{{if not .Subtotal}}{{quantity .Usage}}{{end}}</td>
+<td class="number{{zeroClass .Cost}}">{{amount .Cost}}</td>
+<td class="number">{{quantity .Modifier}}</td>
+</tr>
+{{else}}<tr><td colspan="6">this item holds no period</td></tr>
+{{end}}</tbody>
+</table>
+</details>
+{{end}}
 {{else}}
-<p>this statement holds no line item</p>
+<p>this section holds no line item</p>
 {{end}}
 {{end}}

--- a/internal/console/httpui/theme.go
+++ b/internal/console/httpui/theme.go
@@ -1,0 +1,81 @@
+package httpui
+
+import (
+	"net/http"
+	"strings"
+)
+
+// The theme is the one thing a viewer sets. The stylesheet follows the
+// operating system's light or dark setting on its own, and a viewer who wants
+// the other one says so with the form in the navigation bar. The choice is
+// kept in a cookie the browser holds, so the console still writes nothing on
+// either side it reads, and it travels back on every request as the data-theme
+// attribute of the page.
+const (
+	themeRoute  = "/theme"
+	themeCookie = "theme"
+	themeLight  = "light"
+	themeDark   = "dark"
+	// themeAuto clears the cookie: the page follows the operating system
+	// again, which is what a page without the attribute does.
+	themeAuto = "auto"
+	// themeCookieAge is a year in seconds. A demo console outlives no laptop,
+	// and a choice that expired would fall back to the operating system's.
+	themeCookieAge = 365 * 24 * 60 * 60
+)
+
+// themeFrom reads the viewer's choice. A cookie that is missing or holds
+// anything but the two themes is no choice, and the page follows the operating
+// system.
+func themeFrom(r *http.Request) string {
+	cookie, err := r.Cookie(themeCookie)
+	if err != nil {
+		return ""
+	}
+	switch cookie.Value {
+	case themeLight, themeDark:
+		return cookie.Value
+	}
+	return ""
+}
+
+// theme stores the choice the form posted and sends the viewer back to the
+// page the form was on. A choice that is none of the three is answered with
+// the error page, the way any unreadable parameter is.
+func (h *handlers) theme(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		h.failFrom(w, r, &paramError{name: "theme", reason: "could not be read: " + err.Error()}, nil)
+		return
+	}
+
+	cookie := &http.Cookie{
+		Name:     themeCookie,
+		Path:     "/",
+		MaxAge:   themeCookieAge,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	switch choice := r.PostForm.Get("theme"); choice {
+	case themeLight, themeDark:
+		cookie.Value = choice
+	case themeAuto:
+		cookie.MaxAge = -1
+	default:
+		h.failFrom(w, r, &paramError{name: "theme", reason: "is not auto, light or dark"}, nil)
+		return
+	}
+
+	http.SetCookie(w, cookie)
+	http.Redirect(w, r, backPath(r.PostForm.Get("back")), http.StatusSeeOther)
+}
+
+// backPath is where the viewer lands after choosing: the page the form was on,
+// as long as that is a path of this console. A value carrying a host, an
+// absolute URL or a protocol-relative one, would send the viewer off the
+// console, and lands on the front page instead.
+func backPath(back string) string {
+	if !strings.HasPrefix(back, "/") || strings.HasPrefix(back, "//") || strings.HasPrefix(back, `/\`) {
+		return "/"
+	}
+	return back
+}

--- a/internal/console/reporting/client.go
+++ b/internal/console/reporting/client.go
@@ -121,9 +121,10 @@ func (e *ProblemError) Error() string {
 // ProjectsQuery narrows a project list. Every field is optional, and an empty
 // one filters nothing.
 type ProjectsQuery struct {
-	Platform string
-	Cloud    string
-	Cursor   string
+	Platform   string
+	Cloud      string
+	ExternalID string
+	Cursor     string
 }
 
 // ResourcesQuery narrows a resource list. Every field is optional, and an empty
@@ -135,6 +136,9 @@ type ResourcesQuery struct {
 	State        string
 	Status       string
 	Cursor       string
+	// Limit is how many rows one page carries at most, within the API's
+	// bounds. Zero leaves the API's default.
+	Limit int
 }
 
 // ListProjects reads one page of the registered projects. The page's
@@ -144,6 +148,7 @@ func (c *Client) ListProjects(ctx context.Context, q ProjectsQuery) (httpapi.Pro
 	query := url.Values{}
 	setFilter(query, "platform", q.Platform)
 	setFilter(query, "cloud", q.Cloud)
+	setFilter(query, "external_id", q.ExternalID)
 	setFilter(query, "cursor", q.Cursor)
 
 	var page httpapi.ProjectList
@@ -215,6 +220,9 @@ func (c *Client) ListResources(ctx context.Context, q ResourcesQuery) (httpapi.R
 	setFilter(query, "state", q.State)
 	setFilter(query, "status", q.Status)
 	setFilter(query, "cursor", q.Cursor)
+	if q.Limit > 0 {
+		query.Set("limit", strconv.Itoa(q.Limit))
+	}
 
 	var page httpapi.ResourceList
 	request, err := c.get(ctx, withQuery("/api/v1/resources", query), &page)

--- a/internal/console/reporting/client_test.go
+++ b/internal/console/reporting/client_test.go
@@ -116,12 +116,13 @@ func TestReadsCarryTheTokenAndTheQuery(t *testing.T) {
 		{
 			name:    "a filtered project list",
 			body:    emptyPage,
-			wantURI: "/api/v1/projects?cloud=os-sim&cursor=abc&platform=openstack",
+			wantURI: "/api/v1/projects?cloud=os-sim&cursor=abc&external_id=p-1&platform=openstack",
 			call: func(ctx context.Context, c *Client) (Request, error) {
 				_, request, err := c.ListProjects(ctx, ProjectsQuery{
-					Platform: "openstack",
-					Cloud:    "os-sim",
-					Cursor:   "abc",
+					Platform:   "openstack",
+					Cloud:      "os-sim",
+					ExternalID: "p-1",
+					Cursor:     "abc",
 				})
 				return request, err
 			},
@@ -166,7 +167,7 @@ func TestReadsCarryTheTokenAndTheQuery(t *testing.T) {
 		{
 			name: "a filtered resource list",
 			body: emptyPage,
-			wantURI: "/api/v1/resources?cloud=os-sim&cursor=abc&project_id=p-1" +
+			wantURI: "/api/v1/resources?cloud=os-sim&cursor=abc&limit=50&project_id=p-1" +
 				"&resource_type=instance&state=active&status=all",
 			call: func(ctx context.Context, c *Client) (Request, error) {
 				_, request, err := c.ListResources(ctx, ResourcesQuery{
@@ -176,6 +177,7 @@ func TestReadsCarryTheTokenAndTheQuery(t *testing.T) {
 					State:        "active",
 					Status:       "all",
 					Cursor:       "abc",
+					Limit:        50,
 				})
 				return request, err
 			},


### PR DESCRIPTION
This branch reworks the demo console's pages for reading rather than for proving the routes work: a dark mode with a switch, every table sortable and filterable, the resources page as a fleet view over a status, a window and an instant, a project link on every resource, and the statement page as a bill with a summary and folding items. The console still ships no JavaScript and loads one stylesheet: every control is a link or a form that reloads the page with its state in the query string, so every view has a URL, and the test that forbids a script element and a second asset still passes on every route.

## The change set, in commit order

- **`d16c105` Filter projects by external id and size resource pages in the client** — `internal/console/reporting`. `ProjectsQuery` gains `ExternalID`, the filter `GET /api/v1/projects` serves with exact equality, and `ResourcesQuery` gains `Limit` within the API's bounds; zero leaves the API's default, so nothing else changes.
- **`c2e951f` Add a dark mode and a theme switch to the console** — `theme.go`, `render.go`, `router.go`, `layout.gohtml`, `console.css`. Every colour is a token with a light and a dark value through `light-dark()`, so the pages follow the operating system on their own. The switch at the right end of the navigation posts `auto`, `light` or `dark` to `/theme`, the one route that is not a page: it keeps the choice in a cookie for a year, `auto` deletes it, and the viewer is sent back to the page the form was on, or to `/` when the back path is not the console's. The page renders the cookie as `data-theme` on its root element. `GET /theme` lands on the error page with 405. The layout also defines the two partials every table is rendered with, and the stylesheet carries the rules of the later commits.
- **`157324a` Sort and filter a console table on the console's side** — `table.go`, `funcs.go`. A table declares its columns once with the cell a row shows in it. `<table>.sort` holds a column key, with a hyphen for descending, and `<table>.q` the filter text, named after the table so several tables of one page keep their own. Text sorts folded, a number by value and descending on the first click, a column without a cell neither sorts nor filters. The filter form carries every other parameter of the page as hidden inputs. A table can open in a default order. The template functions gain `emptyText`, `zeroClass` and `unknownStamp`.
- **`acd60d6` Render the overview, pricing and catalog tables through the helper** — the five overview tables, the version list and the catalog declare their columns; a table the filter emptied says so in place of the rows.
- **`f6cf163` Resolve a project by the pair a resource names it with** — `projects.go`, `errors.go`. `/project` accepts `cloud` and `external_id` beside `id`, resolves the pair through the project list filtered by both, checks the answer for an exact match on each, and answers 404 for a pair nothing is registered under and 400 for a pair without its cloud. The registry listing and the four tables of a project page go through the helper, and a list that fits one page is no longer counted as one.
- **`c93247b` Rework the resources and statement pages around the table helper** — `resources.go`, `fleet.go`, `runs.go`, `bill.go`, `svg.go`, the six page templates, the tests, the reference page. The resources page reads the fleet under `status` (`active` by default, `deleted`, `all`) and keeps the rows that existed over the window `from` and `to` or at the instant `at`, now by default, with presets one click away; it asks the API for 1000 rows, the most one page carries, so the filters see the whole simulated fleet. Every row links its project and its own page, prints its lifetime in hours, and folds its last payload under a line that counts its keys. A resource whose history starts without a create prints `unknown` for its creation and lifetime, the line above the table counts such rows, and the resource page names the event the history starts with and counts the lifetime from it. A statement is rendered in sections, each with a summary table sorted by total descending whose rows open and scroll to a folded detail block with one row per metric and period, zeros muted, identifiers in a monospace face; related costs get the same treatment.

## What the console does not do

- The Reporting API has no time filter on its resource list, so the window and the instant are applied to the rows the page holds. Above 1000 resources the filter is page-local, which the row count says.
- The API leaves `created_at` null for a history that starts without a create and serves no first event on the projection row, so the listing cannot show a "first seen" instant without one lifecycle call per row. On the dev cluster with the simulator's `missing-create` fault, 18 of 48 rows under `status=all` are such rows. Exposing `first_event_at` on the projection row is a Reporting API change and is not part of this branch; its issue is not filed yet.
- The period tables of a bill's line items sort through their headings but carry no filter form: they are a few rows under each resource, and the summary table above them filters the blocks.

## Checks

- Every commit was checked out into a worktree and passed `go build ./...` and `go test` for `cmd/tally-console`, `internal/console/...` and `docs`.
- At the head, `golangci-lint v2.13.2` via `go run` reports 0 issues on the console packages, and `go test ./docs/` accepts the rewritten reference page.
- The pages were rendered from the test fixtures and screenshotted with headless Chrome in light and dark, before and after each change to the resources and statement pages.
- The running dev console, still the binary from before this branch, was used to read the resource `079faae9-9d39-426f-a963-769cb12aa629` and confirm that its history starts with `compute.instance.power_on` and carries the fold warning `history_starts_without_create`. The branch was not run against the dev cluster.

## Notes for the reviewer

- `light-dark()` needs a browser from 2024 or later. The console runs on a developer's laptop, and an older browser gets the default colours rather than a broken page.
- The theme cookie is the console's only write, and it is to the viewer's browser: the console still writes nothing to the Reporting API or the engine database.
- The detail block a summary row opens is named in `open` and in the fragment, so the page comes back with that block unfolded and the browser scrolls to it. This is server-side on purpose, so it behaves the same in every browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
