### PR TITLE
Make the demo console answer one question at a time

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,7 +27,7 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default. Engine: one row per statement of the project. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: one row per statement of the project. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
@@ -57,6 +57,19 @@ that is not after `from`. Each bound is read as RFC 3339 or as the form the
 inputs write. The rest of the page is read as it stands now, whatever the
 window is: the relations, the projects a traversal reaches, and every statement
 a run wrote for the project.
+
+Each resource type of that summary folds open into the resources of the project
+that lived in the window, by the rule the fleet reads a window by, sorted by
+their ids, each with its state, its creation, its deletion and its lifetime in
+hours, and each linking its own page. The filter above the table matches a row
+on its type and on the resources folded under it, so a resource id finds the
+type it sits in. The two numbers come from two places: the summary counts by
+folding the events of the window, and the fold lists what the projection holds
+today, so a resource the project has since handed on is counted and not listed,
+and a type the projection holds nothing of is drawn without a fold. The
+resources are read as one page of at most 1000, the widest the API serves, and
+a project that holds more says under the table that a type may have run
+resources the fold does not name.
 
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a

--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,7 +27,7 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: one row per statement of the project. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: every statement of the project, grouped into the periods that were billed. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
@@ -70,6 +70,28 @@ and a type the projection holds nothing of is drawn without a fold. The
 resources are read as one page of at most 1000, the widest the API serves, and
 a project that holds more says under the table that a type may have run
 resources the fold does not name.
+
+The statements are one row per billing period rather than one per statement. A
+period accumulates them: the regular run that billed it, every run that
+replaced one of those, and every correction booked against the run that closed
+it. The row carries what the project is charged for the period, which is the
+sum of the statements whose run stands, and folds open into all of them, each
+with its kind, its status, its own total and a link to the statement itself. A
+statement that counts for nothing is drawn in the muted colour and says it was
+replaced.
+
+A run stands when its status is `completed` or `finalized`, which are the two
+an export reads; a `superseded` run was replaced by another of its kind and a
+`failed` one billed nothing, and neither is added up. This is why a correction
+adds to the period rather than replacing it: a correction re-meters the period
+whole and stores the difference against the run it corrects, so its statement
+is a credit note over the run that closed the month, and the two together are
+what the project owes. A period is billed in one currency, so the sum is one
+amount; a period whose standing statements disagree prints each currency
+rather than adding them up. The status of the period is the standing regular
+run's, and a period whose every run was replaced stands at nothing and is
+charged nothing. The filter matches a period on its instant and on the kinds
+and statuses folded under it, so `correction` finds the months that hold one.
 
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a

--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,7 +27,7 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the current month. Engine: one row per statement of the project. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default. Engine: one row per statement of the project. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
@@ -47,6 +47,16 @@ match on each, and a pair nothing is registered under is answered 404. The
 relations of a project link either end that is not the project of the page, so
 a relation another project leaves leads to it and one this project leaves
 leads to what it reaches.
+
+What a project ran is read over a window, `from` and `to`, with the same inputs
+and the same spans the fleet is read over: the last 24 hours, the last 7 days,
+this month, last month. The window is this month while the request names
+neither bound. The summary route takes both bounds, so a request carrying one
+and not the other is answered 400 naming the missing one, and so is a `to`
+that is not after `from`. Each bound is read as RFC 3339 or as the form the
+inputs write. The rest of the page is read as it stands now, whatever the
+window is: the relations, the projects a traversal reaches, and every statement
+a run wrote for the project.
 
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a

--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -28,7 +28,7 @@ environment, under the names the settings table below lists.
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
 | `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the current month. Engine: one row per statement of the project. |
-| `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console keeps the rows that existed in the window `from` and `to` or at the instant `at`, now by default, and prints each one's lifetime in hours. Each row links its project by cloud and external id, and folds its last payload. |
+| `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
@@ -111,51 +111,61 @@ metric of every period, with the period's total as a row of its own. A descripti
 only repeats the item's type and id is left out. A value of exactly zero is
 printed in the muted colour, so the amounts that are not zero stand out.
 
-## The fleet over a window and at an instant
+## The fleet at an instant and over a window
 
-The resource list is read under one status and shown over a window or at an
-instant. The status is the API's own filter, chosen with the switch above the
-table: `active` serves the rows whose state is not deleted and is the default,
-`deleted` serves those alone, and `all` serves both. A `status` that is none of
-the three is answered 400. Switching the status drops the cursor, because a
-cursor positions a walk through one status and means nothing in another. A
-deleted resource is only on the page when the status admits it, so looking
-back starts with switching the status to `all`.
+The resource list is read under one status, and that page is then read one of
+two ways. The status is the API's own filter, chosen with the switch on the
+`show` line above the table: `active` serves the rows whose state is not
+deleted and is the default, `deleted` serves those alone, and `all` serves
+both. A `status` that is none of the three is answered 400. Switching the
+status drops the cursor, because a cursor positions a walk through one status
+and means nothing in another. A deleted resource is only on the page when the
+status admits it, so looking back starts with switching the status to `all`.
 
-The window and the instant are the console's filters, applied to the rows the
-API served. Each of `from`, `to` and `at` is read as RFC 3339 or as the form
-the inputs write, `2026-03-15T12:00`, which carries no zone and is read as UTC;
-one that does not parse is answered 400.
+The two ways are the console's own filters, applied to the rows the API
+served, and the switch on the `when` line chooses between them: **at an
+instant**, which answers what runs right now or what ran at one moment, and
+**over a window**, which answers what lived between two moments. The page
+draws the inputs and the presets of the chosen way alone, so a window and an
+instant are never asked for at once. Which way a request means is `mode`,
+either `instant` or `window`; a request that names no mode means the window
+when it carries `from` or `to`, and the instant otherwise. A `mode` that is
+neither is answered 400. What the other way would be asked with is ignored,
+so a stale `at` on a window page changes nothing, and switching ways drops the
+parameters of the way being left.
+
+Each of `at`, `from` and `to` is read as RFC 3339 or as the form the inputs
+write, `2026-03-15T12:00`, which carries no zone and is read as UTC; one that
+does not parse is answered 400.
+
+The instant is `at`, and the page opens on it: a resource existed at it when
+it was created at or before it and not deleted at or before it; a resource
+whose history shows no create has no creation time and is taken to have
+existed all along. Without `at` the instant is now, so the page opens on what
+runs right now. The instant presets are now, which is no parameter at all, 24
+hours ago, 7 days ago, the start of this month and the start of last month.
+The instant input stays empty while nothing is pinned, so the page opens on
+now without claiming an instant was chosen.
 
 The window is `from` and `to`, half-open: a resource existed in it when it was
 created before `to` and not deleted at or before `from`. Either bound may be
 left out, which leaves the window open on that side, and a `to` that is not
-after `from` is answered 400. The window presets are the last 24 hours, the
-last 7 days, this month, last month, and all, which is no window.
-
-The instant is `at`: a resource existed at it when it was created at or before
-it and not deleted at or before it; a resource whose history shows no create
-has no creation time and is taken to have existed all along. With neither a
-window nor an instant the page shows what exists now, so it opens on what runs
-right now. With a window and no instant it shows everything that lived in the
-window. With an instant, inside a window or not, it shows what existed at that
-instant. The instant presets are now, offered while there is no window, 24
-hours ago, 7 days ago, the start of this month, the start of last month, and
-clear, offered while an instant is pinned inside a window. The instant input
-stays empty while nothing is pinned, so applying a window does not pin the
-instant to now on the way.
+after `from` is answered 400. A window with neither bound holds every row of
+the page, whenever it lived. The window presets are the last 24 hours, the
+last 7 days, this month, last month, and any time, which is the window with
+neither bound.
 
 The page asks the API for 1000 rows, the most one page carries, so that the
 filters are applied to as much of the fleet as one call holds; the fleet of the
 simulated month fits. A page the API followed with a cursor, or one reached by
 a cursor, counts its rows as one page, and its next link carries the status,
-the window and the instant along. The line above the table says how many of
-the rows the API served the filters kept, and a page the filters emptied says
-so in place of the rows.
+the mode, the window and the instant along. The line beside the status switch
+says how many of the rows the API served the filters kept and what they were
+kept for, and a page the filters emptied says so in place of the rows.
 
 Every row prints its lifetime in hours at two places: from its creation to
-its deletion, or to now for a resource still there, whatever the window and
-the instant are. A resource whose history starts without a create has no
+its deletion, or to now for a resource still there, whatever the page is read
+at. A resource whose history starts without a create has no
 creation time, which the API leaves null and the fold reports as
 `history_starts_without_create`; the row prints `unknown` for its creation and
 its lifetime, and the line above the table counts such rows. The resource page

--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,7 +27,7 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: every statement of the project, grouped into the periods that were billed. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: every statement of the project, grouped into the periods that were billed, and for a partner what every run settles for it. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
@@ -46,7 +46,13 @@ project page resolves it through the project list filtered by both, an exact
 match on each, and a pair nothing is registered under is answered 404. The
 relations of a project link either end that is not the project of the page, so
 a relation another project leaves leads to it and one this project leaves
-leads to what it reaches.
+leads to what it reaches. A relation folds open into the pricing adjustments
+its metadata carries, one row per adjustment with its type, its scope, its rate
+and its description, so what a `managed_by` relation grants a reseller and what
+it owes them is read where the relation is. The filter matches a relation on
+its type and on the adjustments under it. The registry holds every adjustments
+document to the schema when it is written, so one this console cannot read is
+reported in the row rather than as a failed page.
 
 What a project ran is read over a window, `from` and `to`, with the same inputs
 and the same spans the fleet is read over: the last 24 hours, the last 7 days,
@@ -93,6 +99,21 @@ run's, and a period whose every run was replaced stands at nothing and is
 charged nothing. The filter matches a period on its instant and on the kinds
 and statuses folded under it, so `correction` finds the months that hold one.
 
+A partner carries one more table, `kickbacks`, which is what the runs settle
+for it. A partner is never billed, because `managed_by` attributes no cost, so
+it has no statement of its own; a kickback is what the operator owes it, and it
+is a line on the statement of the project that was adjusted. The table is one
+row per period with what the partner is owed for it, folding open into every
+record: the run kind, the adjusted project, the scope, the rate, the base and
+the amount, each with a link to the statement the record was applied to. The
+arithmetic is the engine's own, read through the settlement `tally-engine
+kickbacks` reports: a regular run's records are what it owes, and a
+correction's are the difference to the run it corrects, so a period adds up the
+way its statements do. Only the runs that stand are read. The table is drawn
+for a project of platform `partner` and for no other, because the beneficiary
+column holds an external id alone and a project of another platform could carry
+the same one.
+
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a
 cursor on its own.
@@ -129,7 +150,7 @@ The tables and their names per page:
 | --- | --- |
 | `/` | `stats`, `events`, `rejected`, `periods`, `runs` |
 | `/projects` | `projects` |
-| `/project` | `relations`, `related`, `activity`, `statements` |
+| `/project` | `relations`, `related`, `activity`, `kickbacks`, `statements` |
 | `/resources` | `resources` |
 | `/resource` | `segments`, `events` |
 | `/pricing` | `models` |

--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -43,7 +43,10 @@ because a cloud name, a resource id and a statement key may each carry a slash.
 A resource names its project by cloud and external id, not by the id the API
 assigns, so the project links on the resource pages carry that pair. The
 project page resolves it through the project list filtered by both, an exact
-match on each, and a pair nothing is registered under is answered 404.
+match on each, and a pair nothing is registered under is answered 404. The
+relations of a project link either end that is not the project of the page, so
+a relation another project leaves leads to it and one this project leaves
+leads to what it reaches.
 
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a

--- a/internal/console/httpui/errors.go
+++ b/internal/console/httpui/errors.go
@@ -30,6 +30,12 @@ func missingParameter(name string) error {
 	return &paramError{name: name, reason: "is missing"}
 }
 
+// unreadableInstant reports a bound or an instant that was sent in a form no
+// page can read.
+func unreadableInstant(name string, err error) error {
+	return &paramError{name: name, reason: "is not an instant: " + err.Error()}
+}
+
 // unreadableUUID reports a parameter that was sent but is no id.
 func unreadableUUID(name string, err error) error {
 	return &paramError{name: name, reason: fmt.Sprintf("is not a UUID: %v", err)}

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -15,18 +15,23 @@ import (
 )
 
 // The resources page lists the part of the fleet the Reporting API serves
-// under one status, and of those rows the ones that existed over a window or
-// at an instant. The status is the API's own filter, active by default. The
-// window and the instant are the console's, applied to the rows the API
-// served.
+// under one status, and of those rows the ones the chosen time keeps. The
+// status is the API's own filter, active by default. The time is the
+// console's, applied to the rows the API served.
 //
-// The window is from and to, a half-open span: a resource existed in it when
-// it was created before to and not deleted at or before from. The instant is
-// at: a resource existed at it when it was created at or before it and not
-// deleted at or before it. Without a window and without an instant the page
-// shows what exists now, so it opens on what runs right now. With a window and
-// no instant it shows everything that lived in the window. With an instant,
-// whether inside a window or not, it shows what existed at that instant.
+// A viewer reads the fleet one of two ways, and never both at once: at an
+// instant, which answers what runs right now or what ran at one moment, or
+// over a window, which answers what lived between two moments. Which of the
+// two a request means is the mode parameter, and a request that names none
+// means the window when it carries a bound of one and the instant otherwise.
+// The parameters of the other way are ignored rather than combined, so one
+// page is one question.
+//
+// The instant is at, now when it is absent: a resource existed at it when it
+// was created at or before it and not deleted at or before it. The window is
+// from and to, a half-open span: a resource existed in it when it was created
+// before to and not deleted at or before from. A window with neither bound is
+// every row the page holds, whenever it lived.
 //
 // A deleted resource is only on the page when the status admits it, so
 // looking back starts with switching the status to all. Every row carries the
@@ -46,9 +51,15 @@ const (
 	atLayout = "2006-01-02T15:04"
 	// The query parameters of the fleet controls.
 	statusParameter = "status"
+	modeParameter   = "mode"
 	fromParameter   = "from"
 	toParameter     = "to"
 	atParameter     = "at"
+	// The two ways the fleet is read. The instant is the default and travels
+	// as no parameter at all; the window is named, because a window with
+	// neither bound is otherwise indistinguishable from the instant.
+	modeInstant = "instant"
+	modeWindow  = "window"
 	// resourceTable is the name the resource listing's sort and filter
 	// parameters carry.
 	resourceTable = "resources"
@@ -58,27 +69,27 @@ const (
 // prints them. The first is the API's default and the page's.
 var statuses = []string{"active", "deleted", "all"}
 
-// fleetState is what the request says about the fleet: which part of it, over
-// which window, and at which instant. A nil bound is a window open on that
-// side, and Pinned is false while no instant was named, which is now when
-// there is no window either.
+// fleetState is what the request says about the fleet: which part of it, and
+// which time it is read at. Window says which of the two ways was asked for,
+// and the members of the other way are left at their zero values. A nil bound
+// is a window open on that side, and Pinned is false while no instant was
+// named, which is now.
 type fleetState struct {
 	Status string
+	Window bool
 	From   *time.Time
 	To     *time.Time
 	At     time.Time
 	Pinned bool
 }
 
-// windowed reports whether either bound of the window is set.
-func (s fleetState) windowed() bool {
-	return s.From != nil || s.To != nil
-}
-
-// readFleet reads the status, the window and the instant, each falling back
-// to its default when absent. A status the API does not serve, a bound or an
-// instant that does not parse, and a window that ends before it starts are
-// refused the way any unreadable parameter is.
+// readFleet reads the status and the time the fleet is read at, each falling
+// back to its default when absent. Only the parameters of the mode in effect
+// are read: what the other way would have been asked with says nothing about
+// this page and is not held against the request either. A status the API does
+// not serve, a mode that is neither way, a bound or an instant that does not
+// parse, and a window that ends before it starts are refused the way any
+// unreadable parameter is.
 func readFleet(r *http.Request, now time.Time) (fleetState, error) {
 	query := r.URL.Query()
 	state := fleetState{Status: statuses[0], At: now}
@@ -90,6 +101,29 @@ func readFleet(r *http.Request, now time.Time) (fleetState, error) {
 		state.Status = status
 	}
 
+	switch mode := query.Get(modeParameter); mode {
+	case "":
+		// A link written before the modes, or by hand, names a window by
+		// carrying a bound of one.
+		state.Window = query.Get(fromParameter) != "" || query.Get(toParameter) != ""
+	case modeWindow:
+		state.Window = true
+	case modeInstant:
+	default:
+		return fleetState{}, &paramError{name: modeParameter, reason: "is not instant or window"}
+	}
+
+	if !state.Window {
+		if at := query.Get(atParameter); at != "" {
+			parsed, err := parseInstant(at)
+			if err != nil {
+				return fleetState{}, &paramError{name: atParameter, reason: "is not an instant: " + err.Error()}
+			}
+			state.At, state.Pinned = parsed, true
+		}
+		return state, nil
+	}
+
 	var err error
 	if state.From, err = optionalInstant(query, fromParameter); err != nil {
 		return fleetState{}, err
@@ -99,14 +133,6 @@ func readFleet(r *http.Request, now time.Time) (fleetState, error) {
 	}
 	if state.From != nil && state.To != nil && !state.To.After(*state.From) {
 		return fleetState{}, &paramError{name: toParameter, reason: "is not after from"}
-	}
-
-	if at := query.Get(atParameter); at != "" {
-		parsed, err := parseInstant(at)
-		if err != nil {
-			return fleetState{}, &paramError{name: atParameter, reason: "is not an instant: " + err.Error()}
-		}
-		state.At, state.Pinned = parsed, true
 	}
 	return state, nil
 }
@@ -134,24 +160,20 @@ func parseInstant(text string) (time.Time, error) {
 	return time.ParseInLocation(atLayout, text, time.UTC)
 }
 
-// keep reports whether a row is shown: inside the window where one is set,
-// and existing at the instant where one is pinned, or at now when neither is
-// there.
-func keep(resource httpapi.Resource, state fleetState, now time.Time) bool {
+// keep reports whether a row is shown: existing at the instant the page is
+// read at, or having lived inside the window it is read over. A window with
+// neither bound keeps every row.
+func keep(resource httpapi.Resource, state fleetState) bool {
+	if !state.Window {
+		return existedAt(resource, state.At)
+	}
 	if state.From != nil && resource.DeletedAt != nil && !resource.DeletedAt.After(*state.From) {
 		return false
 	}
 	if state.To != nil && resource.CreatedAt != nil && !resource.CreatedAt.Before(*state.To) {
 		return false
 	}
-	switch {
-	case state.Pinned:
-		return existedAt(resource, state.At)
-	case state.windowed():
-		return true
-	default:
-		return existedAt(resource, now)
-	}
+	return true
 }
 
 // existedAt reports whether a resource existed at an instant: created at or
@@ -265,19 +287,22 @@ type choice struct {
 }
 
 // fleetView is what the template renders above the resource table: the status
-// switch, the three inputs with the hidden fields their form carries, the
-// presets of the window and of the instant, and what the filters left of the
-// page.
+// switch, the switch between the two ways of reading the fleet, the inputs of
+// the way in effect with the hidden fields their form carries, that way's
+// presets, and what the filters left of the page.
 type fleetView struct {
-	Path          string
-	Hidden        []field
-	Switch        []choice
-	From          string
-	To            string
-	At            string
-	WindowPresets []choice
-	Presets       []choice
-	Count         string
+	Path   string
+	Hidden []field
+	Switch []choice
+	Modes  []choice
+	// Windowed says which inputs the form draws, the two bounds of a window
+	// or the one instant, so that a page never asks for both.
+	Windowed bool
+	From     string
+	To       string
+	At       string
+	Presets  []choice
+	Count    string
 	// Empty is what the table says when the filters left nothing of a page
 	// that held rows; a page the API served empty says what it always said.
 	Empty string
@@ -286,27 +311,51 @@ type fleetView struct {
 	Unknown string
 }
 
-// buildFleetView lays the controls out for one request. The status links drop
-// the cursor, because a cursor positions a walk through one status and means
-// nothing in another; the window and the instant keep it, because they filter
-// the page the cursor named. The instant input is left empty while nothing is
-// pinned, so that applying a window does not pin the instant to now on the
-// way.
+// buildFleetView lays the controls out for one request. Every link the page
+// draws is built over the parameters of the mode in effect alone, so that
+// following one never leaves a page asking two questions at once; the switch
+// to the other mode is what drops the one and names the other. The status
+// links drop the cursor, because a cursor positions a walk through one status
+// and means nothing in another, while the time links keep it, because they
+// filter the page the cursor named. The instant input is left empty while
+// nothing is pinned, so that the page opens on now without claiming an
+// instant was chosen.
 func buildFleetView(
 	r *http.Request, state fleetState, now time.Time, kept, total, unknown int, paged bool,
 ) fleetView {
 	values := r.URL.Query()
 	view := fleetView{
-		Path:    r.URL.Path,
-		From:    inputValue(state.From),
-		To:      inputValue(state.To),
-		Unknown: unknownText(unknown),
+		Path:     r.URL.Path,
+		Windowed: state.Window,
+		From:     inputValue(state.From),
+		To:       inputValue(state.To),
+		Unknown:  unknownText(unknown),
 	}
 	if state.Pinned {
 		view.At = state.At.UTC().Format(atLayout)
 	}
 
-	own := []string{fromParameter, toParameter, atParameter}
+	// The two modes as their own links, each dropping what the other one is
+	// asked with. The one in effect is what every other link on the page is
+	// built over.
+	asInstant := maps.Clone(values)
+	asInstant.Del(fromParameter)
+	asInstant.Del(toParameter)
+	asInstant.Del(modeParameter)
+	asWindow := maps.Clone(values)
+	asWindow.Del(atParameter)
+	asWindow.Set(modeParameter, modeWindow)
+	view.Modes = []choice{
+		{Label: "at an instant", Link: href(r.URL.Path, asInstant), Current: !state.Window},
+		{Label: "over a window", Link: href(r.URL.Path, asWindow), Current: state.Window},
+	}
+
+	base := asInstant
+	if state.Window {
+		base = asWindow
+	}
+
+	own := []string{modeParameter, fromParameter, toParameter, atParameter}
 	for _, key := range slices.Sorted(maps.Keys(values)) {
 		if slices.Contains(own, key) {
 			continue
@@ -319,7 +368,7 @@ func buildFleetView(
 	}
 
 	for _, status := range statuses {
-		linked := maps.Clone(values)
+		linked := maps.Clone(base)
 		linked.Del("cursor")
 		linked.Set(statusParameter, status)
 		if status == statuses[0] {
@@ -330,8 +379,11 @@ func buildFleetView(
 		})
 	}
 
-	view.WindowPresets = windowPresets(r.URL.Path, values, state, now)
-	view.Presets = instantPresets(r.URL.Path, values, state, now)
+	if state.Window {
+		view.Presets = windowPresets(r.URL.Path, base, state, now)
+	} else {
+		view.Presets = instantPresets(r.URL.Path, base, state, now)
+	}
 	view.Count = fleetCount(state, kept, total, paged)
 	if total > 0 && kept == 0 {
 		view.Empty = "no resource of this page " + existence(state, 1)
@@ -348,8 +400,9 @@ func inputValue(bound *time.Time) string {
 	return bound.UTC().Format(atLayout)
 }
 
-// windowPresets are the windows one click away, four spans behind now that a
-// demo month is read over, and all, which is no window at all.
+// windowPresets are the windows one click away: four spans behind now that a
+// demo month is read over, and any time, which is the window with neither
+// bound and holds every row the page carries.
 func windowPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
 	monthStart := firstOfThisMonthUTC(now)
 	spans := []struct {
@@ -362,27 +415,28 @@ func windowPresets(path string, values url.Values, state fleetState, now time.Ti
 		{"last month", monthStart.AddDate(0, -1, 0), monthStart},
 	}
 
-	var list []choice
+	list := make([]choice, 0, len(spans)+1)
 	for _, span := range spans {
 		linked := maps.Clone(values)
 		linked.Set(fromParameter, stamp(span.from))
 		linked.Set(toParameter, stamp(span.to))
-		list = append(list, choice{
-			Label:   span.label,
-			Link:    href(path, linked),
-			Current: state.From != nil && state.To != nil && state.From.Equal(span.from) && state.To.Equal(span.to),
-		})
+		current := state.From != nil && state.To != nil &&
+			state.From.Equal(span.from) && state.To.Equal(span.to)
+		list = append(list, choice{Label: span.label, Link: href(path, linked), Current: current})
 	}
 
 	linked := maps.Clone(values)
 	linked.Del(fromParameter)
 	linked.Del(toParameter)
-	return append(list, choice{Label: "all", Link: href(path, linked), Current: !state.windowed()})
+	return append(list, choice{
+		Label:   "any time",
+		Link:    href(path, linked),
+		Current: state.From == nil && state.To == nil,
+	})
 }
 
 // instantPresets are the instants one click away: now, which is no parameter
-// at all and is offered while there is no window, four points behind it, and
-// clear, which unpins the instant inside a window.
+// at all, and four points behind it that a demo month is read at.
 func instantPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
 	monthStart := firstOfThisMonthUTC(now)
 	points := []struct {
@@ -397,10 +451,7 @@ func instantPresets(path string, values url.Values, state fleetState, now time.T
 
 	unpinned := maps.Clone(values)
 	unpinned.Del(atParameter)
-	var list []choice
-	if !state.windowed() {
-		list = append(list, choice{Label: "now", Link: href(path, unpinned), Current: !state.Pinned})
-	}
+	list := []choice{{Label: "now", Link: href(path, unpinned), Current: !state.Pinned}}
 	for _, point := range points {
 		linked := maps.Clone(values)
 		linked.Set(atParameter, stamp(point.at))
@@ -409,9 +460,6 @@ func instantPresets(path string, values url.Values, state fleetState, now time.T
 			Link:    href(path, linked),
 			Current: state.Pinned && state.At.Equal(point.at),
 		})
-	}
-	if state.windowed() && state.Pinned {
-		list = append(list, choice{Label: "clear", Link: href(path, unpinned)})
 	}
 	return list
 }
@@ -431,17 +479,19 @@ func fleetCount(state fleetState, kept, total int, paged bool) string {
 // the number the subject has.
 func existence(state fleetState, subjects int) string {
 	switch {
-	case state.Pinned:
+	case !state.Window && state.Pinned:
 		return "existed at " + stamp(state.At)
+	case !state.Window && subjects == 1:
+		return "exists now"
+	case !state.Window:
+		return "exist now"
 	case state.From != nil && state.To != nil:
 		return "existed between " + stamp(*state.From) + " and " + stamp(*state.To)
 	case state.From != nil:
 		return "existed since " + stamp(*state.From)
 	case state.To != nil:
 		return "existed before " + stamp(*state.To)
-	case subjects == 1:
-		return "exists now"
 	default:
-		return "exist now"
+		return "existed at some time"
 	}
 }

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -161,16 +161,23 @@ func parseInstant(text string) (time.Time, error) {
 }
 
 // keep reports whether a row is shown: existing at the instant the page is
-// read at, or having lived inside the window it is read over. A window with
-// neither bound keeps every row.
+// read at, or having lived inside the window it is read over.
 func keep(resource httpapi.Resource, state fleetState) bool {
 	if !state.Window {
 		return existedAt(resource, state.At)
 	}
-	if state.From != nil && resource.DeletedAt != nil && !resource.DeletedAt.After(*state.From) {
+	return livedBetween(resource, state.From, state.To)
+}
+
+// livedBetween reports whether a resource lived inside a half-open window: it
+// was created before to and not deleted at or before from. A nil bound is a
+// window open on that side, and a window with neither bound holds every
+// resource, whenever it lived.
+func livedBetween(resource httpapi.Resource, from, to *time.Time) bool {
+	if from != nil && resource.DeletedAt != nil && !resource.DeletedAt.After(*from) {
 		return false
 	}
-	if state.To != nil && resource.CreatedAt != nil && !resource.CreatedAt.Before(*state.To) {
+	if to != nil && resource.CreatedAt != nil && !resource.CreatedAt.Before(*to) {
 		return false
 	}
 	return true

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -117,7 +117,7 @@ func readFleet(r *http.Request, now time.Time) (fleetState, error) {
 		if at := query.Get(atParameter); at != "" {
 			parsed, err := parseInstant(at)
 			if err != nil {
-				return fleetState{}, &paramError{name: atParameter, reason: "is not an instant: " + err.Error()}
+				return fleetState{}, unreadableInstant(atParameter, err)
 			}
 			state.At, state.Pinned = parsed, true
 		}
@@ -145,7 +145,7 @@ func optionalInstant(query url.Values, name string) (*time.Time, error) {
 	}
 	parsed, err := parseInstant(text)
 	if err != nil {
-		return nil, &paramError{name: name, reason: "is not an instant: " + err.Error()}
+		return nil, unreadableInstant(name, err)
 	}
 	return &parsed, nil
 }
@@ -355,17 +355,7 @@ func buildFleetView(
 		base = asWindow
 	}
 
-	own := []string{modeParameter, fromParameter, toParameter, atParameter}
-	for _, key := range slices.Sorted(maps.Keys(values)) {
-		if slices.Contains(own, key) {
-			continue
-		}
-		for _, value := range values[key] {
-			if value != "" {
-				view.Hidden = append(view.Hidden, field{Name: key, Value: value})
-			}
-		}
-	}
+	view.Hidden = hiddenFields(values, modeParameter, fromParameter, toParameter, atParameter)
 
 	for _, status := range statuses {
 		linked := maps.Clone(base)
@@ -391,6 +381,25 @@ func buildFleetView(
 	return view
 }
 
+// hiddenFields is every parameter of a page as a form carries it through,
+// except the ones the form asks for itself. A form that submits its page keeps
+// the page's identifiers, its cursor, and the order and filter of every table
+// on it that way.
+func hiddenFields(values url.Values, own ...string) []field {
+	var list []field
+	for _, key := range slices.Sorted(maps.Keys(values)) {
+		if slices.Contains(own, key) {
+			continue
+		}
+		for _, value := range values[key] {
+			if value != "" {
+				list = append(list, field{Name: key, Value: value})
+			}
+		}
+	}
+	return list
+}
+
 // inputValue is what a datetime-local input shows for a bound: the bound, or
 // nothing for a side the window is open on.
 func inputValue(bound *time.Time) string {
@@ -400,10 +409,10 @@ func inputValue(bound *time.Time) string {
 	return bound.UTC().Format(atLayout)
 }
 
-// windowPresets are the windows one click away: four spans behind now that a
-// demo month is read over, and any time, which is the window with neither
-// bound and holds every row the page carries.
-func windowPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
+// spanPresets are the four windows one click away, the spans behind now that a
+// demo month is read over. Both bounds travel in every link, so a preset says
+// the whole window rather than half of one.
+func spanPresets(path string, values url.Values, from, to *time.Time, now time.Time) []choice {
 	monthStart := firstOfThisMonthUTC(now)
 	spans := []struct {
 		label    string
@@ -415,20 +424,27 @@ func windowPresets(path string, values url.Values, state fleetState, now time.Ti
 		{"last month", monthStart.AddDate(0, -1, 0), monthStart},
 	}
 
-	list := make([]choice, 0, len(spans)+1)
+	list := make([]choice, 0, len(spans))
 	for _, span := range spans {
 		linked := maps.Clone(values)
 		linked.Set(fromParameter, stamp(span.from))
 		linked.Set(toParameter, stamp(span.to))
-		current := state.From != nil && state.To != nil &&
-			state.From.Equal(span.from) && state.To.Equal(span.to)
-		list = append(list, choice{Label: span.label, Link: href(path, linked), Current: current})
+		list = append(list, choice{
+			Label:   span.label,
+			Link:    href(path, linked),
+			Current: from != nil && to != nil && from.Equal(span.from) && to.Equal(span.to),
+		})
 	}
+	return list
+}
 
+// windowPresets are the spans the fleet is read over and any time, which is
+// the window with neither bound and holds every row the page carries.
+func windowPresets(path string, values url.Values, state fleetState, now time.Time) []choice {
 	linked := maps.Clone(values)
 	linked.Del(fromParameter)
 	linked.Del(toParameter)
-	return append(list, choice{
+	return append(spanPresets(path, values, state.From, state.To, now), choice{
 		Label:   "any time",
 		Link:    href(path, linked),
 		Current: state.From == nil && state.To == nil,

--- a/internal/console/httpui/fleet_test.go
+++ b/internal/console/httpui/fleet_test.go
@@ -41,10 +41,56 @@ func TestReadFleet(t *testing.T) {
 	t.Run("refuses what it cannot read", func(t *testing.T) {
 		t.Parallel()
 
-		for _, query := range []string{"status=zombie", "at=yesterday", "at=2026-13-01T00:00"} {
+		for _, query := range []string{"status=zombie", "at=yesterday", "at=2026-13-01T00:00", "mode=whenever"} {
 			if _, err := readFleet(httptest.NewRequest("GET", "/resources?"+query, nil), testNow); err == nil {
 				t.Errorf("readFleet(%s) accepted it", query)
 			}
+		}
+	})
+
+	t.Run("the mode says which way the fleet is read", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			query  string
+			window bool
+		}{
+			{"", false},
+			{"at=2026-03-03T00:00", false},
+			{"mode=window", true},
+			{"from=2026-03-01T00:00", true},
+			{"to=2026-03-08T00:00", true},
+			{"mode=instant&from=2026-03-01T00:00", false},
+		}
+		for _, tc := range cases {
+			state, err := readFleet(httptest.NewRequest("GET", "/resources?"+tc.query, nil), testNow)
+			if err != nil {
+				t.Fatalf("readFleet(%s) error = %v", tc.query, err)
+			}
+			if state.Window != tc.window {
+				t.Errorf("readFleet(%s) window = %v, want %v", tc.query, state.Window, tc.window)
+			}
+		}
+	})
+
+	t.Run("each way ignores what the other one is asked with", func(t *testing.T) {
+		t.Parallel()
+
+		state, err := readFleet(httptest.NewRequest(
+			"GET", "/resources?mode=window&at=yesterday&from=2026-03-01T00:00", nil), testNow)
+		if err != nil {
+			t.Fatalf("readFleet() error = %v", err)
+		}
+		if state.Pinned || state.From == nil {
+			t.Errorf("state = %+v, want the window alone", state)
+		}
+
+		if state, err = readFleet(httptest.NewRequest(
+			"GET", "/resources?mode=instant&from=nonsense&at=2026-03-03T00:00", nil), testNow); err != nil {
+			t.Fatalf("readFleet() error = %v", err)
+		}
+		if state.From != nil || !state.Pinned {
+			t.Errorf("state = %+v, want the instant alone", state)
 		}
 	})
 }
@@ -153,7 +199,7 @@ func TestKeep(t *testing.T) {
 	at := func(day int) time.Time { return time.Date(2026, 3, day, 0, 0, 0, 0, time.UTC) }
 	window := func(from, to int) fleetState {
 		f, t := at(from), at(to)
-		return fleetState{From: &f, To: &t}
+		return fleetState{Window: true, From: &f, To: &t}
 	}
 
 	cases := []struct {
@@ -170,13 +216,14 @@ func TestKeep(t *testing.T) {
 		{"a window keeps what outlives it", alive, window(5, 8), true},
 		{"a window drops what ended at its start", gone, window(10, 12), false},
 		{"a window drops what began at its end", gone, window(1, 3), false},
-		{"a window open at the end keeps what began after the start", gone, fleetState{From: pointerTo(at(5))}, true},
-		{"a window open at the start drops what began at the end", gone, fleetState{To: pointerTo(at(3))}, false},
-		{"an instant inside a window narrows to it", gone, fleetState{From: pointerTo(at(1)), To: pointerTo(at(12)), At: at(11), Pinned: true}, false},
-		{"an instant alone keeps what existed at it", gone, fleetState{At: at(5), Pinned: true}, true},
+		{"a window open at the end keeps what began after the start", gone, fleetState{Window: true, From: pointerTo(at(5))}, true},
+		{"a window open at the start drops what began at the end", gone, fleetState{Window: true, To: pointerTo(at(3))}, false},
+		{"a window without a bound keeps what is long gone", gone, fleetState{Window: true}, true},
+		{"an instant keeps what existed at it", gone, fleetState{At: at(5), Pinned: true}, true},
+		{"an instant drops what was gone by then", gone, fleetState{At: at(11), Pinned: true}, false},
 	}
 	for _, tc := range cases {
-		if got := keep(tc.resource, tc.state, testNow); got != tc.want {
+		if got := keep(tc.resource, tc.state); got != tc.want {
 			t.Errorf("%s: keep() = %v, want %v", tc.name, got, tc.want)
 		}
 	}

--- a/internal/console/httpui/funcs.go
+++ b/internal/console/httpui/funcs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/core/money"
@@ -26,21 +27,28 @@ const (
 // page decides on its own how many places an amount carries.
 func funcMap() template.FuncMap {
 	return template.FuncMap{
-		"amount":       amount,
-		"quantity":     quantity,
-		"rate":         rate,
-		"price":        price,
-		"stamp":        stamp,
-		"optStamp":     optStamp,
-		"unknownStamp": unknownStamp,
-		"zeroStamp":    zeroStamp,
-		"idText":       idText,
-		"optString":    optString,
-		"pretty":       pretty,
-		"stateClass":   stateClass,
-		"emptyText":    emptyText,
-		"zeroClass":    zeroClass,
+		"amount":        amount,
+		"quantity":      quantity,
+		"rate":          rate,
+		"price":         price,
+		"stamp":         stamp,
+		"optStamp":      optStamp,
+		"unknownStamp":  unknownStamp,
+		"zeroStamp":     zeroStamp,
+		"idText":        idText,
+		"optString":     optString,
+		"pretty":        pretty,
+		"stateClass":    stateClass,
+		"emptyText":     emptyText,
+		"statementLink": statementLink,
+		"zeroClass":     zeroClass,
 	}
+}
+
+// statementLink is the page of one stored statement, addressed the way the
+// engine stores it: the run that wrote it and the key it was written under.
+func statementLink(runID uuid.UUID, key string) string {
+	return link("/statement", "run", runID.String(), "key", key)
 }
 
 // zeroClass is the class a cell of exactly zero is muted with, appended to the

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -1054,6 +1054,73 @@ func TestProjectPage(t *testing.T) {
 		}
 	})
 
+	t.Run("a resource type folds open into its resources", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if api.resourcesQuery.Cloud != "os-sim" || api.resourcesQuery.ProjectID != "p-1" ||
+			api.resourcesQuery.Status != "all" {
+			t.Errorf("the resources were read with %+v, want every status of this project", api.resourcesQuery)
+		}
+		for _, want := range []string{
+			`<details class="cell"><summary>instance</summary>`,
+			`<a href="/resource?cloud=os-sim&amp;id=vm-1&amp;type=instance">vm-1</a>`,
+			`<td class="number">348.00</td>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a page of resources says the folds are not the whole list", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.NextCursor = pointerTo("abc")
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if !strings.Contains(body, "a type may have run resources this list does not name") {
+			t.Errorf("a partial list is not said to be one:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, "/resources")
+		if strings.Contains(body, "a type may have run resources this list does not name") {
+			t.Error("the note is on a page that folds nothing")
+		}
+	})
+
+	t.Run("a type folds only what lived in the window", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		// vm-1 was created in March, so a February window holds none of it and
+		// the row the summary still counts is drawn without a fold.
+		_, body, _ := get(t, handler,
+			"/project?id="+testProjectID.String()+"&from=2026-02-01T00:00&to=2026-02-15T00:00")
+		activity := section(t, body, "What this project ran", "Statements")
+		if strings.Contains(activity, ">vm-1</a>") || !strings.Contains(activity, "<td>instance</td>") {
+			t.Errorf("a window before the resource existed folds it open:\n%s", activity)
+		}
+	})
+
+	t.Run("the activity filter finds the type a resource sits in", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String()+"&activity.q=vm-1")
+		activity := section(t, body, "What this project ran", "Statements")
+		if !strings.Contains(activity, ">instance</summary>") || !strings.Contains(activity, "1 of 1 row match") {
+			t.Errorf("the filter does not match a row on the resources under it:\n%s", activity)
+		}
+	})
+
 	t.Run("half a window and a window that ends before it starts are refused", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -476,8 +476,12 @@ var (
 	// the relations table links to.
 	testSourceID = uuid.MustParse("55555555-5555-4555-8555-555555555555")
 	testTargetID = uuid.MustParse("66666666-6666-4666-8666-666666666666")
-	testKey      = statements.Key("os-sim", "p-1")
-	testPeriod   = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	// The two other runs of the period testRunID closed: the regular run it
+	// replaced, and the correction booked against it.
+	testSupersededRunID = uuid.MustParse("77777777-7777-4777-8777-777777777777")
+	testCorrectionRunID = uuid.MustParse("88888888-8888-4888-8888-888888888888")
+	testKey             = statements.Key("os-sim", "p-1")
+	testPeriod          = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 )
 
 // fullAPI answers every Reporting API call of every page.
@@ -605,10 +609,22 @@ func fullStore(t *testing.T) *fakeStore {
 			Total:    mustDecimal(t, "128.45"),
 			Currency: "EUR",
 		},
-		projectStatements: []store.ProjectStatementRow{{
-			RunID: testRunID, PeriodFrom: testPeriod, Kind: "regular", Status: "completed",
-			Total: mustDecimal(t, "128.45"), Currency: "EUR",
-		}},
+		// One month as a period accumulates it: the run that was replaced, the
+		// run that closed it, and the correction booked against that one.
+		projectStatements: []store.ProjectStatementRow{
+			{
+				RunID: testSupersededRunID, PeriodFrom: testPeriod, Kind: "regular", Status: "superseded",
+				Total: mustDecimal(t, "150.00"), Currency: "EUR",
+			},
+			{
+				RunID: testRunID, PeriodFrom: testPeriod, Kind: "regular", Status: "finalized",
+				Total: mustDecimal(t, "128.45"), Currency: "EUR",
+			},
+			{
+				RunID: testCorrectionRunID, PeriodFrom: testPeriod, Kind: "correction", Status: "finalized",
+				Total: mustDecimal(t, "-2.55"), Currency: "EUR",
+			},
+		},
 		pricingModels: []store.PricingModel{{
 			Version: "2026-03", ValidFrom: testPeriod, Currency: "EUR", ImportedAt: testPeriod,
 		}},
@@ -987,6 +1003,63 @@ func TestProjectPage(t *testing.T) {
 		}
 	})
 
+	t.Run("a period adds up the statements that stand", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		statements := section(t, body, "Statements", "")
+		for _, want := range []string{
+			// 128.45 of the run that closed the month less the 2.55 the
+			// correction credits; the 150.00 that was replaced counts for
+			// nothing.
+			`<td class="number">125.90 EUR</td>`,
+			`<td class="number">3</td>`,
+			"<td>finalized</td>",
+			`<details class="cell"><summary>2026-03-01T00:00:00Z</summary>`,
+			`<tr class="muted">`,
+			"<td>superseded, replaced</td>",
+			`<a href="/statement?key=os-sim%2Fp-1&amp;run=` + testCorrectionRunID.String() + `">open</a>`,
+		} {
+			if !strings.Contains(statements, want) {
+				t.Errorf("the statements lack %q:\n%s", want, statements)
+			}
+		}
+		if strings.Contains(statements, "150.00 EUR</td>\n<td>") {
+			t.Error("the replaced run is counted")
+		}
+	})
+
+	t.Run("a period whose runs were all replaced is charged nothing", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		for i := range engine.projectStatements {
+			engine.projectStatements[i].Status = "superseded"
+		}
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		statements := section(t, body, "Statements", "")
+		if !strings.Contains(statements, "<td>none</td>") || !strings.Contains(statements, ">none</td>") {
+			t.Errorf("a period standing at nothing says otherwise:\n%s", statements)
+		}
+	})
+
+	t.Run("the statements filter finds a period by what it holds", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String()+"&statements.q=correction")
+		statements := section(t, body, "Statements", "")
+		if !strings.Contains(statements, "1 of 1 row match") ||
+			!strings.Contains(statements, "2026-03-01T00:00:00Z") {
+			t.Errorf("the filter does not match a period on the statements under it:\n%s", statements)
+		}
+	})
+
 	t.Run("the activity opens on this month", func(t *testing.T) {
 		t.Parallel()
 
@@ -1145,13 +1218,17 @@ func TestProjectPage(t *testing.T) {
 }
 
 // section is what one page prints between two of its headings, so an assertion
-// about one table reads that table alone and not a link another table drew.
+// about one table reads that table alone and not a link another table drew. An
+// empty to reads to the end of the page, which is where the last section ends.
 func section(t *testing.T, body, from, to string) string {
 	t.Helper()
 
 	_, after, found := strings.Cut(body, "<h2>"+from+"</h2>")
 	if !found {
 		t.Fatalf("the page has no %q heading:\n%s", from, body)
+	}
+	if to == "" {
+		return after
 	}
 	before, _, found := strings.Cut(after, "<h2>"+to+"</h2>")
 	if !found {

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -1908,8 +1908,8 @@ func TestFleet(t *testing.T) {
 		}
 		for _, want := range []string{
 			`aria-current="true">active</a>`,
+			`aria-current="true">at an instant</a>`,
 			`aria-current="true">now</a>`,
-			`aria-current="true">all</a>`,
 			`name="at" value=""`,
 			"1 of 1 row exists now",
 			`<th class="number"><a href="/resources?resources.sort=-lifetime_hours">lifetime hours</a></th>`,
@@ -1922,6 +1922,9 @@ func TestFleet(t *testing.T) {
 		}
 		if strings.Contains(body, "on this page") {
 			t.Error("a fleet that fits one page is called a page")
+		}
+		if form := fleetForm(t, body); strings.Contains(form, `name="from"`) || strings.Contains(form, `name="to"`) {
+			t.Errorf("the instant asks for a window as well:\n%s", form)
 		}
 	})
 
@@ -2085,13 +2088,13 @@ func TestFleet(t *testing.T) {
 	})
 }
 
-// fleetForm cuts the fleet form out of a page, so a test can tell its hidden
-// fields from the table filter's, which carries the window and the instant on
-// purpose.
+// fleetForm cuts the fleet form out of a page, so a test can tell its inputs
+// and hidden fields from the table filter's, which carries the window and the
+// instant on purpose.
 func fleetForm(t *testing.T, body string) string {
 	t.Helper()
 
-	start := strings.Index(body, `<form class="tools fleet"`)
+	start := strings.Index(body, `<form class="fleet-row"`)
 	if start < 0 {
 		t.Fatalf("the page carries no fleet form:\n%s", body)
 	}
@@ -2132,13 +2135,16 @@ func TestFleetWindow(t *testing.T) {
 			"2 of 2 rows existed between 2026-03-02T00:00:00Z and 2026-03-08T00:00:00Z",
 			`name="from" value="2026-03-02T00:00"`,
 			`name="to" value="2026-03-08T00:00"`,
-			`name="at" value=""`,
+			`aria-current="true">over a window</a>`,
 			// vm-2 lived a week whatever the window is.
 			`<td class="number">168.00</td>`,
 		} {
 			if !strings.Contains(body, want) {
 				t.Errorf("the page lacks %q:\n%s", want, body)
 			}
+		}
+		if form := fleetForm(t, body); strings.Contains(form, `name="at"`) {
+			t.Errorf("the window asks for an instant as well:\n%s", form)
 		}
 		if strings.Contains(body, `>now</a>`) {
 			t.Error("a window offers the instant now")
@@ -2162,25 +2168,51 @@ func TestFleetWindow(t *testing.T) {
 		}
 	})
 
-	t.Run("an instant inside a window narrows to it", func(t *testing.T) {
+	t.Run("a window without a bound holds whatever lived", func(t *testing.T) {
 		t.Parallel()
 
 		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
 
-		_, body, _ := get(t, handler, "/resources?status=all&from=2026-03-02T00:00:00Z&to=2026-03-08T00:00:00Z&at=2026-03-05T00:00:00Z")
+		_, body, _ := get(t, handler, "/resources?status=all&mode=window")
 		for _, want := range []string{
 			">vm-1</a>", ">vm-2</a>",
-			"2 of 2 rows existed at 2026-03-05T00:00:00Z",
-			`>clear</a>`,
+			"2 of 2 rows existed at some time",
+			`aria-current="true">any time</a>`,
 		} {
 			if !strings.Contains(body, want) {
 				t.Errorf("the page lacks %q:\n%s", want, body)
 			}
 		}
+	})
 
-		_, body, _ = get(t, handler, "/resources?status=all&from=2026-03-02T00:00:00Z&to=2026-03-08T00:00:00Z&at=2026-03-11T00:00:00Z")
-		if strings.Contains(body, ">vm-2</a>") || !strings.Contains(body, "1 of 2 rows existed at 2026-03-11T00:00:00Z") {
-			t.Errorf("an instant after vm-2 ended keeps it:\n%s", body)
+	t.Run("a window ignores an instant and the switch drops it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		// The instant would have dropped vm-2, which ended before it; the
+		// window the request also names is what the page answers.
+		_, body, _ := get(t, handler,
+			"/resources?status=all&mode=window&from=2026-03-02T00:00:00Z&to=2026-03-08T00:00:00Z&at=2026-03-11T00:00:00Z")
+		if !strings.Contains(body, ">vm-2</a>") ||
+			!strings.Contains(body, "2 of 2 rows existed between 2026-03-02T00:00:00Z and 2026-03-08T00:00:00Z") {
+			t.Errorf("the window did not answer alone:\n%s", body)
+		}
+		// The switch drops the window and keeps the instant of the request,
+		// which is what the other way is read at.
+		if !strings.Contains(body, `<a href="/resources?at=2026-03-11T00%3A00%3A00Z&amp;status=all">at an instant</a>`) {
+			t.Errorf("the switch to the instant keeps the window:\n%s", body)
+		}
+	})
+
+	t.Run("the switch to the window drops the instant", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, twoResources(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?status=all&at=2026-03-05T00:00:00Z")
+		if !strings.Contains(body, `<a href="/resources?mode=window&amp;status=all">over a window</a>`) {
+			t.Errorf("the switch to the window keeps the instant:\n%s", body)
 		}
 	})
 
@@ -2225,12 +2257,12 @@ func TestFleetWindow(t *testing.T) {
 
 		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
 
-		_, body, _ := get(t, handler, "/resources?status=all&resources.q=vm")
+		_, body, _ := get(t, handler, "/resources?mode=window&status=all&resources.q=vm")
 		for _, want := range []string{
-			`<a href="/resources?from=2026-03-01T00%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-04-01T00%3A00%3A00Z">this month</a>`,
-			`<a href="/resources?from=2026-02-01T00%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-03-01T00%3A00%3A00Z">last month</a>`,
-			`<a href="/resources?from=2026-03-08T12%3A00%3A00Z&amp;resources.q=vm&amp;status=all&amp;to=2026-03-15T12%3A00%3A00Z">last 7 days</a>`,
-			`<a href="/resources?resources.q=vm&amp;status=all" aria-current="true">all</a>`,
+			`<a href="/resources?from=2026-03-01T00%3A00%3A00Z&amp;mode=window&amp;resources.q=vm&amp;status=all&amp;to=2026-04-01T00%3A00%3A00Z">this month</a>`,
+			`<a href="/resources?from=2026-02-01T00%3A00%3A00Z&amp;mode=window&amp;resources.q=vm&amp;status=all&amp;to=2026-03-01T00%3A00%3A00Z">last month</a>`,
+			`<a href="/resources?from=2026-03-08T12%3A00%3A00Z&amp;mode=window&amp;resources.q=vm&amp;status=all&amp;to=2026-03-15T12%3A00%3A00Z">last 7 days</a>`,
+			`<a href="/resources?mode=window&amp;resources.q=vm&amp;status=all" aria-current="true">any time</a>`,
 		} {
 			if !strings.Contains(body, want) {
 				t.Errorf("the page lacks %q:\n%s", want, body)
@@ -2241,8 +2273,8 @@ func TestFleetWindow(t *testing.T) {
 		if !strings.Contains(body, `aria-current="true">this month</a>`) {
 			t.Error("the window in effect is not marked")
 		}
-		if !strings.Contains(body, `<a href="/resources">all</a>`) {
-			t.Error("all does not clear the window")
+		if !strings.Contains(body, `<a href="/resources?mode=window">any time</a>`) {
+			t.Error("any time does not clear the window")
 		}
 		form := fleetForm(t, body)
 		if strings.Contains(form, `type="hidden" name="from"`) || strings.Contains(form, `type="hidden" name="to"`) {

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -471,8 +471,13 @@ func pointerTo[T any](value T) *T {
 var (
 	testProjectID = uuid.MustParse("11111111-1111-4111-8111-111111111111")
 	testRunID     = uuid.MustParse("22222222-2222-4222-8222-222222222222")
-	testKey       = statements.Key("os-sim", "p-1")
-	testPeriod    = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	// testSourceID is the project a relation reaching testProjectID leaves and
+	// testTargetID the one a relation leaving it reaches, which are the two ends
+	// the relations table links to.
+	testSourceID = uuid.MustParse("55555555-5555-4555-8555-555555555555")
+	testTargetID = uuid.MustParse("66666666-6666-4666-8666-666666666666")
+	testKey      = statements.Key("os-sim", "p-1")
+	testPeriod   = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 )
 
 // fullAPI answers every Reporting API call of every page.
@@ -514,6 +519,14 @@ func fullAPI(t *testing.T) *fakeAPI {
 			Id:           uuid.MustParse("33333333-3333-4333-8333-333333333333"),
 			RelationType: "infrastructure_tenant",
 			SourceId:     testProjectID,
+			TargetId:     testTargetID,
+			ValidFrom:    created,
+			Metadata:     map[string]interface{}{},
+			CreatedAt:    created,
+		}, {
+			Id:           uuid.MustParse("55555555-5555-4555-8555-555555555555"),
+			RelationType: "infrastructure_tenant",
+			SourceId:     testSourceID,
 			TargetId:     testProjectID,
 			ValidFrom:    created,
 			Metadata:     map[string]interface{}{},
@@ -963,7 +976,32 @@ func TestProjectPage(t *testing.T) {
 		if !strings.Contains(body, "run="+testRunID.String()) {
 			t.Error("the statement row does not link to its run")
 		}
+		relations := section(t, body, "Relations", "Related projects")
+		for _, end := range []uuid.UUID{testSourceID, testTargetID} {
+			if !strings.Contains(relations, `<a href="/project?id=`+end.String()+`">`+end.String()+"</a>") {
+				t.Errorf("the relations do not link the project %s:\n%s", end, relations)
+			}
+		}
+		if strings.Contains(relations, `<a href="/project?id=`+testProjectID.String()+`">`) {
+			t.Errorf("a relation links this project back to the page it is printed on:\n%s", relations)
+		}
 	})
+}
+
+// section is what one page prints between two of its headings, so an assertion
+// about one table reads that table alone and not a link another table drew.
+func section(t *testing.T, body, from, to string) string {
+	t.Helper()
+
+	_, after, found := strings.Cut(body, "<h2>"+from+"</h2>")
+	if !found {
+		t.Fatalf("the page has no %q heading:\n%s", from, body)
+	}
+	before, _, found := strings.Cut(after, "<h2>"+to+"</h2>")
+	if !found {
+		t.Fatalf("the page has no %q heading:\n%s", to, body)
+	}
+	return before
 }
 
 func TestPricingPage(t *testing.T) {

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -206,6 +206,10 @@ type fakeStore struct {
 	projectStatementsErr error
 	projectStatementsKey string
 
+	kickbacks            []store.Kickback
+	kickbacksErr         error
+	kickbacksBeneficiary string
+
 	pricingModels    []store.PricingModel
 	pricingModelsErr error
 
@@ -251,6 +255,11 @@ func (f *fakeStore) GetStatement(_ context.Context, runID uuid.UUID, key string)
 func (f *fakeStore) ListStatementsForProject(_ context.Context, key string) ([]store.ProjectStatementRow, error) {
 	f.projectStatementsKey = key
 	return f.projectStatements, f.projectStatementsErr
+}
+
+func (f *fakeStore) ListKickbacksForBeneficiary(_ context.Context, beneficiary string) ([]store.Kickback, error) {
+	f.kickbacksBeneficiary = beneficiary
+	return f.kickbacks, f.kickbacksErr
 }
 
 func (f *fakeStore) ListPricingModels(context.Context) ([]store.PricingModel, error) {
@@ -529,12 +538,18 @@ func fullAPI(t *testing.T) *fakeAPI {
 			CreatedAt:    created,
 		}, {
 			Id:           uuid.MustParse("55555555-5555-4555-8555-555555555555"),
-			RelationType: "infrastructure_tenant",
+			RelationType: "managed_by",
 			SourceId:     testSourceID,
 			TargetId:     testProjectID,
 			ValidFrom:    created,
-			Metadata:     map[string]interface{}{},
-			CreatedAt:    created,
+			Metadata: map[string]interface{}{"pricing_adjustments": []interface{}{
+				map[string]interface{}{
+					"type": "discount", "rate": "0.150000", "scope": "all",
+					"description": "reseller end-customer discount",
+				},
+				map[string]interface{}{"type": "kickback", "rate": "0.100000", "scope": "openstack.instance"},
+			}},
+			CreatedAt: created,
 		}}},
 		related: httpapi.RelatedProjectList{Items: []httpapi.RelatedProject{{
 			Project:      project,
@@ -1003,6 +1018,56 @@ func TestProjectPage(t *testing.T) {
 		}
 	})
 
+	t.Run("a relation folds open into the adjustments it carries", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		relations := section(t, body, "Relations", "Related projects")
+		for _, want := range []string{
+			`<details class="cell"><summary>managed_by</summary>`,
+			"<td>discount</td>",
+			"<td>reseller end-customer discount</td>",
+			`<td class="number">0.150000</td>`,
+			"<td>openstack.instance</td>",
+			// The relation that carries none is drawn without a fold.
+			"<td>infrastructure_tenant</td>",
+		} {
+			if !strings.Contains(relations, want) {
+				t.Errorf("the relations lack %q:\n%s", want, relations)
+			}
+		}
+	})
+
+	t.Run("the relations filter finds a relation by its adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String()+"&relations.q=kickback")
+		relations := section(t, body, "Relations", "Related projects")
+		if !strings.Contains(relations, "1 of 2 rows match") || !strings.Contains(relations, ">managed_by</summary>") {
+			t.Errorf("the filter does not match a relation on what it grants:\n%s", relations)
+		}
+	})
+
+	t.Run("an adjustments document the console cannot read is reported in the row", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.relations.Items[1].Metadata = map[string]interface{}{"pricing_adjustments": "not an array"}
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want the page anyway", status)
+		}
+		if !strings.Contains(body, "adjustments unreadable") {
+			t.Errorf("the row does not say the document could not be read:\n%s", body)
+		}
+	})
+
 	t.Run("a period adds up the statements that stand", func(t *testing.T) {
 		t.Parallel()
 
@@ -1057,6 +1122,65 @@ func TestProjectPage(t *testing.T) {
 		if !strings.Contains(statements, "1 of 1 row match") ||
 			!strings.Contains(statements, "2026-03-01T00:00:00Z") {
 			t.Errorf("the filter does not match a period on the statements under it:\n%s", statements)
+		}
+	})
+
+	t.Run("a partner is shown what every period settles for it", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.project.Platform = "partner"
+		api.project.Cloud = "partner"
+		api.project.ExternalId = "cloudhouse"
+		engine := fullStore(t)
+		engine.kickbacks = []store.Kickback{
+			{
+				RunID: testRunID, PeriodFrom: testPeriod, Kind: "regular", Status: "finalized",
+				StatementKey: testKey, Cloud: "os-sim", ProjectID: "p-1", Scope: "all",
+				Rate: mustDecimal(t, "0.10"), Base: mustDecimal(t, "593.55"),
+				Amount: mustDecimal(t, "59.36"), Currency: "EUR",
+			},
+			{
+				RunID: testCorrectionRunID, PeriodFrom: testPeriod, Kind: "correction", Status: "finalized",
+				StatementKey: testKey, Cloud: "os-sim", ProjectID: "p-1", Scope: "all",
+				Rate: mustDecimal(t, "0.10"), Base: mustDecimal(t, "-2.55"),
+				Amount: mustDecimal(t, "-0.26"), Currency: "EUR",
+			},
+		}
+		handler, _ := serve(t, api, engine, testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if engine.kickbacksBeneficiary != "cloudhouse" {
+			t.Errorf("the settlement was read for %q, want the partner", engine.kickbacksBeneficiary)
+		}
+		kickbacks := section(t, body, "Kickbacks", "Statements")
+		for _, want := range []string{
+			// 59.36 the run owes less the 0.26 the correction takes back.
+			`<td class="number">59.10 EUR</td>`,
+			`<td class="number">2</td>`,
+			"<td>finalized</td>",
+			`<details class="cell"><summary>2026-03-01T00:00:00Z</summary>`,
+			"<td>correction</td>",
+			`<a href="/statement?key=os-sim%2Fp-1&amp;run=` + testRunID.String() + `">open</a>`,
+		} {
+			if !strings.Contains(kickbacks, want) {
+				t.Errorf("the settlement lacks %q:\n%s", want, kickbacks)
+			}
+		}
+	})
+
+	t.Run("a project that is no partner reads no settlement", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if engine.kickbacksBeneficiary != "" {
+			t.Errorf("a project of platform openstack was read as a beneficiary: %q", engine.kickbacksBeneficiary)
+		}
+		if strings.Contains(body, "<h2>Kickbacks</h2>") {
+			t.Error("a project that settles nothing carries a settlement table")
 		}
 	})
 

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -986,6 +986,95 @@ func TestProjectPage(t *testing.T) {
 			t.Errorf("a relation links this project back to the page it is printed on:\n%s", relations)
 		}
 	})
+
+	t.Run("the activity opens on this month", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		if !api.summaryFrom.Equal(testPeriod) || !api.summaryTo.Equal(testPeriod.AddDate(0, 1, 0)) {
+			t.Errorf("the summary was read over %s to %s, want this month", api.summaryFrom, api.summaryTo)
+		}
+		for _, want := range []string{
+			`name="from" value="2026-03-01T00:00"`,
+			`name="to" value="2026-04-01T00:00"`,
+			`aria-current="true">this month</a>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a window is read over what it names", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler,
+			"/project?id="+testProjectID.String()+"&from=2026-02-01T00:00&to=2026-02-15T00:00:00Z")
+		if !api.summaryFrom.Equal(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)) ||
+			!api.summaryTo.Equal(time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("the summary was read over %s to %s, want the window of the request",
+				api.summaryFrom, api.summaryTo)
+		}
+		for _, want := range []string{
+			`name="from" value="2026-02-01T00:00"`,
+			`name="to" value="2026-02-15T00:00"`,
+			"2026-02-01T00:00:00Z to 2026-02-15T00:00:00Z",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, `aria-current="true">this month</a>`) {
+			t.Error("a window of its own is marked as this month")
+		}
+	})
+
+	t.Run("the window presets carry the project and mark the one in effect", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		id := testProjectID.String()
+		_, body, _ := get(t, handler, "/project?id="+id+"&activity.sort=minutes")
+		for _, want := range []string{
+			`<a href="/project?activity.sort=minutes&amp;from=2026-02-01T00%3A00%3A00Z&amp;id=` + id +
+				`&amp;to=2026-03-01T00%3A00%3A00Z">last month</a>`,
+			`<input type="hidden" name="id" value="` + id + `">`,
+			`<input type="hidden" name="activity.sort" value="minutes">`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page lacks %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("half a window and a window that ends before it starts are refused", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		cases := []struct {
+			query  string
+			reason string
+		}{
+			{"&from=2026-03-01T00:00", "the parameter to is missing"},
+			{"&to=2026-03-01T00:00", "the parameter from is missing"},
+			{"&from=2026-03-08T00:00&to=2026-03-02T00:00", "the parameter to is not after from"},
+			{"&from=whenever&to=2026-03-02T00:00", "the parameter from is not an instant"},
+		}
+		for _, tc := range cases {
+			status, body, _ := get(t, handler, "/project?id="+testProjectID.String()+tc.query)
+			if status != http.StatusBadRequest || !strings.Contains(body, tc.reason) {
+				t.Errorf("%s: status = %d, body:\n%s", tc.query, status, body)
+			}
+		}
+	})
 }
 
 // section is what one page prints between two of its headings, so an assertion

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -40,7 +40,7 @@ type projectRow struct {
 // ran this month, and what every run billed it.
 type projectData struct {
 	Project    httpapi.Project
-	Relations  listing[httpapi.Relation]
+	Relations  listing[relationRow]
 	Related    listing[relatedRow]
 	Activity   listing[httpapi.ProjectActivity]
 	From       time.Time
@@ -51,12 +51,12 @@ type projectData struct {
 
 // The columns of a project page's tables.
 var (
-	relationColumns = []column[httpapi.Relation]{
-		textCol("relation type", func(r httpapi.Relation) string { return r.RelationType }),
-		textCol("source", func(r httpapi.Relation) string { return r.SourceId.String() }),
-		textCol("target", func(r httpapi.Relation) string { return r.TargetId.String() }),
-		textCol("valid from", func(r httpapi.Relation) string { return stamp(r.ValidFrom) }),
-		textCol("valid to", func(r httpapi.Relation) string { return optStamp(r.ValidTo) }),
+	relationColumns = []column[relationRow]{
+		textCol("relation type", func(r relationRow) string { return r.Relation.RelationType }),
+		textCol("source", func(r relationRow) string { return r.Relation.SourceId.String() }),
+		textCol("target", func(r relationRow) string { return r.Relation.TargetId.String() }),
+		textCol("valid from", func(r relationRow) string { return stamp(r.Relation.ValidFrom) }),
+		textCol("valid to", func(r relationRow) string { return optStamp(r.Relation.ValidTo) }),
 	}
 	relatedColumns = []column[relatedRow]{
 		textCol("project", func(r relatedRow) string {
@@ -80,6 +80,17 @@ var (
 		numberCol("total", func(r projectStatementRow) decimal.Decimal { return r.Row.Total }),
 	}
 )
+
+// relationRow is one relation of a project and the pages of the projects at
+// its ends. The listing holds the relations of both directions, so either end
+// can be another project, and that end is what the link leads to. The end that
+// is the project of the page gets no link: it would lead back to the page it is
+// printed on.
+type relationRow struct {
+	Relation   httpapi.Relation
+	SourceLink string
+	TargetLink string
+}
 
 // relatedRow is one project a traversal reached and its own page.
 type relatedRow struct {
@@ -181,6 +192,15 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	listed := make([]relationRow, 0, len(relations.Items))
+	for _, relation := range relations.Items {
+		listed = append(listed, relationRow{
+			Relation:   relation,
+			SourceLink: otherProjectLink(relation.SourceId, id),
+			TargetLink: otherProjectLink(relation.TargetId, id),
+		})
+	}
+
 	reached := make([]relatedRow, 0, len(related.Items))
 	for _, project := range related.Items {
 		reached = append(reached, relatedRow{
@@ -199,7 +219,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	data := projectData{
 		Project:    project,
-		Relations:  tabulate(r, "relations", relationColumns, relations.Items),
+		Relations:  tabulate(r, "relations", relationColumns, listed),
 		Related:    tabulate(r, "related", relatedColumns, reached),
 		Activity:   tabulate(r, "activity", activityColumns, summary.ResourceTypes),
 		From:       from,
@@ -244,6 +264,15 @@ func (h *handlers) projectID(ctx context.Context, r *http.Request, src *sources)
 	}
 	return uuid.Nil, nothingRegistered(
 		fmt.Errorf("no project is registered under the cloud %s and the external id %s", cloud, externalID))
+}
+
+// otherProjectLink is the page of one end of a relation, and nothing for the
+// end that is the project the page is about.
+func otherProjectLink(end, self uuid.UUID) string {
+	if end == self {
+		return ""
+	}
+	return link("/project", "id", end.String())
 }
 
 // projectLink is the page of the project a resource names, addressed by the

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -3,6 +3,7 @@ package httpui
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/b42labs/tally/internal/console/reporting"
 	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/core/adjustment"
+	projectcore "github.com/b42labs/tally/internal/core/project"
 	"github.com/b42labs/tally/internal/engine/statements"
 	"github.com/b42labs/tally/internal/reporting/httpapi"
 )
@@ -49,7 +52,10 @@ type projectData struct {
 	Activity  listing[activityRow]
 	// Partial is set when the API served one page of the project's resources
 	// and held more, so the folds say they are not the whole list.
-	Partial    bool
+	Partial bool
+	// Kickbacks is what a partner is owed, per period, and is empty for every
+	// project that is not one.
+	Kickbacks  listing[settlementRow]
 	Window     windowView
 	From       time.Time
 	To         time.Time
@@ -91,8 +97,11 @@ type windowView struct {
 
 // The columns of a project page's tables.
 var (
+	// The type column is searched as the type and the adjustments the relation
+	// carries, so a filter on kickback finds the relation that grants one. The
+	// type leads the text, so the column still sorts by type.
 	relationColumns = []column[relationRow]{
-		textCol("relation type", func(r relationRow) string { return r.Relation.RelationType }),
+		textCol("relation type", func(r relationRow) string { return r.Searched }),
 		textCol("source", func(r relationRow) string { return r.Relation.SourceId.String() }),
 		textCol("target", func(r relationRow) string { return r.Relation.TargetId.String() }),
 		textCol("valid from", func(r relationRow) string { return stamp(r.Relation.ValidFrom) }),
@@ -136,12 +145,39 @@ type relationRow struct {
 	Relation   httpapi.Relation
 	SourceLink string
 	TargetLink string
+	// Adjustments is the commercial pricing the relation carries, which the
+	// row folds open: a discount the target grants, the kickback it is owed,
+	// a surcharge, a group discount. Unreadable holds what the metadata could
+	// not be read as, and is empty for the metadata this API answers with.
+	Adjustments []adjustment.Adjustment
+	Unreadable  string
+	Searched    string
 }
 
 // relatedRow is one project a traversal reached and its own page.
 type relatedRow struct {
 	Related httpapi.RelatedProject
 	Link    string
+}
+
+// settlementRow is one billing period of a partner: what every run of it
+// settles for the partner, which the row folds open, and what the partner is
+// owed for the period once the runs are added up.
+type settlementRow struct {
+	From     time.Time
+	Records  []store.Kickback
+	Totals   []currencyTotal
+	Sort     decimal.Decimal
+	Status   string
+	Searched string
+}
+
+// settlementColumns is a partner's settlement, one row per period.
+var settlementColumns = []column[settlementRow]{
+	textCol("period", func(r settlementRow) string { return r.Searched }),
+	textCol("status", func(r settlementRow) string { return r.Status }),
+	countCol("records", func(r settlementRow) int64 { return int64(len(r.Records)) }),
+	numberCol("kickback", func(r settlementRow) decimal.Decimal { return r.Sort }),
 }
 
 // periodRow is one billing period of a project: every statement a run wrote
@@ -301,11 +337,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	listed := make([]relationRow, 0, len(relations.Items))
 	for _, relation := range relations.Items {
-		listed = append(listed, relationRow{
-			Relation:   relation,
-			SourceLink: otherProjectLink(relation.SourceId, id),
-			TargetLink: otherProjectLink(relation.TargetId, id),
-		})
+		listed = append(listed, relationOf(relation, id))
 	}
 
 	reached := make([]relatedRow, 0, len(related.Items))
@@ -320,6 +352,19 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	periods := periodRows(billed, key)
 
+	// What a partner is owed. Only a partner is ever a beneficiary, and the
+	// column holds the external id alone, so the read is made for a partner
+	// and for no other project: another platform's project of the same
+	// external id would otherwise answer with a settlement that is not its.
+	var settled []store.Kickback
+	if project.Platform == projectcore.PlatformPartner {
+		if settled, err = h.store.ListKickbacksForBeneficiary(ctx, project.ExternalId); err != nil {
+			h.failFrom(w, r, storeFailed(err), src)
+			return
+		}
+		src.query("ListKickbacksForBeneficiary")
+	}
+
 	data := projectData{
 		Project:    project,
 		Relations:  tabulate(r, "relations", relationColumns, listed),
@@ -331,6 +376,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		To:         to,
 		Key:        key,
 		Statements: tabulate(r, "statements", projectPeriodColumns, periods),
+		Kickbacks:  tabulate(r, "kickbacks", settlementColumns, settlementRows(settled)),
 	}
 	h.render(w, r, "project", page{
 		Title:   "Project " + optString(project.Name, project.ExternalId),
@@ -384,6 +430,49 @@ func activityRows(
 			Resources: under,
 			Searched:  strings.Join(searched, " "),
 		})
+	}
+	return rows
+}
+
+// settlementRows groups what the runs settle for one partner into the periods
+// they settle, oldest first, and adds each period up. Every row a run of a
+// period holds counts: a regular run's rows are what it owes, and a
+// correction's are the difference to the run it corrects, so the two add up to
+// what the partner is owed for the period the way the statements of a period
+// add up to what a project is charged.
+func settlementRows(settled []store.Kickback) []settlementRow {
+	var rows []settlementRow
+	index := make(map[time.Time]int, len(settled))
+	for _, record := range settled {
+		at, held := index[record.PeriodFrom]
+		if !held {
+			at = len(rows)
+			index[record.PeriodFrom] = at
+			rows = append(rows, settlementRow{From: record.PeriodFrom})
+		}
+		rows[at].Records = append(rows[at].Records, record)
+	}
+
+	for i := range rows {
+		sums := make(map[string]decimal.Decimal)
+		searched := []string{stamp(rows[i].From)}
+		for _, record := range rows[i].Records {
+			sums[record.Currency] = sums[record.Currency].Add(record.Amount)
+			searched = append(searched, record.Kind, record.ProjectID)
+			if record.Kind == regularKind {
+				rows[i].Status = record.Status
+			}
+		}
+		for _, currency := range slices.Sorted(maps.Keys(sums)) {
+			rows[i].Totals = append(rows[i].Totals, currencyTotal{Total: sums[currency], Currency: currency})
+		}
+		if len(rows[i].Totals) > 0 {
+			rows[i].Sort = rows[i].Totals[0].Total
+		}
+		if rows[i].Status == "" {
+			rows[i].Status = absent
+		}
+		rows[i].Searched = strings.Join(searched, " ")
 	}
 	return rows
 }
@@ -532,6 +621,37 @@ func (h *handlers) projectID(ctx context.Context, r *http.Request, src *sources)
 	}
 	return uuid.Nil, nothingRegistered(
 		fmt.Errorf("no project is registered under the cloud %s and the external id %s", cloud, externalID))
+}
+
+// relationOf is one relation as the table draws it: the two ends as links, and
+// the pricing adjustments the relation carries read out of its metadata.
+//
+// The registry holds every adjustments document to the schema at the write, so
+// one that does not read here is a document written past this API or a schema
+// this console does not know. It is reported in the row rather than as a failed
+// page: the other relations of the project are readable, and what the document
+// says is what the reader has to see.
+func relationOf(relation httpapi.Relation, self uuid.UUID) relationRow {
+	row := relationRow{
+		Relation:   relation,
+		SourceLink: otherProjectLink(relation.SourceId, self),
+		TargetLink: otherProjectLink(relation.TargetId, self),
+	}
+
+	metadata, err := json.Marshal(relation.Metadata)
+	if err == nil {
+		row.Adjustments, _, err = adjustment.FromMetadata(metadata)
+	}
+	if err != nil {
+		row.Adjustments, row.Unreadable = nil, err.Error()
+	}
+
+	searched := []string{relation.RelationType}
+	for _, line := range row.Adjustments {
+		searched = append(searched, line.Type, line.Scope, line.Description)
+	}
+	row.Searched = strings.Join(searched, " ")
+	return row
 }
 
 // otherProjectLink is the page of one end of a relation, and nothing for the

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -1,9 +1,12 @@
 package httpui
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -39,15 +42,38 @@ type projectRow struct {
 // projectData is one project from both sides: what the registry holds, what it
 // ran over the window the viewer reads, and what every run billed it.
 type projectData struct {
-	Project    httpapi.Project
-	Relations  listing[relationRow]
-	Related    listing[relatedRow]
-	Activity   listing[httpapi.ProjectActivity]
+	Project   httpapi.Project
+	Relations listing[relationRow]
+	Related   listing[relatedRow]
+	Activity  listing[activityRow]
+	// Partial is set when the API served one page of the project's resources
+	// and held more, so the folds say they are not the whole list.
+	Partial    bool
 	Window     windowView
 	From       time.Time
 	To         time.Time
 	Key        string
 	Statements listing[projectStatementRow]
+}
+
+// activityRow is one resource type of a project over the window: what the
+// summary counted of it, and the resources of that type the projection holds
+// for that window, which the row folds open. Searched is what the filter
+// matches the row on, the type and the resources under it.
+type activityRow struct {
+	Activity  httpapi.ProjectActivity
+	Resources []projectResourceRow
+	Searched  string
+}
+
+// projectResourceRow is one resource under a type, its own page, and how long
+// it has lived. It is the resources page's row without the columns that only
+// make sense beside resources of other projects.
+type projectResourceRow struct {
+	Resource httpapi.Resource
+	Link     string
+	Lifetime decimal.Decimal
+	Lived    bool
 }
 
 // windowView is the control above a table that reads one window: the two
@@ -79,12 +105,15 @@ var (
 		textCol("relation type", func(r relatedRow) string { return r.Related.RelationType }),
 		countCol("depth", func(r relatedRow) int64 { return int64(r.Related.Depth) }),
 	}
-	activityColumns = []column[httpapi.ProjectActivity]{
-		textCol("resource type", func(r httpapi.ProjectActivity) string { return r.ResourceType }),
-		countCol("created", func(r httpapi.ProjectActivity) int64 { return int64(r.Created) }),
-		countCol("deleted", func(r httpapi.ProjectActivity) int64 { return int64(r.Deleted) }),
-		countCol("active now", func(r httpapi.ProjectActivity) int64 { return int64(r.ActiveNow) }),
-		countCol("minutes", func(r httpapi.ProjectActivity) int64 { return r.TotalMinutes }),
+	// The type column is searched as the type and the resources folded under
+	// it, so a filter finds the type one resource sits in. The type leads the
+	// text, so the column still sorts by type.
+	activityColumns = []column[activityRow]{
+		textCol("resource type", func(r activityRow) string { return r.Searched }),
+		countCol("created", func(r activityRow) int64 { return int64(r.Activity.Created) }),
+		countCol("deleted", func(r activityRow) int64 { return int64(r.Activity.Deleted) }),
+		countCol("active now", func(r activityRow) int64 { return int64(r.Activity.ActiveNow) }),
+		countCol("minutes", func(r activityRow) int64 { return r.Activity.TotalMinutes }),
 	}
 	projectStatementColumns = []column[projectStatementRow]{
 		textCol("period", func(r projectStatementRow) string { return stamp(r.Row.PeriodFrom) }),
@@ -202,6 +231,22 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The resources of the project, which the activity rows fold open. A
+	// resource names its project by the pair the registry row carries, and the
+	// listing holds every status, because a type of the window is mostly
+	// resources that are gone by now.
+	fleet, request, err := h.api.ListResources(ctx, reporting.ResourcesQuery{
+		Cloud:     project.Cloud,
+		ProjectID: project.ExternalId,
+		Status:    statuses[len(statuses)-1],
+		Limit:     resourcePageLimit,
+	})
+	src.api(request)
+	if err != nil {
+		h.failFrom(w, r, apiFailed(err), src)
+		return
+	}
+
 	key := statements.Key(project.Cloud, project.ExternalId)
 	billed, err := h.store.ListStatementsForProject(ctx, key)
 	src.query("ListStatementsForProject")
@@ -227,6 +272,8 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	activity := activityRows(summary.ResourceTypes, fleet.Items, from, to, now)
+
 	rows := make([]projectStatementRow, 0, len(billed))
 	for _, row := range billed {
 		rows = append(rows, projectStatementRow{
@@ -239,7 +286,8 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		Project:    project,
 		Relations:  tabulate(r, "relations", relationColumns, listed),
 		Related:    tabulate(r, "related", relatedColumns, reached),
-		Activity:   tabulate(r, "activity", activityColumns, summary.ResourceTypes),
+		Activity:   tabulate(r, "activity", activityColumns, activity),
+		Partial:    fleet.NextCursor != nil,
 		Window:     buildWindowView(r, from, to, now),
 		From:       from,
 		To:         to,
@@ -251,6 +299,55 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		Sources: src,
 		Data:    data,
 	})
+}
+
+// activityRows puts the resources of a project under the type they are of, so
+// that a type the summary counted folds open into the resources it counted.
+// Only the resources that lived inside the window are listed, the rule the
+// fleet reads a window by, and they are listed in the order their ids sort in,
+// which is the order a reader looks one up in.
+//
+// A type the summary reports and the projection holds nothing of is drawn
+// without a fold rather than with an empty one: the summary folds the events
+// of the window, and the projection holds what the resources are today, so a
+// resource the project has since handed on is counted here and listed nowhere.
+func activityRows(
+	types []httpapi.ProjectActivity, resources []httpapi.Resource, from, to, now time.Time,
+) []activityRow {
+	byType := make(map[string][]projectResourceRow, len(types))
+	for _, resource := range resources {
+		if !livedBetween(resource, &from, &to) {
+			continue
+		}
+		lifetime, lived := lifetimeHours(resource, now)
+		byType[resource.ResourceType] = append(byType[resource.ResourceType], projectResourceRow{
+			Resource: resource,
+			Link: link("/resource",
+				"cloud", resource.Cloud, "type", resource.ResourceType, "id", resource.ResourceId),
+			Lifetime: lifetime,
+			Lived:    lived,
+		})
+	}
+
+	rows := make([]activityRow, 0, len(types))
+	for _, activity := range types {
+		under := byType[activity.ResourceType]
+		slices.SortFunc(under, func(a, b projectResourceRow) int {
+			return cmp.Compare(a.Resource.ResourceId, b.Resource.ResourceId)
+		})
+
+		searched := make([]string, 0, len(under)+1)
+		searched = append(searched, activity.ResourceType)
+		for _, resource := range under {
+			searched = append(searched, resource.Resource.ResourceId)
+		}
+		rows = append(rows, activityRow{
+			Activity:  activity,
+			Resources: under,
+			Searched:  strings.Join(searched, " "),
+		})
+	}
+	return rows
 }
 
 // readWindow reads the window a project's activity is summarized over: the

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -53,7 +54,7 @@ type projectData struct {
 	From       time.Time
 	To         time.Time
 	Key        string
-	Statements listing[projectStatementRow]
+	Statements listing[periodRow]
 }
 
 // activityRow is one resource type of a project over the window: what the
@@ -115,11 +116,14 @@ var (
 		countCol("active now", func(r activityRow) int64 { return int64(r.Activity.ActiveNow) }),
 		countCol("minutes", func(r activityRow) int64 { return r.Activity.TotalMinutes }),
 	}
-	projectStatementColumns = []column[projectStatementRow]{
-		textCol("period", func(r projectStatementRow) string { return stamp(r.Row.PeriodFrom) }),
-		textCol("run kind", func(r projectStatementRow) string { return r.Row.Kind }),
-		textCol("run status", func(r projectStatementRow) string { return r.Row.Status }),
-		numberCol("total", func(r projectStatementRow) decimal.Decimal { return r.Row.Total }),
+	// A period is searched as the period and every statement under it, so a
+	// filter on a kind or a status finds the month that holds one. The period
+	// leads the text, so the column still sorts by period.
+	projectPeriodColumns = []column[periodRow]{
+		textCol("period", func(r periodRow) string { return r.Searched }),
+		textCol("status", func(r periodRow) string { return r.Status }),
+		countCol("statements", func(r periodRow) int64 { return int64(len(r.Statements)) }),
+		numberCol("total", func(r periodRow) decimal.Decimal { return r.Sort }),
 	}
 )
 
@@ -140,12 +144,52 @@ type relatedRow struct {
 	Link    string
 }
 
-// projectStatementRow is one month of a project's history and the statement it
-// opens.
-type projectStatementRow struct {
-	Row  store.ProjectStatementRow
-	Link string
+// periodRow is one billing period of a project: every statement a run wrote
+// for it, which the row folds open, and what the project is charged for the
+// period once the statements that stand are added up.
+//
+// A period accumulates statements: the regular run that billed it, the run
+// that replaced that one, and every correction booked against the run that
+// closed it. What the project owes for the period is the sum of the ones that
+// stand, and reading it off the rows meant knowing which statuses count.
+type periodRow struct {
+	From       time.Time
+	Statements []projectStatementRow
+	// Totals is what stands, summed per currency, and Sort is the amount the
+	// column is ordered by. A period is billed in one currency, so the sum is
+	// usually one amount; a period whose statements disagree prints each one
+	// rather than adding them up.
+	Totals   []currencyTotal
+	Sort     decimal.Decimal
+	Status   string
+	Searched string
 }
+
+// currencyTotal is an amount in the currency it was billed in.
+type currencyTotal struct {
+	Total    decimal.Decimal
+	Currency string
+}
+
+// projectStatementRow is one statement of a project, the page it opens, and
+// whether it is one of those the period is charged by. A superseded run's
+// statement is on the page for the audit it leaves and counts for nothing.
+type projectStatementRow struct {
+	Row      store.ProjectStatementRow
+	Link     string
+	Standing bool
+}
+
+// standingStatuses are the run statuses whose statements the project is
+// charged by, which are the ones an export reads: a run that stands has either
+// closed its period or is the completed one of its kind. A superseded run was
+// replaced by another of its kind, a failed one billed nothing, and neither is
+// counted.
+var standingStatuses = []string{"completed", "finalized"}
+
+// regularKind is the run kind that bills a period, as opposed to the
+// corrections booked against it afterwards.
+const regularKind = "regular"
 
 // projects lists one page of the registry. The cursor is followed only when the
 // viewer asks for the next page: one request reads one page.
@@ -274,13 +318,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	activity := activityRows(summary.ResourceTypes, fleet.Items, from, to, now)
 
-	rows := make([]projectStatementRow, 0, len(billed))
-	for _, row := range billed {
-		rows = append(rows, projectStatementRow{
-			Row:  row,
-			Link: link("/statement", "run", row.RunID.String(), "key", key),
-		})
-	}
+	periods := periodRows(billed, key)
 
 	data := projectData{
 		Project:    project,
@@ -292,7 +330,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		From:       from,
 		To:         to,
 		Key:        key,
-		Statements: tabulate(r, "statements", projectStatementColumns, rows),
+		Statements: tabulate(r, "statements", projectPeriodColumns, periods),
 	}
 	h.render(w, r, "project", page{
 		Title:   "Project " + optString(project.Name, project.ExternalId),
@@ -348,6 +386,73 @@ func activityRows(
 		})
 	}
 	return rows
+}
+
+// periodRows groups what every run billed one project into the periods the
+// runs billed, oldest period first, which is the order the statements arrive
+// in. Inside a period the statements keep that order too, which is the order
+// the runs started in, so a correction stands under the run it corrects.
+//
+// The period's total is the sum of the statements that stand. A period whose
+// statements were all replaced adds up to nothing, which is what it is: every
+// run of it has been superseded by another the page also holds.
+func periodRows(billed []store.ProjectStatementRow, key string) []periodRow {
+	var rows []periodRow
+	index := make(map[time.Time]int, len(billed))
+	for _, row := range billed {
+		at, held := index[row.PeriodFrom]
+		if !held {
+			at = len(rows)
+			index[row.PeriodFrom] = at
+			rows = append(rows, periodRow{From: row.PeriodFrom})
+		}
+		rows[at].Statements = append(rows[at].Statements, projectStatementRow{
+			Row:      row,
+			Link:     link("/statement", "run", row.RunID.String(), "key", key),
+			Standing: slices.Contains(standingStatuses, row.Status),
+		})
+	}
+
+	for i := range rows {
+		rows[i].total()
+		rows[i].describe()
+	}
+	return rows
+}
+
+// total adds the statements that stand up, per the currency each was billed
+// in, and reports the amount the column is ordered by, which is the first
+// currency of a period billed in more than one.
+func (r *periodRow) total() {
+	sums := make(map[string]decimal.Decimal)
+	for _, statement := range r.Statements {
+		if statement.Standing {
+			sums[statement.Row.Currency] = sums[statement.Row.Currency].Add(statement.Row.Total)
+		}
+	}
+
+	for _, currency := range slices.Sorted(maps.Keys(sums)) {
+		r.Totals = append(r.Totals, currencyTotal{Total: sums[currency], Currency: currency})
+	}
+	if len(r.Totals) > 0 {
+		r.Sort = r.Totals[0].Total
+	}
+}
+
+// describe says what the period stands at and what a filter matches it on. The
+// status is the standing regular run's, which is what says whether the month is
+// closed; a period whose regular run was replaced and not re-run stands at
+// nothing.
+func (r *periodRow) describe() {
+	r.Status = absent
+	searched := []string{stamp(r.From)}
+	for _, statement := range r.Statements {
+		if statement.Standing && statement.Row.Kind == regularKind {
+			r.Status = statement.Row.Status
+		}
+		searched = append(searched, statement.Row.Kind, statement.Row.Status)
+	}
+	r.Searched = strings.Join(searched, " ")
 }
 
 // readWindow reads the window a project's activity is summarized over: the

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -37,16 +37,29 @@ type projectRow struct {
 }
 
 // projectData is one project from both sides: what the registry holds, what it
-// ran this month, and what every run billed it.
+// ran over the window the viewer reads, and what every run billed it.
 type projectData struct {
 	Project    httpapi.Project
 	Relations  listing[relationRow]
 	Related    listing[relatedRow]
 	Activity   listing[httpapi.ProjectActivity]
+	Window     windowView
 	From       time.Time
 	To         time.Time
 	Key        string
 	Statements listing[projectStatementRow]
+}
+
+// windowView is the control above a table that reads one window: the two
+// inputs with the hidden fields their form carries the page through, and the
+// spans one click away. It is the window half of the fleet controls, drawn the
+// same way, for a page whose numbers are a window and nothing else.
+type windowView struct {
+	Path    string
+	Hidden  []field
+	From    string
+	To      string
+	Presets []choice
 }
 
 // The columns of a project page's tables.
@@ -148,6 +161,13 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var src sources
 
+	now := h.now()
+	from, to, err := readWindow(r, now)
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
+
 	id, err := h.projectID(ctx, r, &src)
 	if err != nil {
 		h.failFrom(w, r, err, src)
@@ -175,8 +195,6 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	from := firstOfThisMonthUTC(h.now())
-	to := from.AddDate(0, 1, 0)
 	summary, request, err := h.api.GetProjectSummary(ctx, id, from, to)
 	src.api(request)
 	if err != nil {
@@ -222,6 +240,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		Relations:  tabulate(r, "relations", relationColumns, listed),
 		Related:    tabulate(r, "related", relatedColumns, reached),
 		Activity:   tabulate(r, "activity", activityColumns, summary.ResourceTypes),
+		Window:     buildWindowView(r, from, to, now),
 		From:       from,
 		To:         to,
 		Key:        key,
@@ -232,6 +251,53 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		Sources: src,
 		Data:    data,
 	})
+}
+
+// readWindow reads the window a project's activity is summarized over: the
+// bounds from and to, each in either form an instant is written in, and this
+// month when the request names neither. The summary route takes both bounds,
+// so a request that carries one and not the other is refused rather than
+// answered over half a window it never asked for, and a window that ends no
+// later than it starts is refused the way the fleet's is.
+func readWindow(r *http.Request, now time.Time) (from, to time.Time, err error) {
+	query := r.URL.Query()
+	first, second := query.Get(fromParameter), query.Get(toParameter)
+	if first == "" && second == "" {
+		start := firstOfThisMonthUTC(now)
+		return start, start.AddDate(0, 1, 0), nil
+	}
+	if first == "" {
+		return time.Time{}, time.Time{}, missingParameter(fromParameter)
+	}
+	if second == "" {
+		return time.Time{}, time.Time{}, missingParameter(toParameter)
+	}
+
+	if from, err = parseInstant(first); err != nil {
+		return time.Time{}, time.Time{}, unreadableInstant(fromParameter, err)
+	}
+	if to, err = parseInstant(second); err != nil {
+		return time.Time{}, time.Time{}, unreadableInstant(toParameter, err)
+	}
+	if !to.After(from) {
+		return time.Time{}, time.Time{}, &paramError{name: toParameter, reason: "is not after from"}
+	}
+	return from, to, nil
+}
+
+// buildWindowView lays the window control out for one request. The presets are
+// the fleet's spans over the same bounds, so the two pages are read the same
+// way, and the form carries the rest of the page through, the project the page
+// is about included.
+func buildWindowView(r *http.Request, from, to, now time.Time) windowView {
+	values := r.URL.Query()
+	return windowView{
+		Path:    r.URL.Path,
+		Hidden:  hiddenFields(values, fromParameter, toParameter),
+		From:    from.UTC().Format(atLayout),
+		To:      to.UTC().Format(atLayout),
+		Presets: spanPresets(r.URL.Path, values, &from, &to, now),
+	}
 }
 
 // projectID reads which project the page is about: the id parameter when it

--- a/internal/console/httpui/resources.go
+++ b/internal/console/httpui/resources.go
@@ -90,9 +90,9 @@ var (
 )
 
 // resources lists one page of the projection under the status the viewer
-// chose, and of that page the rows that existed in the window or at the
-// instant. The page is the widest the API serves, so the filters are applied
-// to as much of the fleet as one call can hold.
+// chose, and of that page the rows the instant or the window it is read at
+// keeps. The page is the widest the API serves, so the filters are applied to
+// as much of the fleet as one call can hold.
 func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var src sources
@@ -125,7 +125,7 @@ func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	rows := make([]resourceRow, 0, len(list.Items))
 	unknown := 0
 	for _, resource := range list.Items {
-		if !keep(resource, fleet, now) {
+		if !keep(resource, fleet) {
 			continue
 		}
 		lifetime, lived := lifetimeHours(resource, now)

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -86,6 +86,7 @@ type Store interface {
 	ListStatements(ctx context.Context, runID uuid.UUID) ([]store.StatementRow, error)
 	GetStatement(ctx context.Context, runID uuid.UUID, key string) (store.Statement, error)
 	ListStatementsForProject(ctx context.Context, key string) ([]store.ProjectStatementRow, error)
+	ListKickbacksForBeneficiary(ctx context.Context, beneficiary string) ([]store.Kickback, error)
 	ListPricingModels(ctx context.Context) ([]store.PricingModel, error)
 	GetPricingModel(ctx context.Context, version string) (store.PricingDocument, error)
 	LatestRunWithResource(ctx context.Context, cloud, resourceType, resourceID string) (uuid.UUID, bool, error)

--- a/internal/console/httpui/static/console.css
+++ b/internal/console/httpui/static/console.css
@@ -120,8 +120,51 @@ input[type="search"] {
   min-width: 14rem;
 }
 
-/* The fleet switch is three links drawn as one control, the way the theme
-   buttons are, and the presets are plain links with the current one in bold. */
+/* The fleet controls are two lines under the words for them: what the API
+   serves on the first, and which time the console reads it at on the second.
+   Only the inputs of the chosen time are drawn, and its presets sit under
+   them, so a window and an instant are never asked for at once. */
+.fleet {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.4rem 0.75rem;
+  align-items: center;
+  margin: 0.5rem 0 0;
+}
+
+.fleet-key {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.fleet-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.fleet-row label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.fleet-row .count {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.fleet .presets,
+.fleet .axis {
+  grid-column: 2;
+}
+
+/* A switch is a row of links drawn as one control, the way the theme buttons
+   are, and the presets are plain links with the current one in bold. */
 .switch {
   display: inline-flex;
 }
@@ -161,17 +204,8 @@ p.presets {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  margin: 0.5rem 0 0;
+  margin: 0;
   font-size: 0.85rem;
-}
-
-p.presets span {
-  color: var(--muted);
-}
-
-p.presets span + a,
-p.presets a + span {
-  margin-left: 0.4rem;
 }
 
 p.presets a[aria-current="true"] {
@@ -180,7 +214,7 @@ p.presets a[aria-current="true"] {
 }
 
 p.axis {
-  margin: 0.5rem 0 0;
+  margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
 }

--- a/internal/console/httpui/static/console.css
+++ b/internal/console/httpui/static/console.css
@@ -501,6 +501,27 @@ details.cell > pre {
   min-width: 24rem;
 }
 
+/* A table inside a cell carries what one row is made of, the resources of one
+   resource type for example. It is wider than the cell it folds out of, and
+   its heading does not stick, because it scrolls with the row rather than with
+   the page. */
+details.cell > table.nested {
+  width: auto;
+  min-width: 34rem;
+  margin: 0.35rem 0 0.25rem;
+}
+
+table.nested th {
+  position: static;
+  background: none;
+  font-size: 0.75rem;
+}
+
+table.nested th,
+table.nested td {
+  padding: 0.25rem 0.5rem 0.25rem 0;
+}
+
 svg text {
   fill: var(--ink);
   font-family: system-ui, sans-serif;

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -17,7 +17,19 @@
 {{template "tableHead" .Relations.Table}}
 <tbody>
 {{range .Relations.Rows}}<tr>
-<td>{{.Relation.RelationType}}</td>
+<td>{{if .Adjustments}}<details class="cell"><summary>{{.Relation.RelationType}}</summary>
+<table class="nested">
+<thead><tr><th>adjustment</th><th>scope</th><th class="number">rate</th><th>description</th></tr></thead>
+<tbody>
+{{range .Adjustments}}<tr>
+<td>{{.Type}}</td>
+<td>{{.Scope}}</td>
+<td class="number">{{rate .Rate}}</td>
+<td>{{if .Description}}{{.Description}}{{else}}none{{end}}</td>
+</tr>
+{{end}}</tbody>
+</table>
+</details>{{else if .Unreadable}}{{.Relation.RelationType}} <span class="muted">adjustments unreadable: {{.Unreadable}}</span>{{else}}{{.Relation.RelationType}}{{end}}</td>
 <td>{{if .SourceLink}}<a href="{{.SourceLink}}">{{.Relation.SourceId}}</a>{{else}}{{.Relation.SourceId}}{{end}}</td>
 <td>{{if .TargetLink}}<a href="{{.TargetLink}}">{{.Relation.TargetId}}</a>{{else}}{{.Relation.TargetId}}{{end}}</td>
 <td>{{stamp .Relation.ValidFrom}}</td>
@@ -83,6 +95,38 @@
 </table>
 {{if .Partial}}<p class="axis">a type folds open into the resources of this project the API served in one page; it holds more than one page, so a type may have run resources this list does not name</p>
 {{end}}
+{{if .Kickbacks.Table.Total}}
+<h2>Kickbacks</h2>
+{{template "tableTools" .Kickbacks.Table}}
+<table>
+{{template "tableHead" .Kickbacks.Table}}
+<tbody>
+{{range .Kickbacks.Rows}}<tr>
+<td><details class="cell"><summary>{{stamp .From}}</summary>
+<table class="nested">
+<thead><tr><th>statement</th><th>run kind</th><th>project</th><th>scope</th><th class="number">rate</th><th class="number">base</th><th class="number">amount</th></tr></thead>
+<tbody>
+{{range .Records}}<tr>
+<td><a href="{{statementLink .RunID .StatementKey}}">open</a></td>
+<td>{{.Kind}}</td>
+<td><code>{{.ProjectID}}</code></td>
+<td>{{.Scope}}</td>
+<td class="number">{{rate .Rate}}</td>
+<td class="number">{{amount .Base}}</td>
+<td class="number">{{amount .Amount}} {{.Currency}}</td>
+</tr>
+{{end}}</tbody>
+</table>
+</details></td>
+<td>{{.Status}}</td>
+<td class="number">{{len .Records}}</td>
+<td class="number">{{range $i, $t := .Totals}}{{if $i}} + {{end}}{{amount $t.Total}} {{$t.Currency}}{{else}}none{{end}}</td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .Kickbacks.Table "no run settles a kickback for this partner"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
 <h2>Statements</h2>
 {{template "tableTools" .Statements.Table}}
 <table>

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -42,7 +42,18 @@
 {{end}}</tbody>
 </table>
 
-<h2>What this project ran, {{stamp .From}} to {{stamp .To}}</h2>
+<h2>What this project ran</h2>
+<div class="fleet">
+<span class="fleet-key">when</span>
+<form class="fleet-row" method="get" action="{{.Window.Path}}">
+{{range .Window.Hidden}}<input type="hidden" name="{{.Name}}" value="{{.Value}}">
+{{end}}<label>from <input type="datetime-local" name="from" value="{{.Window.From}}"></label>
+<label>to <input type="datetime-local" name="to" value="{{.Window.To}}"></label>
+<button type="submit">apply</button>
+<span class="count">{{stamp .From}} to {{stamp .To}}</span>
+</form>
+<p class="presets">{{range .Window.Presets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</p>
+</div>
 {{template "tableTools" .Activity.Table}}
 <table>
 {{template "tableHead" .Activity.Table}}

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -59,16 +59,30 @@
 {{template "tableHead" .Activity.Table}}
 <tbody>
 {{range .Activity.Rows}}<tr>
-<td>{{.ResourceType}}</td>
-<td class="number">{{.Created}}</td>
-<td class="number">{{.Deleted}}</td>
-<td class="number">{{.ActiveNow}}</td>
-<td class="number">{{.TotalMinutes}}</td>
+<td>{{if .Resources}}<details class="cell"><summary>{{.Activity.ResourceType}}</summary>
+<table class="nested">
+<thead><tr><th>resource</th><th>state</th><th>created</th><th>deleted</th><th class="number">lifetime hours</th></tr></thead>
+<tbody>
+{{range .Resources}}<tr>
+<td><a href="{{.Link}}">{{.Resource.ResourceId}}</a></td>
+<td>{{.Resource.State}}</td>
+<td>{{unknownStamp .Resource.CreatedAt}}</td>
+<td>{{optStamp .Resource.DeletedAt}}</td>
+<td class="number">{{if .Lived}}{{amount .Lifetime}}{{else}}unknown{{end}}</td>
+</tr>
+{{end}}</tbody>
+</table>
+</details>{{else}}{{.Activity.ResourceType}}{{end}}</td>
+<td class="number">{{.Activity.Created}}</td>
+<td class="number">{{.Activity.Deleted}}</td>
+<td class="number">{{.Activity.ActiveNow}}</td>
+<td class="number">{{.Activity.TotalMinutes}}</td>
 </tr>
 {{else}}<tr><td colspan="5">{{emptyText .Activity.Table "this project ran nothing in this window"}}</td></tr>
 {{end}}</tbody>
 </table>
-
+{{if .Partial}}<p class="axis">a type folds open into the resources of this project the API served in one page; it holds more than one page, so a type may have run resources this list does not name</p>
+{{end}}
 <h2>Statements</h2>
 {{template "tableTools" .Statements.Table}}
 <table>

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -17,11 +17,11 @@
 {{template "tableHead" .Relations.Table}}
 <tbody>
 {{range .Relations.Rows}}<tr>
-<td>{{.RelationType}}</td>
-<td>{{.SourceId}}</td>
-<td>{{.TargetId}}</td>
-<td>{{stamp .ValidFrom}}</td>
-<td>{{optStamp .ValidTo}}</td>
+<td>{{.Relation.RelationType}}</td>
+<td>{{if .SourceLink}}<a href="{{.SourceLink}}">{{.Relation.SourceId}}</a>{{else}}{{.Relation.SourceId}}{{end}}</td>
+<td>{{if .TargetLink}}<a href="{{.TargetLink}}">{{.Relation.TargetId}}</a>{{else}}{{.Relation.TargetId}}{{end}}</td>
+<td>{{stamp .Relation.ValidFrom}}</td>
+<td>{{optStamp .Relation.ValidTo}}</td>
 </tr>
 {{else}}<tr><td colspan="5">{{emptyText .Relations.Table "this project has no relation"}}</td></tr>
 {{end}}</tbody>

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -89,10 +89,22 @@
 {{template "tableHead" .Statements.Table}}
 <tbody>
 {{range .Statements.Rows}}<tr>
-<td><a href="{{.Link}}">{{stamp .Row.PeriodFrom}}</a></td>
+<td><details class="cell"><summary>{{stamp .From}}</summary>
+<table class="nested">
+<thead><tr><th>statement</th><th>run kind</th><th>run status</th><th class="number">total</th></tr></thead>
+<tbody>
+{{range .Statements}}<tr{{if not .Standing}} class="muted"{{end}}>
+<td><a href="{{.Link}}">open</a></td>
 <td>{{.Row.Kind}}</td>
-<td>{{.Row.Status}}</td>
+<td>{{.Row.Status}}{{if not .Standing}}, replaced{{end}}</td>
 <td class="number">{{amount .Row.Total}} {{.Row.Currency}}</td>
+</tr>
+{{end}}</tbody>
+</table>
+</details></td>
+<td>{{.Status}}</td>
+<td class="number">{{len .Statements}}</td>
+<td class="number">{{range $i, $t := .Totals}}{{if $i}} + {{end}}{{amount $t.Total}} {{$t.Currency}}{{else}}none{{end}}</td>
 </tr>
 {{else}}<tr><td colspan="4">{{emptyText .Statements.Table "no run has billed this project"}}</td></tr>
 {{end}}</tbody>

--- a/internal/console/httpui/templates/resources.gohtml
+++ b/internal/console/httpui/templates/resources.gohtml
@@ -1,15 +1,20 @@
 {{define "content"}}
-<form class="tools fleet" method="get" action="{{.Fleet.Path}}">
+<div class="fleet">
+<span class="fleet-key">show</span>
+<p class="fleet-row"><span class="switch">{{range .Fleet.Switch}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</span><span class="count">{{.Fleet.Count}}</span></p>
+<span class="fleet-key">when</span>
+<form class="fleet-row" method="get" action="{{.Fleet.Path}}">
 {{range .Fleet.Hidden}}<input type="hidden" name="{{.Name}}" value="{{.Value}}">
-{{end}}<span class="switch">{{range .Fleet.Switch}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</span>
+{{end}}<span class="switch">{{range .Fleet.Modes}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</span>
+{{if .Fleet.Windowed}}<input type="hidden" name="mode" value="window">
 <label>from <input type="datetime-local" name="from" value="{{.Fleet.From}}"></label>
 <label>to <input type="datetime-local" name="to" value="{{.Fleet.To}}"></label>
-<label>at <input type="datetime-local" name="at" value="{{.Fleet.At}}"></label>
-<button type="submit">apply</button>
-<span class="count">{{.Fleet.Count}}</span>
+{{else}}<label>at <input type="datetime-local" name="at" value="{{.Fleet.At}}"></label>
+{{end}}<button type="submit">apply</button>
 </form>
-<p class="presets"><span>window</span>{{range .Fleet.WindowPresets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}<span>instant</span>{{range .Fleet.Presets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</p>
+<p class="presets">{{range .Fleet.Presets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</p>
 <p class="axis">every instant is UTC; a lifetime runs from the creation to the deletion, or to now{{if .Fleet.Unknown}}; {{.Fleet.Unknown}}{{end}}</p>
+</div>
 {{template "tableTools" .Items.Table}}
 <table>
 {{template "tableHead" .Items.Table}}

--- a/internal/console/store/queries.sql
+++ b/internal/console/store/queries.sql
@@ -83,3 +83,22 @@ SELECT cloud, platform, resource_type, resource_id, project_id, dimension,
 FROM correction_deltas
 WHERE run_id = $1
 ORDER BY cloud, platform, resource_type, resource_id, project_id, dimension;
+
+-- The runs a partner's settlement is read from: every run that stands of every
+-- period that ever settled a kickback for the partner. A period is read whole,
+-- rather than only the runs holding a record for the partner, because a
+-- correction that takes a kickback away holds no record of it and is what the
+-- settlement of that period then hangs on.
+-- name: ListRunsSettlingFor :many
+SELECT r.id, r.period_from, r.kind, r.status
+FROM runs r
+WHERE r.status IN ('completed', 'finalized')
+  AND r.period_from IN (
+    SELECT a.period_from FROM (
+        SELECT DISTINCT s.period_from
+        FROM adjustment_records ar
+        JOIN runs s ON s.id = ar.run_id
+        WHERE ar.beneficiary = $1
+    ) a
+  )
+ORDER BY r.period_from, r.started_at;

--- a/internal/console/store/sqlcgen/queries.sql.go
+++ b/internal/console/store/sqlcgen/queries.sql.go
@@ -347,6 +347,58 @@ func (q *Queries) ListRuns(ctx context.Context, limit int32) ([]Run, error) {
 	return items, nil
 }
 
+const listRunsSettlingFor = `-- name: ListRunsSettlingFor :many
+SELECT r.id, r.period_from, r.kind, r.status
+FROM runs r
+WHERE r.status IN ('completed', 'finalized')
+  AND r.period_from IN (
+    SELECT a.period_from FROM (
+        SELECT DISTINCT s.period_from
+        FROM adjustment_records ar
+        JOIN runs s ON s.id = ar.run_id
+        WHERE ar.beneficiary = $1
+    ) a
+  )
+ORDER BY r.period_from, r.started_at
+`
+
+type ListRunsSettlingForRow struct {
+	ID         pgtype.UUID
+	PeriodFrom pgtype.Timestamptz
+	Kind       string
+	Status     string
+}
+
+// The runs a partner's settlement is read from: every run that stands of every
+// period that ever settled a kickback for the partner. A period is read whole,
+// rather than only the runs holding a record for the partner, because a
+// correction that takes a kickback away holds no record of it and is what the
+// settlement of that period then hangs on.
+func (q *Queries) ListRunsSettlingFor(ctx context.Context, beneficiary pgtype.Text) ([]ListRunsSettlingForRow, error) {
+	rows, err := q.db.Query(ctx, listRunsSettlingFor, beneficiary)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRunsSettlingForRow
+	for rows.Next() {
+		var i ListRunsSettlingForRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PeriodFrom,
+			&i.Kind,
+			&i.Status,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStatements = `-- name: ListStatements :many
 SELECT project_id, total, currency
 FROM project_statements

--- a/internal/console/store/store.go
+++ b/internal/console/store/store.go
@@ -32,6 +32,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/console/store/sqlcgen"
+	"github.com/b42labs/tally/internal/engine/export"
 )
 
 // poolMaxConns bounds the pool. A demo console serves one viewer clicking
@@ -122,6 +123,26 @@ type ProjectStatementRow struct {
 	Status     string
 	Total      decimal.Decimal
 	Currency   string
+}
+
+// Kickback is one kickback of one run as the settlement report reads it: what
+// a partner is owed for one project, under the run that owes it. A correction's
+// rows are the difference to the run it corrects, which is what makes the
+// kickbacks of a period add up the way its statements do.
+type Kickback struct {
+	RunID      uuid.UUID
+	PeriodFrom time.Time
+	Kind       string
+	Status     string
+	// StatementKey is the key the statement of the adjusted project is stored
+	// under, and Cloud and ProjectID are its two halves.
+	StatementKey     string
+	Cloud, ProjectID string
+	RelationID       uuid.UUID
+	Scope            string
+	Rate             decimal.Decimal
+	Base, Amount     decimal.Decimal
+	Currency         string
 }
 
 // PricingModel is one imported catalog version without its document.
@@ -269,6 +290,58 @@ func (s *Store) ListStatementsForProject(ctx context.Context, key string) ([]Pro
 			Total:      total,
 			Currency:   row.Currency,
 		})
+	}
+	return list, nil
+}
+
+// ListKickbacksForBeneficiary returns what every run that stands settles for
+// one partner, oldest period first and inside a period in the order the runs
+// started.
+//
+// The arithmetic is the engine's own: each run is read through
+// export.LoadKickbacks, which renders a regular run's kickback records as they
+// stand and a correction's as the difference to the run it corrects. Doing it
+// here a second time would be a second implementation of what a partner is
+// paid, and the two would drift.
+//
+// The runs are read one by one rather than in one query, because a
+// correction's settlement is a diff of two runs and only that read knows which
+// run to diff against. A partner is settled by one regular run and its
+// corrections per period, so the reads are one per run of the periods the
+// partner appears in.
+func (s *Store) ListKickbacksForBeneficiary(ctx context.Context, beneficiary string) ([]Kickback, error) {
+	runs, err := s.q.ListRunsSettlingFor(ctx, pgtype.Text{String: beneficiary, Valid: true})
+	if err != nil {
+		return nil, fmt.Errorf("ListRunsSettlingFor: %w", err)
+	}
+
+	var list []Kickback
+	for _, run := range runs {
+		id := uuidOf(run.ID)
+		loaded, err := export.LoadKickbacks(ctx, s.pool, id)
+		if err != nil {
+			return nil, fmt.Errorf("LoadKickbacks of %s: %w", id, err)
+		}
+		for _, kickback := range loaded.Kickbacks {
+			if kickback.Beneficiary != beneficiary {
+				continue
+			}
+			list = append(list, Kickback{
+				RunID:        id,
+				PeriodFrom:   timeOf(run.PeriodFrom),
+				Kind:         run.Kind,
+				Status:       run.Status,
+				StatementKey: kickback.StatementKey,
+				Cloud:        kickback.Cloud,
+				ProjectID:    kickback.ProjectID,
+				RelationID:   kickback.RelationID,
+				Scope:        kickback.Scope,
+				Rate:         kickback.Rate,
+				Base:         kickback.Base,
+				Amount:       kickback.Amount,
+				Currency:     kickback.Currency,
+			})
+		}
 	}
 	return list, nil
 }


### PR DESCRIPTION
The demo console asked its questions in a way that only someone who knows the engine could answer, and the commercial side of the registry was not on it at all. Six changes, one per commit.

## The fleet is read one way at a time

The resource page asked for a window and an instant at once: three inputs side by side, both sets of presets under them, and a precedence rule nobody could read off the controls. An instant inside a window won, the window then only decided which rows the instant applied to, and the instant presets carried a `clear` that existed for that case alone.

They are two questions now, and the page asks one of them: the `when` switch chooses **at an instant**, which answers what runs now or ran at one moment, or **over a window**, which answers what lived between two moments. Only the chosen way's inputs and presets are drawn, and every link the page draws is built over its parameters, so following one never leaves a page asking both. `mode` says which way; a request without it means the window when it carries a bound and the instant otherwise, so older links still read as they did. The window with neither bound is `any time`, which used to be called `all` and sat next to the status switch's own `all`.

The controls are two labelled lines, `show` and `when`, so what the API serves and what the console filters are told apart at a glance.

## A project page answers for a window, and shows what is under its numbers

- **What this project ran** is read over a window with the same inputs and spans the fleet uses, this month by default. Both bounds travel together, because the summary route takes both; one without the other is answered 400 naming what is missing.
- Each resource type folds open into the resources of that type that lived in the window, each with its state, creation, deletion and lifetime, each linking its own page. The filter matches a type on the resources under it, so a resource id finds where it sits.
- The statements are one row per **billing period** rather than one per statement, carrying what the project is charged for the month and folding open into every statement the period accumulated. What is added up is the statements whose run stands, `completed` or `finalized`, the two an export reads; a superseded run is drawn muted and says it was replaced. This is what makes a corrected month readable: 788.97 for the run that closed it, −2.58 for the credit note, 786.39 owed.
- Both ends of a relation are links, except the end that is the project of the page.

## The commercial side is on the pages now

- A relation folds open into the pricing adjustments its metadata carries, so a reseller's 15% and the 10% commission are read on the relation that grants them rather than off a statement of a month that already ran.
- A partner's page carries the settlement: one row per period with what the partner is owed, folding into every record with its run kind, adjusted project, scope, rate, base and amount. A partner is never billed, so it has no statement; the kickback is what the operator owes it.

The settlement arithmetic is not repeated. The store reads each standing run through `export.LoadKickbacks`, which is what `tally-engine kickbacks` renders: a regular run's records as they stand, a correction's as the difference to the run it corrects. A period therefore adds up the way its statements do, and the console and the CLI cannot drift apart.

## Checks

- `go build ./...`, `go test ./...` and `golangci-lint run` are clean. Each of the six commits was checked out and built and tested on its own.
- Every change was rendered against a dev cluster carrying a finalized 2026-07 with a finalized correction, in both modes and on a partner, a meta member, a Gardener project and an OpenStack tenant.
- The settlement was checked against the CLI: `tally-engine kickbacks --period 2026-07` reports 59.36 for `cloudhouse` and −58.05 for the correction, and the console prints 1.31 EUR for the period.
- One unrelated flake showed up in full-suite runs, `cmd/tally-openstack-collector` `TestRunServes…` failing its 5s shutdown assertion under load. That package has no console dependency (`go list -deps` shows none) and the test fails on a clean tree too.

## Notes for the reviewer

- The activity fold and the summary counts come from two places, which the reference page states: the summary folds the events of the window, the fold lists what the projection holds today, so a resource the project has since handed on is counted and not listed.
- The project's resources are read as one page of 1000; a project holding more says under the table that a type may have run resources the fold does not name.
- The settlement is read for a project of platform `partner` and no other, because `adjustment_records.beneficiary` holds an external id alone and external ids are unique per cloud only.
- No equivalent total exists for a meta-project: the engine has a correction-aware diff for kickbacks and for nothing else, and writing a second one here is what the settlement read avoids.
- `docs/reference/command-line/tally-console.md` follows every change; the generated block in it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
