### PR TITLE
Show a statement's JSON export in the demo console

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -33,9 +33,10 @@ environment, under the names the settings table below lists.
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
 | `/run?id=` | Engine: the run, its statements, its correction deltas. |
-| `/statement?run=&key=` | Engine: one statement document rendered as a bill: its head, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. |
+| `/statement?run=&key=` | Engine: the run, and one statement document rendered as a bill: its head, the file the JSON export writes for it, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. |
+| `/statement.json?run=&key=` | Engine: the run and the statement. Not a page: the bytes `tally-engine export --format json` writes for the statement, served as `application/json`, and with `download` set as an attachment. |
 | `/static/console.css` | The embedded stylesheet, the only asset the pages load. |
-| `/theme` | Nothing. The one route that is not a page: it takes the theme form's POST, keeps the choice in a cookie, and sends the viewer back. |
+| `/theme` | Nothing. Not a page: it takes the theme form's POST, keeps the choice in a cookie, and sends the viewer back. |
 
 Every identifier travels in a query parameter rather than in a path segment,
 because a cloud name, a resource id and a statement key may each carry a slash.
@@ -177,6 +178,39 @@ metric of every period, with the period's total as a row of its own. A descripti
 only repeats the item's type and id is left out. A value of exactly zero is
 printed in the muted colour, so the amounts that are not zero stand out.
 
+## The export of a statement
+
+The statement page carries, under its head, the file
+`tally-engine export --format json` writes for the statement:
+`statement-<key>.json` for a regular run and `credit-note-<key>.json` for a
+correction, with its size in bytes. The document is folded, and two links lead
+to `/statement.json`, which serves the same bytes on their own: `open` shows
+them in the browser, and `download` saves them.
+
+The console does not print the stored document. The engine database keeps it as
+JSONB, which holds the members in an order of its own, and the export renders
+every document again in the order the
+[export formats](/reference/formats/exports) list, indented by two spaces and
+closed by a newline. The console hands the stored document to the export's own
+renderer, so what the page and the route show is the file an export of the run
+writes, byte for byte.
+
+Only a run that stands is exported, `completed` or `finalized`, which is the
+rule `tally-engine export` applies. The statement of any other run, a
+`superseded` or a `failed` one, says in place of the file that its run is not
+exported, and `/statement.json` answers 404 for it. A stored document the export
+refuses, one holding a member the engine's types do not have, shows the
+export's error in place of the file, and `/statement.json` answers 503.
+
+The file is named the way the export names it, in two parameters of
+`Content-Disposition`. `filename*` carries the name percent-encoded and is the
+one a browser reads, so the `%2F` between the cloud and the project reaches the
+saved file as it is; `filename` carries it plain for a client that reads
+nothing else. One name differs from the export's: of two statements of one run
+whose file names differ in ASCII case alone, the export writes the second under
+the SHA-256 digest of its key, and the console, which reads one statement at a
+time, names each after its key.
+
 ## The fleet at an instant and over a window
 
 The resource list is read under one status, and that page is then read one of
@@ -259,11 +293,12 @@ engine read under the name its query carries in
 [`internal/console/store/queries.sql`](https://github.com/B42Labs/tally/blob/main/internal/console/store/queries.sql).
 
 A failure renders one error page carrying the wrapped error: 400 for a parameter
-that is missing or unreadable, 404 for a lookup that found nothing and for an
-API 404, 502 for a Reporting API call that failed or that the API refused the
-token for, and 503 for an engine query that failed or a stored document that
-does not decode. A path the console has no page for is answered 404 on that same
-error page, and a route asked with a method it does not answer 405.
+that is missing or unreadable, 404 for a lookup that found nothing, for an API
+404 and for the file of a statement whose run is not exported, 502 for a
+Reporting API call that failed or that the API refused the token for, and 503
+for an engine query that failed or a stored document that does not decode or
+that the export refuses. A path the console has no page for is answered 404 on
+that same error page, and a route asked with a method it does not answer 405.
 
 Amounts are rendered at two decimal places and quantities at four, the scales
 the engine rounds them to. A catalog price is rendered with the digits the

--- a/internal/console/httpui/export.go
+++ b/internal/console/httpui/export.go
@@ -1,0 +1,153 @@
+package httpui
+
+import (
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/export"
+	"github.com/b42labs/tally/internal/engine/statements"
+)
+
+// A statement's export is the file tally-engine export --format json writes for
+// it, and the console serves those bytes rather than the stored document. The
+// engine database keeps a document as JSONB, which holds the members in an
+// order of its own, and the export renders every document again in the order
+// the concept prints it in: the stored bytes carry the right values in a file
+// no ERP receives. The rendering is the export's own, called on the stored
+// document, so the page, the route and an exported file hold the same bytes.
+const (
+	// exportRoute serves the file on its own, as JSON rather than as a page.
+	exportRoute = "/statement.json"
+	// downloadParameter turns the answer of exportRoute into an attachment.
+	downloadParameter = "download"
+	// jsonContentType is what exportRoute answers with.
+	jsonContentType = "application/json"
+)
+
+// exportView is what the statement page says about the file the export writes
+// for the statement: the file, its bytes and the two links to it, or, where
+// there is no file, why.
+type exportView struct {
+	File         string
+	JSON         string
+	Size         int
+	OpenLink     string
+	DownloadLink string
+	// Note says why the page shows no file: a run the export does not read, or
+	// a stored document the export refuses.
+	Note string
+}
+
+// buildExportView renders the file the export writes for one statement of a
+// run. A document the export refuses leaves the bill standing: the page says
+// what the export said, and the route is where that refusal is an error.
+func buildExportView(run store.Run, key string, document []byte) exportView {
+	if !export.Exportable(run.Status) {
+		return exportView{Note: notExported(run).Error()}
+	}
+	body, err := export.RenderStatement(run.ID, run.Kind, statements.Statement{Key: key, Document: document})
+	if err != nil {
+		return exportView{Note: "the export refuses this statement: " + err.Error()}
+	}
+
+	runID := run.ID.String()
+	return exportView{
+		File:         export.DocumentFileName(run.Kind, key),
+		JSON:         string(body),
+		Size:         len(body),
+		OpenLink:     link(exportRoute, "run", runID, "key", key),
+		DownloadLink: link(exportRoute, "run", runID, "key", key, downloadParameter, "1"),
+	}
+}
+
+// notExported says why a run's statements have no file, in the words the
+// export refuses such a run with.
+func notExported(run store.Run) error {
+	return fmt.Errorf("run %s is %s, and only a completed or finalized run is exported", run.ID, run.Status)
+}
+
+// statementExport serves the file the export writes for one statement: the
+// bytes alone, as JSON, opened in the browser or, with the download parameter,
+// saved under the name the export gives the file. A run the export does not
+// read has no such file and is answered 404, and a document the export refuses
+// 503, both on the error page.
+func (h *handlers) statementExport(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var src sources
+
+	runID, err := uuidParameter(r, "run")
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
+	key, err := stringParameter(r, "key")
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
+
+	stored, err := h.store.GetStatement(ctx, runID, key)
+	src.query("GetStatement")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
+	run, err := h.store.GetRun(ctx, runID)
+	src.query("GetRun")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+	if !export.Exportable(run.Status) {
+		h.fail(w, r, http.StatusNotFound, "the export writes no file for this statement", notExported(run), src)
+		return
+	}
+
+	body, err := export.RenderStatement(run.ID, run.Kind, statements.Statement{Key: key, Document: stored.Document})
+	if err != nil {
+		h.failFrom(w, r, documentFailed(err), src)
+		return
+	}
+
+	disposition := "inline"
+	if r.URL.Query().Get(downloadParameter) != "" {
+		disposition = "attachment"
+	}
+	w.Header().Set("Content-Type", jsonContentType)
+	w.Header().Set("Content-Disposition", contentDisposition(disposition, export.DocumentFileName(run.Kind, key)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// contentDisposition names the file twice. The plain filename parameter is for
+// a client that reads nothing else, curl -J for one. A browser takes filename*
+// over it, whose value RFC 8187 percent-encodes, and that is the one that keeps
+// the name: Chrome reads a percent escape in the plain parameter as one, so the
+// %2F the export puts between the cloud and the project would come back as a
+// slash and the file would be saved under a name the export never gave it.
+func contentDisposition(disposition, name string) string {
+	var encoded strings.Builder
+	for i := range len(name) {
+		c := name[i]
+		if isAttrChar(c) {
+			encoded.WriteByte(c)
+			continue
+		}
+		fmt.Fprintf(&encoded, "%%%02X", c)
+	}
+	return mime.FormatMediaType(disposition, map[string]string{"filename": name}) +
+		"; filename*=UTF-8''" + encoded.String()
+}
+
+// isAttrChar reports whether RFC 8187 lets a byte stand for itself in an
+// extended parameter value. Every other byte is percent-encoded.
+func isAttrChar(c byte) bool {
+	if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
+		return true
+	}
+	return strings.IndexByte("!#$&+-.^_`|~", c) >= 0
+}

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
@@ -680,6 +681,20 @@ func goldenStatement(t *testing.T) []byte {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading the golden statement: %v", err)
+	}
+	return raw
+}
+
+// goldenCreditNote is the credit note the engine's export golden holds for the
+// correction of that month.
+func goldenCreditNote(t *testing.T) []byte {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "engine", "export", "testdata", "golden", "correction",
+		"credit-note-os-prod%2Fproj-456.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the golden credit note: %v", err)
 	}
 	return raw
 }
@@ -1574,6 +1589,239 @@ func TestStatementPage(t *testing.T) {
 	})
 }
 
+func TestStatementExport(t *testing.T) {
+	t.Parallel()
+
+	query := "?run=" + testRunID.String() + "&key=" + url.QueryEscape(testKey)
+	statementPath := "/statement" + query
+	exportPath := "/statement.json" + query
+
+	t.Run("the page shows the file the export writes", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, statementPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		golden := goldenStatement(t)
+		for _, want := range []string{
+			"<code>statement-os-sim%2Fp-1.json</code>, " + strconv.Itoa(len(golden)) + " bytes",
+			`<a href="/statement.json?key=os-sim%2Fp-1&amp;run=` + testRunID.String() + `">open</a>`,
+			`<a href="/statement.json?download=1&amp;key=os-sim%2Fp-1&amp;run=` + testRunID.String() +
+				`">download</a>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+		if got := exportedDocument(t, body); got != string(golden) {
+			t.Errorf("the page shows\n%s\nwant the golden statement\n%s", got, golden)
+		}
+	})
+
+	t.Run("the route serves the bytes the export writes", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		for _, c := range []struct{ path, disposition string }{
+			{path: exportPath, disposition: "inline"},
+			{path: exportPath + "&download=1", disposition: "attachment"},
+		} {
+			status, header, body := fetch(t, handler, c.path)
+			if status != http.StatusOK {
+				t.Fatalf("%s: status = %d, want %d:\n%s", c.path, status, http.StatusOK, body)
+			}
+			if got := header.Get("Content-Type"); got != "application/json" {
+				t.Errorf("%s: content type = %q, want application/json", c.path, got)
+			}
+			want := c.disposition + "; filename=statement-os-sim%2Fp-1.json; " +
+				"filename*=UTF-8''statement-os-sim%252Fp-1.json"
+			if got := header.Get("Content-Disposition"); got != want {
+				t.Errorf("%s: content disposition = %q, want %q", c.path, got, want)
+			}
+			if golden := goldenStatement(t); !bytes.Equal(body, golden) {
+				t.Errorf("%s: body =\n%s\nwant the golden statement\n%s", c.path, body, golden)
+			}
+		}
+	})
+
+	t.Run("a document stored in another member order", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.statement.Document = reorderedDocument(t, goldenStatement(t))
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		golden := goldenStatement(t)
+		if _, _, body := fetch(t, handler, exportPath); !bytes.Equal(body, golden) {
+			t.Errorf("the route serves\n%s\nwant the golden statement\n%s", body, golden)
+		}
+		_, page, _ := get(t, handler, statementPath)
+		if got := exportedDocument(t, page); got != string(golden) {
+			t.Errorf("the page shows\n%s\nwant the golden statement\n%s", got, golden)
+		}
+	})
+
+	t.Run("the credit note of a correction", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.run = store.Run{
+			ID:            testCorrectionRunID,
+			PeriodFrom:    testPeriod,
+			PeriodTo:      testPeriod.AddDate(0, 1, 0),
+			Kind:          "correction",
+			CorrectsRunID: testRunID,
+			Status:        "finalized",
+		}
+		engine.statement = store.Statement{
+			Document: goldenCreditNote(t),
+			Total:    mustDecimal(t, "-24.00"),
+			Currency: "EUR",
+		}
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		correction := "?run=" + testCorrectionRunID.String() + "&key=" + url.QueryEscape(testKey)
+		status, header, body := fetch(t, handler, "/statement.json"+correction)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		if golden := goldenCreditNote(t); !bytes.Equal(body, golden) {
+			t.Errorf("body =\n%s\nwant the golden credit note\n%s", body, golden)
+		}
+		if got := header.Get("Content-Disposition"); !strings.HasSuffix(got, "credit-note-os-sim%252Fp-1.json") {
+			t.Errorf("content disposition = %q, want it to name the credit note", got)
+		}
+		if _, page, _ := get(t, handler, "/statement"+correction); !strings.Contains(page,
+			"<code>credit-note-os-sim%2Fp-1.json</code>") {
+			t.Errorf("the page does not name the credit note:\n%s", page)
+		}
+	})
+
+	t.Run("a run the export does not read", func(t *testing.T) {
+		t.Parallel()
+
+		for _, status := range []string{"superseded", "failed"} {
+			engine := fullStore(t)
+			engine.run.Status = status
+			handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+			want := "is " + status + ", and only a completed or finalized run is exported"
+			code, page, _ := get(t, handler, statementPath)
+			if code != http.StatusOK {
+				t.Fatalf("%s: page status = %d, want %d", status, code, http.StatusOK)
+			}
+			if !strings.Contains(page, want) || strings.Contains(page, `<details class="export">`) {
+				t.Errorf("%s: the page does not say its run is not exported, or shows a file:\n%s", status, page)
+			}
+			code, body, _ := get(t, handler, exportPath)
+			if code != http.StatusNotFound {
+				t.Errorf("%s: route status = %d, want %d", status, code, http.StatusNotFound)
+			}
+			if !strings.Contains(body, want) {
+				t.Errorf("%s: the route does not say why:\n%s", status, body)
+			}
+		}
+	})
+
+	t.Run("a document the export refuses", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		golden := goldenStatement(t)
+		engine.statement.Document = append([]byte(`{"invoice_number":"2026-03-0001",`), golden[1:]...)
+		handler, logged := serve(t, fullAPI(t), engine, testNow)
+
+		code, page, _ := get(t, handler, statementPath)
+		if code != http.StatusOK {
+			t.Fatalf("page status = %d, want %d: the bill stands without the file", code, http.StatusOK)
+		}
+		if !strings.Contains(page, "the export refuses this statement") || !strings.Contains(page, "invoice_number") {
+			t.Errorf("the page does not carry the export's refusal:\n%s", page)
+		}
+		code, body, _ := get(t, handler, exportPath)
+		if code != http.StatusServiceUnavailable {
+			t.Errorf("route status = %d, want %d", code, http.StatusServiceUnavailable)
+		}
+		if !strings.Contains(body, "invoice_number") || !strings.Contains(logged.String(), "invoice_number") {
+			t.Errorf("the refusal did not reach the page and the log:\n%s\n%s", body, logged.String())
+		}
+	})
+
+	t.Run("no such statement", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.statementErr = fmt.Errorf("GetStatement: %w", pgx.ErrNoRows)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		if code, _, _ := get(t, handler, exportPath); code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
+		}
+	})
+}
+
+// fetch asks the console for one route and reads the whole answer, headers
+// included, for a route whose headers are part of what it serves.
+func fetch(t *testing.T, handler http.Handler, path string) (status int, header http.Header, body []byte) {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+
+	result := recorder.Result()
+	defer func() { _ = result.Body.Close() }()
+
+	read, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("reading the answer of %s: %v", path, err)
+	}
+	return result.StatusCode, result.Header, read
+}
+
+// exportPattern finds the document the export section of a statement page
+// shows.
+var exportPattern = regexp.MustCompile(
+	`(?s)<details class="export">\s*<summary>the document</summary>\s*<pre>(.*?)</pre>`)
+
+// exportedDocument is the document a statement page shows as the export's
+// file, with the escaping the template put on it taken off again.
+func exportedDocument(t *testing.T, body string) string {
+	t.Helper()
+
+	match := exportPattern.FindStringSubmatch(body)
+	if match == nil {
+		t.Fatalf("the page shows no exported document:\n%s", body)
+	}
+	return html.UnescapeString(match[1])
+}
+
+// reorderedDocument is a document with its members in another order and
+// without its whitespace, the way JSONB hands a stored one back in an order of
+// its own: here the keys of every object sorted by their bytes. The numbers
+// keep the text they were stored as.
+func reorderedDocument(t *testing.T, document []byte) []byte {
+	t.Helper()
+
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		t.Fatalf("decoding the document: %v", err)
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encoding the document: %v", err)
+	}
+	if bytes.Equal(body, document) {
+		t.Fatal("the document came back in the order it was stored in")
+	}
+	return body
+}
+
 // relatedCostDocument is a statement whose costs are one attributed project's,
 // which the golden statement holds none of.
 func relatedCostDocument(t *testing.T) []byte {
@@ -1709,6 +1957,8 @@ func TestRequiredParameters(t *testing.T) {
 		{path: "/statement?key=os-sim%2Fp-1", parameter: "run"},
 		{path: "/statement?run=" + testRunID.String(), parameter: "key"},
 		{path: "/statement?run=not-a-uuid&key=os-sim%2Fp-1", parameter: "run"},
+		{path: "/statement.json?key=os-sim%2Fp-1", parameter: "run"},
+		{path: "/statement.json?run=" + testRunID.String(), parameter: "key"},
 	}
 
 	for _, c := range cases {
@@ -2807,7 +3057,7 @@ func TestBill(t *testing.T) {
 		handler, _ := serve(t, fullAPI(t), billStore(t), testNow)
 
 		_, body, _ := get(t, handler, statementPath+"&items.q=vm-4")
-		if strings.Count(body, "<details") != 1 || !strings.Contains(body, `id="li-1"`) {
+		if strings.Count(body, `<details class="item"`) != 1 || !strings.Contains(body, `id="li-1"`) {
 			t.Errorf("the blocks do not follow the filter:\n%s", body)
 		}
 		if !strings.Contains(body, "1 of 2 rows match") {

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -7,8 +7,10 @@
 // handler rendered, and a page that shows a number read that number itself.
 // Sorting and filtering a table are links and a form that reload the page
 // with the table's state in the query string, and the theme is a form that
-// posts the choice to /theme, the one route that is not a page: it keeps the
-// choice in a cookie and sends the viewer back.
+// posts the choice to /theme, which is not a page: it keeps the choice in a
+// cookie and sends the viewer back. /statement.json is not a page either: it
+// serves the file the JSON export writes for a statement, as the export's own
+// bytes rather than as HTML.
 //
 // Every identifier travels in a query parameter rather than in a path segment.
 // A cloud name, a resource id and a statement key may each carry a slash, and a
@@ -140,6 +142,7 @@ func NewRouter(opts Options) (http.Handler, error) {
 	r.Get("/catalog", h.catalog)
 	r.Get("/run", h.run)
 	r.Get("/statement", h.statement)
+	r.Get(exportRoute, h.statementExport)
 	r.Get("/static/console.css", h.stylesheet)
 	r.Post(themeRoute, h.theme)
 	r.NotFound(h.notFound)

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -65,6 +65,9 @@ type statementData struct {
 	Adjustments listing[adjustments.Line]
 	Items       billSection
 	Related     []billSection
+	// Export is the file the JSON export writes for the statement, or why
+	// there is none.
+	Export exportView
 }
 
 // adjustmentColumns is the adjustments table of a statement.
@@ -132,7 +135,9 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 }
 
 // statement shows one stored document as a bill. The document is what the run
-// wrote: the page decodes it and prints it, and computes none of it again.
+// wrote: the page decodes it and prints it, and computes none of it again. The
+// run is read for the file the export writes beside the bill, which its kind
+// names and its status decides whether there is one at all.
 func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 	var src sources
 
@@ -161,6 +166,13 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	run, err := h.store.GetRun(r.Context(), runID)
+	src.query("GetRun")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
 	data := statementData{
 		Key:         key,
 		Cloud:       absent,
@@ -169,6 +181,7 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 		RunLink:     link("/run", "id", runID.String()),
 		Document:    document,
 		Adjustments: tabulate(r, "adjustments", adjustmentColumns, document.Adjustments),
+		Export:      buildExportView(run, key, stored.Document),
 	}
 	// A key this cannot read is shown as it is stored: the page is about that
 	// stored row, and a guessed pair would name one nothing was stored under.

--- a/internal/console/httpui/static/console.css
+++ b/internal/console/httpui/static/console.css
@@ -501,6 +501,19 @@ details.cell > pre {
   min-width: 24rem;
 }
 
+/* The file the JSON export writes for a statement folds under the head of the
+   page. Opened, it scrolls within the viewport rather than within the few
+   lines a payload in a cell gets. */
+details.export > summary {
+  color: var(--accent);
+  cursor: pointer;
+}
+
+details.export > pre {
+  max-height: 70vh;
+  margin-top: 0.35rem;
+}
+
 /* A table inside a cell carries what one row is made of, the resources of one
    resource type for example. It is wider than the cell it folds out of, and
    its heading does not stick, because it scrolls with the row rather than with

--- a/internal/console/httpui/templates/statement.gohtml
+++ b/internal/console/httpui/templates/statement.gohtml
@@ -11,6 +11,17 @@
 {{with .Document.KickbackTotal}}<dt>kickback total</dt><dd>{{amount .Decimal}}</dd>{{end}}
 </dl>
 
+<h2>Export</h2>
+{{with .Export}}{{if .File}}
+<p><code>{{.File}}</code>, {{.Size}} bytes, as <code>tally-engine export --format json</code> writes it: <a href="{{.OpenLink}}">open</a>, <a href="{{.DownloadLink}}">download</a></p>
+<details class="export">
+<summary>the document</summary>
+<pre>{{.JSON}}</pre>
+</details>
+{{else}}
+<p class="muted">{{.Note}}</p>
+{{end}}{{end}}
+
 {{if .Adjustments.Table.Total}}
 <h2>Adjustments</h2>
 {{template "tableTools" .Adjustments.Table}}

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -63,6 +63,14 @@ const (
 	statusFinalized = "finalized"
 )
 
+// Exportable reports whether a run of this status is exported: a completed or
+// a finalized one. Load refuses every other status, and a reader that shows a
+// statement's file asks the same question before it renders one, so the two
+// cannot disagree about which runs an ERP receives.
+func Exportable(status string) bool {
+	return status == statusCompleted || status == statusFinalized
+}
+
 // Run is one run as an exporter receives it: its row, its statements, its rated
 // records, the kickbacks it settles, and, for a correction, its deltas. It is
 // everything the file writers below need, so an exporter runs with no database
@@ -202,7 +210,7 @@ func load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID, artifacts bo
 		}
 		return Run{}, fmt.Errorf("reading the run %s: %w", runID, err)
 	}
-	if row.Status != statusCompleted && row.Status != statusFinalized {
+	if !Exportable(row.Status) {
 		return Run{}, fmt.Errorf("%w: run %s is %s, and only a completed or finalized run is exported",
 			ErrRunNotExportable, runID, row.Status)
 	}

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -1494,6 +1494,107 @@ func TestJSONFilesRefusals(t *testing.T) {
 	}
 }
 
+// TestRenderStatement pins the bytes one statement renders to against the file
+// the JSON writer puts it in, which TestExportGolden pins in turn. A reader
+// that shows a statement's file calls this rather than JSONFiles, so a
+// difference here is a page showing a file no export writes.
+func TestRenderStatement(t *testing.T) {
+	cases := []struct {
+		name   string
+		run    func(t *testing.T) export.Run
+		golden string
+	}{
+		{name: "the statements of a regular run", run: regularRun, golden: "regular"},
+		{name: "the credit note of a correction", run: correctionRun, golden: "correction"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			run := c.run(t)
+			for _, statement := range run.Statements {
+				got, err := export.RenderStatement(run.ID, run.Kind, statement)
+				if err != nil {
+					t.Fatalf("RenderStatement(%s) error = %v, want nil", statement.Key, err)
+				}
+				file := export.DocumentFileName(run.Kind, statement.Key)
+				want := read(t, filepath.Join("testdata", "golden", c.golden, file))
+				if !bytes.Equal(got, want) {
+					t.Errorf("RenderStatement(%s) =\n%s\nwant %s\n%s", statement.Key, got, file, want)
+				}
+			}
+		})
+	}
+
+	t.Run("a document stored in another member order", func(t *testing.T) {
+		run := regularRun(t)
+		statement := run.Statements[1]
+		statement.Document = reordered(t, statement.Document)
+
+		got, err := export.RenderStatement(run.ID, run.Kind, statement)
+		if err != nil {
+			t.Fatalf("RenderStatement() error = %v, want nil", err)
+		}
+		if want := read(t, filepath.Join("testdata", "golden", "regular", statementFile)); !bytes.Equal(got, want) {
+			t.Errorf("RenderStatement() =\n%s\nwant\n%s", got, want)
+		}
+	})
+
+	t.Run("a document holding a field the type does not have", func(t *testing.T) {
+		run := regularRun(t)
+		statement := run.Statements[1]
+		statement.Document = []byte(`{"project_id":"proj-456","invoice_number":"2026-03-0001"}`)
+
+		_, err := export.RenderStatement(run.ID, run.Kind, statement)
+		if err == nil {
+			t.Fatal("RenderStatement() error = nil, want the document refused")
+		}
+		for _, want := range []string{statementKey, regularRunID.String(), "invoice_number"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("RenderStatement() error = %v, want it to name %s", err, want)
+			}
+		}
+	})
+}
+
+// reordered is a document with its members in another order and without its
+// whitespace, the way JSONB hands a stored one back in an order of its own:
+// here the keys of every object sorted by their bytes. The numbers keep the
+// text they were stored as, so only the order and the layout differ.
+func reordered(t *testing.T, document []byte) []byte {
+	t.Helper()
+
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		t.Fatalf("decoding the document: %v", err)
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encoding the document: %v", err)
+	}
+	if bytes.Equal(body, document) {
+		t.Fatal("the document came back in the order it was stored in")
+	}
+	return body
+}
+
+// TestExportable pins which run statuses an export is produced from: the two
+// that bill, and none of the three a period keeps for audit.
+func TestExportable(t *testing.T) {
+	for status, want := range map[string]bool{
+		"completed":  true,
+		"finalized":  true,
+		"running":    false,
+		"failed":     false,
+		"superseded": false,
+	} {
+		if got := export.Exportable(status); got != want {
+			t.Errorf("Exportable(%q) = %t, want %t", status, got, want)
+		}
+	}
+}
+
 // TestExportOntoAFile pins what an --out that names an existing file reports.
 // The path is an operator's, and mkdir is the first thing either writer does
 // with it, so the error names the directory it could not create and carries the

--- a/internal/engine/export/json.go
+++ b/internal/engine/export/json.go
@@ -238,7 +238,7 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 		if err != nil {
 			return fmt.Errorf("the statement %s of run %s: %w", statement.Key, run.ID, err)
 		}
-		document, err := renderDocument(run, statement)
+		document, err := RenderStatement(run.ID, run.Kind, statement)
 		if err != nil {
 			return err
 		}
@@ -315,29 +315,35 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 	return writeIndexedFiles(j.Dir, files, artifact{name: runFileName, body: body})
 }
 
-// renderDocument re-renders one stored document. The document is decoded into
-// the type its run's kind renders and marshalled again, which is what turns the
-// key order JSONB stores an object in back into the field order the concept
-// prints it in. Unknown fields are refused rather than dropped: a document the
-// engine's own types do not hold every field of is one this version cannot
-// render without losing part of it.
-func renderDocument(run Run, statement statements.Statement) ([]byte, error) {
+// RenderStatement re-renders one stored document the way the JSON export writes
+// it. The document is decoded into the type the run's kind renders, a statement
+// or a credit note, and marshalled again, which is what turns the key order
+// JSONB stores an object in back into the field order the concept prints it in.
+// Unknown fields are refused rather than dropped: a document the engine's own
+// types do not hold every field of is one this version cannot render without
+// losing part of it.
+//
+// The bytes are the file DocumentFileName names, and JSONFiles writes them from
+// here, so a reader that shows a statement's file shows what an export of the
+// run writes rather than a copy of it. Of the statement only the key and the
+// document are read, and the run id names the run in an error.
+func RenderStatement(runID uuid.UUID, kind string, statement statements.Statement) ([]byte, error) {
 	decoder := json.NewDecoder(bytes.NewReader(statement.Document))
 	decoder.DisallowUnknownFields()
 
 	var document any = &statements.Document{}
-	if run.Kind == runs.KindCorrection {
+	if kind == runs.KindCorrection {
 		document = &corrections.CreditNote{}
 	}
 	if err := decoder.Decode(document); err != nil {
 		return nil, fmt.Errorf("decoding the stored document of statement %s of run %s: %w",
-			statement.Key, run.ID, err)
+			statement.Key, runID, err)
 	}
 
 	body, err := marshal(document)
 	if err != nil {
 		return nil, fmt.Errorf("rendering the document of statement %s of run %s: %w",
-			statement.Key, run.ID, err)
+			statement.Key, runID, err)
 	}
 	return body, nil
 }


### PR DESCRIPTION
Closes #133

The statement page of the demo console now carries the file `tally-engine export --format json` writes for the statement, and `/statement.json` serves the same bytes on their own, to open in the browser or to download under the export's file name. The console renders the stored document through the export's own renderer, so the page, the route and an exported file hold the same bytes.

## Commits

1. `3767606` Render one statement the way the export writes it. `renderDocument` becomes `export.RenderStatement(runID, kind, statement)`, and `JSONFiles` writes its documents from it. `export.Exportable(status)` is the rule `Load` applied inline (a completed or a finalized run), now in one place. `TestRenderStatement` pins the rendered bytes to the golden files for a statement, a credit note and a document stored in another member order; `TestExportable` pins the five run statuses.
2. `ad3b030` Show the file the JSON export writes on the statement page. A folded `Export` section under the head of `/statement` shows the file name, its size and two links to `/statement.json`, which answers `application/json`, `inline`, or with `download=1` as an `attachment`. The name travels in `filename*` (RFC 8187), so the `%2F` between cloud and project survives Chrome, and in `filename` for clients such as `curl -J`. A run that is neither completed nor finalized shows a note, and the route answers 404. A document the export refuses leaves the bill standing with the export's error, and the route answers 503. The page reads `GetRun` beside `GetStatement`.
3. `ae4d0cd` Document the export of a statement in the console reference: the route table, a section on the export, and the error statuses in `docs/reference/command-line/tally-console.md`.

## Acceptance criteria

#133 was filed at draft depth. These are the criteria of the plan approved for it.

| # | Criterion | Evidence |
| --- | --- | --- |
| 1 | `/statement.json` serves the bytes `JSONFiles.Export` writes, also for a stored document in another member order | `TestRenderStatement`, `TestExportGolden`, `TestStatementExport` |
| 2 | The page shows the file name, its size, the JSON, and the open and download links | `TestStatementExport/the_page_shows_the_file_the_export_writes` |
| 3 | `inline` and `attachment`, the name in `filename*`, `application/json` | `TestStatementExport/the_route_serves_the_bytes_the_export_writes` |
| 4 | A correction's file is `credit-note-<key>.json` and holds the credit note | `TestStatementExport/the_credit_note_of_a_correction` |
| 5 | A superseded or failed run shows a note, and the route answers 404 | `TestStatementExport/a_run_the_export_does_not_read` |
| 6 | A document the export refuses: the page stands with a note, and the route answers 503 | `TestStatementExport/a_document_the_export_refuses` |
| 7 | No JavaScript, and the console writes nothing | `TestEveryRouteRendersWithoutScripts`; the console diff adds no file write and no exec |
| 8 | The reference is current | `go test ./docs/`, `make docs-build` |

Run locally: `go build ./...`, `go vet ./...`, `make lint` (0 issues), `make test`, `make docs-build`.

Not run: an end-to-end comparison against a real export (`tally-engine export` of the finalized 2026-07 run, `cmp` against `/statement.json`), because the dev cluster was down.

## Notes

- `TestBill` counted every `<details` on the statement page. It now counts `<details class="item"`, the item blocks its assertion is about, because the export section is a `details` element of its own.
- The download is named by `export.DocumentFileName`. Of two statements of one run whose file names differ in ASCII case alone, the export writes the second under its digest, while the console reads one statement at a time and names each after its key. The reference states this.
- Not part of this change: how the bill renders a credit note, and a view of a whole run's export (`run.json`, `kickbacks.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
