### PR TITLE
Render credit notes as credit notes and show a run's stats in the demo console

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -32,8 +32,8 @@ environment, under the names the settings table below lists.
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
-| `/run?id=` | Engine: the run, its statements, its correction deltas. |
-| `/statement?run=&key=` | Engine: the run, and one statement document rendered as a bill: its head, the file the JSON export writes for it, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. |
+| `/run?id=` | Engine: the run, the stats it stored, its statements, its correction deltas. |
+| `/statement?run=&key=` | Engine: the run, and one statement document rendered as a bill: its head, the file the JSON export writes for it, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. The document of a correction run is a credit note and is rendered as one: its head carries the deltas, its adjustments what changed, and each item's block one row per dimension. |
 | `/statement.json?run=&key=` | Engine: the run and the statement. Not a page: the bytes `tally-engine export --format json` writes for the statement, served as `application/json`, and with `download` set as an attachment. |
 | `/static/console.css` | The embedded stylesheet, the only asset the pages load. |
 | `/theme` | Nothing. Not a page: it takes the theme form's POST, keeps the choice in a cookie, and sends the viewer back. |
@@ -156,8 +156,8 @@ The tables and their names per page:
 | `/resource` | `segments`, `events` |
 | `/pricing` | `models` |
 | `/catalog` | `dimensions` |
-| `/run` | `statements`, `deltas` |
-| `/statement` | `adjustments`; `items` and `rc-<n>`, the summaries of the line items and of the n-th related cost; `li-<n>` and `rc-<n>-li-<n>`, the metric tables of the items, which sort and carry no filter |
+| `/run` | `statements`, `deltas`; the lists of what the run reported, `warnings`, `metering_warnings`, `counter_warnings`, `attribution_warnings`, `adjustment_warnings`, `unpriced`, `unreadable`, `unregistered_projects` and `violations` |
+| `/statement` | `adjustments`; `items` and `rc-<n>`, the summaries of the line items and of the n-th related cost; `li-<n>` and `rc-<n>-li-<n>`, the metric tables of the items, which sort and carry no filter. A credit note carries the same names, its `li-<n>` tables holding one row per dimension |
 
 A paged listing, `/projects` and `/resources`, is sorted and filtered within
 the page the API answered, which its row count says, and its next link carries
@@ -177,6 +177,20 @@ block's heading links the resource's page, and its table holds one row per
 metric of every period, with the period's total as a row of its own. A description that
 only repeats the item's type and id is left out. A value of exactly zero is
 printed in the muted colour, so the amounts that are not zero stand out.
+
+A credit note is rendered the same way, and the run decides which of the two a
+stored document is: a correction run stores a credit note under every key, and
+the page reads it as one, which is the rule `tally-engine export` decodes a
+document by. The head names the run the note corrects and carries the base,
+net and kickback deltas where the note holds them. The adjustments table shows
+each adjustment's rate beside what the corrected run applied, what the
+correction applied and the difference. A section's summary lists resource type,
+resource and total, and it opens in the order the note lists its items: a note
+credits some items and debits others, so neither direction of the total puts
+the largest movement first, and a heading still sorts it. An item's block holds
+one row per dimension, with the amount the corrected run billed, the amount
+the correction rated and the delta. A document stored under a correction run
+that names no run it corrects is not a credit note and is answered 503.
 
 ## The export of a statement
 
@@ -210,6 +224,40 @@ nothing else. One name differs from the export's: of two statements of one run
 whose file names differ in ASCII case alone, the export writes the second under
 the SHA-256 digest of its key, and the console, which reads one statement at a
 time, names each after its key.
+
+## What a run reported
+
+The run page carries, under its head, what the run stored about itself. The
+counts come first: the snapshot, the instant up to which the run read the
+events; the candidates it considered; the usage and rated records it wrote; its
+statements, which a correction calls credit notes; its adjustment records; and
+for a correction the deltas and the adjustment deltas it wrote. A run that
+failed names the error it failed with above them.
+
+Every list of findings follows as a table of its own, drawn when it holds a
+row and named after the member of the stats it lists, which is the name the
+list carries in the `run.json` of an export:
+
+| Table | What it lists | A row leads to |
+| --- | --- | --- |
+| `warnings` | what the run found about itself: a period that had not ended | nothing |
+| `metering_warnings` | resources the metering pass warned about, a history that starts without a create for example | the resource |
+| `counter_warnings` | counters that could not be read for a resource, with the metric and the window | the resource |
+| `attribution_warnings` | projects claimed twice or sitting in a cycle, with the relation that lost | the project |
+| `adjustment_warnings` | relations whose kickbacks were dropped because their target is not a partner | nothing |
+| `unpriced` | resource types the pricing model does not price, counting the resources skipped | nothing |
+| `unreadable` | usage fields no quantity could be read from, counting the drafts | nothing |
+| `unregistered_projects` | projects the run met resources of and no registry row names | the project's resources |
+| `violations` | invariant violations, one row per violation of a resource | the resource |
+
+An unregistered project has no project page, so its row leads to the resource
+list filtered to its cloud and project under every status. A run whose lists
+are all empty says it reported no finding.
+
+A run that is still running has stored no stats, and its page says so. Stats
+the console cannot read, a value that is not JSON or a member the engine's
+types do not have, are shown as they were stored beside the reason, and the
+rest of the page stands. The page reports them and does not log them.
 
 ## The fleet at an instant and over a window
 

--- a/internal/console/httpui/bill.go
+++ b/internal/console/httpui/bill.go
@@ -113,18 +113,27 @@ func buildBillSection(
 	}
 }
 
-// buildItemRow lays one item out, summary and detail alike.
-func buildItemRow(r *http.Request, anchor, cloud string, item statements.LineItem) itemRow {
+// openLink is the page with the detail block under anchor unfolded and
+// scrolled to, and whether the request is already that page: the link names
+// the block in the open parameter and in its fragment. A statement's items and
+// a credit note's items are opened the same way.
+func openLink(r *http.Request, anchor string) (string, bool) {
 	values := r.URL.Query()
 	opened := maps.Clone(values)
 	opened.Set(openParameter, anchor)
+	return href(r.URL.Path, opened) + "#" + anchor, values.Get(openParameter) == anchor
+}
+
+// buildItemRow lays one item out, summary and detail alike.
+func buildItemRow(r *http.Request, anchor, cloud string, item statements.LineItem) itemRow {
+	opening, open := openLink(r, anchor)
 	row := itemRow{
 		Anchor:       anchor,
-		OpenLink:     href(r.URL.Path, opened) + "#" + anchor,
+		OpenLink:     opening,
 		ResourceType: item.ResourceType,
 		ResourceID:   item.ResourceID,
 		Total:        item.Total.Decimal,
-		Open:         values.Get(openParameter) == anchor,
+		Open:         open,
 	}
 	if item.Description != item.ResourceType+" "+item.ResourceID {
 		row.Description = item.Description

--- a/internal/console/httpui/creditnote.go
+++ b/internal/console/httpui/creditnote.go
@@ -1,0 +1,214 @@
+package httpui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/corrections"
+	"github.com/b42labs/tally/internal/engine/runs"
+)
+
+// creditNoteData is one stored credit note rendered as what it is. A correction
+// run stores a credit note under each key rather than a statement: per resource
+// the dimensions the correction and the run it corrects disagree on, with what
+// that run billed, what the correction rated and the difference. The page lays
+// it out the way the bill lays out a statement, its own items as one section
+// and one section per related cost, with a folding block per item that holds
+// one row per dimension.
+type creditNoteData struct {
+	Key          string
+	Cloud        string
+	Project      string
+	RunID        uuid.UUID
+	RunLink      string
+	CorrectsLink string
+	Note         corrections.CreditNote
+	Adjustments  listing[corrections.AdjustmentChange]
+	Items        creditSection
+	Related      []creditSection
+	// Export is the file the JSON export writes for the note, or why there is
+	// none.
+	Export exportView
+}
+
+// creditSection is one section of a note: the summary of its items and, for a
+// related cost, what the section is about.
+type creditSection struct {
+	Currency string
+	Summary  listing[creditItemRow]
+	Related  *corrections.RelatedCost
+}
+
+// creditItemRow is one item of a note, in the summary table and as the detail
+// block the summary row leads to.
+type creditItemRow struct {
+	Anchor string
+	// OpenLink is the page with this block unfolded and scrolled to.
+	OpenLink     string
+	ResourceType string
+	ResourceID   string
+	Total        decimal.Decimal
+	// Open is whether the detail block is rendered unfolded, which the open
+	// parameter decides for one block at a time.
+	Open         bool
+	ResourceLink string
+	Dimensions   listing[changeRow]
+}
+
+// changeRow is one dimension of one item of a note: what the corrected run
+// billed, what the correction rated, and the difference the project is credited
+// or debited for.
+type changeRow struct {
+	Dimension string
+	Old       decimal.Decimal
+	New       decimal.Decimal
+	Delta     decimal.Decimal
+}
+
+// The columns of a credit note's tables: the summary of a section, the
+// dimensions of an item, and the adjustment changes of the note.
+var (
+	creditItemColumns = []column[creditItemRow]{
+		textCol("resource type", func(r creditItemRow) string { return r.ResourceType }),
+		textCol("resource", func(r creditItemRow) string { return r.ResourceID }),
+		numberCol("total", func(r creditItemRow) decimal.Decimal { return r.Total }),
+	}
+	changeColumns = []column[changeRow]{
+		textCol("dimension", func(r changeRow) string { return r.Dimension }),
+		numberCol("old", func(r changeRow) decimal.Decimal { return r.Old }),
+		numberCol("new", func(r changeRow) decimal.Decimal { return r.New }),
+		numberCol("delta", func(r changeRow) decimal.Decimal { return r.Delta }),
+	}
+	adjustmentChangeColumns = []column[corrections.AdjustmentChange]{
+		textCol("type", func(r corrections.AdjustmentChange) string { return r.Type }),
+		textCol("relation type", func(r corrections.AdjustmentChange) string { return r.RelationType }),
+		textCol("target", func(r corrections.AdjustmentChange) string { return r.RelationTarget }),
+		textCol("scope", func(r corrections.AdjustmentChange) string { return r.Scope }),
+		numberCol("rate", func(r corrections.AdjustmentChange) decimal.Decimal { return r.Rate.Decimal }),
+		numberCol("old", func(r corrections.AdjustmentChange) decimal.Decimal { return r.Old.Decimal }),
+		numberCol("new", func(r corrections.AdjustmentChange) decimal.Decimal { return r.New.Decimal }),
+		numberCol("delta", func(r corrections.AdjustmentChange) decimal.Decimal { return r.Delta.Decimal }),
+	}
+)
+
+// storesCreditNotes reports whether a run stores a credit note under each key
+// rather than a statement. It is the rule the export decodes a stored document
+// by, so the bill and the export block under its head read the same document.
+func storesCreditNotes(run store.Run) bool {
+	return run.Kind == runs.KindCorrection
+}
+
+// creditNote shows the credit note a correction run stored under key. The run
+// is already read, by the statement handler that chose this page for its kind.
+// The page decodes the note and prints it, and computes none of it again.
+func (h *handlers) creditNote(
+	w http.ResponseWriter, r *http.Request, run store.Run, key string, stored store.Statement, src sources,
+) {
+	note, err := readCreditNote(stored)
+	if err != nil {
+		h.failFrom(w, r,
+			documentFailed(fmt.Errorf("reading the credit note of %s in run %s: %w", key, run.ID, err)), src)
+		return
+	}
+
+	cloud, project, linkCloud := splitKey(key)
+	data := creditNoteData{
+		Key:          key,
+		Cloud:        cloud,
+		Project:      project,
+		RunID:        run.ID,
+		RunLink:      link("/run", "id", run.ID.String()),
+		CorrectsLink: link("/run", "id", note.CorrectsRunID),
+		Note:         note,
+		Adjustments:  tabulate(r, "adjustments", adjustmentChangeColumns, note.Adjustments),
+		Export:       buildExportView(run, key, stored.Document),
+	}
+
+	data.Items = buildCreditSection(r, itemsTable, itemAnchor, linkCloud, note.Currency, note.LineItems)
+	for index := range note.RelatedCosts {
+		related := &note.RelatedCosts[index]
+		prefix := fmt.Sprintf("rc-%d", index)
+		section := buildCreditSection(r, prefix, prefix+"-"+itemAnchor, linkCloud, note.Currency, related.LineItems)
+		section.Related = related
+		data.Related = append(data.Related, section)
+	}
+
+	h.render(w, r, "creditnote", page{
+		Title:   "Credit note " + key,
+		Sources: src,
+		Data:    data,
+	})
+}
+
+// readCreditNote decodes a stored document and refuses one that is not a credit
+// note. JSON accepts any object into a struct of optional members, so a
+// statement stored under a correction run would render as a note of nothing
+// rather than fail; a credit note is the document that names the run it
+// corrects.
+func readCreditNote(stored store.Statement) (corrections.CreditNote, error) {
+	var note corrections.CreditNote
+	if err := json.Unmarshal(stored.Document, &note); err != nil {
+		return corrections.CreditNote{}, err
+	}
+	if note.Currency == "" || note.BillingPeriod.From == "" || note.CorrectsRunID == "" {
+		return corrections.CreditNote{}, errors.New("not a credit note document")
+	}
+	return note, nil
+}
+
+// buildCreditSection lays one section of a note out, the way buildBillSection
+// lays out one of a statement. The summary opens in the note's own order rather
+// than by total: a note credits some items and debits others, so neither
+// direction of the total puts the largest movement first, and a click on the
+// heading still sorts.
+func buildCreditSection(
+	r *http.Request, table, anchor, cloud, currency string, items []corrections.LineItem,
+) creditSection {
+	rows := make([]creditItemRow, 0, len(items))
+	for index, item := range items {
+		rows = append(rows, buildCreditItemRow(r, fmt.Sprintf("%s-%d", anchor, index), cloud, item))
+	}
+	return creditSection{
+		Currency: currency,
+		Summary:  tabulate(r, table, creditItemColumns, rows),
+	}
+}
+
+// buildCreditItemRow lays one item of a note out, summary and detail alike: one
+// row per dimension, in the order of their names. No resource link is built
+// without the cloud, which is a key the page could not read.
+func buildCreditItemRow(r *http.Request, anchor, cloud string, item corrections.LineItem) creditItemRow {
+	opening, open := openLink(r, anchor)
+	row := creditItemRow{
+		Anchor:       anchor,
+		OpenLink:     opening,
+		ResourceType: item.ResourceType,
+		ResourceID:   item.ResourceID,
+		Total:        item.Total.Decimal,
+		Open:         open,
+	}
+	if cloud != "" {
+		row.ResourceLink = link("/resource", "cloud", cloud, "type", item.ResourceType, "id", item.ResourceID)
+	}
+
+	changes := make([]changeRow, 0, len(item.Dimensions))
+	for _, name := range slices.Sorted(maps.Keys(item.Dimensions)) {
+		change := item.Dimensions[name]
+		changes = append(changes, changeRow{
+			Dimension: name,
+			Old:       change.Old.Decimal,
+			New:       change.New.Decimal,
+			Delta:     change.Delta.Decimal,
+		})
+	}
+	row.Dimensions = tabulate(r, anchor, changeColumns, changes)
+	return row
+}

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -605,6 +605,7 @@ func fullStore(t *testing.T) *fakeStore {
 		PricingVersion: "2026-03",
 		Status:         "completed",
 		Clouds:         []string{"os-sim"},
+		Stats:          []byte(allStatsFixture),
 		StartedAt:      testPeriod.AddDate(0, 1, 0),
 		CompletedAt:    testPeriod.AddDate(0, 1, 0).Add(time.Minute),
 	}
@@ -1902,6 +1903,266 @@ func TestCreditNote(t *testing.T) {
 			strings.Count(body, "<h2>Related cost of")
 		if forms != 3 || sections != 3 {
 			t.Errorf("%d filter forms for %d sections, want 3 of each", forms, sections)
+		}
+	})
+}
+
+// allStatsFixture holds one entry in every list a run's stats carry, so the
+// run page draws each of its tables. fullStore's run carries it.
+const allStatsFixture = `{
+  "snapshot_at": "2026-04-04T00:00:00Z",
+  "candidates": 12,
+  "usage_records": 10,
+  "rated_records": 30,
+  "statements": 2,
+  "adjustment_records": 1,
+  "warnings": [{"code": "period_not_ended", "detail": "the period has not ended"}],
+  "metering_warnings": [
+    {"cloud": "os-sim", "resource_type": "instance", "resource_id": "vm-9", "code": "history_starts_without_create"}
+  ],
+  "counter_warnings": [
+    {
+      "cloud": "os-sim", "resource_type": "instance", "resource_id": "vm-8", "metric": "egress_gb",
+      "from_ts": "2026-03-01T00:00:00Z", "to_ts": "2026-04-01T00:00:00Z",
+      "code": "counter_source_failed", "detail": "connection refused"
+    }
+  ],
+  "attribution_warnings": [{"code": "attribution_cycle", "project_id": "11111111-1111-4111-8111-111111111111"}],
+  "adjustment_warnings": [
+    {
+      "code": "adjustment_kickback_target_not_partner", "relation_id": "99999999-9999-4999-8999-999999999999",
+      "target_platform": "openstack", "target_id": "p-7"
+    }
+  ],
+  "unpriced": [{"platform": "openstack", "resource_type": "image", "count": 9}],
+  "unreadable": [{"platform": "openstack", "resource_type": "volume", "field": "size_gb", "count": 2}],
+  "unregistered_projects": [{"cloud": "os-sim", "project_id": "p-9", "resources": 3}],
+  "violations": [
+    {
+      "cloud": "os-sim", "resource_type": "volume", "resource_id": "vol-1",
+      "violations": [{"invariant": "coverage", "detail": "an interval is missing"}]
+    }
+  ]
+}`
+
+// TestRunStats reads what a run stored about itself on its page.
+func TestRunStats(t *testing.T) {
+	t.Parallel()
+
+	runPath := "/run?id=" + testRunID.String()
+
+	withStats := func(t *testing.T, kind string, stats []byte) *fakeStore {
+		t.Helper()
+
+		engine := fullStore(t)
+		engine.run.Kind = kind
+		engine.run.Stats = stats
+		return engine
+	}
+	// listOf is the part of a page under one list's heading, up to the next
+	// heading of either level.
+	listOf := func(t *testing.T, body, heading string) string {
+		t.Helper()
+
+		_, after, found := strings.Cut(body, "<h3>"+heading+"</h3>")
+		if !found {
+			t.Fatalf("the page has no %q list:\n%s", heading, body)
+		}
+		if end := strings.Index(after, "<h"); end >= 0 {
+			return after[:end]
+		}
+		return after
+	}
+
+	t.Run("every list is drawn with its rows", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", []byte(allStatsFixture)), testNow)
+
+		status, body, _ := get(t, handler, runPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"<dt>snapshot</dt><dd>2026-04-04T00:00:00Z</dd>",
+			"<dt>candidates</dt><dd>12</dd>",
+			"<dt>usage records</dt><dd>10</dd>",
+			"<dt>rated records</dt><dd>30</dd>",
+			"<dt>adjustment records</dt><dd>1</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the counts do not carry %q", want)
+			}
+		}
+		lists := map[string]string{
+			"Run warnings":            "<td>period_not_ended</td>",
+			"Metering warnings":       "<td>history_starts_without_create</td>",
+			"Counter warnings":        "<td>counter_source_failed</td>",
+			"Attribution warnings":    "<td>attribution_cycle</td>",
+			"Adjustment warnings":     "<td>adjustment_kickback_target_not_partner</td>",
+			"Unpriced resource types": "<td>image</td>",
+			"Unreadable quantities":   "<td>size_gb</td>",
+			"Unregistered projects":   "<code>p-9</code>",
+			"Invariant violations":    "<td>coverage</td>",
+		}
+		for heading, row := range lists {
+			if list := listOf(t, body, heading); !strings.Contains(list, row) {
+				t.Errorf("the %s list does not carry %q:\n%s", heading, row, list)
+			}
+		}
+		if got := strings.Count(body, "<h3>"); got != len(lists) {
+			t.Errorf("the page draws %d lists, want %d", got, len(lists))
+		}
+		if strings.Contains(body, "this run reported no finding") {
+			t.Error("the page says the run found nothing")
+		}
+	})
+
+	t.Run("every finding links what it is about", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", []byte(allStatsFixture)), testNow)
+
+		_, body, _ := get(t, handler, runPath)
+		for _, want := range []string{
+			`href="/resource?cloud=os-sim&amp;id=vm-9&amp;type=instance"`,
+			`href="/resource?cloud=os-sim&amp;id=vm-8&amp;type=instance"`,
+			`href="/resource?cloud=os-sim&amp;id=vol-1&amp;type=volume"`,
+			`href="/project?id=11111111-1111-4111-8111-111111111111"`,
+			`href="/resources?cloud=os-sim&amp;project_id=p-9&amp;status=all"`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q", want)
+			}
+		}
+		if list := listOf(t, body, "Attribution warnings"); !strings.Contains(list, "<td>none</td>") {
+			t.Errorf("a warning without a relation does not say so:\n%s", list)
+		}
+	})
+
+	t.Run("a filter empties one list and leaves the others", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", []byte(allStatsFixture)), testNow)
+
+		_, body, _ := get(t, handler, runPath+"&metering_warnings.q=nomatch")
+		if list := listOf(t, body, "Metering warnings"); !strings.Contains(list, "no row matches the filter") {
+			t.Errorf("the emptied list does not say so:\n%s", list)
+		}
+		if list := listOf(t, body, "Unpriced resource types"); !strings.Contains(list, "<td>image</td>") {
+			t.Errorf("the filter of one list emptied another:\n%s", list)
+		}
+	})
+
+	t.Run("a regular run counts statements and a correction credit notes and deltas", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", []byte(allStatsFixture)), testNow)
+		_, body, _ := get(t, handler, runPath)
+		if !strings.Contains(body, "<dt>statements</dt><dd>2</dd>") {
+			t.Error("a regular run does not count its statements")
+		}
+		for _, unwanted := range []string{"<dt>credit notes</dt>", "<dt>deltas</dt>", "<dt>adjustment deltas</dt>"} {
+			if strings.Contains(body, unwanted) {
+				t.Errorf("a regular run carries %q", unwanted)
+			}
+		}
+
+		correction := []byte(`{"candidates": 1, "usage_records": 1, "rated_records": 1, "statements": 6,
+			"deltas": 184, "adjustment_deltas": 5}`)
+		handler, _ = serve(t, fullAPI(t), withStats(t, "correction", correction), testNow)
+		_, body, _ = get(t, handler, runPath)
+		for _, want := range []string{
+			"<dt>credit notes</dt><dd>6</dd>", "<dt>deltas</dt><dd>184</dd>", "<dt>adjustment deltas</dt><dd>5</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("a correction does not carry %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a failed run says why", func(t *testing.T) {
+		t.Parallel()
+
+		failed := []byte(`{"candidates": 3, "usage_records": 0, "rated_records": 0, "statements": 0,
+			"error": "metering the period: boom"}`)
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", failed), testNow)
+
+		_, body, _ := get(t, handler, runPath)
+		for _, want := range []string{
+			`<p class="error">this run failed: metering the period: boom</p>`, "this run reported no finding",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a clean run says it found nothing", func(t *testing.T) {
+		t.Parallel()
+
+		clean := []byte(`{"candidates": 1, "usage_records": 1, "rated_records": 1, "statements": 1}`)
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", clean), testNow)
+
+		_, body, _ := get(t, handler, runPath)
+		if !strings.Contains(body, "this run reported no finding") {
+			t.Errorf("the page does not say the run found nothing:\n%s", body)
+		}
+		if strings.Contains(body, "<h3>") {
+			t.Error("the page draws a list the run did not report")
+		}
+	})
+
+	t.Run("a run that stored no stats", func(t *testing.T) {
+		t.Parallel()
+
+		for _, stats := range [][]byte{[]byte("{}"), []byte("null"), nil} {
+			handler, _ := serve(t, fullAPI(t), withStats(t, "regular", stats), testNow)
+
+			status, body, _ := get(t, handler, runPath)
+			if status != http.StatusOK {
+				t.Fatalf("status = %d for %q, want %d", status, stats, http.StatusOK)
+			}
+			if !strings.Contains(body, "this run stored no stats") || strings.Contains(body, "<h3>") {
+				t.Errorf("the page for %q does not say the run stored no stats:\n%s", stats, body)
+			}
+		}
+	})
+
+	t.Run("stats that are no JSON", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), withStats(t, "regular", []byte("not json")), testNow)
+
+		status, body, _ := get(t, handler, runPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"the console cannot read the stats this run stored:", "invalid character", "<h2>Statements</h2>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("stats holding a member the engine does not have", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t),
+			withStats(t, "regular", []byte(`{"candidates": 1, "surprise": true}`)), testNow)
+
+		status, body, _ := get(t, handler, runPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		if !strings.Contains(body, "json: unknown field &#34;surprise&#34;") {
+			t.Errorf("the page does not name the member it cannot read:\n%s", body)
+		}
+		_, stored, _ := strings.Cut(body, "<pre>")
+		if stored, _, _ = strings.Cut(stored, "</pre>"); !strings.Contains(stored, "&#34;surprise&#34;: true") {
+			t.Errorf("the page does not show what was stored:\n%s", body)
 		}
 	})
 }

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -1589,6 +1589,323 @@ func TestStatementPage(t *testing.T) {
 	})
 }
 
+// creditNoteDocument is a credit note carrying what the golden one does not: a
+// second item, a related cost, an adjustment and the three deltas. Its items
+// are listed in an order that is not their order by total, so the page shows
+// whether it keeps the note's order.
+const creditNoteDocument = `{
+  "billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+  "project_id": "p-1",
+  "platform": "openstack",
+  "corrects_run_id": "22222222-2222-4222-8222-222222222222",
+  "line_items": [
+    {
+      "resource_type": "instance", "resource_id": "vm-5", "platform": "openstack",
+      "dimensions": {
+        "vcpus": {"old": 16.98, "new": 15.83, "delta": -1.15},
+        "ram_gb": {"old": 8.50, "new": 7.93, "delta": -0.57}
+      },
+      "total": -1.72
+    },
+    {
+      "resource_type": "instance", "resource_id": "vm-7", "platform": "openstack",
+      "dimensions": {"vcpus": {"old": 1.00, "new": 1.50, "delta": 0.50}},
+      "total": 0.50
+    }
+  ],
+  "related_costs": [
+    {
+      "relation_type": "infrastructure_tenant", "project_id": "p-2", "platform": "openstack",
+      "line_items": [
+        {
+          "resource_type": "instance", "resource_id": "vm-6", "platform": "openstack",
+          "dimensions": {"vcpus": {"old": 2.00, "new": 1.64, "delta": -0.36}},
+          "total": -0.36
+        }
+      ],
+      "total": -0.36
+    }
+  ],
+  "base_delta": -1.58,
+  "adjustments": [
+    {
+      "type": "project_discount", "relation_type": "member_of", "relation_target": "acme",
+      "relation_id": "99999999-9999-4999-8999-999999999999", "scope": "all",
+      "rate": 0.100000, "old": -87.66, "new": -87.50, "delta": 0.16
+    }
+  ],
+  "net_delta": -1.42,
+  "kickback_delta": 0.00,
+  "total": -1.42,
+  "currency": "EUR"
+}`
+
+// TestCreditNote reads a statement of a correction run, which is a credit note.
+// The export block of the page prints the same numbers as JSON, so every value
+// is looked for as the bill's own markup or inside the bill's sections, which
+// the export block stands above.
+func TestCreditNote(t *testing.T) {
+	t.Parallel()
+
+	notePath := "/statement?run=" + testCorrectionRunID.String() + "&key=" + url.QueryEscape(testKey)
+
+	noteStore := func(t *testing.T, document string) *fakeStore {
+		t.Helper()
+
+		engine := fullStore(t)
+		engine.run = store.Run{
+			ID:            testCorrectionRunID,
+			PeriodFrom:    testPeriod,
+			PeriodTo:      testPeriod.AddDate(0, 1, 0),
+			Kind:          "correction",
+			CorrectsRunID: testRunID,
+			Status:        "finalized",
+		}
+		engine.statement = store.Statement{Document: []byte(document), Currency: "EUR"}
+		return engine
+	}
+
+	t.Run("the golden credit note shows its dimensions", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, string(goldenCreditNote(t))), testNow)
+
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"<h1>Credit note os-sim/p-1</h1>",
+			`href="/run?id=3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4"`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+		bill := section(t, body, "Line items", "")
+		for _, want := range []string{
+			"<td>disk_gb</td>", `<td class="number">59.52</td>`, `<td class="number">49.92</td>`,
+			`<td class="number">-9.60</td>`,
+			"<td>ram_gb</td>", `<td class="number">29.76</td>`, `<td class="number">24.96</td>`,
+			`<td class="number">-4.80</td>`,
+			"<td>vcpus</td>", "-24.00 EUR",
+		} {
+			if !strings.Contains(bill, want) {
+				t.Errorf("the bill does not carry %q:\n%s", want, bill)
+			}
+		}
+	})
+
+	t.Run("a note without adjustments shows none of their terms", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, string(goldenCreditNote(t))), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		for _, unwanted := range []string{
+			">hours<", "<dt>base delta</dt>", "<dt>net delta</dt>", "<dt>kickback delta</dt>", "<h2>Adjustments</h2>",
+		} {
+			if strings.Contains(body, unwanted) {
+				t.Errorf("the page carries %q, which this credit note holds none of", unwanted)
+			}
+		}
+	})
+
+	t.Run("the deltas and the adjustment changes", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, creditNoteDocument), testNow)
+
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"<dt>base delta</dt><dd>-1.58</dd>",
+			"<dt>net delta</dt><dd>-1.42</dd>",
+			"<dt>kickback delta</dt><dd>0.00</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the head does not carry %q", want)
+			}
+		}
+		adjustments := section(t, body, "Adjustments", "Line items")
+		for _, want := range []string{
+			"<td>project_discount</td>", `<td class="number">0.100000</td>`,
+			`<td class="number">-87.66</td>`, `<td class="number">-87.50</td>`, `<td class="number">0.16</td>`,
+		} {
+			if !strings.Contains(adjustments, want) {
+				t.Errorf("the adjustments do not carry %q:\n%s", want, adjustments)
+			}
+		}
+	})
+
+	t.Run("a related cost", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, creditNoteDocument), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		related := section(t, body, "Related cost of <code>p-2</code>", "")
+		for _, want := range []string{"<code>vm-6</code>", `<td class="number">-0.36</td>`} {
+			if !strings.Contains(related, want) {
+				t.Errorf("the related cost does not carry %q:\n%s", want, related)
+			}
+		}
+	})
+
+	t.Run("the items keep the note's order until one is asked for", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, creditNoteDocument), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		if strings.Contains(body, "aria-sort") {
+			t.Error("a table opens sorted")
+		}
+		items := section(t, body, "Line items", "Related cost of <code>p-2</code>")
+		first, second := strings.Index(items, "<code>vm-5</code>"), strings.Index(items, "<code>vm-7</code>")
+		if first < 0 || second < 0 || first > second {
+			t.Errorf("the items are not in the note's order:\n%s", items)
+		}
+
+		_, body, _ = get(t, handler, notePath+"&items.sort=-total")
+		items = section(t, body, "Line items", "Related cost of <code>p-2</code>")
+		first, second = strings.Index(items, "<code>vm-7</code>"), strings.Index(items, "<code>vm-5</code>")
+		if first < 0 || second < 0 || first > second {
+			t.Errorf("the items are not sorted by total:\n%s", items)
+		}
+		if !strings.Contains(items, `aria-sort="descending"`) {
+			t.Error("the sorted heading does not say so")
+		}
+	})
+
+	t.Run("the summary leads to an unfolded block", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, creditNoteDocument), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		want := `href="/statement?key=os-sim%2Fp-1&amp;open=li-0&amp;run=` + testCorrectionRunID.String() + `#li-0"`
+		if !strings.Contains(body, want) {
+			t.Errorf("the summary does not lead to the block:\n%s", body)
+		}
+		if strings.Contains(body, " open>") {
+			t.Error("a block starts unfolded")
+		}
+
+		_, body, _ = get(t, handler, notePath+"&open=li-0")
+		if !strings.Contains(body, `<details class="item" id="li-0" open>`) {
+			t.Errorf("the block the link names is not unfolded:\n%s", body)
+		}
+	})
+
+	t.Run("a note without items", func(t *testing.T) {
+		t.Parallel()
+
+		document := `{"billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+			"project_id": "p-1", "platform": "openstack",
+			"corrects_run_id": "22222222-2222-4222-8222-222222222222",
+			"line_items": [], "related_costs": [], "total": 0.00, "currency": "EUR"}`
+		handler, _ := serve(t, fullAPI(t), noteStore(t, document), testNow)
+
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		if !strings.Contains(body, "this section holds no line item") {
+			t.Errorf("the page does not say the note holds no item:\n%s", body)
+		}
+	})
+
+	t.Run("an item without dimensions", func(t *testing.T) {
+		t.Parallel()
+
+		document := `{"billing_period": {"from": "2026-03-01T00:00:00Z", "to": "2026-04-01T00:00:00Z"},
+			"project_id": "p-1", "platform": "openstack",
+			"corrects_run_id": "22222222-2222-4222-8222-222222222222",
+			"line_items": [{"resource_type": "instance", "resource_id": "vm-5", "platform": "openstack",
+				"dimensions": {}, "total": 0.00}],
+			"related_costs": [], "total": 0.00, "currency": "EUR"}`
+		handler, _ := serve(t, fullAPI(t), noteStore(t, document), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		if !strings.Contains(body, "this item holds no dimension") {
+			t.Errorf("the block does not say the item holds no dimension:\n%s", body)
+		}
+	})
+
+	t.Run("a statement stored under a correction run", func(t *testing.T) {
+		t.Parallel()
+
+		handler, logged := serve(t, fullAPI(t), noteStore(t, string(goldenStatement(t))), testNow)
+
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusServiceUnavailable, body)
+		}
+		want := fmt.Sprintf("reading the credit note of %s in run %s: not a credit note document",
+			testKey, testCorrectionRunID)
+		if !strings.Contains(body, want) {
+			t.Errorf("the page does not carry %q:\n%s", want, body)
+		}
+		if !strings.Contains(logged.String(), "not a credit note document") {
+			t.Errorf("the log does not carry the failure:\n%s", logged.String())
+		}
+	})
+
+	t.Run("a document that is no JSON", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, "not json at all"), testNow)
+
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusServiceUnavailable, body)
+		}
+		for _, want := range []string{"reading the credit note of", "invalid character"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("the run cannot be read", func(t *testing.T) {
+		t.Parallel()
+
+		engine := noteStore(t, creditNoteDocument)
+		engine.runErr = fmt.Errorf("GetRun: %w", errors.New("connection refused"))
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+		status, body, _ := get(t, handler, notePath)
+		if status != http.StatusServiceUnavailable || !strings.Contains(body, "GetRun") {
+			t.Errorf("status = %d, want %d naming GetRun:\n%s", status, http.StatusServiceUnavailable, body)
+		}
+
+		engine = noteStore(t, creditNoteDocument)
+		engine.runErr = fmt.Errorf("GetRun: %w", pgx.ErrNoRows)
+		handler, _ = serve(t, fullAPI(t), engine, testNow)
+		if status, _, _ := get(t, handler, notePath); status != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", status, http.StatusNotFound)
+		}
+	})
+
+	t.Run("every table of the note carries its form", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), noteStore(t, creditNoteDocument), testNow)
+
+		_, body, _ := get(t, handler, notePath)
+		forms := strings.Count(body, `<form class="tools"`)
+		// The dimension tables inside the items sort and carry no form, the
+		// way the metric tables of a statement do.
+		sections := strings.Count(body, "<h2>Adjustments</h2>") + strings.Count(body, "<h2>Line items</h2>") +
+			strings.Count(body, "<h2>Related cost of")
+		if forms != 3 || sections != 3 {
+			t.Errorf("%d filter forms for %d sections, want 3 of each", forms, sections)
+		}
+	})
+}
+
 func TestStatementExport(t *testing.T) {
 	t.Parallel()
 

--- a/internal/console/httpui/render.go
+++ b/internal/console/httpui/render.go
@@ -38,6 +38,7 @@ var pageNames = []string{
 	"catalog",
 	"run",
 	"statement",
+	"creditnote",
 	errorPage,
 }
 

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -136,8 +136,10 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 
 // statement shows one stored document as a bill. The document is what the run
 // wrote: the page decodes it and prints it, and computes none of it again. The
-// run is read for the file the export writes beside the bill, which its kind
-// names and its status decides whether there is one at all.
+// run is read first, because its kind decides what the document is: a
+// correction run stores a credit note under every key, which creditNote
+// renders, and every other run a statement. The run's status decides whether
+// the export writes a file for the document at all.
 func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 	var src sources
 
@@ -159,17 +161,21 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	document, err := readStatement(stored)
-	if err != nil {
-		h.failFrom(w, r,
-			documentFailed(fmt.Errorf("reading the statement of %s in run %s: %w", key, runID, err)), src)
-		return
-	}
-
 	run, err := h.store.GetRun(r.Context(), runID)
 	src.query("GetRun")
 	if err != nil {
 		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+	if storesCreditNotes(run) {
+		h.creditNote(w, r, run, key, stored, src)
+		return
+	}
+
+	document, err := readStatement(stored)
+	if err != nil {
+		h.failFrom(w, r,
+			documentFailed(fmt.Errorf("reading the statement of %s in run %s: %w", key, runID, err)), src)
 		return
 	}
 

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -173,22 +173,16 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cloud, project, linkCloud := splitKey(key)
 	data := statementData{
 		Key:         key,
-		Cloud:       absent,
-		Project:     key,
+		Cloud:       cloud,
+		Project:     project,
 		RunID:       runID,
 		RunLink:     link("/run", "id", runID.String()),
 		Document:    document,
 		Adjustments: tabulate(r, "adjustments", adjustmentColumns, document.Adjustments),
 		Export:      buildExportView(run, key, stored.Document),
-	}
-	// A key this cannot read is shown as it is stored: the page is about that
-	// stored row, and a guessed pair would name one nothing was stored under.
-	// The resource links need the cloud, and a key without one links nothing.
-	linkCloud := ""
-	if cloud, project, keyErr := statements.ParseKey(key); keyErr == nil {
-		data.Cloud, data.Project, linkCloud = cloud, project, cloud
 	}
 
 	data.Items = buildBillSection(r, itemsTable, itemAnchor, linkCloud, document.Currency, document.LineItems)
@@ -205,6 +199,19 @@ func (h *handlers) statement(w http.ResponseWriter, r *http.Request) {
 		Sources: src,
 		Data:    data,
 	})
+}
+
+// splitKey reads the pair a statement key was built from. A key this cannot
+// read is shown as it is stored: the page is about that stored row, and a
+// guessed pair would name one nothing was stored under. The resource links
+// need the cloud, and a key without one links nothing, which an empty linkCloud
+// says.
+func splitKey(key string) (cloud, project, linkCloud string) {
+	parsedCloud, parsedProject, err := statements.ParseKey(key)
+	if err != nil {
+		return absent, key, ""
+	}
+	return parsedCloud, parsedProject, parsedCloud
 }
 
 // readStatement decodes a stored document and refuses one that is not a

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -14,12 +14,13 @@ import (
 	"github.com/b42labs/tally/internal/engine/statements"
 )
 
-// runData is one metering run: what it billed, and what it moved if it
-// corrected an earlier one.
+// runData is one metering run: what it reported about itself, what it billed,
+// and what it moved if it corrected an earlier one.
 type runData struct {
 	Run          store.Run
 	CorrectsLink string
 	CatalogLink  string
+	Stats        statsView
 	Statements   listing[statementBar]
 	Deltas       listing[store.Delta]
 }
@@ -117,6 +118,7 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 
 	data := runData{
 		Run:        run,
+		Stats:      buildRunStats(r, run),
 		Statements: tabulate(r, "statements", statementColumns, statementBars(id, billed)),
 		Deltas:     tabulate(r, "deltas", deltaColumns, deltas),
 	}

--- a/internal/console/httpui/runstats.go
+++ b/internal/console/httpui/runstats.go
@@ -1,0 +1,266 @@
+package httpui
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/adjustments"
+	"github.com/b42labs/tally/internal/engine/attribution"
+	"github.com/b42labs/tally/internal/engine/counters"
+	"github.com/b42labs/tally/internal/engine/metering"
+	"github.com/b42labs/tally/internal/engine/rating"
+	"github.com/b42labs/tally/internal/engine/runs"
+	"github.com/b42labs/tally/internal/engine/statements"
+)
+
+// statsView is what the run page says about the stats a run stored: whether it
+// stored any, whether the console can read them, what they count, and every
+// list of findings, one table each. A table is named after the member of the
+// stats it lists, so a reader of an export's run.json finds each list under the
+// same name.
+type statsView struct {
+	// Stored is false for a run that stored no stats, which is a run still
+	// running: its row holds the column's empty default.
+	Stored bool
+	// Unreadable is why the console cannot read the stats, and Raw is what was
+	// stored, shown in their place.
+	Unreadable string
+	Raw        string
+	// Correction says the counts are a correction's, which calls its
+	// statements credit notes and counts the deltas it wrote.
+	Correction bool
+	Values     runs.CorrectionStats
+	// Findings is how many rows the lists hold together, so a run that found
+	// nothing says so.
+	Findings int
+
+	Warnings             listing[runs.Warning]
+	MeteringWarnings     listing[meteringRow]
+	CounterWarnings      listing[counterRow]
+	AttributionWarnings  listing[attributionRow]
+	AdjustmentWarnings   listing[adjustments.Warning]
+	Unpriced             listing[rating.UnpricedResourceType]
+	UnreadableQuantities listing[rating.UnreadableQuantity]
+	UnregisteredProjects listing[unregisteredRow]
+	Violations           listing[violationRow]
+}
+
+// meteringRow is one warning of the metering pass with the page of the
+// resource it is about.
+type meteringRow struct {
+	metering.Warning
+	Link string
+}
+
+// counterRow is one warning of the counter pass with the page of the resource
+// it is about.
+type counterRow struct {
+	counters.Warning
+	Link string
+}
+
+// attributionRow is one warning of the attribution pass with the page of the
+// project it is about. Relation is the losing relation, which a cycle warning
+// does not have.
+type attributionRow struct {
+	attribution.Warning
+	Relation string
+	Link     string
+}
+
+// unregisteredRow is one project the run met resources of and no registry row
+// names. It has no project page, so it leads to the resources it holds.
+type unregisteredRow struct {
+	statements.UnregisteredProject
+	Link string
+}
+
+// violationRow is one invariant violation of one resource. The engine groups
+// violations by resource; the table holds one row per violation.
+type violationRow struct {
+	Cloud        string
+	ResourceType string
+	ResourceID   string
+	Invariant    string
+	Detail       string
+	Link         string
+}
+
+// The columns of the stats tables, one set per list.
+var (
+	runWarningColumns = []column[runs.Warning]{
+		textCol("code", func(r runs.Warning) string { return r.Code }),
+		textCol("detail", func(r runs.Warning) string { return r.Detail }),
+	}
+	meteringWarningColumns = []column[meteringRow]{
+		textCol("code", func(r meteringRow) string { return r.Code }),
+		textCol("cloud", func(r meteringRow) string { return r.Cloud }),
+		textCol("resource type", func(r meteringRow) string { return r.ResourceType }),
+		textCol("resource", func(r meteringRow) string { return r.ResourceID }),
+	}
+	counterWarningColumns = []column[counterRow]{
+		textCol("code", func(r counterRow) string { return r.Code }),
+		textCol("cloud", func(r counterRow) string { return r.Cloud }),
+		textCol("resource type", func(r counterRow) string { return r.ResourceType }),
+		textCol("resource", func(r counterRow) string { return r.ResourceID }),
+		textCol("metric", func(r counterRow) string { return r.Metric }),
+		textCol("from", func(r counterRow) string { return stamp(r.FromTS) }),
+		textCol("to", func(r counterRow) string { return stamp(r.ToTS) }),
+		textCol("detail", func(r counterRow) string { return r.Detail }),
+	}
+	attributionWarningColumns = []column[attributionRow]{
+		textCol("code", func(r attributionRow) string { return r.Code }),
+		textCol("project", func(r attributionRow) string { return r.ProjectID.String() }),
+		textCol("relation", func(r attributionRow) string { return r.Relation }),
+	}
+	adjustmentWarningColumns = []column[adjustments.Warning]{
+		textCol("code", func(r adjustments.Warning) string { return r.Code }),
+		textCol("relation", func(r adjustments.Warning) string { return r.RelationID }),
+		textCol("target platform", func(r adjustments.Warning) string { return r.TargetPlatform }),
+		textCol("target", func(r adjustments.Warning) string { return r.TargetID }),
+	}
+	unpricedColumns = []column[rating.UnpricedResourceType]{
+		textCol("platform", func(r rating.UnpricedResourceType) string { return r.Platform }),
+		textCol("resource type", func(r rating.UnpricedResourceType) string { return r.ResourceType }),
+		countCol("count", func(r rating.UnpricedResourceType) int64 { return int64(r.Count) }),
+	}
+	unreadableColumns = []column[rating.UnreadableQuantity]{
+		textCol("platform", func(r rating.UnreadableQuantity) string { return r.Platform }),
+		textCol("resource type", func(r rating.UnreadableQuantity) string { return r.ResourceType }),
+		textCol("field", func(r rating.UnreadableQuantity) string { return r.Field }),
+		countCol("count", func(r rating.UnreadableQuantity) int64 { return int64(r.Count) }),
+	}
+	unregisteredColumns = []column[unregisteredRow]{
+		textCol("cloud", func(r unregisteredRow) string { return r.Cloud }),
+		textCol("project", func(r unregisteredRow) string { return r.ProjectID }),
+		countCol("resources", func(r unregisteredRow) int64 { return int64(r.Resources) }),
+	}
+	violationColumns = []column[violationRow]{
+		textCol("cloud", func(r violationRow) string { return r.Cloud }),
+		textCol("resource type", func(r violationRow) string { return r.ResourceType }),
+		textCol("resource", func(r violationRow) string { return r.ResourceID }),
+		textCol("invariant", func(r violationRow) string { return r.Invariant }),
+		textCol("detail", func(r violationRow) string { return r.Detail }),
+	}
+)
+
+// readRunStats reads the stats a run stored. The bool is false for bytes that
+// hold nothing, which is the column before the run wrote to it: no bytes, JSON
+// null, or an object without members. The decoding is strict: a member the
+// engine's types do not have is refused rather than dropped, because a page
+// that silently left out part of what a run reported would read as a run that
+// reported less.
+func readRunStats(raw []byte) (runs.CorrectionStats, bool, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return runs.CorrectionStats{}, false, nil
+	}
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return runs.CorrectionStats{}, true, err
+	}
+	if len(members) == 0 {
+		return runs.CorrectionStats{}, false, nil
+	}
+
+	var stats runs.CorrectionStats
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&stats); err != nil {
+		return runs.CorrectionStats{}, true, err
+	}
+	return stats, true, nil
+}
+
+// buildRunStats lays the stats of a run out. Stats the console cannot read are
+// shown as they were stored, beside the reason, and leave the rest of the page
+// standing: the page is about the run, and its statements and deltas read fine
+// without them. They are reported on the page and not logged, the way the
+// project page reports relation adjustments it cannot read.
+func buildRunStats(r *http.Request, run store.Run) statsView {
+	stats, stored, err := readRunStats(run.Stats)
+	view := statsView{Stored: stored, Correction: storesCreditNotes(run)}
+	if err != nil {
+		view.Unreadable = err.Error()
+		view.Raw = rawStats(run.Stats)
+		return view
+	}
+	if !stored {
+		return view
+	}
+
+	metered := make([]meteringRow, 0, len(stats.MeteringWarnings))
+	for _, warning := range stats.MeteringWarnings {
+		metered = append(metered, meteringRow{
+			Warning: warning,
+			Link:    link("/resource", "cloud", warning.Cloud, "type", warning.ResourceType, "id", warning.ResourceID),
+		})
+	}
+	counted := make([]counterRow, 0, len(stats.CounterWarnings))
+	for _, warning := range stats.CounterWarnings {
+		counted = append(counted, counterRow{
+			Warning: warning,
+			Link:    link("/resource", "cloud", warning.Cloud, "type", warning.ResourceType, "id", warning.ResourceID),
+		})
+	}
+	attributed := make([]attributionRow, 0, len(stats.AttributionWarnings))
+	for _, warning := range stats.AttributionWarnings {
+		relation := warning.RelationID
+		if relation == "" {
+			relation = absent
+		}
+		attributed = append(attributed, attributionRow{
+			Warning:  warning,
+			Relation: relation,
+			Link:     link("/project", "id", warning.ProjectID.String()),
+		})
+	}
+	unregistered := make([]unregisteredRow, 0, len(stats.UnregisteredProjects))
+	for _, project := range stats.UnregisteredProjects {
+		unregistered = append(unregistered, unregisteredRow{
+			UnregisteredProject: project,
+			Link: link("/resources", "cloud", project.Cloud, "project_id", project.ProjectID,
+				statusParameter, "all"),
+		})
+	}
+	var violations []violationRow
+	for _, resource := range stats.Violations {
+		for _, violation := range resource.Violations {
+			violations = append(violations, violationRow{
+				Cloud:        resource.Cloud,
+				ResourceType: resource.ResourceType,
+				ResourceID:   resource.ResourceID,
+				Invariant:    violation.Invariant,
+				Detail:       violation.Detail,
+				Link: link("/resource", "cloud", resource.Cloud, "type", resource.ResourceType,
+					"id", resource.ResourceID),
+			})
+		}
+	}
+
+	view.Values = stats
+	view.Warnings = tabulate(r, "warnings", runWarningColumns, stats.Warnings)
+	view.MeteringWarnings = tabulate(r, "metering_warnings", meteringWarningColumns, metered)
+	view.CounterWarnings = tabulate(r, "counter_warnings", counterWarningColumns, counted)
+	view.AttributionWarnings = tabulate(r, "attribution_warnings", attributionWarningColumns, attributed)
+	view.AdjustmentWarnings = tabulate(r, "adjustment_warnings", adjustmentWarningColumns, stats.AdjustmentWarnings)
+	view.Unpriced = tabulate(r, "unpriced", unpricedColumns, stats.Unpriced)
+	view.UnreadableQuantities = tabulate(r, "unreadable", unreadableColumns, stats.Unreadable)
+	view.UnregisteredProjects = tabulate(r, "unregistered_projects", unregisteredColumns, unregistered)
+	view.Violations = tabulate(r, "violations", violationColumns, violations)
+	view.Findings = len(stats.Warnings) + len(metered) + len(counted) + len(attributed) +
+		len(stats.AdjustmentWarnings) + len(stats.Unpriced) + len(stats.Unreadable) + len(unregistered) +
+		len(violations)
+	return view
+}
+
+// rawStats is the stored stats as the page shows them when it cannot read
+// them: indented when they are JSON at all, and as the bytes they are when not.
+func rawStats(raw []byte) string {
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	return pretty(value)
+}

--- a/internal/console/httpui/templates/creditnote.gohtml
+++ b/internal/console/httpui/templates/creditnote.gohtml
@@ -1,0 +1,92 @@
+{{define "content"}}
+<dl>
+<dt>cloud</dt><dd>{{.Cloud}}</dd>
+<dt>project</dt><dd><code>{{.Project}}</code></dd>
+<dt>platform</dt><dd>{{.Note.Platform}}</dd>
+<dt>run</dt><dd><a href="{{.RunLink}}"><code>{{.RunID}}</code></a></dd>
+<dt>corrects</dt><dd><a href="{{.CorrectsLink}}"><code>{{.Note.CorrectsRunID}}</code></a></dd>
+<dt>billing period</dt><dd>{{.Note.BillingPeriod.From}} to {{.Note.BillingPeriod.To}}</dd>
+<dt>total</dt><dd>{{amount .Note.Total.Decimal}} {{.Note.Currency}}</dd>
+{{with .Note.BaseDelta}}<dt>base delta</dt><dd>{{amount .Decimal}}</dd>{{end}}
+{{with .Note.NetDelta}}<dt>net delta</dt><dd>{{amount .Decimal}}</dd>{{end}}
+{{with .Note.KickbackDelta}}<dt>kickback delta</dt><dd>{{amount .Decimal}}</dd>{{end}}
+</dl>
+
+<h2>Export</h2>
+{{template "statementExport" .Export}}
+
+{{if .Adjustments.Table.Total}}
+<h2>Adjustments</h2>
+{{template "tableTools" .Adjustments.Table}}
+<table>
+{{template "tableHead" .Adjustments.Table}}
+<tbody>
+{{range .Adjustments.Rows}}<tr>
+<td>{{.Type}}</td>
+<td>{{.RelationType}}</td>
+<td><code>{{.RelationTarget}}</code></td>
+<td>{{.Scope}}</td>
+<td class="number">{{rate .Rate.Decimal}}</td>
+<td class="number{{zeroClass .Old.Decimal}}">{{amount .Old.Decimal}}</td>
+<td class="number{{zeroClass .New.Decimal}}">{{amount .New.Decimal}}</td>
+<td class="number{{zeroClass .Delta.Decimal}}">{{amount .Delta.Decimal}}</td>
+</tr>
+{{else}}<tr><td colspan="8">{{emptyText .Adjustments.Table "this credit note carries no adjustment change"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+<h2>Line items</h2>
+{{template "creditSection" .Items}}
+
+{{range .Related}}
+<h2>Related cost of <code>{{.Related.ProjectID}}</code></h2>
+<dl>
+<dt>relation type</dt><dd>{{.Related.RelationType}}</dd>
+<dt>project</dt><dd><code>{{.Related.ProjectID}}</code></dd>
+<dt>platform</dt><dd>{{.Related.Platform}}</dd>
+<dt>total</dt><dd>{{amount .Related.Total.Decimal}} {{.Currency}}</dd>
+</dl>
+{{template "creditSection" .}}
+{{end}}
+{{end}}
+
+{{/* creditSection is one section of a credit note: the summary table of its
+     items, then the detail block of every item the summary shows, in its
+     order, each holding one row per dimension. */}}
+{{define "creditSection"}}
+{{if .Summary.Table.Total}}
+{{template "tableTools" .Summary.Table}}
+<table>
+{{template "tableHead" .Summary.Table}}
+<tbody>
+{{range .Summary.Rows}}<tr>
+<td>{{.ResourceType}}</td>
+<td><a href="{{.OpenLink}}"><code>{{.ResourceID}}</code></a></td>
+<td class="number{{zeroClass .Total}}">{{amount .Total}} {{$.Currency}}</td>
+</tr>
+{{else}}<tr><td colspan="3">{{emptyText .Summary.Table "this section holds no line item"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{range .Summary.Rows}}
+<details class="item" id="{{.Anchor}}"{{if .Open}} open{{end}}>
+<summary><span>{{.ResourceType}} <code>{{.ResourceID}}</code></span><span class="total{{zeroClass .Total}}">{{amount .Total}} {{$.Currency}}</span></summary>
+{{if .ResourceLink}}<p class="muted"><a href="{{.ResourceLink}}">the resource's page</a></p>{{end}}
+<table>
+{{template "tableHead" .Dimensions.Table}}
+<tbody>
+{{range .Dimensions.Rows}}<tr>
+<td>{{.Dimension}}</td>
+<td class="number{{zeroClass .Old}}">{{amount .Old}}</td>
+<td class="number{{zeroClass .New}}">{{amount .New}}</td>
+<td class="number{{zeroClass .Delta}}">{{amount .Delta}}</td>
+</tr>
+{{else}}<tr><td colspan="4">this item holds no dimension</td></tr>
+{{end}}</tbody>
+</table>
+</details>
+{{end}}
+{{else}}
+<p>this section holds no line item</p>
+{{end}}
+{{end}}

--- a/internal/console/httpui/templates/layout.gohtml
+++ b/internal/console/httpui/templates/layout.gohtml
@@ -52,3 +52,16 @@
      numeric column is aligned over its numbers. */}}
 {{define "tableHead"}}<thead><tr>{{range .Headers}}{{if .Link}}<th{{if .Numeric}} class="number"{{end}}{{if .Sort}} aria-sort="{{.Sort}}"{{end}}><a href="{{.Link}}">{{.Label}}</a></th>{{else}}<th>{{.Label}}</th>{{end}}{{end}}</tr></thead>
 {{end}}
+
+{{/* statementExport is the file the JSON export writes for one stored
+     document, or the note saying why there is none. The statement page and the
+     credit-note page both print it under their Export heading. */}}
+{{define "statementExport"}}{{if .File}}
+<p><code>{{.File}}</code>, {{.Size}} bytes, as <code>tally-engine export --format json</code> writes it: <a href="{{.OpenLink}}">open</a>, <a href="{{.DownloadLink}}">download</a></p>
+<details class="export">
+<summary>the document</summary>
+<pre>{{.JSON}}</pre>
+</details>
+{{else}}
+<p class="muted">{{.Note}}</p>
+{{end}}{{end}}

--- a/internal/console/httpui/templates/run.gohtml
+++ b/internal/console/httpui/templates/run.gohtml
@@ -11,6 +11,9 @@
 {{if .CorrectsLink}}<dt>corrects</dt><dd><a href="{{.CorrectsLink}}">{{.Run.CorrectsRunID}}</a></dd>{{end}}
 </dl>
 
+<h2>What this run reported</h2>
+{{template "runStats" .Stats}}
+
 <h2>Statements</h2>
 {{if .Statements.Table.Total}}
 {{template "tableTools" .Statements.Table}}
@@ -48,5 +51,188 @@
 {{else}}<tr><td colspan="8">{{emptyText .Deltas.Table "this run moved nothing"}}</td></tr>
 {{end}}</tbody>
 </table>
+{{end}}
+{{end}}
+
+{{/* runStats is what a run stored about itself: its counts, the error it
+     failed with, and every list of findings its passes reported, one table
+     per list that holds anything. A table only a filter emptied stays drawn,
+     so it can say so. */}}
+{{define "runStats"}}
+{{if .Unreadable}}
+<p class="muted">the console cannot read the stats this run stored: {{.Unreadable}}</p>
+<pre>{{.Raw}}</pre>
+{{else if not .Stored}}
+<p class="muted">this run stored no stats</p>
+{{else}}
+{{with .Values.Error}}<p class="error">this run failed: {{.}}</p>{{end}}
+<dl>
+<dt>snapshot</dt><dd>{{optStamp .Values.SnapshotAt}}</dd>
+<dt>candidates</dt><dd>{{.Values.Candidates}}</dd>
+<dt>usage records</dt><dd>{{.Values.UsageRecords}}</dd>
+<dt>rated records</dt><dd>{{.Values.RatedRecords}}</dd>
+<dt>{{if .Correction}}credit notes{{else}}statements{{end}}</dt><dd>{{.Values.Statements}}</dd>
+<dt>adjustment records</dt><dd>{{.Values.AdjustmentRecords}}</dd>
+{{if .Correction}}<dt>deltas</dt><dd>{{.Values.Deltas}}</dd>
+<dt>adjustment deltas</dt><dd>{{.Values.AdjustmentDeltas}}</dd>
+{{end}}</dl>
+{{if eq .Findings 0}}
+<p>this run reported no finding</p>
+{{else}}
+
+{{if .Warnings.Table.Total}}
+<h3>Run warnings</h3>
+{{template "tableTools" .Warnings.Table}}
+<table>
+{{template "tableHead" .Warnings.Table}}
+<tbody>
+{{range .Warnings.Rows}}<tr>
+<td>{{.Code}}</td>
+<td>{{.Detail}}</td>
+</tr>
+{{else}}<tr><td colspan="2">{{emptyText .Warnings.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .MeteringWarnings.Table.Total}}
+<h3>Metering warnings</h3>
+{{template "tableTools" .MeteringWarnings.Table}}
+<table>
+{{template "tableHead" .MeteringWarnings.Table}}
+<tbody>
+{{range .MeteringWarnings.Rows}}<tr>
+<td>{{.Code}}</td>
+<td>{{.Cloud}}</td>
+<td>{{.ResourceType}}</td>
+<td><a href="{{.Link}}"><code>{{.ResourceID}}</code></a></td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .MeteringWarnings.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .CounterWarnings.Table.Total}}
+<h3>Counter warnings</h3>
+{{template "tableTools" .CounterWarnings.Table}}
+<table>
+{{template "tableHead" .CounterWarnings.Table}}
+<tbody>
+{{range .CounterWarnings.Rows}}<tr>
+<td>{{.Code}}</td>
+<td>{{.Cloud}}</td>
+<td>{{.ResourceType}}</td>
+<td><a href="{{.Link}}"><code>{{.ResourceID}}</code></a></td>
+<td>{{.Metric}}</td>
+<td>{{stamp .FromTS}}</td>
+<td>{{stamp .ToTS}}</td>
+<td>{{.Detail}}</td>
+</tr>
+{{else}}<tr><td colspan="8">{{emptyText .CounterWarnings.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .AttributionWarnings.Table.Total}}
+<h3>Attribution warnings</h3>
+{{template "tableTools" .AttributionWarnings.Table}}
+<table>
+{{template "tableHead" .AttributionWarnings.Table}}
+<tbody>
+{{range .AttributionWarnings.Rows}}<tr>
+<td>{{.Code}}</td>
+<td><a href="{{.Link}}"><code>{{.ProjectID}}</code></a></td>
+<td>{{.Relation}}</td>
+</tr>
+{{else}}<tr><td colspan="3">{{emptyText .AttributionWarnings.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .AdjustmentWarnings.Table.Total}}
+<h3>Adjustment warnings</h3>
+{{template "tableTools" .AdjustmentWarnings.Table}}
+<table>
+{{template "tableHead" .AdjustmentWarnings.Table}}
+<tbody>
+{{range .AdjustmentWarnings.Rows}}<tr>
+<td>{{.Code}}</td>
+<td><code>{{.RelationID}}</code></td>
+<td>{{.TargetPlatform}}</td>
+<td><code>{{.TargetID}}</code></td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .AdjustmentWarnings.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .Unpriced.Table.Total}}
+<h3>Unpriced resource types</h3>
+{{template "tableTools" .Unpriced.Table}}
+<table>
+{{template "tableHead" .Unpriced.Table}}
+<tbody>
+{{range .Unpriced.Rows}}<tr>
+<td>{{.Platform}}</td>
+<td>{{.ResourceType}}</td>
+<td class="number">{{.Count}}</td>
+</tr>
+{{else}}<tr><td colspan="3">{{emptyText .Unpriced.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .UnreadableQuantities.Table.Total}}
+<h3>Unreadable quantities</h3>
+{{template "tableTools" .UnreadableQuantities.Table}}
+<table>
+{{template "tableHead" .UnreadableQuantities.Table}}
+<tbody>
+{{range .UnreadableQuantities.Rows}}<tr>
+<td>{{.Platform}}</td>
+<td>{{.ResourceType}}</td>
+<td>{{.Field}}</td>
+<td class="number">{{.Count}}</td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .UnreadableQuantities.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .UnregisteredProjects.Table.Total}}
+<h3>Unregistered projects</h3>
+{{template "tableTools" .UnregisteredProjects.Table}}
+<table>
+{{template "tableHead" .UnregisteredProjects.Table}}
+<tbody>
+{{range .UnregisteredProjects.Rows}}<tr>
+<td>{{.Cloud}}</td>
+<td><a href="{{.Link}}"><code>{{.ProjectID}}</code></a></td>
+<td class="number">{{.Resources}}</td>
+</tr>
+{{else}}<tr><td colspan="3">{{emptyText .UnregisteredProjects.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{if .Violations.Table.Total}}
+<h3>Invariant violations</h3>
+{{template "tableTools" .Violations.Table}}
+<table>
+{{template "tableHead" .Violations.Table}}
+<tbody>
+{{range .Violations.Rows}}<tr>
+<td>{{.Cloud}}</td>
+<td>{{.ResourceType}}</td>
+<td><a href="{{.Link}}"><code>{{.ResourceID}}</code></a></td>
+<td>{{.Invariant}}</td>
+<td>{{.Detail}}</td>
+</tr>
+{{else}}<tr><td colspan="5">{{emptyText .Violations.Table "nothing is listed"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+
+{{end}}
 {{end}}
 {{end}}

--- a/internal/console/httpui/templates/statement.gohtml
+++ b/internal/console/httpui/templates/statement.gohtml
@@ -12,15 +12,7 @@
 </dl>
 
 <h2>Export</h2>
-{{with .Export}}{{if .File}}
-<p><code>{{.File}}</code>, {{.Size}} bytes, as <code>tally-engine export --format json</code> writes it: <a href="{{.OpenLink}}">open</a>, <a href="{{.DownloadLink}}">download</a></p>
-<details class="export">
-<summary>the document</summary>
-<pre>{{.JSON}}</pre>
-</details>
-{{else}}
-<p class="muted">{{.Note}}</p>
-{{end}}{{end}}
+{{template "statementExport" .Export}}
 
 {{if .Adjustments.Table.Total}}
 <h2>Adjustments</h2>


### PR DESCRIPTION
Closes #135

The demo console's statement page now renders the document of a correction run as the credit note it is, and the run page shows the stats every run stores. Both stay read-only and script-free, and neither needs a change to the engine, the export, the store queries or the Reporting API.

## Commits

1. `57cde5c` Share the export block, the open link and the key split. The export markup of the statement page becomes the `statementExport` template in the layout, the open-link computation of `buildItemRow` becomes `openLink`, and the key split becomes `splitKey`, so the credit-note page uses all three. The statement page renders the same bytes, and its tests pass unchanged.
2. `197c922` Render a correction's credit note as a credit note. The statement handler reads the run before the document and, for a correction run (`storesCreditNotes`, the rule `export.RenderStatement` decodes by), hands the document to `creditNote`. It decodes the document into `corrections.CreditNote` and renders the new `creditnote` page: the corrected run linked in the head beside the base, net and kickback deltas, the adjustment changes with old, new and delta, and per item a folding block with one row per dimension. Items keep the note's order until a heading sorts them. A document under a correction run that names no corrected run answers 503 with `reading the credit note of <key> in run <id>: not a credit note document`. `TestCreditNote` holds twelve subtests; eight of them failed against the code before this commit.
3. `f114d7f` Show what a run reported on its run page. `runs.stats` is decoded strictly into `runs.CorrectionStats` and shown under "What this run reported": the counts (credit notes, deltas and adjustment deltas for a correction), a failed run's error, and one table per non-empty list, each named after its stats key, each finding linking its resource or project. An unregistered project has no project page and links `/resources` filtered to it. A run that stored nothing says so, and stats the console cannot read are shown as stored beside the reason while the rest of the page stands. `TestRunStats` holds nine subtests, and `fullStore`'s run carries the new `allStatsFixture`, so the form-count and no-script tests cover the new tables.
4. `1669e36` Document the credit note and what a run reported in the console reference: the route and table lists, a paragraph on the credit note, and a section "What a run reported".

## Verification

Run locally: `make fmt`, `go vet ./...`, `go test ./internal/console/... -count=1`, `go test ./docs/... -count=1`, `make lint` (0 issues), `make docs-build`. `TestCreditNote` ran against the code before the fix and failed in eight subtests: the golden note's dimensions, the absence of hours and adjustment terms, the deltas and adjustment changes, the related cost, the item order, the item without dimensions, and both 503 cases.

Not run: the live criterion, which checks the demo month's credit note for `os-sim/10e287d5788957a2a331cabd1b5dccdf` (net delta `-580.49`, kickback delta `-58.05`, 37 blocks with dimensions) and the July regular run's page (38 metering warnings, unpriced `image` 9 and `loadbalancer` 5). The dev cluster was down, and `make console` failed with `dial tcp 127.0.0.1:5432: connect: connection refused`. After `make demo`, `make console` shows both pages.

`make test` was not run whole: the Docker-backed packages time out on this laptop when they run in parallel, and none of them is touched.

## Notes

- The tests look for values inside the bill's sections or as exact markup (`<dt>base delta</dt><dd>-1.58</dd>`), because the export block above them prints the same numbers as JSON, and a page-wide match would have passed before the fix.
- Deviations from the issue's plan, all mechanical: `dimensionRow` and `dimensionColumns` are `changeRow` and `changeColumns`, because the catalog in `pricing.go` owns the first two names; the kind check lives in `storesCreditNotes` in `creditnote.go`; `openLink` returns unnamed results, since a result named `href` would shadow the `href` function it calls; the list of unreadable quantities is `statsView.UnreadableQuantities`, since `Unreadable` carries the error text; `buildCreditItemRow` and `rawStats` are two small helpers the plan did not name.
- Not part of this change: the period page and a run's JSON export (#136), the meta-project rollup (#137), and `first_event_at` in the resource list (#138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
