### PR TITLE
Add a billing period page and a run's JSON export to the demo console

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -25,16 +25,19 @@ environment, under the names the settings table below lists.
 
 | Route | What it reads |
 | --- | --- |
-| `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, the 20 newest runs. |
+| `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, each linking its own page and the run that finalized it; the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
 | `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: every statement of the project, grouped into the periods that were billed, and for a partner what every run settles for it. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
-| `/run?id=` | Engine: the run, the stats it stored, its statements, its correction deltas. |
+| `/period?month=` | Engine: the billing period, every run of it, and what each run's statements add up to per currency. |
+| `/run?id=` | Engine: the run, linking its period; the stats it stored; its statements; the files the JSON export writes for it, `run.json` and `kickbacks.json`, and what it settles for each partner; its correction deltas. |
 | `/statement?run=&key=` | Engine: the run, and one statement document rendered as a bill: its head, the file the JSON export writes for it, its adjustments, a summary table of its line items sorted by total, and a folding detail block per item with one row per metric and period. The document of a correction run is a credit note and is rendered as one: its head carries the deltas, its adjustments what changed, and each item's block one row per dimension. |
 | `/statement.json?run=&key=` | Engine: the run and the statement. Not a page: the bytes `tally-engine export --format json` writes for the statement, served as `application/json`, and with `download` set as an attachment. |
+| `/run.json?run=` | Engine: the run, its statements and what it settles. Not a page: the `run.json` `tally-engine export --format json` writes for the run, served as `application/json`, and with `download` set as an attachment. |
+| `/kickbacks.json?run=` | Engine: the same read. Not a page: the `kickbacks.json` `tally-engine export --format json` writes for the run, served the same way. |
 | `/static/console.css` | The embedded stylesheet, the only asset the pages load. |
 | `/theme` | Nothing. Not a page: it takes the theme form's POST, keeps the choice in a cookie, and sends the viewer back. |
 
@@ -156,7 +159,8 @@ The tables and their names per page:
 | `/resource` | `segments`, `events` |
 | `/pricing` | `models` |
 | `/catalog` | `dimensions` |
-| `/run` | `statements`, `deltas`; the lists of what the run reported, `warnings`, `metering_warnings`, `counter_warnings`, `attribution_warnings`, `adjustment_warnings`, `unpriced`, `unreadable`, `unregistered_projects` and `violations` |
+| `/period` | `runs` |
+| `/run` | `statements`, `settlement`, `deltas`; the lists of what the run reported, `warnings`, `metering_warnings`, `counter_warnings`, `attribution_warnings`, `adjustment_warnings`, `unpriced`, `unreadable`, `unregistered_projects` and `violations` |
 | `/statement` | `adjustments`; `items` and `rc-<n>`, the summaries of the line items and of the n-th related cost; `li-<n>` and `rc-<n>-li-<n>`, the metric tables of the items, which sort and carry no filter. A credit note carries the same names, its `li-<n>` tables holding one row per dimension |
 
 A paged listing, `/projects` and `/resources`, is sorted and filtered within
@@ -192,6 +196,30 @@ one row per dimension, with the amount the corrected run billed, the amount
 the correction rated and the delta. A document stored under a correction run
 that names no run it corrects is not a credit note and is answered 503.
 
+## A billing period
+
+A billing period has a page of its own, `/period?month=`, addressed by the
+month in the `YYYY-MM` form `tally-engine` reads `--period` in:
+`/period?month=2026-07`. A `month` that is missing or not of that form is
+answered 400, and a month no run ever opened, which has no billing period, 404.
+The overview's period table links every month to its page, and every run page
+links the month the run billed.
+
+The head says where the month stands: its status, `open`, `grace` or
+`finalized`, when it was finalized and by which run, linking that run's page,
+and what the month bills. What it bills is the sum of the statements of the
+runs that stand, by the rule the project page adds one project up by: a run
+stands when it is `completed` or `finalized`, which is the regular run and
+every correction booked against it. A month billed in two currencies prints
+each sum on its own.
+
+The `runs` table lists every run the engine recorded for the month, in the
+order the runs started, so a correction stands under the run it corrects. Each
+row carries the run's kind, status, pricing version, start and completion, how
+many statements it wrote and what they add up to, and links the run's page. A
+`superseded`, `failed` or `running` run is drawn in the muted colour and says
+it counts for nothing.
+
 ## The export of a statement
 
 The statement page carries, under its head, the file
@@ -224,6 +252,38 @@ nothing else. One name differs from the export's: of two statements of one run
 whose file names differ in ASCII case alone, the export writes the second under
 the SHA-256 digest of its key, and the console, which reads one statement at a
 time, names each after its key.
+
+## The export of a run
+
+The run page carries, below its statements, the two files that
+`tally-engine export --format json` writes for the run beside them:
+`run.json`, the index naming every statement file with its cloud, its project
+and its total, and `kickbacks.json`, what the run settles for its partners.
+Each is folded under its name and its size in bytes, and two links lead to
+`/run.json` and `/kickbacks.json`, which serve the same bytes on their own:
+`open` shows them in the browser, and `download` saves them under the name the
+export gives the file. The files of every run share those two names, so two
+downloads into one directory collide there the way two exports into one
+directory would. The index is the one an export writes without `--rollup`,
+and it names no rollup document.
+
+The console reads the run through the export's own read and hands it to the
+export's own renderers, so the page and the routes show what an export of the
+run writes, byte for byte. That includes every statement document: a statement
+the export refuses, one holding a member the engine's types do not have, makes
+the export refuse the whole run. The page then shows the export's error in
+place of the files, and both routes answer 503. A run that does not stand, a
+`superseded`, `failed` or `running` one, is not exported, which is the rule
+`tally-engine export` applies: its page says so in place of the files, and
+both routes answer 404.
+
+Below the files, the `settlement` table lays `kickbacks.json` out: one
+row per partner and currency, with the number of projects the kickbacks came
+off and what the run owes the partner, read off the document rather than added
+up again. A partner links its own page. A correction's rows are the difference
+to the run it corrects, negative where usage was corrected down, which the
+page says above the table. A run that owes no partner says so in place of the
+rows.
 
 ## What a run reported
 
@@ -342,10 +402,11 @@ engine read under the name its query carries in
 
 A failure renders one error page carrying the wrapped error: 400 for a parameter
 that is missing or unreadable, 404 for a lookup that found nothing, for an API
-404 and for the file of a statement whose run is not exported, 502 for a
-Reporting API call that failed or that the API refused the token for, and 503
-for an engine query that failed or a stored document that does not decode or
-that the export refuses. A path the console has no page for is answered 404 on
+404 and for a file of a statement or of a run whose run is not exported, 502
+for a Reporting API call that failed or that the API refused the token for, and
+503 for an engine query that failed, a stored document that does not decode or
+that the export refuses, and the files of a run whose statements the export
+refuses. A path the console has no page for is answered 404 on
 that same error page, and a route asked with a method it does not answer 405.
 
 Amounts are rendered at two decimal places and quantities at four, the scales

--- a/internal/console/httpui/errors.go
+++ b/internal/console/httpui/errors.go
@@ -41,6 +41,12 @@ func unreadableUUID(name string, err error) error {
 	return &paramError{name: name, reason: fmt.Sprintf("is not a UUID: %v", err)}
 }
 
+// unreadableMonth reports a month that was sent in a form other than the
+// YYYY-MM a billing period is named by.
+func unreadableMonth(name, value string) error {
+	return &paramError{name: name, reason: fmt.Sprintf("is not a YYYY-MM month: %q", value)}
+}
+
 // apiError tags a failure the Reporting API returned, storeError one the engine
 // database returned, and documentError a stored document that did not decode
 // into what the page renders. A handler tags an error where it receives it, so

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/b42labs/tally/internal/console/reporting"
 	"github.com/b42labs/tally/internal/console/store"
 	"github.com/b42labs/tally/internal/core/money"
+	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/engine/pricing"
 	"github.com/b42labs/tally/internal/engine/statements"
 	"github.com/b42labs/tally/internal/reporting/httpapi"
@@ -199,6 +200,9 @@ type fakeStore struct {
 	runTotals    []store.RunTotal
 	runTotalsErr error
 
+	runExport    export.Run
+	runExportErr error
+
 	runs      []store.Run
 	runsErr   error
 	runsLimit int32
@@ -312,6 +316,10 @@ func (f *fakeStore) ListResourceSegments(
 
 func (f *fakeStore) ListCorrectionDeltas(context.Context, uuid.UUID) ([]store.Delta, error) {
 	return f.deltas, f.deltasErr
+}
+
+func (f *fakeStore) LoadRunExport(context.Context, uuid.UUID) (export.Run, error) {
+	return f.runExport, f.runExportErr
 }
 
 // serve builds the console over two fakes and hands back the log it writes, so
@@ -690,6 +698,38 @@ func fullStore(t *testing.T) *fakeStore {
 			{RunID: testSupersededRunID, Currency: "EUR", Statements: 2, Total: mustDecimal(t, "150.00")},
 			{RunID: testRunID, Currency: "EUR", Statements: 2, Total: mustDecimal(t, "192.45")},
 			{RunID: testCorrectionRunID, Currency: "EUR", Statements: 1, Total: mustDecimal(t, "-2.55")},
+		},
+		// What an export of testRunID renders from: its one statement, and the
+		// kickback the partner cloudhouse is owed for it.
+		runExport: export.Run{
+			ID:             testRunID,
+			Kind:           "regular",
+			PeriodFrom:     testPeriod,
+			PeriodTo:       testPeriod.AddDate(0, 1, 0),
+			Status:         "completed",
+			PricingVersion: "2026-03",
+			Clouds:         []string{"os-sim"},
+			StartedAt:      testPeriod.AddDate(0, 1, 0),
+			CompletedAt:    testPeriod.AddDate(0, 1, 0).Add(time.Minute),
+			Stats:          json.RawMessage("{}"),
+			Statements: []statements.Statement{{
+				Key:      testKey,
+				Document: goldenStatement(t),
+				Total:    mustDecimal(t, "128.45"),
+				Currency: "EUR",
+			}},
+			Kickbacks: []export.Kickback{{
+				Beneficiary:  "cloudhouse",
+				Currency:     "EUR",
+				StatementKey: testKey,
+				Cloud:        "os-sim",
+				ProjectID:    "p-1",
+				RelationID:   testSourceID,
+				Scope:        "all",
+				Rate:         mustDecimal(t, "0.100000"),
+				Base:         mustDecimal(t, "128.45"),
+				Amount:       mustDecimal(t, "12.85"),
+			}},
 		},
 		runs:   []store.Run{run},
 		run:    run,
@@ -2806,6 +2846,365 @@ func relatedCostDocument(t *testing.T) []byte {
 	return raw
 }
 
+func TestRunExport(t *testing.T) {
+	t.Parallel()
+
+	runPath := "/run?id=" + testRunID.String()
+	query := "?run=" + testRunID.String()
+	routes := []string{"/run.json", "/kickbacks.json"}
+
+	t.Run("the page shows the two files the export writes", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, runPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"<code>run.json</code>",
+			"<code>kickbacks.json</code>",
+			`<a href="/run.json?run=` + testRunID.String() + `">open</a>`,
+			`<a href="/run.json?download=1&amp;run=` + testRunID.String() + `">download</a>`,
+			`<a href="/kickbacks.json?run=` + testRunID.String() + `">open</a>`,
+			`<a href="/kickbacks.json?download=1&amp;run=` + testRunID.String() + `">download</a>`,
+			`<a href="/period?month=2026-03">`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+		if got := strings.Count(body, "<li><span>"); got != 4 {
+			t.Errorf("the footer lists %d reads, want 4:\n%s", got, body)
+		}
+		for _, want := range []string{"GetRun", "ListStatements", "ListCorrectionDeltas", "LoadRunExport"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the footer does not name %q", want)
+			}
+		}
+	})
+
+	t.Run("the settlement of a run", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, runPath)
+		settles := section(t, body, "What this run settles", "What this run moved")
+		for _, want := range []string{
+			`href="/project?cloud=partner&amp;external_id=cloudhouse"`,
+			"<code>cloudhouse</code>",
+			`<td class="number">1</td>`,
+			"12.85 EUR",
+		} {
+			if !strings.Contains(settles, want) {
+				t.Errorf("the settlement does not carry %q:\n%s", want, settles)
+			}
+		}
+		if strings.Contains(body, "a correction settles the difference") {
+			t.Error("a regular run's settlement says it is a difference")
+		}
+	})
+
+	t.Run("the settlement is read off the rendered document", func(t *testing.T) {
+		t.Parallel()
+
+		if owed, err := readSettlement([]byte("not json")); err == nil || owed != nil {
+			t.Errorf("readSettlement() = %v, %v, want no rows and an error", owed, err)
+		}
+		owed, err := readSettlement([]byte(`{"beneficiaries":[]}`))
+		if err != nil || len(owed) != 0 {
+			t.Errorf("readSettlement() = %v, %v, want no rows and no error", owed, err)
+		}
+	})
+
+	t.Run("the files of a regular run are the export's", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.run, engine.runExport = goldenRegularExport(t)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		golden := "?run=" + engine.run.ID.String()
+		for _, name := range []string{"run.json", "kickbacks.json"} {
+			want := exportGolden(t, "regular", name)
+			status, header, body := fetch(t, handler, "/"+name+golden)
+			if status != http.StatusOK {
+				t.Fatalf("%s: status = %d, want %d:\n%s", name, status, http.StatusOK, body)
+			}
+			if got := header.Get("Content-Type"); got != "application/json" {
+				t.Errorf("%s: content type = %q, want application/json", name, got)
+			}
+			if got, disposition := header.Get("Content-Disposition"),
+				"inline; filename="+name+"; filename*=UTF-8''"+name; got != disposition {
+				t.Errorf("%s: content disposition = %q, want %q", name, got, disposition)
+			}
+			if !bytes.Equal(body, want) {
+				t.Errorf("%s: body =\n%s\nwant the golden\n%s", name, body, want)
+			}
+
+			_, header, _ = fetch(t, handler, "/"+name+golden+"&download=1")
+			if got := header.Get("Content-Disposition"); !strings.HasPrefix(got, "attachment; filename="+name) {
+				t.Errorf("%s: content disposition = %q, want an attachment", name, got)
+			}
+		}
+
+		_, page, _ := get(t, handler, "/run?id="+engine.run.ID.String())
+		documents := exportPattern.FindAllStringSubmatch(page, -1)
+		if len(documents) != 2 {
+			t.Fatalf("the page folds %d documents, want run.json and kickbacks.json:\n%s", len(documents), page)
+		}
+		for i, name := range []string{"run.json", "kickbacks.json"} {
+			want := exportGolden(t, "regular", name)
+			if got := html.UnescapeString(documents[i][1]); got != string(want) {
+				t.Errorf("the page shows\n%s\nwant the golden %s\n%s", got, name, want)
+			}
+			if size := "<code>" + name + "</code>, " + strconv.Itoa(len(want)) + " bytes"; !strings.Contains(page, size) {
+				t.Errorf("the page does not carry %q", size)
+			}
+		}
+	})
+
+	t.Run("the files of a correction are the export's", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.run, engine.runExport = goldenCorrectionExport(t)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		golden := "?run=" + engine.run.ID.String()
+		for _, name := range []string{"run.json", "kickbacks.json"} {
+			want := exportGolden(t, "correction", name)
+			if _, _, body := fetch(t, handler, "/"+name+golden); !bytes.Equal(body, want) {
+				t.Errorf("%s: body =\n%s\nwant the golden\n%s", name, body, want)
+			}
+		}
+
+		_, page, _ := get(t, handler, "/run?id="+engine.run.ID.String())
+		for _, want := range []string{
+			"a correction settles the difference to the run it corrects",
+			"this run settles nothing for a partner",
+		} {
+			if !strings.Contains(page, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, page)
+			}
+		}
+	})
+
+	t.Run("a run that billed and settles nothing", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.runExport.Statements, engine.runExport.Kickbacks = nil, nil
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		if _, _, body := fetch(t, handler, "/run.json"+query); !bytes.Contains(body, []byte(`"statements": []`)) {
+			t.Errorf("run.json does not list an empty statement list:\n%s", body)
+		}
+		if _, _, body := fetch(t, handler, "/kickbacks.json"+query); !bytes.Contains(body, []byte(`"beneficiaries": []`)) {
+			t.Errorf("kickbacks.json does not list an empty beneficiary list:\n%s", body)
+		}
+		if _, page, _ := get(t, handler, runPath); !strings.Contains(page, "this run settles nothing for a partner") {
+			t.Errorf("the page does not say the run settles nothing:\n%s", page)
+		}
+	})
+
+	t.Run("a run the export does not read", func(t *testing.T) {
+		t.Parallel()
+
+		for _, status := range []string{"superseded", "failed", "running"} {
+			engine := fullStore(t)
+			engine.run.Status = status
+			handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+			want := "is " + status + ", and only a completed or finalized run is exported"
+			code, page, _ := get(t, handler, runPath)
+			if code != http.StatusOK {
+				t.Fatalf("%s: page status = %d, want %d", status, code, http.StatusOK)
+			}
+			if !strings.Contains(page, want) {
+				t.Errorf("%s: the page does not say its run is not exported:\n%s", status, page)
+			}
+			for _, unwanted := range []string{`<details class="export">`, "What this run settles", "LoadRunExport"} {
+				if strings.Contains(page, unwanted) {
+					t.Errorf("%s: the page carries %q", status, unwanted)
+				}
+			}
+			for _, route := range routes {
+				code, body, _ := get(t, handler, route+query)
+				if code != http.StatusNotFound {
+					t.Errorf("%s: %s status = %d, want %d", status, route, code, http.StatusNotFound)
+				}
+				if !strings.Contains(body, want) {
+					t.Errorf("%s: %s does not say why:\n%s", status, route, body)
+				}
+			}
+		}
+	})
+
+	t.Run("a statement the export refuses", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		golden := goldenStatement(t)
+		engine.runExport.Statements[0].Document = append([]byte(`{"invoice_number":"2026-03-0001",`), golden[1:]...)
+		handler, logged := serve(t, fullAPI(t), engine, testNow)
+
+		code, page, _ := get(t, handler, runPath)
+		if code != http.StatusOK {
+			t.Fatalf("page status = %d, want %d: the run page stands without the files", code, http.StatusOK)
+		}
+		if !strings.Contains(page, "the export refuses this run") || !strings.Contains(page, "invoice_number") {
+			t.Errorf("the page does not carry the export's refusal:\n%s", page)
+		}
+		if strings.Contains(page, `<details class="export">`) {
+			t.Error("the page shows a file of a run the export refuses")
+		}
+		for _, route := range routes {
+			code, body, _ := get(t, handler, route+query)
+			if code != http.StatusServiceUnavailable {
+				t.Errorf("%s status = %d, want %d", route, code, http.StatusServiceUnavailable)
+			}
+			if !strings.Contains(body, "invoice_number") {
+				t.Errorf("%s does not carry the refusal:\n%s", route, body)
+			}
+		}
+		if !strings.Contains(logged.String(), "invoice_number") {
+			t.Errorf("the refusal did not reach the log:\n%s", logged.String())
+		}
+	})
+
+	t.Run("the export cannot be read", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.runExportErr = fmt.Errorf("LoadRunExport: %w", errors.New("connection refused"))
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		for _, path := range []string{runPath, "/run.json" + query, "/kickbacks.json" + query} {
+			code, body, _ := get(t, handler, path)
+			if code != http.StatusServiceUnavailable {
+				t.Errorf("%s: status = %d, want %d", path, code, http.StatusServiceUnavailable)
+			}
+			if !strings.Contains(body, "LoadRunExport") {
+				t.Errorf("%s: the page does not name the read that failed:\n%s", path, body)
+			}
+		}
+	})
+
+	t.Run("a run that moved while it was read", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.runExportErr = fmt.Errorf("LoadRunExport: %w", fmt.Errorf(
+			"%w: run %s is superseded, and only a completed or finalized run is exported",
+			export.ErrRunNotExportable, testRunID))
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		code, page, _ := get(t, handler, runPath)
+		if code != http.StatusOK || !strings.Contains(page, "is superseded, and only") {
+			t.Errorf("page status = %d, want %d and the reason:\n%s", code, http.StatusOK, page)
+		}
+		for _, route := range routes {
+			if code, body, _ := get(t, handler, route+query); code != http.StatusNotFound {
+				t.Errorf("%s status = %d, want %d:\n%s", route, code, http.StatusNotFound, body)
+			}
+		}
+	})
+
+	t.Run("no such run", func(t *testing.T) {
+		t.Parallel()
+
+		for _, c := range []struct {
+			err  error
+			want int
+		}{
+			{err: fmt.Errorf("GetRun: %w", pgx.ErrNoRows), want: http.StatusNotFound},
+			{err: fmt.Errorf("GetRun: %w", errors.New("connection refused")), want: http.StatusServiceUnavailable},
+		} {
+			engine := fullStore(t)
+			engine.runErr = c.err
+			handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+			if code, body, _ := get(t, handler, "/run.json"+query); code != c.want {
+				t.Errorf("%v: status = %d, want %d:\n%s", c.err, code, c.want, body)
+			}
+		}
+	})
+}
+
+// goldenRegularExport is the export package's regular golden run as the run page
+// reads it: the run row, and the run the export renders run.json and
+// kickbacks.json from, whose two files are that run's goldens.
+func goldenRegularExport(t *testing.T) (store.Run, export.Run) {
+	t.Helper()
+
+	id := uuid.MustParse("3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4")
+	started := time.Date(2026, 4, 4, 0, 0, 0, 0, time.UTC)
+	row := store.Run{
+		ID: id, PeriodFrom: testPeriod, PeriodTo: testPeriod.AddDate(0, 1, 0),
+		Kind: "regular", PricingVersion: "2026-03", Status: "finalized",
+		Stats: []byte("{}"), StartedAt: started, CompletedAt: started.Add(time.Minute),
+	}
+	return row, export.Run{
+		ID: id, Kind: "regular", PeriodFrom: testPeriod, PeriodTo: testPeriod.AddDate(0, 1, 0),
+		Status: "finalized", PricingVersion: "2026-03", Clouds: []string{},
+		StartedAt: started, CompletedAt: started.Add(time.Minute), Stats: json.RawMessage("{}"),
+		// In the order the export reads them, which is by key: os-dr sorts before
+		// os-prod.
+		Statements: []statements.Statement{{
+			Key:      "os-dr/proj-789",
+			Document: exportGolden(t, "regular", "statement-os-dr%2Fproj-789.json"),
+			Total:    mustDecimal(t, "22.32"),
+			Currency: "EUR",
+		}, {
+			Key:      "os-prod/proj-456",
+			Document: goldenStatement(t),
+			Total:    mustDecimal(t, "128.45"),
+			Currency: "EUR",
+		}},
+	}
+}
+
+// goldenCorrectionExport is the correction of that run, the same way.
+func goldenCorrectionExport(t *testing.T) (store.Run, export.Run) {
+	t.Helper()
+
+	id := uuid.MustParse("4b9d2c17-6e85-4f3a-8a01-c5d4e6f7a8b9")
+	corrects := uuid.MustParse("3f1e6a58-9c24-4d0b-8f77-2a5c1b93e0d4")
+	started := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	row := store.Run{
+		ID: id, PeriodFrom: testPeriod, PeriodTo: testPeriod.AddDate(0, 1, 0),
+		Kind: "correction", CorrectsRunID: corrects, PricingVersion: "2026-03", Status: "finalized",
+		Stats: []byte("{}"), StartedAt: started, CompletedAt: started.Add(time.Minute),
+	}
+	return row, export.Run{
+		ID: id, Kind: "correction", CorrectsRunID: corrects,
+		PeriodFrom: testPeriod, PeriodTo: testPeriod.AddDate(0, 1, 0),
+		Status: "finalized", PricingVersion: "2026-03", Clouds: []string{},
+		StartedAt: started, CompletedAt: started.Add(time.Minute), Stats: json.RawMessage("{}"),
+		Statements: []statements.Statement{{
+			Key:      "os-prod/proj-456",
+			Document: goldenCreditNote(t),
+			Total:    mustDecimal(t, "-24.00"),
+			Currency: "EUR",
+		}},
+	}
+}
+
+// exportGolden reads one golden file of the export package, which is what an
+// export of that run wrote.
+func exportGolden(t *testing.T, run, name string) []byte {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "engine", "export", "testdata", "golden", run, name))
+	if err != nil {
+		t.Fatalf("reading the golden %s of the %s run: %v", name, run, err)
+	}
+	return raw
+}
+
 func TestCatalogPage(t *testing.T) {
 	t.Parallel()
 
@@ -2906,6 +3305,10 @@ func TestRequiredParameters(t *testing.T) {
 		{path: "/period?month=2026-13", parameter: "month"},
 		{path: "/period?month=2026-3", parameter: "month"},
 		{path: "/period?month=july", parameter: "month"},
+		{path: "/run.json", parameter: "run"},
+		{path: "/run.json?run=not-a-uuid", parameter: "run"},
+		{path: "/kickbacks.json", parameter: "run"},
+		{path: "/kickbacks.json?run=not-a-uuid", parameter: "run"},
 	}
 
 	for _, c := range cases {

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -187,6 +187,18 @@ type fakeStore struct {
 	periods    []store.Period
 	periodsErr error
 
+	// The three reads of a period page. periodAsked holds the instant each of
+	// them was asked for, in the order they were asked.
+	period      store.Period
+	periodErr   error
+	periodAsked []time.Time
+
+	periodRuns    []store.Run
+	periodRunsErr error
+
+	runTotals    []store.RunTotal
+	runTotalsErr error
+
 	runs      []store.Run
 	runsErr   error
 	runsLimit int32
@@ -232,6 +244,21 @@ type fakeStore struct {
 
 func (f *fakeStore) ListPeriods(context.Context) ([]store.Period, error) {
 	return f.periods, f.periodsErr
+}
+
+func (f *fakeStore) GetPeriod(_ context.Context, from time.Time) (store.Period, error) {
+	f.periodAsked = append(f.periodAsked, from)
+	return f.period, f.periodErr
+}
+
+func (f *fakeStore) ListRunsForPeriod(_ context.Context, from time.Time) ([]store.Run, error) {
+	f.periodAsked = append(f.periodAsked, from)
+	return f.periodRuns, f.periodRunsErr
+}
+
+func (f *fakeStore) ListRunTotalsForPeriod(_ context.Context, from time.Time) ([]store.RunTotal, error) {
+	f.periodAsked = append(f.periodAsked, from)
+	return f.runTotals, f.runTotalsErr
 }
 
 func (f *fakeStore) ListRuns(_ context.Context, limit int32) ([]store.Run, error) {
@@ -486,8 +513,9 @@ var (
 	// the relations table links to.
 	testSourceID = uuid.MustParse("55555555-5555-4555-8555-555555555555")
 	testTargetID = uuid.MustParse("66666666-6666-4666-8666-666666666666")
-	// The two other runs of the period testRunID closed: the regular run it
-	// replaced, and the correction booked against it.
+	// The other runs of the period testRunID closed: a regular run that failed,
+	// the regular run testRunID replaced, and the correction booked against it.
+	testFailedRunID     = uuid.MustParse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
 	testSupersededRunID = uuid.MustParse("77777777-7777-4777-8777-777777777777")
 	testCorrectionRunID = uuid.MustParse("88888888-8888-4888-8888-888888888888")
 	testKey             = statements.Key("os-sim", "p-1")
@@ -614,6 +642,55 @@ func fullStore(t *testing.T) *fakeStore {
 		periods: []store.Period{{
 			From: testPeriod, To: testPeriod.AddDate(0, 1, 0), Status: "open",
 		}},
+		// March as its period page reads it: closed by testRunID, and holding a
+		// run that failed, the run testRunID replaced, and the correction booked
+		// against testRunID.
+		period: store.Period{
+			From:           testPeriod,
+			To:             testPeriod.AddDate(0, 1, 0),
+			Status:         "finalized",
+			FinalizedRunID: testRunID,
+			FinalizedAt:    time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC),
+		},
+		periodRuns: []store.Run{
+			{
+				ID:             testFailedRunID,
+				Kind:           "regular",
+				Status:         "failed",
+				PricingVersion: "2026-03",
+				StartedAt:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:             testSupersededRunID,
+				Kind:           "regular",
+				Status:         "superseded",
+				PricingVersion: "2026-03",
+				StartedAt:      time.Date(2026, 4, 1, 6, 0, 0, 0, time.UTC),
+				CompletedAt:    time.Date(2026, 4, 1, 6, 1, 0, 0, time.UTC),
+			},
+			{
+				ID:             testRunID,
+				Kind:           "regular",
+				Status:         "finalized",
+				PricingVersion: "2026-03",
+				StartedAt:      time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+				CompletedAt:    time.Date(2026, 4, 2, 0, 1, 0, 0, time.UTC),
+			},
+			{
+				ID:             testCorrectionRunID,
+				Kind:           "correction",
+				CorrectsRunID:  testRunID,
+				Status:         "finalized",
+				PricingVersion: "2026-03",
+				StartedAt:      time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+				CompletedAt:    time.Date(2026, 4, 10, 0, 1, 0, 0, time.UTC),
+			},
+		},
+		runTotals: []store.RunTotal{
+			{RunID: testSupersededRunID, Currency: "EUR", Statements: 2, Total: mustDecimal(t, "150.00")},
+			{RunID: testRunID, Currency: "EUR", Statements: 2, Total: mustDecimal(t, "192.45")},
+			{RunID: testCorrectionRunID, Currency: "EUR", Statements: 1, Total: mustDecimal(t, "-2.55")},
+		},
 		runs:   []store.Run{run},
 		run:    run,
 		runErr: nil,
@@ -735,6 +812,7 @@ func pagePaths() []string {
 		"/catalog?version=2026-03",
 		"/run?id=" + testRunID.String(),
 		"/statement?run=" + testRunID.String() + "&key=" + url.QueryEscape(testKey),
+		"/period?month=2026-03",
 	}
 }
 
@@ -852,6 +930,31 @@ func TestOverviewPage(t *testing.T) {
 			if !strings.Contains(body, want) {
 				t.Errorf("the footer does not name %q", want)
 			}
+		}
+	})
+
+	t.Run("a period links its page and the run that closed it", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/")
+		periods := section(t, body, "Billing periods", "Metering runs")
+		if !strings.Contains(periods, `<a href="/period?month=2026-03">2026-03-01T00:00:00Z</a>`) {
+			t.Errorf("the period does not link its page:\n%s", periods)
+		}
+		if !strings.Contains(periods, "<td>none</td>") {
+			t.Errorf("the open period names a run that closed it:\n%s", periods)
+		}
+
+		engine := fullStore(t)
+		engine.periods = []store.Period{engine.period}
+		handler, _ = serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ = get(t, handler, "/")
+		periods = section(t, body, "Billing periods", "Metering runs")
+		if !strings.Contains(periods, `<a href="/run?id=`+testRunID.String()+`">`+testRunID.String()+`</a>`) {
+			t.Errorf("the finalized period does not link the run that closed it:\n%s", periods)
 		}
 	})
 }
@@ -1498,6 +1601,268 @@ func TestRunPage(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestPeriodPage(t *testing.T) {
+	t.Parallel()
+
+	const periodPath = "/period?month=2026-03"
+
+	t.Run("a finalized month", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, periodPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+		}
+		for _, want := range []string{
+			"<title>tally console: Billing period 2026-03</title>",
+			"<dt>status</dt><dd>finalized</dd>",
+			"<dt>finalized at</dt><dd>2026-04-05T00:00:00Z</dd>",
+			`<dt>finalized by</dt><dd><a href="/run?id=` + testRunID.String() + `">`,
+			"<dt>billed</dt><dd>189.90 EUR</dd>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+		// The failed run billed nothing and the superseded one was replaced, so
+		// neither is added up: 192.45 and -2.55 are, and 150.00 is not.
+		if strings.Contains(body, "339.90") {
+			t.Error("the page adds the superseded run up as well")
+		}
+	})
+
+	t.Run("every run of the month in the order it started", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		runs := section(t, body, "Runs", "Where this page came from")
+		last := -1
+		for _, id := range []uuid.UUID{testFailedRunID, testSupersededRunID, testRunID, testCorrectionRunID} {
+			at := strings.Index(runs, `<a href="/run?id=`+id.String()+`"><code>`+id.String()+`</code></a>`)
+			if at < 0 {
+				t.Fatalf("the run table does not link the run %s:\n%s", id, runs)
+			}
+			if at < last {
+				t.Errorf("the run %s is listed before the run that started ahead of it", id)
+			}
+			last = at
+		}
+		if got := strings.Count(body, `<tr class="muted">`); got != 2 {
+			t.Errorf("the page mutes %d rows, want the failed and the superseded run", got)
+		}
+		if got := strings.Count(body, "counts for nothing"); got != 2 {
+			t.Errorf("the page says %d times that a run counts for nothing, want 2", got)
+		}
+		for _, want := range []string{"150.00 EUR", "192.45 EUR", "-2.55 EUR"} {
+			if !strings.Contains(runs, want) {
+				t.Errorf("the run table does not carry %q", want)
+			}
+		}
+		failed := periodRunOf(t, runs, testFailedRunID)
+		if !strings.Contains(failed, "<td>none</td>") || !strings.Contains(failed, `<td class="number">none</td>`) {
+			t.Errorf("the failed run does not print none as its completion and as its total:\n%s", failed)
+		}
+	})
+
+	t.Run("a month billed in two currencies", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.runTotals = append(engine.runTotals,
+			store.RunTotal{RunID: testRunID, Currency: "USD", Statements: 1, Total: mustDecimal(t, "10.00")})
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		if !strings.Contains(body, "<dt>billed</dt><dd>189.90 EUR + 10.00 USD</dd>") {
+			t.Errorf("the head does not add each currency up on its own:\n%s", body)
+		}
+		regular := periodRunOf(t, section(t, body, "Runs", "Where this page came from"), testRunID)
+		if !strings.Contains(regular, "192.45 EUR + 10.00 USD") || !strings.Contains(regular, `<td class="number">3</td>`) {
+			t.Errorf("the regular run does not carry both currencies and three statements:\n%s", regular)
+		}
+	})
+
+	t.Run("a total whose run the listing does not hold", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.runTotals = append(engine.runTotals, store.RunTotal{
+			RunID:      uuid.MustParse("99999999-9999-4999-8999-999999999999"),
+			Currency:   "EUR",
+			Statements: 1,
+			Total:      mustDecimal(t, "1000.00"),
+		})
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		if !strings.Contains(body, "<dt>billed</dt><dd>189.90 EUR</dd>") {
+			t.Errorf("a total of a run the page does not show changed what the month bills:\n%s", body)
+		}
+	})
+
+	t.Run("an open month", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.period = store.Period{From: testPeriod, To: testPeriod.AddDate(0, 1, 0), Status: "open"}
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		for _, want := range []string{"<dt>finalized at</dt><dd>none</dd>", "<dt>finalized by</dt><dd>none</dd>"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("a month without a run", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.periodRuns, engine.runTotals = nil, nil
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		status, body, _ := get(t, handler, periodPath)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want %d", status, http.StatusOK)
+		}
+		for _, want := range []string{"no run has been recorded for this period", "<dt>billed</dt><dd>none</dd>"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page does not carry %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, "<table>") {
+			t.Error("the page draws a run table with nothing in it")
+		}
+	})
+
+	t.Run("a month whose every run was replaced", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.periodRuns = []store.Run{engine.periodRuns[1]}
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		if !strings.Contains(body, "<dt>billed</dt><dd>none</dd>") {
+			t.Errorf("a month whose runs were all replaced bills something:\n%s", body)
+		}
+		if got := strings.Count(body, `<tr class="muted">`); got != 1 {
+			t.Errorf("the page mutes %d rows, want the superseded run", got)
+		}
+	})
+
+	t.Run("the run table filters", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, periodPath+"&runs.q=correction")
+		if !strings.Contains(body, "1 of 4 rows match") {
+			t.Errorf("the filter does not say what matched:\n%s", body)
+		}
+	})
+
+	t.Run("no such month", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		engine.periodErr = fmt.Errorf("GetPeriod: %w", pgx.ErrNoRows)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		if status, body, _ := get(t, handler, periodPath); status != http.StatusNotFound {
+			t.Errorf("status = %d, want %d:\n%s", status, http.StatusNotFound, body)
+		}
+	})
+
+	t.Run("a read that fails", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			query string
+			set   func(f *fakeStore, err error)
+		}{
+			{query: "GetPeriod", set: func(f *fakeStore, err error) { f.periodErr = err }},
+			{query: "ListRunsForPeriod", set: func(f *fakeStore, err error) { f.periodRunsErr = err }},
+			{query: "ListRunTotalsForPeriod", set: func(f *fakeStore, err error) { f.runTotalsErr = err }},
+		}
+		for _, c := range cases {
+			engine := fullStore(t)
+			c.set(engine, fmt.Errorf("%s: %w", c.query, errors.New("connection refused")))
+			handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+			status, body, _ := get(t, handler, periodPath)
+			if status != http.StatusServiceUnavailable {
+				t.Errorf("%s: status = %d, want %d", c.query, status, http.StatusServiceUnavailable)
+			}
+			if !strings.Contains(body, c.query) {
+				t.Errorf("%s: the page does not name the read that failed:\n%s", c.query, body)
+			}
+		}
+	})
+
+	t.Run("three reads in the footer", func(t *testing.T) {
+		t.Parallel()
+
+		engine := fullStore(t)
+		handler, _ := serve(t, fullAPI(t), engine, testNow)
+
+		_, body, _ := get(t, handler, periodPath)
+		if got := strings.Count(body, "<li><span>"); got != 3 {
+			t.Errorf("the footer lists %d reads, want 3:\n%s", got, body)
+		}
+		for _, want := range []string{"GetPeriod", "ListRunsForPeriod", "ListRunTotalsForPeriod"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the footer does not name %q", want)
+			}
+		}
+		if len(engine.periodAsked) != 3 {
+			t.Fatalf("the page asked for %d months, want 3", len(engine.periodAsked))
+		}
+		for _, asked := range engine.periodAsked {
+			if !asked.Equal(testPeriod) {
+				t.Errorf("the page asked for %s, want %s", stamp(asked), stamp(testPeriod))
+			}
+		}
+	})
+
+	t.Run("a month the page cannot read", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		for _, month := range []string{"2026-13", "2026-3", "july"} {
+			status, body, _ := get(t, handler, "/period?month="+month)
+			if status != http.StatusBadRequest {
+				t.Errorf("%s: status = %d, want %d", month, status, http.StatusBadRequest)
+			}
+			if !strings.Contains(body, "the parameter month is not a YYYY-MM month") {
+				t.Errorf("%s: the page does not say what is wrong with the month:\n%s", month, body)
+			}
+		}
+	})
+}
+
+// periodRunOf is the row the run table of a period page draws for one run,
+// from the link to the run to the end of the row.
+func periodRunOf(t *testing.T, runs string, id uuid.UUID) string {
+	t.Helper()
+
+	start := strings.Index(runs, `<a href="/run?id=`+id.String()+`">`)
+	if start < 0 {
+		t.Fatalf("the run table holds no row of %s:\n%s", id, runs)
+	}
+	end := strings.Index(runs[start:], "</tr>")
+	if end < 0 {
+		t.Fatalf("the row of %s does not end:\n%s", id, runs)
+	}
+	return runs[start : start+end]
 }
 
 func TestStatementPage(t *testing.T) {
@@ -2537,6 +2902,10 @@ func TestRequiredParameters(t *testing.T) {
 		{path: "/statement?run=not-a-uuid&key=os-sim%2Fp-1", parameter: "run"},
 		{path: "/statement.json?key=os-sim%2Fp-1", parameter: "run"},
 		{path: "/statement.json?run=" + testRunID.String(), parameter: "key"},
+		{path: "/period", parameter: "month"},
+		{path: "/period?month=2026-13", parameter: "month"},
+		{path: "/period?month=2026-3", parameter: "month"},
+		{path: "/period?month=july", parameter: "month"},
 	}
 
 	for _, c := range cases {

--- a/internal/console/httpui/overview.go
+++ b/internal/console/httpui/overview.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
 	"github.com/b42labs/tally/internal/console/store"
@@ -26,7 +27,7 @@ type overviewData struct {
 	Stats    listing[statRow]
 	Events   listing[httpapi.EventStatsItem]
 	Rejected listing[httpapi.DeadLetteredEvent]
-	Periods  listing[store.Period]
+	Periods  listing[billingPeriodRow]
 	Runs     listing[runRow]
 	From     time.Time
 	To       time.Time
@@ -52,12 +53,12 @@ var (
 		textCol("received at", func(r httpapi.DeadLetteredEvent) string { return stamp(r.ReceivedAt) }),
 		textCol("reason", func(r httpapi.DeadLetteredEvent) string { return r.Reason }),
 	}
-	periodColumns = []column[store.Period]{
-		textCol("from", func(r store.Period) string { return stamp(r.From) }),
-		textCol("to", func(r store.Period) string { return stamp(r.To) }),
-		textCol("status", func(r store.Period) string { return r.Status }),
-		textCol("finalized by", func(r store.Period) string { return idText(r.FinalizedRunID) }),
-		textCol("finalized at", func(r store.Period) string { return zeroStamp(r.FinalizedAt) }),
+	periodColumns = []column[billingPeriodRow]{
+		textCol("from", func(r billingPeriodRow) string { return stamp(r.Period.From) }),
+		textCol("to", func(r billingPeriodRow) string { return stamp(r.Period.To) }),
+		textCol("status", func(r billingPeriodRow) string { return r.Period.Status }),
+		textCol("finalized by", func(r billingPeriodRow) string { return idText(r.Period.FinalizedRunID) }),
+		textCol("finalized at", func(r billingPeriodRow) string { return zeroStamp(r.Period.FinalizedAt) }),
 	}
 	runColumns = []column[runRow]{
 		textCol("run", func(r runRow) string { return r.Run.ID.String() }),
@@ -134,7 +135,7 @@ func (h *handlers) overview(w http.ResponseWriter, r *http.Request) {
 		Stats:    tabulate(r, "stats", statColumns, statRows(stats.Items)),
 		Events:   tabulate(r, "events", eventColumns, events.Items),
 		Rejected: tabulate(r, "rejected", rejectedColumns, rejected.Items),
-		Periods:  tabulate(r, "periods", periodColumns, periods),
+		Periods:  tabulate(r, "periods", periodColumns, billingPeriodRows(periods)),
 		Runs:     tabulate(r, "runs", runColumns, runRows(runs)),
 		From:     from,
 		To:       to,
@@ -170,6 +171,29 @@ func runRows(runs []store.Run) []runRow {
 	rows := make([]runRow, 0, len(runs))
 	for _, run := range runs {
 		rows = append(rows, runRow{Run: run, Link: link("/run", "id", run.ID.String())})
+	}
+	return rows
+}
+
+// billingPeriodRow is one billing month of the overview, the page that shows
+// it, and the page of the run that closed it, which a month that is not closed
+// has none of.
+type billingPeriodRow struct {
+	Period  store.Period
+	Link    string
+	RunLink string
+}
+
+// billingPeriodRows links every month to its period page, and a closed month
+// to the run that closed it.
+func billingPeriodRows(periods []store.Period) []billingPeriodRow {
+	rows := make([]billingPeriodRow, 0, len(periods))
+	for _, billing := range periods {
+		row := billingPeriodRow{Period: billing, Link: periodLink(billing.From)}
+		if billing.FinalizedRunID != uuid.Nil {
+			row.RunLink = link("/run", "id", billing.FinalizedRunID.String())
+		}
+		rows = append(rows, row)
 	}
 	return rows
 }

--- a/internal/console/httpui/period.go
+++ b/internal/console/httpui/period.go
@@ -1,0 +1,164 @@
+package httpui
+
+import (
+	"maps"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/period"
+)
+
+// monthParameter names the billing month a period page is about, in the
+// YYYY-MM form tally-engine reads a --period in.
+const monthParameter = "month"
+
+// periodData is one billing month: where it stands, what it bills once its
+// standing runs are added up, and every run the engine recorded for it.
+type periodData struct {
+	Period store.Period
+	// FinalizedLink is the page of the run that closed the month, and empty for
+	// a month that is not closed.
+	FinalizedLink string
+	// Totals is what the statements of the standing runs add up to, per
+	// currency, sorted by currency.
+	Totals []currencyTotal
+	Runs   listing[periodRunRow]
+}
+
+// periodRunRow is one run of a month, the page that shows it, and what its own
+// statements add up to. A run that does not stand is listed for the audit it
+// leaves and counts for nothing.
+type periodRunRow struct {
+	Run        store.Run
+	Link       string
+	Statements int64
+	Totals     []currencyTotal
+	Sort       decimal.Decimal
+	Standing   bool
+}
+
+// periodRunColumns is the run table of a period page.
+var periodRunColumns = []column[periodRunRow]{
+	textCol("run", func(r periodRunRow) string { return r.Run.ID.String() }),
+	textCol("kind", func(r periodRunRow) string { return r.Run.Kind }),
+	textCol("status", func(r periodRunRow) string { return r.Run.Status }),
+	textCol("pricing", func(r periodRunRow) string { return r.Run.PricingVersion }),
+	textCol("started", func(r periodRunRow) string { return zeroStamp(r.Run.StartedAt) }),
+	textCol("completed", func(r periodRunRow) string { return zeroStamp(r.Run.CompletedAt) }),
+	countCol("statements", func(r periodRunRow) int64 { return r.Statements }),
+	numberCol("total", func(r periodRunRow) decimal.Decimal { return r.Sort }),
+}
+
+// periodLink is the page of the billing month that starts at from.
+func periodLink(from time.Time) string {
+	return link("/period", monthParameter, period.Format(from))
+}
+
+// readMonth reads the month a period page is about, which it cannot be built
+// without.
+func readMonth(r *http.Request) (time.Time, error) {
+	value, err := stringParameter(r, monthParameter)
+	if err != nil {
+		return time.Time{}, err
+	}
+	from, _, err := period.Parse(value)
+	if err != nil {
+		return time.Time{}, unreadableMonth(monthParameter, value)
+	}
+	return from, nil
+}
+
+// billingPeriod shows one billing month: where it stands, every run the engine
+// recorded for it, and what the month bills, which is what the statements of
+// its standing runs add up to by the rule the project page adds one project up
+// by. A month no run ever opened has no row, and the page answers 404 for it.
+func (h *handlers) billingPeriod(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var src sources
+
+	from, err := readMonth(r)
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
+
+	billing, err := h.store.GetPeriod(ctx, from)
+	src.query("GetPeriod")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
+	recorded, err := h.store.ListRunsForPeriod(ctx, from)
+	src.query("ListRunsForPeriod")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
+	totals, err := h.store.ListRunTotalsForPeriod(ctx, from)
+	src.query("ListRunTotalsForPeriod")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
+	rows, standing := periodRunRows(recorded, totals)
+	data := periodData{
+		Period: billing,
+		Totals: standing,
+		Runs:   tabulate(r, "runs", periodRunColumns, rows),
+	}
+	if billing.FinalizedRunID != uuid.Nil {
+		data.FinalizedLink = link("/run", "id", billing.FinalizedRunID.String())
+	}
+
+	h.render(w, r, "period", page{
+		Title:   "Billing period " + period.Format(from),
+		Sources: src,
+		Data:    data,
+	})
+}
+
+// periodRunRows puts every run of a month beside what its statements add up to,
+// in the order the runs started, and adds the standing ones up per currency. A
+// total whose run the listing does not hold is dropped: it belongs to a run the
+// page does not show.
+func periodRunRows(recorded []store.Run, totals []store.RunTotal) ([]periodRunRow, []currencyTotal) {
+	byRun := make(map[uuid.UUID][]store.RunTotal, len(recorded))
+	for _, total := range totals {
+		byRun[total.RunID] = append(byRun[total.RunID], total)
+	}
+
+	sums := make(map[string]decimal.Decimal)
+	rows := make([]periodRunRow, 0, len(recorded))
+	for _, run := range recorded {
+		row := periodRunRow{
+			Run:      run,
+			Link:     link("/run", "id", run.ID.String()),
+			Standing: slices.Contains(standingStatuses, run.Status),
+		}
+		for _, total := range byRun[run.ID] {
+			row.Totals = append(row.Totals, currencyTotal{Total: total.Total, Currency: total.Currency})
+			row.Statements += total.Statements
+			if row.Standing {
+				sums[total.Currency] = sums[total.Currency].Add(total.Total)
+			}
+		}
+		if len(row.Totals) > 0 {
+			row.Sort = row.Totals[0].Total
+		}
+		rows = append(rows, row)
+	}
+
+	var standing []currencyTotal
+	for _, currency := range slices.Sorted(maps.Keys(sums)) {
+		standing = append(standing, currencyTotal{Total: sums[currency], Currency: currency})
+	}
+	return rows, standing
+}

--- a/internal/console/httpui/render.go
+++ b/internal/console/httpui/render.go
@@ -39,6 +39,7 @@ var pageNames = []string{
 	"run",
 	"statement",
 	"creditnote",
+	"period",
 	errorPage,
 }
 

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -83,6 +83,9 @@ type API interface {
 // the reason API is. *store.Store satisfies it as it is.
 type Store interface {
 	ListPeriods(ctx context.Context) ([]store.Period, error)
+	GetPeriod(ctx context.Context, from time.Time) (store.Period, error)
+	ListRunsForPeriod(ctx context.Context, from time.Time) ([]store.Run, error)
+	ListRunTotalsForPeriod(ctx context.Context, from time.Time) ([]store.RunTotal, error)
 	ListRuns(ctx context.Context, limit int32) ([]store.Run, error)
 	GetRun(ctx context.Context, id uuid.UUID) (store.Run, error)
 	ListStatements(ctx context.Context, runID uuid.UUID) ([]store.StatementRow, error)
@@ -140,6 +143,7 @@ func NewRouter(opts Options) (http.Handler, error) {
 	r.Get("/resource", h.resource)
 	r.Get("/pricing", h.pricing)
 	r.Get("/catalog", h.catalog)
+	r.Get("/period", h.billingPeriod)
 	r.Get("/run", h.run)
 	r.Get("/statement", h.statement)
 	r.Get(exportRoute, h.statementExport)

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -8,9 +8,10 @@
 // Sorting and filtering a table are links and a form that reload the page
 // with the table's state in the query string, and the theme is a form that
 // posts the choice to /theme, which is not a page: it keeps the choice in a
-// cookie and sends the viewer back. /statement.json is not a page either: it
-// serves the file the JSON export writes for a statement, as the export's own
-// bytes rather than as HTML.
+// cookie and sends the viewer back. /statement.json, /run.json and
+// /kickbacks.json are not pages either: they serve the files the JSON export
+// writes for a statement and for a run, as the export's own bytes rather than
+// as HTML.
 //
 // Every identifier travels in a query parameter rather than in a path segment.
 // A cloud name, a resource id and a statement key may each carry a slash, and a
@@ -39,6 +40,7 @@ import (
 
 	"github.com/b42labs/tally/internal/console/reporting"
 	"github.com/b42labs/tally/internal/console/store"
+	"github.com/b42labs/tally/internal/engine/export"
 	"github.com/b42labs/tally/internal/reporting/httpapi"
 )
 
@@ -99,6 +101,7 @@ type Store interface {
 		ctx context.Context, runID uuid.UUID, cloud, resourceType, resourceID string,
 	) ([]store.Segment, error)
 	ListCorrectionDeltas(ctx context.Context, runID uuid.UUID) ([]store.Delta, error)
+	LoadRunExport(ctx context.Context, runID uuid.UUID) (export.Run, error)
 }
 
 // handlers is what every route is served from: the two read seams, the clock,
@@ -147,6 +150,8 @@ func NewRouter(opts Options) (http.Handler, error) {
 	r.Get("/run", h.run)
 	r.Get("/statement", h.statement)
 	r.Get(exportRoute, h.statementExport)
+	r.Get(runFileRoute, h.runFile)
+	r.Get(kickbacksFileRoute, h.kickbacksFile)
 	r.Get("/static/console.css", h.stylesheet)
 	r.Post(themeRoute, h.theme)
 	r.NotFound(h.notFound)

--- a/internal/console/httpui/runexport.go
+++ b/internal/console/httpui/runexport.go
@@ -1,0 +1,225 @@
+package httpui
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/console/store"
+	projectcore "github.com/b42labs/tally/internal/core/project"
+	"github.com/b42labs/tally/internal/engine/export"
+)
+
+// A run's export is the two documents tally-engine export --format json writes
+// beside the statements: run.json, the index that names every statement file
+// and what it totals, and kickbacks.json, what the run settles for its
+// partners. The console serves the export's own bytes for both, rendered from
+// the export's own read of the run, the way it serves the file of a statement.
+const (
+	// runFileRoute serves the run.json of a run on its own, as JSON rather than
+	// as a page.
+	runFileRoute = "/run.json"
+	// kickbacksFileRoute serves the kickbacks.json of a run the same way.
+	kickbacksFileRoute = "/kickbacks.json"
+)
+
+// runExportView is what the run page says about the export of its run: the two
+// files and what the run owes each partner, or, where the export writes
+// nothing, why.
+type runExportView struct {
+	// Note says why the page shows no file: a run the export does not read, or
+	// one whose statements it refuses.
+	Note       string
+	Index      exportView
+	Settlement exportView
+	Partners   listing[partnerOwed]
+}
+
+// partnerOwed is what a run settles for one partner in one currency, as the
+// settlement the export renders says, and the page of that partner.
+type partnerOwed struct {
+	Beneficiary string
+	Currency    string
+	Projects    int64
+	Total       decimal.Decimal
+	Link        string
+}
+
+// partnerOwedColumns is the settlement table of a run page.
+var partnerOwedColumns = []column[partnerOwed]{
+	textCol("partner", func(r partnerOwed) string { return r.Beneficiary }),
+	textCol("currency", func(r partnerOwed) string { return r.Currency }),
+	countCol("projects", func(r partnerOwed) int64 { return r.Projects }),
+	numberCol("kickback", func(r partnerOwed) decimal.Decimal { return r.Total }),
+}
+
+// settlementDocument is the part of kickbacks.json the settlement table prints:
+// per partner and currency, what the partner is owed and how many projects that
+// came off. The breakdown under each entry is not read, because the table
+// prints none of it.
+type settlementDocument struct {
+	Beneficiaries []struct {
+		Beneficiary   string          `json:"beneficiary"`
+		Currency      string          `json:"currency"`
+		KickbackTotal decimal.Decimal `json:"kickback_total"`
+		Projects      int64           `json:"projects"`
+	} `json:"beneficiaries"`
+}
+
+// renderRunExport renders the two documents an export of the run writes beside
+// the statements. The index comes first: a statement the export refuses
+// refuses the whole export, and an export that refuses the run writes no
+// settlement either.
+func renderRunExport(run export.Run) (index, settlement []byte, err error) {
+	if index, err = export.RunJSON(run); err != nil {
+		return nil, nil, err
+	}
+	if settlement, err = export.KickbacksJSON(run); err != nil {
+		return nil, nil, err
+	}
+	return index, settlement, nil
+}
+
+// readSettlement reads what a run owes each partner off the kickbacks.json the
+// export rendered for it, in the order the document holds them, which is by
+// partner and then by currency. The totals are the export's: the page adds
+// nothing up again.
+func readSettlement(body []byte) ([]partnerOwed, error) {
+	var document settlementDocument
+	if err := json.Unmarshal(body, &document); err != nil {
+		return nil, err
+	}
+
+	owed := make([]partnerOwed, 0, len(document.Beneficiaries))
+	for _, entry := range document.Beneficiaries {
+		owed = append(owed, partnerOwed{
+			Beneficiary: entry.Beneficiary,
+			Currency:    entry.Currency,
+			Projects:    entry.Projects,
+			Total:       entry.KickbackTotal,
+			// A partner is a registry row whose cloud is its platform, and the
+			// project page resolves it by that pair.
+			Link: projectLink(projectcore.PlatformPartner, entry.Beneficiary),
+		})
+	}
+	return owed, nil
+}
+
+// buildRunExport renders the export of a run for its page. A run the export
+// does not read has no file, and nothing is read for it; a run that moved out
+// of the statuses the export reads between the page's two reads says so the
+// same way. Any other failed read is returned, and the page fails as it does
+// for its other reads. A run whose statements the export refuses leaves the
+// page standing: the page says what the export said, and the two routes are
+// where that refusal is an error.
+func (h *handlers) buildRunExport(r *http.Request, run store.Run, src *sources) (runExportView, error) {
+	if !export.Exportable(run.Status) {
+		return runExportView{Note: notExported(run).Error()}, nil
+	}
+
+	loaded, err := h.store.LoadRunExport(r.Context(), run.ID)
+	src.query("LoadRunExport")
+	if errors.Is(err, export.ErrRunNotExportable) {
+		return runExportView{Note: err.Error()}, nil
+	}
+	if err != nil {
+		return runExportView{}, err
+	}
+
+	index, settlement, err := renderRunExport(loaded)
+	if err != nil {
+		return runExportView{Note: "the export refuses this run: " + err.Error()}, nil
+	}
+	owed, err := readSettlement(settlement)
+	if err != nil {
+		return runExportView{Note: "the export refuses this run: " + err.Error()}, nil
+	}
+
+	id := run.ID.String()
+	return runExportView{
+		Index:      fileView(export.RunFileName, runFileRoute, id, index),
+		Settlement: fileView(export.KickbacksJSONFileName, kickbacksFileRoute, id, settlement),
+		Partners:   tabulate(r, "settlement", partnerOwedColumns, owed),
+	}, nil
+}
+
+// fileView is one file of a run's export as the page prints it: its name, its
+// bytes, and the two links to the route that serves it.
+func fileView(name, route, runID string, body []byte) exportView {
+	return exportView{
+		File:         name,
+		JSON:         string(body),
+		Size:         len(body),
+		OpenLink:     link(route, "run", runID),
+		DownloadLink: link(route, "run", runID, downloadParameter, "1"),
+	}
+}
+
+// runFile serves the run.json of a run.
+func (h *handlers) runFile(w http.ResponseWriter, r *http.Request) {
+	h.serveRunFile(w, r, export.RunFileName)
+}
+
+// kickbacksFile serves the kickbacks.json of a run.
+func (h *handlers) kickbacksFile(w http.ResponseWriter, r *http.Request) {
+	h.serveRunFile(w, r, export.KickbacksJSONFileName)
+}
+
+// serveRunFile serves one of the two files the export writes for a run beside
+// its statements: the bytes alone, as JSON, opened in the browser or, with the
+// download parameter, saved under the name the export gives the file. A run the
+// export does not read has no such file and is answered 404, and a run whose
+// statements the export refuses 503, both on the error page.
+func (h *handlers) serveRunFile(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := r.Context()
+	var src sources
+
+	runID, err := uuidParameter(r, "run")
+	if err != nil {
+		h.failFrom(w, r, err, src)
+		return
+	}
+
+	run, err := h.store.GetRun(ctx, runID)
+	src.query("GetRun")
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+	if !export.Exportable(run.Status) {
+		h.fail(w, r, http.StatusNotFound, "the export writes no file for this run", notExported(run), src)
+		return
+	}
+
+	loaded, err := h.store.LoadRunExport(ctx, runID)
+	src.query("LoadRunExport")
+	if errors.Is(err, export.ErrRunNotExportable) {
+		h.fail(w, r, http.StatusNotFound, "the export writes no file for this run", err, src)
+		return
+	}
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
+	index, settlement, err := renderRunExport(loaded)
+	if err != nil {
+		h.failFrom(w, r, documentFailed(err), src)
+		return
+	}
+	body := index
+	if name == export.KickbacksJSONFileName {
+		body = settlement
+	}
+
+	disposition := "inline"
+	if r.URL.Query().Get(downloadParameter) != "" {
+		disposition = "attachment"
+	}
+	w.Header().Set("Content-Type", jsonContentType)
+	w.Header().Set("Content-Disposition", contentDisposition(disposition, name))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -18,6 +18,7 @@ import (
 // and what it moved if it corrected an earlier one.
 type runData struct {
 	Run          store.Run
+	PeriodLink   string
 	CorrectsLink string
 	CatalogLink  string
 	Stats        statsView
@@ -118,6 +119,7 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 
 	data := runData{
 		Run:        run,
+		PeriodLink: periodLink(run.PeriodFrom),
 		Stats:      buildRunStats(r, run),
 		Statements: tabulate(r, "statements", statementColumns, statementBars(id, billed)),
 		Deltas:     tabulate(r, "deltas", deltaColumns, deltas),

--- a/internal/console/httpui/runs.go
+++ b/internal/console/httpui/runs.go
@@ -24,6 +24,10 @@ type runData struct {
 	Stats        statsView
 	Statements   listing[statementBar]
 	Deltas       listing[store.Delta]
+	// Export is the two files the JSON export writes for the run beside its
+	// statements and what the run settles for its partners, or why there are
+	// none.
+	Export runExportView
 }
 
 // The columns of a run page's tables. The share bar draws the total and is
@@ -117,12 +121,19 @@ func (h *handlers) run(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	exported, err := h.buildRunExport(r, run, &src)
+	if err != nil {
+		h.failFrom(w, r, storeFailed(err), src)
+		return
+	}
+
 	data := runData{
 		Run:        run,
 		PeriodLink: periodLink(run.PeriodFrom),
 		Stats:      buildRunStats(r, run),
 		Statements: tabulate(r, "statements", statementColumns, statementBars(id, billed)),
 		Deltas:     tabulate(r, "deltas", deltaColumns, deltas),
+		Export:     exported,
 	}
 	if run.CorrectsRunID != uuid.Nil {
 		data.CorrectsLink = link("/run", "id", run.CorrectsRunID.String())

--- a/internal/console/httpui/templates/creditnote.gohtml
+++ b/internal/console/httpui/templates/creditnote.gohtml
@@ -13,7 +13,7 @@
 </dl>
 
 <h2>Export</h2>
-{{template "statementExport" .Export}}
+{{template "exportFile" .Export}}
 
 {{if .Adjustments.Table.Total}}
 <h2>Adjustments</h2>

--- a/internal/console/httpui/templates/layout.gohtml
+++ b/internal/console/httpui/templates/layout.gohtml
@@ -53,10 +53,11 @@
 {{define "tableHead"}}<thead><tr>{{range .Headers}}{{if .Link}}<th{{if .Numeric}} class="number"{{end}}{{if .Sort}} aria-sort="{{.Sort}}"{{end}}><a href="{{.Link}}">{{.Label}}</a></th>{{else}}<th>{{.Label}}</th>{{end}}{{end}}</tr></thead>
 {{end}}
 
-{{/* statementExport is the file the JSON export writes for one stored
-     document, or the note saying why there is none. The statement page and the
-     credit-note page both print it under their Export heading. */}}
-{{define "statementExport"}}{{if .File}}
+{{/* exportFile is one file the JSON export writes, or the note saying why
+     there is none. The statement page and the credit-note page print the file
+     of their document under their Export heading, and the run page the two
+     files of its run. */}}
+{{define "exportFile"}}{{if .File}}
 <p><code>{{.File}}</code>, {{.Size}} bytes, as <code>tally-engine export --format json</code> writes it: <a href="{{.OpenLink}}">open</a>, <a href="{{.DownloadLink}}">download</a></p>
 <details class="export">
 <summary>the document</summary>

--- a/internal/console/httpui/templates/overview.gohtml
+++ b/internal/console/httpui/templates/overview.gohtml
@@ -53,11 +53,11 @@
 {{template "tableHead" .Periods.Table}}
 <tbody>
 {{range .Periods.Rows}}<tr>
-<td>{{stamp .From}}</td>
-<td>{{stamp .To}}</td>
-<td>{{.Status}}</td>
-<td>{{idText .FinalizedRunID}}</td>
-<td>{{zeroStamp .FinalizedAt}}</td>
+<td><a href="{{.Link}}">{{stamp .Period.From}}</a></td>
+<td>{{stamp .Period.To}}</td>
+<td>{{.Period.Status}}</td>
+<td>{{if .RunLink}}<a href="{{.RunLink}}">{{.Period.FinalizedRunID}}</a>{{else}}none{{end}}</td>
+<td>{{zeroStamp .Period.FinalizedAt}}</td>
 </tr>
 {{else}}<tr><td colspan="5">{{emptyText .Periods.Table "no period is opened"}}</td></tr>
 {{end}}</tbody>

--- a/internal/console/httpui/templates/period.gohtml
+++ b/internal/console/httpui/templates/period.gohtml
@@ -1,0 +1,33 @@
+{{define "content"}}
+<dl>
+<dt>period</dt><dd>{{stamp .Period.From}} to {{stamp .Period.To}}</dd>
+<dt>status</dt><dd>{{.Period.Status}}</dd>
+<dt>finalized at</dt><dd>{{zeroStamp .Period.FinalizedAt}}</dd>
+<dt>finalized by</dt><dd>{{if .FinalizedLink}}<a href="{{.FinalizedLink}}"><code>{{.Period.FinalizedRunID}}</code></a>{{else}}none{{end}}</dd>
+<dt>billed</dt><dd>{{range $i, $t := .Totals}}{{if $i}} + {{end}}{{amount $t.Total}} {{$t.Currency}}{{else}}none{{end}}</dd>
+</dl>
+<p class="muted">a period bills what the statements of its standing runs add up to: the runs that are completed or finalized, which are the regular run and every correction booked against it</p>
+
+<h2>Runs</h2>
+{{if .Runs.Table.Total}}
+{{template "tableTools" .Runs.Table}}
+<table>
+{{template "tableHead" .Runs.Table}}
+<tbody>
+{{range .Runs.Rows}}<tr{{if not .Standing}} class="muted"{{end}}>
+<td><a href="{{.Link}}"><code>{{.Run.ID}}</code></a></td>
+<td>{{.Run.Kind}}</td>
+<td>{{.Run.Status}}{{if not .Standing}}, counts for nothing{{end}}</td>
+<td>{{.Run.PricingVersion}}</td>
+<td>{{zeroStamp .Run.StartedAt}}</td>
+<td>{{zeroStamp .Run.CompletedAt}}</td>
+<td class="number">{{.Statements}}</td>
+<td class="number">{{range $i, $t := .Totals}}{{if $i}} + {{end}}{{amount $t.Total}} {{$t.Currency}}{{else}}none{{end}}</td>
+</tr>
+{{else}}<tr><td colspan="8">{{emptyText .Runs.Table "no run has been recorded for this period"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{else}}
+<p>no run has been recorded for this period</p>
+{{end}}
+{{end}}

--- a/internal/console/httpui/templates/run.gohtml
+++ b/internal/console/httpui/templates/run.gohtml
@@ -32,6 +32,33 @@
 <p>this run produced no statement</p>
 {{end}}
 
+<h2>Export</h2>
+{{with .Export}}{{if .Note}}
+<p class="muted">{{.Note}}</p>
+{{else}}{{template "exportFile" .Index}}{{template "exportFile" .Settlement}}{{end}}{{end}}
+
+{{if not .Export.Note}}
+<h2>What this run settles</h2>
+{{if eq .Run.Kind "correction"}}<p class="muted">a correction settles the difference to the run it corrects</p>
+{{end}}{{if .Export.Partners.Table.Total}}
+{{template "tableTools" .Export.Partners.Table}}
+<table>
+{{template "tableHead" .Export.Partners.Table}}
+<tbody>
+{{range .Export.Partners.Rows}}<tr>
+<td><a href="{{.Link}}"><code>{{.Beneficiary}}</code></a></td>
+<td>{{.Currency}}</td>
+<td class="number">{{.Projects}}</td>
+<td class="number{{zeroClass .Total}}">{{amount .Total}} {{.Currency}}</td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .Export.Partners.Table "this run settles nothing for a partner"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{else}}
+<p>this run settles nothing for a partner</p>
+{{end}}
+{{end}}
+
 {{if .Deltas.Table.Total}}
 <h2>What this run moved</h2>
 {{template "tableTools" .Deltas.Table}}

--- a/internal/console/httpui/templates/run.gohtml
+++ b/internal/console/httpui/templates/run.gohtml
@@ -1,7 +1,7 @@
 {{define "content"}}
 <dl>
 <dt>run</dt><dd>{{.Run.ID}}</dd>
-<dt>period</dt><dd>{{stamp .Run.PeriodFrom}} to {{stamp .Run.PeriodTo}}</dd>
+<dt>period</dt><dd><a href="{{.PeriodLink}}">{{stamp .Run.PeriodFrom}} to {{stamp .Run.PeriodTo}}</a></dd>
 <dt>kind</dt><dd>{{.Run.Kind}}</dd>
 <dt>status</dt><dd>{{.Run.Status}}</dd>
 <dt>clouds</dt><dd>{{range .Run.Clouds}}{{.}} {{end}}</dd>

--- a/internal/console/httpui/templates/statement.gohtml
+++ b/internal/console/httpui/templates/statement.gohtml
@@ -12,7 +12,7 @@
 </dl>
 
 <h2>Export</h2>
-{{template "statementExport" .Export}}
+{{template "exportFile" .Export}}
 
 {{if .Adjustments.Table.Total}}
 <h2>Adjustments</h2>

--- a/internal/console/store/queries.sql
+++ b/internal/console/store/queries.sql
@@ -13,6 +13,32 @@ FROM runs
 ORDER BY started_at DESC
 LIMIT $1;
 
+-- The head of a period page: one month, where it stands, and which run closed
+-- it.
+-- name: GetPeriod :one
+SELECT period_from, period_to, status, finalized_run_id, finalized_at
+FROM billing_periods
+WHERE period_from = $1;
+
+-- The run table of a period page: every run of one month in the order the
+-- runs started, so a correction stands under the run it corrects.
+-- name: ListRunsForPeriod :many
+SELECT id, period_from, period_to, kind, corrects_run_id, pricing_version,
+       status, clouds, stats, started_at, completed_at
+FROM runs
+WHERE period_from = $1
+ORDER BY started_at, id;
+
+-- The totals of a period page: per run of one month and currency, how many
+-- statements the run wrote and what they add up to.
+-- name: ListRunTotalsForPeriod :many
+SELECT s.run_id, s.currency, count(*) AS statements, sum(s.total)::numeric AS total
+FROM project_statements s
+JOIN runs r ON r.id = s.run_id
+WHERE r.period_from = $1
+GROUP BY s.run_id, s.currency
+ORDER BY s.run_id, s.currency;
+
 -- The header of a run page: the eleven columns a run carries.
 -- name: GetRun :one
 SELECT id, period_from, period_to, kind, corrects_run_id, pricing_version,

--- a/internal/console/store/sqlcgen/queries.sql.go
+++ b/internal/console/store/sqlcgen/queries.sql.go
@@ -11,6 +11,27 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getPeriod = `-- name: GetPeriod :one
+SELECT period_from, period_to, status, finalized_run_id, finalized_at
+FROM billing_periods
+WHERE period_from = $1
+`
+
+// The head of a period page: one month, where it stands, and which run closed
+// it.
+func (q *Queries) GetPeriod(ctx context.Context, periodFrom pgtype.Timestamptz) (BillingPeriod, error) {
+	row := q.db.QueryRow(ctx, getPeriod, periodFrom)
+	var i BillingPeriod
+	err := row.Scan(
+		&i.PeriodFrom,
+		&i.PeriodTo,
+		&i.Status,
+		&i.FinalizedRunID,
+		&i.FinalizedAt,
+	)
+	return i, err
+}
+
 const getPricingModel = `-- name: GetPricingModel :one
 SELECT version, valid_from, currency, imported_at, document
 FROM pricing_models
@@ -306,6 +327,49 @@ func (q *Queries) ListResourceSegments(ctx context.Context, arg ListResourceSegm
 	return items, nil
 }
 
+const listRunTotalsForPeriod = `-- name: ListRunTotalsForPeriod :many
+SELECT s.run_id, s.currency, count(*) AS statements, sum(s.total)::numeric AS total
+FROM project_statements s
+JOIN runs r ON r.id = s.run_id
+WHERE r.period_from = $1
+GROUP BY s.run_id, s.currency
+ORDER BY s.run_id, s.currency
+`
+
+type ListRunTotalsForPeriodRow struct {
+	RunID      pgtype.UUID
+	Currency   string
+	Statements int64
+	Total      pgtype.Numeric
+}
+
+// The totals of a period page: per run of one month and currency, how many
+// statements the run wrote and what they add up to.
+func (q *Queries) ListRunTotalsForPeriod(ctx context.Context, periodFrom pgtype.Timestamptz) ([]ListRunTotalsForPeriodRow, error) {
+	rows, err := q.db.Query(ctx, listRunTotalsForPeriod, periodFrom)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRunTotalsForPeriodRow
+	for rows.Next() {
+		var i ListRunTotalsForPeriodRow
+		if err := rows.Scan(
+			&i.RunID,
+			&i.Currency,
+			&i.Statements,
+			&i.Total,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRuns = `-- name: ListRuns :many
 SELECT id, period_from, period_to, kind, corrects_run_id, pricing_version,
        status, clouds, stats, started_at, completed_at
@@ -317,6 +381,48 @@ LIMIT $1
 // The run list of the overview page, newest first and bounded by the caller.
 func (q *Queries) ListRuns(ctx context.Context, limit int32) ([]Run, error) {
 	rows, err := q.db.Query(ctx, listRuns, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Run
+	for rows.Next() {
+		var i Run
+		if err := rows.Scan(
+			&i.ID,
+			&i.PeriodFrom,
+			&i.PeriodTo,
+			&i.Kind,
+			&i.CorrectsRunID,
+			&i.PricingVersion,
+			&i.Status,
+			&i.Clouds,
+			&i.Stats,
+			&i.StartedAt,
+			&i.CompletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRunsForPeriod = `-- name: ListRunsForPeriod :many
+SELECT id, period_from, period_to, kind, corrects_run_id, pricing_version,
+       status, clouds, stats, started_at, completed_at
+FROM runs
+WHERE period_from = $1
+ORDER BY started_at, id
+`
+
+// The run table of a period page: every run of one month in the order the
+// runs started, so a correction stands under the run it corrects.
+func (q *Queries) ListRunsForPeriod(ctx context.Context, periodFrom pgtype.Timestamptz) ([]Run, error) {
+	rows, err := q.db.Query(ctx, listRunsForPeriod, periodFrom)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/console/store/store.go
+++ b/internal/console/store/store.go
@@ -188,6 +188,15 @@ type Delta struct {
 	Currency     string
 }
 
+// RunTotal is what one run of a period billed in one currency: how many
+// statements it wrote and what they add up to.
+type RunTotal struct {
+	RunID      uuid.UUID
+	Currency   string
+	Statements int64
+	Total      decimal.Decimal
+}
+
 // ListPeriods returns every billing period, newest month first.
 func (s *Store) ListPeriods(ctx context.Context) ([]Period, error) {
 	rows, err := s.q.ListPeriods(ctx)
@@ -197,15 +206,19 @@ func (s *Store) ListPeriods(ctx context.Context) ([]Period, error) {
 
 	periods := make([]Period, 0, len(rows))
 	for _, row := range rows {
-		periods = append(periods, Period{
-			From:           timeOf(row.PeriodFrom),
-			To:             timeOf(row.PeriodTo),
-			Status:         row.Status,
-			FinalizedRunID: uuidOf(row.FinalizedRunID),
-			FinalizedAt:    timeOf(row.FinalizedAt),
-		})
+		periods = append(periods, periodOf(row))
 	}
 	return periods, nil
+}
+
+// GetPeriod returns one billing month. A month no run ever opened comes back as
+// pgx.ErrNoRows, which is what the page turns into its not-found answer.
+func (s *Store) GetPeriod(ctx context.Context, from time.Time) (Period, error) {
+	row, err := s.q.GetPeriod(ctx, pgTime(from))
+	if err != nil {
+		return Period{}, fmt.Errorf("GetPeriod: %w", err)
+	}
+	return periodOf(row), nil
 }
 
 // ListRuns returns the newest runs by start, at most limit of them.
@@ -230,6 +243,45 @@ func (s *Store) GetRun(ctx context.Context, id uuid.UUID) (Run, error) {
 		return Run{}, fmt.Errorf("GetRun: %w", err)
 	}
 	return runOf(row), nil
+}
+
+// ListRunsForPeriod returns every run of one billing month in the order the
+// runs started. A month no run was recorded for has none.
+func (s *Store) ListRunsForPeriod(ctx context.Context, from time.Time) ([]Run, error) {
+	rows, err := s.q.ListRunsForPeriod(ctx, pgTime(from))
+	if err != nil {
+		return nil, fmt.Errorf("ListRunsForPeriod: %w", err)
+	}
+
+	list := make([]Run, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, runOf(row))
+	}
+	return list, nil
+}
+
+// ListRunTotalsForPeriod returns, per run of one billing month and currency,
+// how many statements the run wrote and what they add up to, by run and then
+// by currency. One statement total that is not a number makes the sum of its
+// run one too, and that sum is dropped and logged the way a listing drops any
+// such row.
+func (s *Store) ListRunTotalsForPeriod(ctx context.Context, from time.Time) ([]RunTotal, error) {
+	rows, err := s.q.ListRunTotalsForPeriod(ctx, pgTime(from))
+	if err != nil {
+		return nil, fmt.Errorf("ListRunTotalsForPeriod: %w", err)
+	}
+
+	list := make([]RunTotal, 0, len(rows))
+	for _, row := range rows {
+		id := uuidOf(row.RunID)
+		total, ok := amountOf(row.Total)
+		if !ok {
+			s.skipped("ListRunTotalsForPeriod", "run", id, "currency", row.Currency)
+			continue
+		}
+		list = append(list, RunTotal{RunID: id, Currency: row.Currency, Statements: row.Statements, Total: total})
+	}
+	return list, nil
 }
 
 // ListStatements returns the statements of a run, largest total first.
@@ -344,6 +396,21 @@ func (s *Store) ListKickbacksForBeneficiary(ctx context.Context, beneficiary str
 		}
 	}
 	return list, nil
+}
+
+// LoadRunExport returns one run with what the JSON export renders its run.json
+// and its kickbacks.json from: the run row, its statements and what it settles
+// for its partners, read through export.LoadIndex under one snapshot. The read
+// and the rendering are the export's own, for the reason
+// ListKickbacksForBeneficiary gives: a second implementation of what an ERP
+// receives would drift. A run the export does not read is refused with
+// export.ErrRunNotExportable, which errors.Is still finds.
+func (s *Store) LoadRunExport(ctx context.Context, runID uuid.UUID) (export.Run, error) {
+	run, err := export.LoadIndex(ctx, s.pool, runID)
+	if err != nil {
+		return export.Run{}, fmt.Errorf("LoadRunExport: %w", err)
+	}
+	return run, nil
 }
 
 // ListPricingModels returns the imported catalog versions, the one in force
@@ -478,6 +545,19 @@ func (s *Store) skipped(query string, keys ...any) {
 		append([]any{"query", query}, keys...)...)
 }
 
+// periodOf maps a billing period row to the value a page renders. The run that
+// closed it and when that happened read as the zero values for a month that is
+// not finalized, which is the pairing the schema admits.
+func periodOf(row sqlcgen.BillingPeriod) Period {
+	return Period{
+		From:           timeOf(row.PeriodFrom),
+		To:             timeOf(row.PeriodTo),
+		Status:         row.Status,
+		FinalizedRunID: uuidOf(row.FinalizedRunID),
+		FinalizedAt:    timeOf(row.FinalizedAt),
+	}
+}
+
 // runOf maps a run row to the value a page renders. The three nullable columns
 // each read as the absence they stand for: a regular run corrects nothing, a
 // run of a period no model priced carries no version, and a run that did not
@@ -522,6 +602,11 @@ func uuidOf(id pgtype.UUID) uuid.UUID {
 // pgUUID maps an id to the parameter the generated queries take.
 func pgUUID(id uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
+// pgTime maps an instant to the parameter the generated queries take.
+func pgTime(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
 }
 
 // timeOf maps a stored timestamp to UTC. A NULL column reads as the zero time:

--- a/internal/console/store/store_integration_test.go
+++ b/internal/console/store/store_integration_test.go
@@ -286,6 +286,107 @@ func TestStore(t *testing.T) {
 		}
 	})
 
+	t.Run("GetPeriod reads one month", func(t *testing.T) {
+		march, err := f.store.GetPeriod(ctx, periodFrom)
+		if err != nil {
+			t.Fatalf("reading March: %v", err)
+		}
+		if stamp(march.From) != stamp(periodFrom) || stamp(march.To) != stamp(periodTo) ||
+			march.Status != "finalized" {
+			t.Errorf("got the period [%s, %s) %s, want the finalized March",
+				stamp(march.From), stamp(march.To), march.Status)
+		}
+		if march.FinalizedRunID != f.regular || stamp(march.FinalizedAt) != stamp(finalizedAt) {
+			t.Errorf("got March finalized by %s at %s, want %s at %s",
+				march.FinalizedRunID, stamp(march.FinalizedAt), f.regular, stamp(finalizedAt))
+		}
+	})
+
+	t.Run("GetPeriod names itself on a month no run opened", func(t *testing.T) {
+		_, err := f.store.GetPeriod(ctx, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+		if !errors.Is(err, pgx.ErrNoRows) {
+			t.Fatalf("got %v, want pgx.ErrNoRows", err)
+		}
+		if !strings.HasPrefix(err.Error(), "GetPeriod:") {
+			t.Errorf("got the message %q, want it to start with GetPeriod:", err)
+		}
+	})
+
+	t.Run("ListRunsForPeriod returns every run of a month in the order they started", func(t *testing.T) {
+		march, err := f.store.ListRunsForPeriod(ctx, periodFrom)
+		if err != nil {
+			t.Fatalf("listing the runs of March: %v", err)
+		}
+		if want := []uuid.UUID{f.regular, f.correction}; !reflect.DeepEqual(idsOf(march), want) {
+			t.Errorf("got the runs %v, want %v", idsOf(march), want)
+		}
+
+		april, err := f.store.ListRunsForPeriod(ctx, openFrom)
+		if err != nil {
+			t.Fatalf("listing the runs of April: %v", err)
+		}
+		if len(april) != 0 {
+			t.Errorf("got the runs %v of April, want none", idsOf(april))
+		}
+	})
+
+	t.Run("ListRunTotalsForPeriod adds up each run's statements per currency", func(t *testing.T) {
+		f.logs.Reset()
+		totals, err := f.store.ListRunTotalsForPeriod(ctx, periodFrom)
+		if err != nil {
+			t.Fatalf("adding up March: %v", err)
+		}
+		// The correction's one statement is not a number, which makes its sum one
+		// too: the listing leaves it out and says so.
+		if len(totals) != 1 {
+			t.Fatalf("got %d totals, want the regular run's alone: %v", len(totals), totals)
+		}
+		got := totals[0]
+		if got.RunID != f.regular || got.Currency != currency || got.Statements != 3 ||
+			got.Total.StringFixed(2) != "173.09" {
+			t.Errorf("got %s %s, %d statements, %s, want %s %s, 3 statements, 173.09",
+				got.RunID, got.Currency, got.Statements, got.Total.StringFixed(2), f.regular, currency)
+		}
+		assertSkipped(t, f.logs, "ListRunTotalsForPeriod", f.correction.String())
+
+		april, err := f.store.ListRunTotalsForPeriod(ctx, openFrom)
+		if err != nil {
+			t.Fatalf("adding up April: %v", err)
+		}
+		if len(april) != 0 {
+			t.Errorf("got %d totals of April, want none", len(april))
+		}
+	})
+
+	t.Run("LoadRunExport reads the statements and no rated record", func(t *testing.T) {
+		run, err := f.store.LoadRunExport(ctx, f.regular)
+		if err != nil {
+			t.Fatalf("loading the export of the regular run: %v", err)
+		}
+		keys := make([]string, 0, len(run.Statements))
+		for _, statement := range run.Statements {
+			keys = append(keys, statement.Key)
+		}
+		if want := []string{drKey, secondDRKey, projectKey}; !reflect.DeepEqual(keys, want) {
+			t.Errorf("got the statements %v, want %v", keys, want)
+		}
+		if len(run.Rated) != 0 || len(run.Deltas) != 0 || len(run.Kickbacks) != 0 {
+			t.Errorf("got %d rated records, %d deltas and %d kickbacks, want none of them",
+				len(run.Rated), len(run.Deltas), len(run.Kickbacks))
+		}
+		if want := []string{cloud}; !reflect.DeepEqual(run.Clouds, want) {
+			t.Errorf("got the clouds %v, want %v", run.Clouds, want)
+		}
+	})
+
+	t.Run("LoadRunExport refuses a statement total that is not a number", func(t *testing.T) {
+		_, err := f.store.LoadRunExport(ctx, f.correction)
+		if err == nil || !strings.HasPrefix(err.Error(), "LoadRunExport:") ||
+			!strings.Contains(err.Error(), "is not a number") {
+			t.Fatalf("got %v, want LoadRunExport to refuse the total that is not a number", err)
+		}
+	})
+
 	t.Run("ListStatements orders by total and breaks the tie on the key", func(t *testing.T) {
 		rows, err := f.store.ListStatements(ctx, f.regular)
 		if err != nil {

--- a/internal/engine/export/export.go
+++ b/internal/engine/export/export.go
@@ -6,7 +6,8 @@
 // JSON and the CSV file writers are the first implementations of the interface,
 // and an ERP adapter is another one rather than a change to the loader.
 // LoadKickbacks is that read narrowed to the partner settlement, for the report
-// that renders nothing else.
+// that renders nothing else, and LoadIndex to the statements and the
+// settlement, for a reader that shows the index and the settlement of a run.
 //
 // The package writes nothing to the database, and only a completed or a
 // finalized run is loaded at all: the superseded, failed and running rows a
@@ -172,7 +173,7 @@ type BillingExporter interface {
 // naming the row that carries them: an export short of a value, or holding a
 // zero where a number was meant, is one nobody can tell from a correct one.
 func Load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error) {
-	return load(ctx, pool, runID, true)
+	return load(ctx, pool, runID, reads{statements: true, records: true})
 }
 
 // LoadKickbacks reads one run and what it settles for its partners, under the
@@ -183,14 +184,33 @@ func Load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error)
 // of rows, each with a usage object to decode, so reading them would hold the
 // snapshot and its pooled connection for a decode nothing is rendered from.
 func LoadKickbacks(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error) {
-	return load(ctx, pool, runID, false)
+	return load(ctx, pool, runID, reads{})
 }
 
-// load is the read the two share. artifacts says whether the statements, the
-// rated records and a correction's deltas are read on top of the run row and
-// the kickbacks, which is what separates a full export from the settlement
-// report.
-func load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID, artifacts bool) (Run, error) {
+// LoadIndex reads one run with what RunJSON and KickbacksJSON render from it:
+// the run row, its statements and what it settles for its partners, under the
+// snapshot and with the refusals Load applies, and without the rated records
+// and a correction's deltas: three queries for a regular run and four for a
+// correction. A reader that shows the index and the settlement of a run renders
+// neither of the two, and a month of rated records is tens of thousands of rows
+// to read and decode.
+func LoadIndex(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID) (Run, error) {
+	return load(ctx, pool, runID, reads{statements: true})
+}
+
+// reads is what load reads on top of the run row and its kickbacks, which is
+// what the three reads differ in: a full export reads both, the index the
+// statements alone, and the settlement report neither.
+type reads struct {
+	// statements is the documents the run billed.
+	statements bool
+	// records is the rated records and, for a correction, its deltas.
+	records bool
+}
+
+// load is the read the three share: the run row and its kickbacks, and on top
+// of them what reads asks for.
+func load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID, what reads) (Run, error) {
 	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
 	if err != nil {
 		return Run{}, fmt.Errorf("reading the run %s: %w", runID, err)
@@ -243,10 +263,12 @@ func load(ctx context.Context, pool *pgxpool.Pool, runID uuid.UUID, artifacts bo
 		run.Clouds = []string{}
 	}
 
-	if artifacts {
+	if what.statements {
 		if run.Statements, err = loadStatements(ctx, q, id, runID); err != nil {
 			return Run{}, err
 		}
+	}
+	if what.records {
 		if run.Rated, err = loadRated(ctx, q, id, runID); err != nil {
 			return Run{}, err
 		}

--- a/internal/engine/export/export_integration_test.go
+++ b/internal/engine/export/export_integration_test.go
@@ -841,6 +841,69 @@ func TestLoadKickbacksReadsTheSettlementAlone(t *testing.T) {
 	})
 }
 
+// TestLoadIndexReadsTheIndexAlone pins the read a reader renders run.json and
+// kickbacks.json from: the statements and the settlement, under the snapshot
+// and with the refusals of the full read, and none of the rated records or the
+// deltas only a full export renders.
+func TestLoadIndexReadsTheIndexAlone(t *testing.T) {
+	db := storetest.NewDB(t)
+	pool := db.Store.Pool()
+
+	corrected := seedCompletedRun(t, db)
+	seedAdjustmentRecord(t, db, corrected, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "126.48", "12.65")
+	// The month is closed after its rows are written: the records of a finalized
+	// run are immutable, and the trigger refuses an insert under one.
+	finalizeRun(t, db, corrected)
+
+	correction := seedCorrectionRun(t, db, corrected)
+	seedStatement(t, db, correction, statementKey, []byte(`{"project_id": "proj-456"}`), "106.08")
+	usageID := seedUsage(t, db, correction, usageSeed{
+		cloud: instance.Cloud, resourceID: instance.ResourceID, projectID: projectID,
+		state: "active", from: periodFrom, to: periodTo, usage: `{"vcpus": 4}`,
+	})
+	seedRated(t, db, correction, usageID, "vcpus", "106.08")
+	seedDelta(t, db, correction, corrected, deltaSeed{
+		cloud: instance.Cloud, resourceID: instance.ResourceID, projectID: projectID,
+		dimension: "vcpus", old: "126.48", current: "106.08", difference: "-20.40",
+	})
+	seedAdjustmentRecord(t, db, correction, relation1, statementKey, "partner-corp",
+		"kickback", "all", "0.100000", "106.08", "10.61")
+
+	run, err := export.LoadIndex(t.Context(), pool, correction)
+	if err != nil {
+		t.Fatalf("LoadIndex() error = %v, want nil", err)
+	}
+	if run.ID != correction || run.Kind != runs.KindCorrection || run.CorrectsRunID != corrected {
+		t.Errorf("the run is %s, a %s correcting %s, want the correction %s of %s",
+			run.ID, run.Kind, run.CorrectsRunID, correction, corrected)
+	}
+	if len(run.Statements) != 1 || run.Statements[0].Key != statementKey {
+		t.Errorf("the index read %d statements, want the one of %s", len(run.Statements), statementKey)
+	}
+	if len(run.Rated) != 0 || len(run.Deltas) != 0 {
+		t.Errorf("the index read %d rated records and %d deltas, want none of them",
+			len(run.Rated), len(run.Deltas))
+	}
+
+	got := kickbackRows(run.Kickbacks)
+	want := kickbackRows([]export.Kickback{
+		kickback("partner-corp", "os-prod", projectID, relation1, "all", "0.100000", "-20.40", "-2.04"),
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("the kickbacks are %v, want %v", got, want)
+	}
+
+	t.Run("a run that is not exportable", func(t *testing.T) {
+		runID := seedRun(t, db, runSeed{kind: runs.KindRegular, status: "superseded"})
+
+		_, err := export.LoadIndex(t.Context(), pool, runID)
+		if !errors.Is(err, export.ErrRunNotExportable) {
+			t.Fatalf("LoadIndex() error = %v, want one matching ErrRunNotExportable", err)
+		}
+	})
+}
+
 // TestLoadCarriesAStoredDocumentThroughJSONB pins the round trip a statement
 // takes. It is stored in a jsonb column, which parses the document and hands it
 // back in its own key order and spacing, and what an ERP receives has to be the

--- a/internal/engine/export/export_test.go
+++ b/internal/engine/export/export_test.go
@@ -606,6 +606,84 @@ func TestExportGolden(t *testing.T) {
 	}
 }
 
+// TestRunJSON pins the index a reader renders on its own against the run.json
+// the JSON writer puts beside the documents, which TestExportGolden pins in
+// turn. A reader that shows a run's index calls this rather than JSONFiles, so
+// a difference here is a page showing an index no export writes.
+func TestRunJSON(t *testing.T) {
+	cases := []struct {
+		name   string
+		run    func(t *testing.T) export.Run
+		golden string
+	}{
+		{name: "a regular run", run: regularRun, golden: "regular"},
+		{name: "a correction", run: correctionRun, golden: "correction"},
+		{name: "a rolled-up run", run: rollupRun, golden: "rollup"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := export.RunJSON(c.run(t))
+			if err != nil {
+				t.Fatalf("RunJSON() error = %v, want nil", err)
+			}
+			want := read(t, filepath.Join("testdata", "golden", c.golden, runFile))
+			if !bytes.Equal(got, want) {
+				t.Errorf("RunJSON() =\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+
+	t.Run("a run that billed nobody", func(t *testing.T) {
+		run := regularRun(t)
+		run.Statements = nil
+
+		got, err := export.RunJSON(run)
+		if err != nil {
+			t.Fatalf("RunJSON() error = %v, want nil", err)
+		}
+		if !bytes.Contains(got, []byte(`"statements": []`)) {
+			t.Errorf("RunJSON() =\n%s\nwant an empty statement list rather than a null", got)
+		}
+	})
+
+	// The statements TestJSONFilesRefusals has the export refuse, which refuse
+	// the index the same way.
+	refusals := []struct {
+		name     string
+		key      string
+		document string
+	}{
+		{name: "a document that is not an object", key: statementKey, document: `[1,2]`},
+		{
+			name: "a document holding a field the type does not have",
+			key:  statementKey,
+			document: `{"billing_period":{"from":"2026-03-01T00:00:00Z","to":"2026-04-01T00:00:00Z"},` +
+				`"project_id":"proj-456","invoice_number":"2026-03-0001"}`,
+		},
+		{name: "a key that is not cloud/project", key: "proj-456", document: `{"project_id":"proj-456"}`},
+	}
+	for _, c := range refusals {
+		t.Run(c.name, func(t *testing.T) {
+			run := regularRun(t)
+			run.Statements = []statements.Statement{{
+				Key:      c.key,
+				Document: []byte(c.document),
+				Total:    decimal.RequireFromString("128.45"),
+				Currency: currency,
+			}}
+
+			got, err := export.RunJSON(run)
+			if err == nil || !strings.Contains(err.Error(), c.key) {
+				t.Fatalf("RunJSON() error = %v, want the statement %s refused", err, c.key)
+			}
+			if got != nil {
+				t.Errorf("RunJSON() = %s, want no bytes beside the refusal", got)
+			}
+		})
+	}
+}
+
 // TestExportReplacesAnEarlierExport pins what exporting one run into one
 // directory twice does. The second pass has to produce the bytes of the first,
 // and it has to write over what is there rather than beside it: an operator who

--- a/internal/engine/export/json.go
+++ b/internal/engine/export/json.go
@@ -18,8 +18,8 @@ import (
 	"github.com/b42labs/tally/internal/engine/statements"
 )
 
-// runFileName is the index every JSON export carries beside its documents.
-const runFileName = "run.json"
+// RunFileName is the index every JSON export carries beside its documents.
+const RunFileName = "run.json"
 
 // The two prefixes a document file carries. What a regular run bills a project
 // is a statement, and what a correction hands it is a credit note, so the name
@@ -190,6 +190,66 @@ type rollupEntry struct {
 // cancelable, and stopping halfway through would leave the directory holding
 // part of an export.
 func (j JSONFiles) Export(_ context.Context, run Run) error {
+	index, documents, err := renderIndex(run)
+	if err != nil {
+		return err
+	}
+
+	kickbacks, err := KickbacksJSON(run)
+	if err != nil {
+		return err
+	}
+
+	body, err := marshal(index)
+	if err != nil {
+		return fmt.Errorf("rendering %s of run %s: %w", RunFileName, run.ID, err)
+	}
+
+	if err := prepareDir(j.Dir); err != nil {
+		return err
+	}
+	files := make([]artifact, 0, len(documents)+1)
+	for _, entry := range index.Statements {
+		files = append(files, artifact{name: entry.File, body: documents[entry.File]})
+	}
+	// The rollup documents follow the statements they sum, so a reader that picks
+	// one up finds every invoice it names beside it.
+	if index.Rollup != nil {
+		for _, entry := range index.Rollup.Documents {
+			files = append(files, artifact{name: entry.File, body: documents[entry.File]})
+		}
+	}
+	// The settlement goes in with the documents rather than after the index, so
+	// it is on stable storage before run.json names the month. No document takes
+	// its name away from it: DocumentFileName prefixes every one of them with
+	// statement- or credit-note-, and RollupFileName every group's with rollup-.
+	files = append(files, artifact{name: KickbacksJSONFileName, body: kickbacks})
+	return writeIndexedFiles(j.Dir, files, artifact{name: RunFileName, body: body})
+}
+
+// RunJSON renders the run.json JSONFiles writes for the run: the index of the
+// run, one entry per document beside the file the document is written to, and
+// the rollup where the run carries one. The documents are rendered on the way,
+// because a statement the export refuses refuses the index with it, so a reader
+// that shows a run's index shows one only for a run an export writes.
+func RunJSON(run Run) ([]byte, error) {
+	index, _, err := renderIndex(run)
+	if err != nil {
+		return nil, err
+	}
+	body, err := marshal(index)
+	if err != nil {
+		return nil, fmt.Errorf("rendering %s of run %s: %w", RunFileName, run.ID, err)
+	}
+	return body, nil
+}
+
+// renderIndex renders what an export of the run writes beside the settlement:
+// the index, and every document it names, keyed by the name the document is
+// written under. A statement whose key or whose stored document is refused
+// refuses the whole index, which is what keeps Export from touching the
+// directory for such a run.
+func renderIndex(run Run) (runDocument, map[string][]byte, error) {
 	index := runDocument{
 		RunID:      run.ID.String(),
 		Kind:       run.Kind,
@@ -236,11 +296,11 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 	for _, statement := range run.Statements {
 		cloud, projectID, err := statements.ParseKey(statement.Key)
 		if err != nil {
-			return fmt.Errorf("the statement %s of run %s: %w", statement.Key, run.ID, err)
+			return runDocument{}, nil, fmt.Errorf("the statement %s of run %s: %w", statement.Key, run.ID, err)
 		}
 		document, err := RenderStatement(run.ID, run.Kind, statement)
 		if err != nil {
-			return err
+			return runDocument{}, nil, err
 		}
 		name := uniqueName(folded, documentPrefix(run.Kind), statement.Key)
 		documents[name] = document
@@ -265,7 +325,7 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 		for _, group := range run.Rollup.Groups {
 			body, err := renderRollup(run, *run.Rollup, group, written)
 			if err != nil {
-				return err
+				return runDocument{}, nil, err
 			}
 			// Two targets whose keys differ in ASCII case alone resolve to one file
 			// on APFS, SMB and NTFS, so the second of such a pair takes its digest
@@ -282,37 +342,7 @@ func (j JSONFiles) Export(_ context.Context, run Run) error {
 			})
 		}
 	}
-
-	kickbacks, err := KickbacksJSON(run)
-	if err != nil {
-		return err
-	}
-
-	body, err := marshal(index)
-	if err != nil {
-		return fmt.Errorf("rendering %s of run %s: %w", runFileName, run.ID, err)
-	}
-
-	if err := prepareDir(j.Dir); err != nil {
-		return err
-	}
-	files := make([]artifact, 0, len(documents)+1)
-	for _, entry := range index.Statements {
-		files = append(files, artifact{name: entry.File, body: documents[entry.File]})
-	}
-	// The rollup documents follow the statements they sum, so a reader that picks
-	// one up finds every invoice it names beside it.
-	if index.Rollup != nil {
-		for _, entry := range index.Rollup.Documents {
-			files = append(files, artifact{name: entry.File, body: documents[entry.File]})
-		}
-	}
-	// The settlement goes in with the documents rather than after the index, so
-	// it is on stable storage before run.json names the month. No document takes
-	// its name away from it: DocumentFileName prefixes every one of them with
-	// statement- or credit-note-, and RollupFileName every group's with rollup-.
-	files = append(files, artifact{name: kickbacksJSONFileName, body: kickbacks})
-	return writeIndexedFiles(j.Dir, files, artifact{name: runFileName, body: body})
+	return index, documents, nil
 }
 
 // RenderStatement re-renders one stored document the way the JSON export writes

--- a/internal/engine/export/kickbacks.go
+++ b/internal/engine/export/kickbacks.go
@@ -26,7 +26,7 @@ import (
 // The two files the settlement is written to: the document by the JSON writer
 // and the table by the CSV writer.
 const (
-	kickbacksJSONFileName = "kickbacks.json"
+	KickbacksJSONFileName = "kickbacks.json"
 	kickbacksCSVFileName  = "kickbacks.csv"
 )
 
@@ -379,7 +379,7 @@ func KickbacksJSON(run Run) ([]byte, error) {
 
 	body, err := marshal(document)
 	if err != nil {
-		return nil, fmt.Errorf("rendering %s of run %s: %w", kickbacksJSONFileName, run.ID, err)
+		return nil, fmt.Errorf("rendering %s of run %s: %w", KickbacksJSONFileName, run.ID, err)
 	}
 	return body, nil
 }


### PR DESCRIPTION
Closes #136

The demo console gains a page per billing period and, on every run page, the two documents `tally-engine export --format json` writes beside a run's statements. `/period?month=YYYY-MM` shows where a month stands, the run that finalized it, every run the engine recorded for it, and what the month bills: the statements of its standing runs, completed or finalized, summed per currency by the rule the project page applies to one project. The run page carries the run's `run.json` and `kickbacks.json`, folded and served on their own at `/run.json` and `/kickbacks.json`, plus a table of what the run owes each partner. Both files are the export's own bytes, read and rendered by the export package, and the settlement table reads its totals off the rendered `kickbacks.json` rather than adding them up again.

## Commits

1. **Render run.json and load a run's index through the export** (`8611324`). `JSONFiles.Export` hands its index and document rendering to `renderIndex`, which the new `RunJSON` shares, so a reader and the writer produce the same bytes and refuse the same statements. `load` takes a `reads{statements, records}` instead of a bool, and the new `LoadIndex` reads the run row, its statements and its kickbacks without the rated records and the deltas. `RunFileName` and `KickbacksJSONFileName` are exported. `TestRunJSON` pins the three `run.json` goldens (regular, correction, rollup), the empty list and the three refusals of `TestJSONFilesRefusals`; `TestLoadIndexReadsTheIndexAlone` pins the narrowed read against a database.
2. **Read a billing period and a run's export in the console store** (`8bed570`). Three SELECTs, `GetPeriod`, `ListRunsForPeriod` and `ListRunTotalsForPeriod`, with the sqlc output regenerated, and `LoadRunExport` through `export.LoadIndex`. A run's sum that is not a number is dropped and logged like any listing row. New `TestStore` subtests cover each method.
3. **Add a billing period page to the demo console** (`1d12f0c`). `period.go` and `period.gohtml`; the overview's period table links each month and the run that closed it, and a run page links its period. `TestPeriodPage` covers the standing rule, two currencies, a total without a listed run, an open month, a month without runs, a month whose runs were all replaced, the filter, 404, the three failing reads and the unreadable months.
4. **Show and serve a run's JSON export on its run page** (`5834366`). `runexport.go` adds the Export section, the settlement table and the two routes, which answer 404 for a run that does not stand and 503 for a run whose statements the export refuses. The `statementExport` template define becomes the shared `exportFile`. `TestRunExport` compares the routes and the page byte for byte with the export package's regular and correction goldens.
5. **Document the billing period page and a run's export** (`a5daea5`). `docs/reference/command-line/tally-console.md`: the routes, the `runs` and `settlement` tables, `## A billing period`, `## The export of a run`, and the error statuses.

## Verification

- `go build ./...` and `go vet ./...` pass.
- `go test ./internal/engine/export/... ./internal/console/... ./docs/...` passes, the export and console store integration tests included.
- `make lint` reports 0 issues.
- `make generate` leaves the tree clean.
- `npm run docs:build` builds.

## Notes

- The Export section of the run page sits after the statements, not between the head and "What this run reported" as the issue placed it. `TestRunStats`, which the issue requires to pass unchanged, reads the first `<pre>` of the run page as the stored stats, and the export's folded documents would come first. The reference describes the section where it is.
- `TestPeriodPage` cuts the run table from its heading to the footer heading rather than to the end of the page: the same check, without the footer's query names.
- Not run: the three dev-cluster criteria of the issue (`/period?month=2026-07` after `make demo`, `/run.json` compared byte for byte with the `run.json` of `tally-engine export`, and the `cloudhouse` settlement row compared with `tally-engine kickbacks`). The dev cluster was not reachable while this was built.
- The run page reads and renders every statement document of an exportable run on each view. That is what lets it show the two files only for a run an export actually writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
