### PR TITLE
Show a meta-project's member_of rollup on its demo console page

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -27,7 +27,7 @@ environment, under the names the settings table below lists.
 | --- | --- |
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, each linking its own page and the run that finalized it; the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
-| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into. Engine: every statement of the project, grouped into the periods that were billed, and for a partner what every run settles for it. |
+| `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into; for a meta-project, the `member_of` relations that reach it at the first and at the last instant of every billing period, and each member project. Engine: every statement of the project, grouped into the periods that were billed, for a partner what every run settles for it, and for a meta-project the billing periods, their runs, and the statements of every run that stands, through the export's own read. |
 | `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
@@ -118,6 +118,32 @@ for a project of platform `partner` and for no other, because the beneficiary
 column holds an external id alone and a project of another platform could carry
 the same one.
 
+A meta-project carries one more table, `rollup`, which is what its members are
+billed. A meta-project owns no resources and has no statement of its own: every
+project that is `member_of` it is billed on its own statement. The table is one
+row per billing period, with the status of the regular run that stands, the
+number of members and what the runs that stand billed them, folding open into
+one row per member and run: the member's project id, linking its page, its
+cloud, a link to its statement, the run kind and the total. The sum is the one
+`tally-engine export --rollup member_of` writes, by the engine's own function:
+a member is counted one relation deep, once per meta-project however often its
+membership was closed and opened again, under each of two meta-projects it
+belongs to, and with its statement's total, related costs included. A period
+adds up the runs that stand the way the statements table does, so a
+correction's credit notes move the group's period the way they move each
+member's. The window of the page does not apply to the table.
+
+The membership is read through the Reporting API when the page is read: the
+`member_of` relations that reach the meta-project at the first instant of the
+period and at its last microsecond. A relation created or closed after the fact
+therefore changes what an earlier period shows, the way it changes an export,
+and a membership that began and ended inside a period is valid at neither
+instant and is not counted, although the export counts it; the page says so
+under the table. A run whose members the engine refuses to sum, one that billed
+them in two currencies, is reported in place of the table, and a run that stops
+standing while the page is read is left out. The table is drawn for a project
+of platform `meta` and for no other.
+
 Paging is one page per request. A listing the API answered with a cursor carries
 a next link that repeats the filters and adds that cursor, and nothing follows a
 cursor on its own.
@@ -154,7 +180,7 @@ The tables and their names per page:
 | --- | --- |
 | `/` | `stats`, `events`, `rejected`, `periods`, `runs` |
 | `/projects` | `projects` |
-| `/project` | `relations`, `related`, `activity`, `kickbacks`, `statements` |
+| `/project` | `relations`, `related`, `activity`, `kickbacks`, `rollup`, `statements` |
 | `/resources` | `resources` |
 | `/resource` | `segments`, `events` |
 | `/pricing` | `models` |

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -92,8 +92,23 @@ func (f *fakeAPI) GetProject(_ context.Context, id uuid.UUID) (httpapi.Project, 
 	return f.project, apiRequest("/api/v1/projects/"+id.String(), nil), f.projectErr
 }
 
-func (f *fakeAPI) ListProjectRelations(_ context.Context, id uuid.UUID) (httpapi.RelationList, reporting.Request, error) {
-	return f.relations, apiRequest("/api/v1/projects/"+id.String()+"/relations", nil), f.relationsErr
+func (f *fakeAPI) ListProjectRelations(
+	_ context.Context, id uuid.UUID, q reporting.RelationsQuery,
+) (httpapi.RelationList, reporting.Request, error) {
+	// The query is encoded the way the client encodes it: a filter that was not
+	// set does not travel, and the instant keeps its fraction.
+	query := url.Values{}
+	if q.Direction != "" {
+		query.Set("direction", q.Direction)
+	}
+	if q.RelationType != "" {
+		query.Set("relation_type", q.RelationType)
+	}
+	if !q.At.IsZero() {
+		query.Set("at", q.At.UTC().Format(time.RFC3339Nano))
+	}
+	request := apiRequest("/api/v1/projects/"+id.String()+"/relations", query)
+	return f.relations, request, f.relationsErr
 }
 
 func (f *fakeAPI) ListRelatedProjects(

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -46,9 +46,19 @@ type fakeAPI struct {
 
 	project    httpapi.Project
 	projectErr error
+	// members answers GetProject for the projects a membership names, and
+	// memberErr fails every such read; any other id is answered with project.
+	members   map[uuid.UUID]httpapi.Project
+	memberErr error
 
 	relations    httpapi.RelationList
 	relationsErr error
+	// relationsQueries is every relation read a page asked for, in order. A
+	// read at an instant is answered from memberships, keyed by the instant as
+	// the client sends it, and a read at no instant from relations.
+	relationsQueries []reporting.RelationsQuery
+	memberships      map[string][]httpapi.Relation
+	membershipsErr   error
 
 	related    httpapi.RelatedProjectList
 	relatedErr error
@@ -89,12 +99,18 @@ func (f *fakeAPI) ListProjects(
 }
 
 func (f *fakeAPI) GetProject(_ context.Context, id uuid.UUID) (httpapi.Project, reporting.Request, error) {
-	return f.project, apiRequest("/api/v1/projects/"+id.String(), nil), f.projectErr
+	request := apiRequest("/api/v1/projects/"+id.String(), nil)
+	if member, held := f.members[id]; held {
+		return member, request, f.memberErr
+	}
+	return f.project, request, f.projectErr
 }
 
 func (f *fakeAPI) ListProjectRelations(
 	_ context.Context, id uuid.UUID, q reporting.RelationsQuery,
 ) (httpapi.RelationList, reporting.Request, error) {
+	f.relationsQueries = append(f.relationsQueries, q)
+
 	// The query is encoded the way the client encodes it: a filter that was not
 	// set does not travel, and the instant keeps its fraction.
 	query := url.Values{}
@@ -104,10 +120,15 @@ func (f *fakeAPI) ListProjectRelations(
 	if q.RelationType != "" {
 		query.Set("relation_type", q.RelationType)
 	}
+	at := ""
 	if !q.At.IsZero() {
-		query.Set("at", q.At.UTC().Format(time.RFC3339Nano))
+		at = q.At.UTC().Format(time.RFC3339Nano)
+		query.Set("at", at)
 	}
 	request := apiRequest("/api/v1/projects/"+id.String()+"/relations", query)
+	if at != "" {
+		return httpapi.RelationList{Items: f.memberships[at]}, request, f.membershipsErr
+	}
 	return f.relations, request, f.relationsErr
 }
 
@@ -217,6 +238,12 @@ type fakeStore struct {
 
 	runExport    export.Run
 	runExportErr error
+	// runExports answers LoadRunExport per run ahead of runExport, and
+	// runExportErrs fails the run it names; runExportsAsked holds every run
+	// LoadRunExport was asked for, in order.
+	runExports      map[uuid.UUID]export.Run
+	runExportErrs   map[uuid.UUID]error
+	runExportsAsked []uuid.UUID
 
 	runs      []store.Run
 	runsErr   error
@@ -333,7 +360,14 @@ func (f *fakeStore) ListCorrectionDeltas(context.Context, uuid.UUID) ([]store.De
 	return f.deltas, f.deltasErr
 }
 
-func (f *fakeStore) LoadRunExport(context.Context, uuid.UUID) (export.Run, error) {
+func (f *fakeStore) LoadRunExport(_ context.Context, id uuid.UUID) (export.Run, error) {
+	f.runExportsAsked = append(f.runExportsAsked, id)
+	if err := f.runExportErrs[id]; err != nil {
+		return export.Run{}, err
+	}
+	if run, held := f.runExports[id]; held {
+		return run, nil
+	}
 	return f.runExport, f.runExportErr
 }
 
@@ -1533,6 +1567,527 @@ func section(t *testing.T, body, from, to string) string {
 		t.Fatalf("the page has no %q heading:\n%s", to, body)
 	}
 	return before
+}
+
+// The two member_of relations of the meta-project world: one valid all of
+// March, and one opened in the middle of it, which only the read at the end of
+// the month finds.
+var (
+	testMemberRelationID     = uuid.MustParse("99999999-9999-4999-8999-999999999999")
+	testLateMemberRelationID = uuid.MustParse("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+)
+
+// The instants the membership of a month is read at, as the client sends them
+// and the fake API keys its answers: the first instant and the last
+// microsecond of March and of April.
+const (
+	marchFirst = "2026-03-01T00:00:00Z"
+	marchLast  = "2026-03-31T23:59:59.999999Z"
+	aprilFirst = "2026-04-01T00:00:00Z"
+	aprilLast  = "2026-04-30T23:59:59.999999Z"
+)
+
+// metaProjectAPI is the Reporting API of the meta-project acme, whose members
+// p-1 and p-2 are billed on statements of their own: p-1 is a member all of
+// March, p-2 from the middle of it.
+func metaProjectAPI(t *testing.T) *fakeAPI {
+	t.Helper()
+
+	api := fullAPI(t)
+	api.project = httpapi.Project{
+		Id:         testProjectID,
+		Cloud:      "meta",
+		ExternalId: "acme",
+		Platform:   "meta",
+		Name:       pointerTo("acme"),
+		Metadata:   map[string]interface{}{},
+		CreatedAt:  testPeriod,
+	}
+
+	opened := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+	member := httpapi.Relation{
+		Id: testMemberRelationID, RelationType: "member_of", SourceId: testSourceID, TargetId: testProjectID,
+		ValidFrom: testPeriod, Metadata: map[string]interface{}{}, CreatedAt: testPeriod,
+	}
+	late := httpapi.Relation{
+		Id: testLateMemberRelationID, RelationType: "member_of", SourceId: testTargetID, TargetId: testProjectID,
+		ValidFrom: opened, Metadata: map[string]interface{}{}, CreatedAt: opened,
+	}
+	api.memberships = map[string][]httpapi.Relation{
+		marchFirst: {member},
+		marchLast:  {late, member},
+	}
+	api.members = map[uuid.UUID]httpapi.Project{
+		testSourceID: {
+			Id: testSourceID, Cloud: "os-sim", ExternalId: "p-1", Platform: "openstack",
+			Metadata: map[string]interface{}{}, CreatedAt: testPeriod,
+		},
+		testTargetID: {
+			Id: testTargetID, Cloud: "os-sim", ExternalId: "p-2", Platform: "openstack",
+			Metadata: map[string]interface{}{}, CreatedAt: testPeriod,
+		},
+	}
+	return api
+}
+
+// metaProjectStore is the engine side of that world: March, closed by
+// testRunID, which billed p-1, p-2 and p-3, a project that is no member, and
+// the correction booked against it, which credits p-1. The failed and the
+// superseded run of the month stay among its runs.
+func metaProjectStore(t *testing.T) *fakeStore {
+	t.Helper()
+
+	engine := fullStore(t)
+	engine.periods = []store.Period{{
+		From:           testPeriod,
+		To:             testPeriod.AddDate(0, 1, 0),
+		Status:         "finalized",
+		FinalizedRunID: testRunID,
+		FinalizedAt:    time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC),
+	}}
+	engine.projectStatements = nil
+	engine.runExports = map[uuid.UUID]export.Run{
+		testRunID: billedRun(t, testRunID, "regular",
+			billedLine{"os-sim/p-1", "128.45", "EUR"},
+			billedLine{"os-sim/p-2", "64.00", "EUR"},
+			billedLine{"os-sim/p-3", "10.00", "EUR"}),
+		testCorrectionRunID: billedRun(t, testCorrectionRunID, "correction",
+			billedLine{"os-sim/p-1", "-2.55", "EUR"}),
+	}
+	return engine
+}
+
+// billedLine is one statement of a run's export as the rollup reads it: the key
+// it is stored under, its total and its currency.
+type billedLine struct{ key, total, currency string }
+
+// billedRun is the export of one finalized March run holding the statements
+// given.
+func billedRun(t *testing.T, id uuid.UUID, kind string, lines ...billedLine) export.Run {
+	t.Helper()
+
+	run := export.Run{
+		ID:         id,
+		Kind:       kind,
+		Status:     "finalized",
+		PeriodFrom: testPeriod,
+		PeriodTo:   testPeriod.AddDate(0, 1, 0),
+	}
+	for _, line := range lines {
+		run.Statements = append(run.Statements, statements.Statement{
+			Key: line.key, Total: mustDecimal(t, line.total), Currency: line.currency,
+		})
+	}
+	return run
+}
+
+// servedRollup serves one page of the console and hands back the whole page and
+// what its rollup section prints, failing the test on any status but 200.
+func servedRollup(t *testing.T, api API, engine Store, path string) (body, rollup string) {
+	t.Helper()
+
+	handler, _ := serve(t, api, engine, testNow)
+	status, body, _ := get(t, handler, path)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d:\n%s", status, http.StatusOK, body)
+	}
+	return body, section(t, body, "Rollup", "Statements")
+}
+
+// TestMetaProjectRollup pins what a meta-project's page shows of its members:
+// one row per period, summed by the engine's own rollup over the runs that
+// stand, with the membership read at the first and the last instant of the
+// period.
+func TestMetaProjectRollup(t *testing.T) {
+	t.Parallel()
+
+	page := "/project?id=" + testProjectID.String()
+	noMember := "no run has billed a member of this meta-project"
+
+	t.Run("a period sums what the runs that stand billed its members", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		for _, want := range []string{
+			`<details class="cell"><summary>2026-03-01T00:00:00Z</summary>`,
+			"<td>finalized</td>",
+			`<td class="number">2</td>`,
+			// The 128.45 and 64.00 the regular run billed p-1 and p-2, less the
+			// 2.55 the correction credits p-1.
+			`<td class="number">189.90 EUR</td>`,
+		} {
+			if !strings.Contains(rollup, want) {
+				t.Errorf("the rollup lacks %q:\n%s", want, rollup)
+			}
+		}
+	})
+
+	t.Run("a period folds open into every member of every run", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		for _, want := range []string{
+			`<a href="/project?cloud=os-sim&amp;external_id=p-1">p-1</a>`,
+			`<a href="/project?cloud=os-sim&amp;external_id=p-2">p-2</a>`,
+			`<a href="/statement?key=os-sim%2Fp-1&amp;run=` + testRunID.String() + `">open</a>`,
+			`<a href="/statement?key=os-sim%2Fp-2&amp;run=` + testRunID.String() + `">open</a>`,
+			`<a href="/statement?key=os-sim%2Fp-1&amp;run=` + testCorrectionRunID.String() + `">open</a>`,
+			"<td>regular</td>",
+			"<td>correction</td>",
+			`<td class="number">128.45 EUR</td>`,
+			`<td class="number">64.00 EUR</td>`,
+			`<td class="number">-2.55 EUR</td>`,
+		} {
+			if !strings.Contains(rollup, want) {
+				t.Errorf("the rollup lacks %q:\n%s", want, rollup)
+			}
+		}
+		if got := strings.Count(rollup, ">open</a>"); got != 3 {
+			t.Errorf("the period folds open into %d member rows, want 3:\n%s", got, rollup)
+		}
+		if strings.Contains(rollup, "p-3") {
+			t.Errorf("a project that is no member is summed:\n%s", rollup)
+		}
+	})
+
+	t.Run("the membership is read at the first and the last instant of the period", func(t *testing.T) {
+		t.Parallel()
+
+		api := metaProjectAPI(t)
+		servedRollup(t, api, metaProjectStore(t), page)
+
+		want := []reporting.RelationsQuery{
+			{},
+			{Direction: "incoming", RelationType: "member_of", At: testPeriod},
+			{
+				Direction:    "incoming",
+				RelationType: "member_of",
+				At:           time.Date(2026, 3, 31, 23, 59, 59, 999999000, time.UTC),
+			},
+		}
+		if len(api.relationsQueries) != len(want) {
+			t.Fatalf("the page made %d relation reads, want %d: %+v",
+				len(api.relationsQueries), len(want), api.relationsQueries)
+		}
+		for i, got := range api.relationsQueries {
+			if got.Direction != want[i].Direction || got.RelationType != want[i].RelationType ||
+				!got.At.Equal(want[i].At) {
+				t.Errorf("relation read %d = %+v, want %+v", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("a member both instants read is counted once per run", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		if got := strings.Count(rollup, ">p-1</a>"); got != 2 {
+			t.Errorf("p-1 is listed %d times, want once under each of the two runs:\n%s", got, rollup)
+		}
+	})
+
+	t.Run("a member only the last instant reads is counted", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		if !strings.Contains(rollup, ">p-2</a>") || !strings.Contains(rollup, `<td class="number">64.00 EUR</td>`) {
+			t.Errorf("the member of the second half of the month is missing:\n%s", rollup)
+		}
+	})
+
+	t.Run("only the runs that stand are loaded", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		servedRollup(t, metaProjectAPI(t), engine, page)
+		if got, want := fmt.Sprint(engine.runExportsAsked), fmt.Sprint([]uuid.UUID{testRunID, testCorrectionRunID}); got != want {
+			t.Errorf("the exports of %s were loaded, want %s", got, want)
+		}
+	})
+
+	t.Run("the panel names every read the rollup made", func(t *testing.T) {
+		t.Parallel()
+
+		body, _ := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		for _, want := range []string{
+			"relation_type=member_of",
+			"at=2026-03-31T23%3A59%3A59.999999Z",
+			"GET /api/v1/projects/" + testSourceID.String(),
+			"ListPeriods",
+			"ListRunsForPeriod",
+			"LoadRunExport",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the panel does not name %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("the page says what the membership read misses", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		if !strings.Contains(rollup, "a membership that began and ended inside a period is not counted here") {
+			t.Errorf("the rollup does not say what it misses:\n%s", rollup)
+		}
+	})
+
+	t.Run("the filter finds a period by the members under it", func(t *testing.T) {
+		t.Parallel()
+
+		_, rollup := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page+"&rollup.q=p-2")
+		if !strings.Contains(rollup, "1 of 1 row match") {
+			t.Errorf("the filter does not match a period on a member under it:\n%s", rollup)
+		}
+		_, rollup = servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page+"&rollup.q=nomatch")
+		if !strings.Contains(rollup, "no row matches the filter") {
+			t.Errorf("the emptied table does not say so:\n%s", rollup)
+		}
+	})
+
+	t.Run("every table carries its form and no script is loaded", func(t *testing.T) {
+		t.Parallel()
+
+		body, _ := servedRollup(t, metaProjectAPI(t), metaProjectStore(t), page)
+		if tables, forms := strings.Count(body, "<table>"), strings.Count(body, `<form class="tools"`); tables != forms {
+			t.Errorf("%d tables and %d filter forms", tables, forms)
+		}
+		if strings.Contains(body, "<script") {
+			t.Error("the page carries a script element")
+		}
+	})
+
+	t.Run("no billing period reads no membership", func(t *testing.T) {
+		t.Parallel()
+
+		api, engine := metaProjectAPI(t), metaProjectStore(t)
+		engine.periods = nil
+		_, rollup := servedRollup(t, api, engine, page)
+		if !strings.Contains(rollup, noMember) {
+			t.Errorf("an empty rollup does not say so:\n%s", rollup)
+		}
+		if len(api.relationsQueries) != 1 || api.relationsQueries[0] != (reporting.RelationsQuery{}) {
+			t.Errorf("the page read the relations %+v, want the relations table's read alone", api.relationsQueries)
+		}
+		if len(engine.runExportsAsked) != 0 {
+			t.Errorf("the exports of %v were loaded, want none", engine.runExportsAsked)
+		}
+	})
+
+	t.Run("a membership neither instant reads leaves the runs unread", func(t *testing.T) {
+		t.Parallel()
+
+		api, engine := metaProjectAPI(t), metaProjectStore(t)
+		api.memberships = nil
+		_, rollup := servedRollup(t, api, engine, page)
+		if !strings.Contains(rollup, noMember) {
+			t.Errorf("an empty rollup does not say so:\n%s", rollup)
+		}
+		if len(engine.periodAsked) != 0 || len(engine.runExportsAsked) != 0 {
+			t.Errorf("the runs of %v and the exports of %v were read, want none",
+				engine.periodAsked, engine.runExportsAsked)
+		}
+	})
+
+	t.Run("a month no relation reaches is read no further", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		april := testPeriod.AddDate(0, 1, 0)
+		engine.periods = append([]store.Period{{From: april, To: april.AddDate(0, 1, 0), Status: "open"}},
+			engine.periods...)
+		_, rollup := servedRollup(t, metaProjectAPI(t), engine, page)
+		if len(engine.periodAsked) != 1 || !engine.periodAsked[0].Equal(testPeriod) {
+			t.Errorf("the runs of %v were read, want those of March alone", engine.periodAsked)
+		}
+		if !strings.Contains(rollup, "<summary>2026-03-01T00:00:00Z</summary>") ||
+			strings.Contains(rollup, "2026-04-01T00:00:00Z") {
+			t.Errorf("the rollup does not hold March alone:\n%s", rollup)
+		}
+	})
+
+	t.Run("the periods are listed oldest first", func(t *testing.T) {
+		t.Parallel()
+
+		api, engine := metaProjectAPI(t), metaProjectStore(t)
+		april := testPeriod.AddDate(0, 1, 0)
+		engine.periods = append([]store.Period{{From: april, To: april.AddDate(0, 1, 0), Status: "open"}},
+			engine.periods...)
+		api.memberships[aprilFirst] = api.memberships[marchFirst]
+		api.memberships[aprilLast] = api.memberships[marchLast]
+		_, rollup := servedRollup(t, api, engine, page)
+		march := strings.Index(rollup, "<summary>2026-03-01T00:00:00Z</summary>")
+		later := strings.Index(rollup, "<summary>2026-04-01T00:00:00Z</summary>")
+		if march < 0 || later < 0 || march > later {
+			t.Errorf("March does not come before April:\n%s", rollup)
+		}
+	})
+
+	t.Run("a period whose runs all stopped standing has no row", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		for i := range engine.periodRuns {
+			if engine.periodRuns[i].Status != "failed" {
+				engine.periodRuns[i].Status = "superseded"
+			}
+		}
+		body, rollup := servedRollup(t, metaProjectAPI(t), engine, page)
+		if !strings.Contains(rollup, noMember) {
+			t.Errorf("a period standing at nothing has a row:\n%s", rollup)
+		}
+		if strings.Contains(body, "GET /api/v1/projects/"+testSourceID.String()) {
+			t.Error("a member was read for a period no run stands in")
+		}
+		if len(engine.runExportsAsked) != 0 {
+			t.Errorf("the exports of %v were loaded, want none", engine.runExportsAsked)
+		}
+	})
+
+	t.Run("a run that billed no member adds nothing", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		engine.runExports[testCorrectionRunID] = billedRun(t, testCorrectionRunID, "correction",
+			billedLine{"os-sim/p-3", "-2.55", "EUR"})
+		_, rollup := servedRollup(t, metaProjectAPI(t), engine, page)
+		if !strings.Contains(rollup, `<td class="number">192.45 EUR</td>`) {
+			t.Errorf("the correction of a project that is no member moved the group:\n%s", rollup)
+		}
+		if got := strings.Count(rollup, ">open</a>"); got != 2 {
+			t.Errorf("the period folds open into %d member rows, want 2:\n%s", got, rollup)
+		}
+	})
+
+	t.Run("a project that is no meta-project reads no rollup", func(t *testing.T) {
+		t.Parallel()
+
+		partner := fullAPI(t)
+		partner.project.Platform, partner.project.Cloud, partner.project.ExternalId = "partner", "partner", "cloudhouse"
+		for _, api := range []*fakeAPI{fullAPI(t), partner} {
+			engine := fullStore(t)
+			handler, _ := serve(t, api, engine, testNow)
+			status, body, _ := get(t, handler, page)
+			if status != http.StatusOK {
+				t.Fatalf("%s: status = %d, want %d", api.project.Platform, status, http.StatusOK)
+			}
+			if strings.Contains(body, "<h2>Rollup</h2>") || strings.Contains(body, "ListPeriods") {
+				t.Errorf("%s: the page reads a rollup", api.project.Platform)
+			}
+			if len(api.relationsQueries) != 1 || api.relationsQueries[0] != (reporting.RelationsQuery{}) {
+				t.Errorf("%s: the page read the relations %+v, want the relations table's read alone",
+					api.project.Platform, api.relationsQueries)
+			}
+			if len(engine.runExportsAsked) != 0 {
+				t.Errorf("%s: the exports of %v were loaded, want none", api.project.Platform, engine.runExportsAsked)
+			}
+		}
+	})
+
+	t.Run("a read the rollup cannot make fails the page", func(t *testing.T) {
+		t.Parallel()
+
+		refused := errors.New("connection refused")
+		endpoint := "http://127.0.0.1:1/api/v1/projects/"
+		cases := []struct {
+			name   string
+			fail   func(api *fakeAPI, engine *fakeStore)
+			status int
+			wants  []string
+		}{
+			{
+				name:   "the billing periods",
+				fail:   func(_ *fakeAPI, engine *fakeStore) { engine.periodsErr = errors.New("ListPeriods: connection refused") },
+				status: http.StatusServiceUnavailable,
+				wants:  []string{"ListPeriods: connection refused"},
+			},
+			{
+				name: "the membership",
+				fail: func(api *fakeAPI, _ *fakeStore) {
+					api.membershipsErr = fmt.Errorf("calling %s: %w", endpoint+testProjectID.String()+"/relations", refused)
+				},
+				status: http.StatusBadGateway,
+				wants:  []string{"connection refused", "relation_type=member_of"},
+			},
+			{
+				name: "a member project",
+				fail: func(api *fakeAPI, _ *fakeStore) {
+					api.memberErr = fmt.Errorf("calling %s: %w", endpoint+testSourceID.String(), refused)
+				},
+				status: http.StatusBadGateway,
+				wants:  []string{"connection refused", "GET /api/v1/projects/" + testSourceID.String()},
+			},
+			{
+				name: "the runs of the period",
+				fail: func(_ *fakeAPI, engine *fakeStore) {
+					engine.periodRunsErr = errors.New("ListRunsForPeriod: connection refused")
+				},
+				status: http.StatusServiceUnavailable,
+				wants:  []string{"ListRunsForPeriod: connection refused"},
+			},
+			{
+				name: "the export of a run",
+				fail: func(_ *fakeAPI, engine *fakeStore) {
+					engine.runExportErrs = map[uuid.UUID]error{testRunID: errors.New("LoadRunExport: connection refused")}
+				},
+				status: http.StatusServiceUnavailable,
+				wants:  []string{"LoadRunExport: connection refused"},
+			},
+		}
+		for _, tc := range cases {
+			api, engine := metaProjectAPI(t), metaProjectStore(t)
+			tc.fail(api, engine)
+			handler, logged := serve(t, api, engine, testNow)
+
+			status, body, _ := get(t, handler, page)
+			if status != tc.status {
+				t.Errorf("%s: status = %d, want %d:\n%s", tc.name, status, tc.status, body)
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(body, want) {
+					t.Errorf("%s: the page does not name %q:\n%s", tc.name, want, body)
+				}
+			}
+			if !strings.Contains(logged.String(), tc.wants[0]) {
+				t.Errorf("%s: the log does not carry %q:\n%s", tc.name, tc.wants[0], logged.String())
+			}
+		}
+	})
+
+	t.Run("a run that stopped standing is left out", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		engine.runExportErrs = map[uuid.UUID]error{
+			testCorrectionRunID: fmt.Errorf("LoadRunExport: %w: run %s is superseded",
+				export.ErrRunNotExportable, testCorrectionRunID),
+		}
+		_, rollup := servedRollup(t, metaProjectAPI(t), engine, page)
+		if !strings.Contains(rollup, `<td class="number">192.45 EUR</td>`) {
+			t.Errorf("the run that stopped standing is counted:\n%s", rollup)
+		}
+	})
+
+	t.Run("the engine's refusal stands in place of the table", func(t *testing.T) {
+		t.Parallel()
+
+		engine := metaProjectStore(t)
+		engine.runExports[testRunID] = billedRun(t, testRunID, "regular",
+			billedLine{"os-sim/p-1", "128.45", "EUR"},
+			billedLine{"os-sim/p-2", "64.00", "USD"})
+		_, rollup := servedRollup(t, metaProjectAPI(t), engine, page)
+		want := "the engine refuses the rollup of run " + testRunID.String() +
+			": the rollup of meta/acme holds statements in EUR and in USD"
+		if !strings.Contains(rollup, want) {
+			t.Errorf("the rollup does not carry the refusal %q:\n%s", want, rollup)
+		}
+		if strings.Contains(rollup, "<table") {
+			t.Errorf("a refused rollup draws a table:\n%s", rollup)
+		}
+		if !strings.Contains(rollup, "is not counted here") {
+			t.Errorf("a refused rollup drops the membership note:\n%s", rollup)
+		}
+	})
 }
 
 func TestPricingPage(t *testing.T) {

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -61,6 +61,9 @@ type projectData struct {
 	To         time.Time
 	Key        string
 	Statements listing[periodRow]
+	// Rollup is what the members of a meta-project are billed, per period,
+	// and nil for every project that is not one.
+	Rollup *rollupView
 }
 
 // activityRow is one resource type of a project over the window: what the
@@ -352,6 +355,17 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 
 	periods := periodRows(billed, key)
 
+	// What the members of a meta-project are billed. A meta-project owns no
+	// resources and has no statement of its own, so this is the money its page
+	// shows, and it is read for a meta-project and for no other project.
+	var rollup *rollupView
+	if project.Platform == projectcore.PlatformMeta {
+		if rollup, err = h.buildRollup(r, project, &src); err != nil {
+			h.failFrom(w, r, err, src)
+			return
+		}
+	}
+
 	// What a partner is owed. Only a partner is ever a beneficiary, and the
 	// column holds the external id alone, so the read is made for a partner
 	// and for no other project: another platform's project of the same
@@ -377,6 +391,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		Key:        key,
 		Statements: tabulate(r, "statements", projectPeriodColumns, periods),
 		Kickbacks:  tabulate(r, "kickbacks", settlementColumns, settlementRows(settled)),
+		Rollup:     rollup,
 	}
 	h.render(w, r, "project", page{
 		Title:   "Project " + optString(project.Name, project.ExternalId),

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -290,7 +290,7 @@ func (h *handlers) project(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	relations, request, err := h.api.ListProjectRelations(ctx, id)
+	relations, request, err := h.api.ListProjectRelations(ctx, id, reporting.RelationsQuery{})
 	src.api(request)
 	if err != nil {
 		h.failFrom(w, r, apiFailed(err), src)

--- a/internal/console/httpui/rollup.go
+++ b/internal/console/httpui/rollup.go
@@ -1,0 +1,289 @@
+package httpui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/b42labs/tally/internal/console/reporting"
+	"github.com/b42labs/tally/internal/console/store"
+	projectcore "github.com/b42labs/tally/internal/core/project"
+	"github.com/b42labs/tally/internal/engine/export"
+	"github.com/b42labs/tally/internal/engine/source"
+	"github.com/b42labs/tally/internal/engine/statements"
+	"github.com/b42labs/tally/internal/reporting/httpapi"
+)
+
+// rollupView is a meta-project's rollup, or why the engine refused it.
+type rollupView struct {
+	// Note is the engine's refusal, which the page prints in place of the
+	// table.
+	Note    string
+	Periods listing[rollupRow]
+}
+
+// rollupRow is one billing period of a meta-project: every member a run that
+// stands billed, which the row folds open, and what the group is billed for
+// the period once those runs are added up.
+type rollupRow struct {
+	From    time.Time
+	Members []rollupMemberRow
+	// Count is how many members the runs billed, each counted once however
+	// many of the runs billed it.
+	Count int64
+	// Totals is what the groups of the runs add up to, per currency, and Sort
+	// is the amount the column is ordered by, the way a period of a project
+	// adds up.
+	Totals   []currencyTotal
+	Sort     decimal.Decimal
+	Status   string
+	Searched string
+}
+
+// rollupMemberRow is one member as one run billed it, with the pages of its
+// statement and of its project.
+type rollupMemberRow struct {
+	Run           store.Run
+	Member        export.RollupMember
+	StatementLink string
+	ProjectLink   string
+}
+
+// rollupColumns is a meta-project's rollup, one row per period.
+var rollupColumns = []column[rollupRow]{
+	textCol("period", func(r rollupRow) string { return r.Searched }),
+	textCol("status", func(r rollupRow) string { return r.Status }),
+	countCol("members", func(r rollupRow) int64 { return r.Count }),
+	numberCol("total", func(r rollupRow) decimal.Decimal { return r.Sort }),
+}
+
+// refusedRollup is a run the engine would not sum under the meta-project, one
+// that billed its members in two currencies for example. The page prints it in
+// place of the table rather than failing, because the rest of the page reads
+// fine, the way the run page prints an export it refuses.
+type refusedRollup struct {
+	run uuid.UUID
+	err error
+}
+
+// Error names the run and what the engine said about it.
+func (e refusedRollup) Error() string {
+	return "the engine refuses the rollup of run " + e.run.String() + ": " + e.err.Error()
+}
+
+// Unwrap exposes the engine's own error.
+func (e refusedRollup) Unwrap() error { return e.err }
+
+// lastInstant is the last instant a relation can be valid at inside a billing
+// period. The period is half-open and both databases store instants to the
+// microsecond, so it is the microsecond before the next period starts.
+func lastInstant(billing store.Period) time.Time {
+	return billing.To.Add(-time.Microsecond)
+}
+
+// buildRollup sums what the members of a meta-project are billed, per billing
+// period, oldest first. The sum is the one tally-engine export --rollup
+// member_of writes, export.BuildRollup over each run that stands, and a period
+// adds its runs up the way a period of a project adds up its statements.
+//
+// The export reads the membership out of the registry's database: every
+// relation whose validity overlaps the period. The console reads the registry
+// through the Reporting API, which answers the relations valid at one instant,
+// so it asks at the first and at the last instant of the period. A membership
+// that began and ended between the two is valid at neither and is not counted.
+func (h *handlers) buildRollup(r *http.Request, project httpapi.Project, src *sources) (*rollupView, error) {
+	ctx := r.Context()
+
+	periods, err := h.store.ListPeriods(ctx)
+	src.query("ListPeriods")
+	if err != nil {
+		return nil, storeFailed(err)
+	}
+
+	group := statements.Key(project.Cloud, project.ExternalId)
+	// The projects BuildRollup is handed: the meta-project every relation
+	// reaches, and each member once it has been read.
+	held := map[uuid.UUID]source.Project{project.Id: {
+		ID: project.Id, Platform: project.Platform, Cloud: project.Cloud, ExternalID: project.ExternalId,
+	}}
+
+	var rows []rollupRow
+	// The periods come newest first, and the table reads them oldest first.
+	for _, billing := range slices.Backward(periods) {
+		row, rolled, err := h.rollupPeriod(ctx, project.Id, group, billing, held, src)
+		var refused refusedRollup
+		if errors.As(err, &refused) {
+			return &rollupView{Note: refused.Error()}, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if rolled {
+			rows = append(rows, row)
+		}
+	}
+	return &rollupView{Periods: tabulate(r, "rollup", rollupColumns, rows)}, nil
+}
+
+// rollupPeriod sums one billing period of a meta-project and reports whether a
+// run that stands billed a member in it. A period no relation reaches at either
+// instant, and one in which no run stands, is read no further.
+func (h *handlers) rollupPeriod(
+	ctx context.Context, id uuid.UUID, group string, billing store.Period,
+	held map[uuid.UUID]source.Project, src *sources,
+) (rollupRow, bool, error) {
+	relations, err := h.membership(ctx, id, billing, src)
+	if err != nil || len(relations) == 0 {
+		return rollupRow{}, false, err
+	}
+
+	recorded, err := h.store.ListRunsForPeriod(ctx, billing.From)
+	src.query("ListRunsForPeriod")
+	if err != nil {
+		return rollupRow{}, false, storeFailed(err)
+	}
+	var standing []store.Run
+	for _, run := range recorded {
+		if slices.Contains(standingStatuses, run.Status) {
+			standing = append(standing, run)
+		}
+	}
+	if len(standing) == 0 {
+		return rollupRow{}, false, nil
+	}
+
+	if err := h.resolveMembers(ctx, relations, held, src); err != nil {
+		return rollupRow{}, false, err
+	}
+	projects := slices.Collect(maps.Values(held))
+
+	row := rollupRow{From: billing.From, Status: absent}
+	sums := make(map[string]decimal.Decimal)
+	for _, run := range standing {
+		loaded, err := h.store.LoadRunExport(ctx, run.ID)
+		src.query("LoadRunExport")
+		if errors.Is(err, export.ErrRunNotExportable) {
+			// The run stopped standing between the two reads, and a run that
+			// does not stand counts for nothing.
+			continue
+		}
+		if err != nil {
+			return rollupRow{}, false, storeFailed(err)
+		}
+		if run.Kind == regularKind {
+			row.Status = run.Status
+		}
+
+		rollup, err := export.BuildRollup(loaded, projectcore.RelationMemberOf, projects, relations)
+		if err != nil {
+			return rollupRow{}, false, refusedRollup{run: run.ID, err: err}
+		}
+		for _, summed := range rollup.Groups {
+			if summed.Key != group {
+				continue
+			}
+			for _, member := range summed.Members {
+				row.Members = append(row.Members, rollupMemberRow{
+					Run:           run,
+					Member:        member,
+					StatementLink: statementLink(run.ID, member.StatementKey),
+					ProjectLink:   projectLink(member.Cloud, member.ProjectID),
+				})
+			}
+			sums[summed.Currency] = sums[summed.Currency].Add(summed.Total)
+		}
+	}
+	if len(row.Members) == 0 {
+		return rollupRow{}, false, nil
+	}
+	row.describe(sums)
+	return row, true, nil
+}
+
+// membership reads the member_of relations that reach a meta-project at the
+// first and at the last instant of a billing period, one entry per relation. A
+// relation valid at both instants is read twice and kept once.
+func (h *handlers) membership(
+	ctx context.Context, id uuid.UUID, billing store.Period, src *sources,
+) ([]source.Relation, error) {
+	byID := make(map[uuid.UUID]source.Relation)
+	for _, at := range []time.Time{billing.From, lastInstant(billing)} {
+		list, request, err := h.api.ListProjectRelations(ctx, id, reporting.RelationsQuery{
+			Direction:    string(httpapi.Incoming),
+			RelationType: projectcore.RelationMemberOf,
+			At:           at,
+		})
+		src.api(request)
+		if err != nil {
+			return nil, apiFailed(err)
+		}
+		for _, relation := range list.Items {
+			byID[relation.Id] = source.Relation{
+				ID:           relation.Id,
+				SourceID:     relation.SourceId,
+				TargetID:     relation.TargetId,
+				RelationType: relation.RelationType,
+				ValidFrom:    relation.ValidFrom,
+				ValidTo:      relation.ValidTo,
+			}
+		}
+	}
+
+	// By id, the order the export reads its relations in: BuildRollup names the
+	// currency it met first when it refuses a group, so the order decides what
+	// a refusal says.
+	relations := slices.Collect(maps.Values(byID))
+	slices.SortFunc(relations, func(a, b source.Relation) int { return bytes.Compare(a.ID[:], b.ID[:]) })
+	return relations, nil
+}
+
+// resolveMembers reads the project every relation leaves, once per request:
+// BuildRollup names a member by the cloud and the external id its registry row
+// carries, and refuses a relation whose source it was not handed.
+func (h *handlers) resolveMembers(
+	ctx context.Context, relations []source.Relation, held map[uuid.UUID]source.Project, src *sources,
+) error {
+	for _, relation := range relations {
+		if _, read := held[relation.SourceID]; read {
+			continue
+		}
+		member, request, err := h.api.GetProject(ctx, relation.SourceID)
+		src.api(request)
+		if err != nil {
+			return apiFailed(err)
+		}
+		held[relation.SourceID] = source.Project{
+			ID: member.Id, Platform: member.Platform, Cloud: member.Cloud, ExternalID: member.ExternalId,
+		}
+	}
+	return nil
+}
+
+// describe counts the members of a period, adds its groups up per currency,
+// and says what a filter matches it on: the period, and the run kind, the cloud
+// and the project of every member under it.
+func (r *rollupRow) describe(sums map[string]decimal.Decimal) {
+	for _, currency := range slices.Sorted(maps.Keys(sums)) {
+		r.Totals = append(r.Totals, currencyTotal{Total: sums[currency], Currency: currency})
+	}
+	if len(r.Totals) > 0 {
+		r.Sort = r.Totals[0].Total
+	}
+
+	counted := make(map[string]bool, len(r.Members))
+	searched := []string{stamp(r.From)}
+	for _, member := range r.Members {
+		counted[member.Member.StatementKey] = true
+		searched = append(searched, member.Run.Kind, member.Member.Cloud, member.Member.ProjectID)
+	}
+	r.Count = int64(len(counted))
+	r.Searched = strings.Join(searched, " ")
+}

--- a/internal/console/httpui/router.go
+++ b/internal/console/httpui/router.go
@@ -65,7 +65,9 @@ type Options struct {
 type API interface {
 	ListProjects(ctx context.Context, q reporting.ProjectsQuery) (httpapi.ProjectList, reporting.Request, error)
 	GetProject(ctx context.Context, id uuid.UUID) (httpapi.Project, reporting.Request, error)
-	ListProjectRelations(ctx context.Context, id uuid.UUID) (httpapi.RelationList, reporting.Request, error)
+	ListProjectRelations(
+		ctx context.Context, id uuid.UUID, q reporting.RelationsQuery,
+	) (httpapi.RelationList, reporting.Request, error)
 	ListRelatedProjects(ctx context.Context, id uuid.UUID) (httpapi.RelatedProjectList, reporting.Request, error)
 	GetProjectSummary(
 		ctx context.Context, id uuid.UUID, from, to time.Time,

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -127,6 +127,39 @@
 </table>
 {{end}}
 
+{{with .Rollup}}
+<h2>Rollup</h2>
+{{if .Note}}<p>{{.Note}}</p>
+{{else}}{{template "tableTools" .Periods.Table}}
+<table>
+{{template "tableHead" .Periods.Table}}
+<tbody>
+{{range .Periods.Rows}}<tr>
+<td><details class="cell"><summary>{{stamp .From}}</summary>
+<table class="nested">
+<thead><tr><th>member</th><th>cloud</th><th>statement</th><th>run kind</th><th class="number">total</th></tr></thead>
+<tbody>
+{{range .Members}}<tr>
+<td><a href="{{.ProjectLink}}">{{.Member.ProjectID}}</a></td>
+<td>{{.Member.Cloud}}</td>
+<td><a href="{{.StatementLink}}">open</a></td>
+<td>{{.Run.Kind}}</td>
+<td class="number">{{amount .Member.Total}} {{.Member.Currency}}</td>
+</tr>
+{{end}}</tbody>
+</table>
+</details></td>
+<td>{{.Status}}</td>
+<td class="number">{{.Count}}</td>
+<td class="number">{{range $i, $t := .Totals}}{{if $i}} + {{end}}{{amount $t.Total}} {{$t.Currency}}{{else}}none{{end}}</td>
+</tr>
+{{else}}<tr><td colspan="4">{{emptyText .Periods.Table "no run has billed a member of this meta-project"}}</td></tr>
+{{end}}</tbody>
+</table>
+{{end}}
+<p class="axis">the membership is read from the registry when this page is read, at the first and the last instant of each period, and is not stored with the run: a relation created or closed since changes what an earlier period shows, and a membership that began and ended inside a period is not counted here, although tally-engine export --rollup member_of counts it</p>
+{{end}}
+
 <h2>Statements</h2>
 {{template "tableTools" .Statements.Table}}
 <table>

--- a/internal/console/reporting/client.go
+++ b/internal/console/reporting/client.go
@@ -127,6 +127,15 @@ type ProjectsQuery struct {
 	Cursor     string
 }
 
+// RelationsQuery narrows a relation list. Every field is optional: an empty
+// Direction or RelationType filters nothing, and a zero At is now.
+type RelationsQuery struct {
+	// Direction is incoming, outgoing or both, the values the route takes.
+	Direction    string
+	RelationType string
+	At           time.Time
+}
+
 // ResourcesQuery narrows a resource list. Every field is optional, and an empty
 // one filters nothing.
 type ResourcesQuery struct {
@@ -172,10 +181,25 @@ func (c *Client) GetProject(ctx context.Context, id uuid.UUID) (httpapi.Project,
 	return project, request, nil
 }
 
-// ListProjectRelations reads the relations one project has right now.
-func (c *Client) ListProjectRelations(ctx context.Context, id uuid.UUID) (httpapi.RelationList, Request, error) {
+// ListProjectRelations reads the relations one project has at one instant,
+// narrowed by q. A zero query reads them as they stand now, in both
+// directions and of every type.
+func (c *Client) ListProjectRelations(
+	ctx context.Context, id uuid.UUID, q RelationsQuery,
+) (httpapi.RelationList, Request, error) {
+	query := url.Values{}
+	setFilter(query, "direction", q.Direction)
+	setFilter(query, "relation_type", q.RelationType)
+	// The instant keeps its fraction rather than going through formatInstant:
+	// the last instant of a billing period is a microsecond before the next one
+	// starts, and rounded to the second it would miss a relation that began in
+	// that second.
+	if !q.At.IsZero() {
+		query.Set("at", q.At.UTC().Format(time.RFC3339Nano))
+	}
+
 	var relations httpapi.RelationList
-	request, err := c.get(ctx, projectRoute(id, "/relations"), &relations)
+	request, err := c.get(ctx, withQuery(projectRoute(id, "/relations"), query), &relations)
 	if err != nil {
 		return httpapi.RelationList{}, request, err
 	}

--- a/internal/console/reporting/client_test.go
+++ b/internal/console/reporting/client_test.go
@@ -30,6 +30,10 @@ var (
 	windowTo   = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 )
 
+// windowLast is the last microsecond of that window, which is the instant a
+// relation read asks about the end of a billing period at.
+var windowLast = windowTo.Add(-time.Microsecond)
+
 // The smallest valid answers of the routes under test. A paged list carries a
 // cursor member, an unpaged one does not.
 const (
@@ -106,7 +110,7 @@ func testClient(t *testing.T, baseURL string) *Client {
 // TestReadsCarryTheTokenAndTheQuery holds every read to the route it is
 // documented for. The path segments, the filters, and their encoding are what
 // decides whether the API answers the question a page asked, and the token has
-// to be on all ten of them.
+// to be on all twelve of them.
 func TestReadsCarryTheTokenAndTheQuery(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -142,7 +146,33 @@ func TestReadsCarryTheTokenAndTheQuery(t *testing.T) {
 			body:    emptyList,
 			wantURI: "/api/v1/projects/11111111-1111-4111-8111-111111111111/relations",
 			call: func(ctx context.Context, c *Client) (Request, error) {
-				_, request, err := c.ListProjectRelations(ctx, testProjectID)
+				_, request, err := c.ListProjectRelations(ctx, testProjectID, RelationsQuery{})
+				return request, err
+			},
+		},
+		{
+			// The instant keeps its fraction: rounded to the second, a read at
+			// the end of a billing period would miss a relation that began in
+			// its last second.
+			name: "the relations reaching one project at an instant",
+			body: emptyList,
+			wantURI: "/api/v1/projects/11111111-1111-4111-8111-111111111111/relations" +
+				"?at=2026-03-31T23%3A59%3A59.999999Z&direction=incoming&relation_type=member_of",
+			call: func(ctx context.Context, c *Client) (Request, error) {
+				_, request, err := c.ListProjectRelations(ctx, testProjectID, RelationsQuery{
+					Direction:    "incoming",
+					RelationType: "member_of",
+					At:           windowLast,
+				})
+				return request, err
+			},
+		},
+		{
+			name:    "the relations of one type",
+			body:    emptyList,
+			wantURI: "/api/v1/projects/11111111-1111-4111-8111-111111111111/relations?relation_type=member_of",
+			call: func(ctx context.Context, c *Client) (Request, error) {
+				_, request, err := c.ListProjectRelations(ctx, testProjectID, RelationsQuery{RelationType: "member_of"})
 				return request, err
 			},
 		},
@@ -386,6 +416,27 @@ func TestProblemsBecomeTypedErrors(t *testing.T) {
 			if !strings.Contains(problem.Error(), want) {
 				t.Errorf("Error() = %q, want it to name %s", problem.Error(), want)
 			}
+		}
+	})
+
+	t.Run("a relation read the API refuses", func(t *testing.T) {
+		server := answering(t, http.StatusNotFound, "application/problem+json",
+			`{"type":"urn:tally:error:not-found","title":"Not found","detail":"no such project","status":404}`)
+
+		_, request, err := testClient(t, server.URL).ListProjectRelations(context.Background(), testProjectID,
+			RelationsQuery{Direction: "incoming", RelationType: "member_of", At: windowLast})
+
+		var problem *ProblemError
+		if !errors.As(err, &problem) {
+			t.Fatalf("ListProjectRelations() error = %v, want a *ProblemError", err)
+		}
+		if problem.Status != http.StatusNotFound {
+			t.Errorf("Status = %d, want 404", problem.Status)
+		}
+		// The refused request is what the error page lists as its provenance,
+		// so it still names the instant it asked about.
+		if !strings.Contains(request.Path, "at=2026-03-31T23%3A59%3A59.999999Z") {
+			t.Errorf("Request.Path = %q, want it to carry the instant", request.Path)
 		}
 	})
 


### PR DESCRIPTION
Closes #137

A meta-project's page in the demo console gains a `rollup` table: one row per billing period with what the runs that stand billed the meta-project's `member_of` members, folding open into one row per member and run with links to its statement and its project page. The sum is the engine's own `export.BuildRollup`, the function behind `tally-engine export --rollup member_of`, and a period adds up its standing runs the way the project page adds up one project. The membership is read through the Reporting API's existing relations route, `direction=incoming&relation_type=member_of`, at the first instant and the last microsecond of each period. A membership that began and ended inside a period is valid at neither instant and is not counted, although the export counts it; the page says so. The Reporting API's contract, the engine, the console store, its SQL, its configuration and `make console` are unchanged.

## Commits

1. Read a project's relations at an instant in the console client (`459d055`). `RelationsQuery` carries `direction`, `relation_type` and `at`. The instant travels as RFC 3339 with its fraction, which the server's validator and binder accept, so the last microsecond of a period is asked as such; a zero query sends the request the relations table always sent. `TestReadsCarryTheTokenAndTheQuery` gains the full query and the type alone, and `TestProblemsBecomeTypedErrors` a refused relation read whose request still carries the instant.
2. Show a meta-project's member_of rollup on its page (`c9c7435`). The new `rollup.go` walks the billing periods oldest first: it reads the membership at the two instants, skips a period no relation reaches or no run stands in, reads each member project once, loads each standing run through `LoadRunExport` (a run refused as not exportable is left out) and sums it with `export.BuildRollup`. An engine refusal, two currencies under one run for example, is printed in place of the table; a failed read answers 502 or 503 like every other read of the page. The template draws the section for platform `meta` alone. `TestMetaProjectRollup` covers the issue's page criteria in 20 subtests over new `metaProjectAPI` and `metaProjectStore` fixtures.
3. Document a meta-project's rollup in the console reference (`1c554bf`). The `/project` route row, two paragraphs on the table and on what its membership read misses against the export, and `rollup` in the table list.

## Verification

- `go build ./...` and `go vet ./...` pass.
- `go test ./internal/console/...` passes, the console store integration test included, and `go test ./docs/` passes.
- `make lint` reports 0 issues.
- `npm run docs:build` builds.

## Notes

- Not run: the two dev-cluster criteria of the issue, the 2026-07 row of `acme` compared with the `rollup-meta%2Facme.json` documents `tally-engine export --rollup member_of` writes for the month's standing runs, and no rollup on the `cloudhouse` page. The dev cluster was not reachable while this was built: no kube context, and neither the API nor the database answered.
- The membership is read through the API at two instants per period, the author's decision of 2026-09-11 over giving the console a login to the reporting database. The gap against the export's overlap read is stated in the issue, in the reference and on the page.
- Helpers beyond the ones the issue names: `rollupPeriod`, `describe` and the `refusedRollup` error that carries an engine refusal up to `buildRollup`. The five failing reads are one table-driven subtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y3TgowpjK334YD1SNJjS4
