### PR TITLE
Show a resource's first event in the demo console's resource list

### DIFF
--- a/docs/reference/command-line/tally-console.md
+++ b/docs/reference/command-line/tally-console.md
@@ -28,7 +28,7 @@ environment, under the names the settings table below lists.
 | `/` | Reporting API: resource counts by cloud, resource type and state; event counts of the last 24 hours per hour; the five newest refused events. Engine: the billing periods, each linking its own page and the run that finalized it; the 20 newest runs. |
 | `/projects` | API: one page of projects, filtered by `platform`, `cloud`, `cursor`. |
 | `/project?id=` or `/project?cloud=&external_id=` | API: the project, addressed by its id or resolved from the pair a resource names it with, its relations, the projects a traversal reaches, its summary over the window `from` and `to`, this month by default, and one page of the project's resources, which the summary rows fold open into; for a meta-project, the `member_of` relations that reach it at the first and at the last instant of every billing period, and each member project. Engine: every statement of the project, grouped into the periods that were billed, for a partner what every run settles for it, and for a meta-project the billing periods, their runs, and the statements of every run that stands, through the export's own read. |
-| `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's lifetime in hours, links its project by cloud and external id, and folds its last payload. |
+| `/resources` | API: one page of up to 1000 resources under `status`, filtered by `cloud`, `project_id`, `resource_type`, `state`, `cursor`. The console reads that page one of two ways, chosen with `mode`: at the instant `at`, now by default, or over the window `from` and `to`. It prints each kept row's creation, or the first event of a history that starts without a create, and its lifetime in hours from that instant, links its project by cloud and external id, and folds its last payload. |
 | `/resource?cloud=&type=&id=` | API: the lifecycle. Engine: the newest run that metered the resource, or the one `run=` names, and its rated segments; a timeline of both. |
 | `/pricing` | Engine: the imported catalog versions. |
 | `/catalog?version=` | Engine: one catalog, parsed by the engine's own parser. |
@@ -71,15 +71,17 @@ a run wrote for the project.
 Each resource type of that summary folds open into the resources of the project
 that lived in the window, by the rule the fleet reads a window by, sorted by
 their ids, each with its state, its creation, its deletion and its lifetime in
-hours, and each linking its own page. The filter above the table matches a row
-on its type and on the resources folded under it, so a resource id finds the
-type it sits in. The two numbers come from two places: the summary counts by
-folding the events of the window, and the fold lists what the projection holds
-today, so a resource the project has since handed on is counted and not listed,
-and a type the projection holds nothing of is drawn without a fold. The
-resources are read as one page of at most 1000, the widest the API serves, and
-a project that holds more says under the table that a type may have run
-resources the fold does not name.
+hours, and each linking its own page; a resource whose history starts without
+a create shows its first event in place of its creation and counts its
+lifetime from it, as the resource list does. The filter above the table
+matches a row on its type and on the resources folded under it, so a resource
+id finds the type it sits in. The two numbers come from two places: the
+summary counts by folding the events of the window, and the fold lists what
+the projection holds today, so a resource the project has since handed on is
+counted and not listed, and a type the projection holds nothing of is drawn
+without a fold. The resources are read as one page of at most 1000, the widest
+the API serves, and a project that holds more says under the table that a
+type may have run resources the fold does not name.
 
 The statements are one row per billing period rather than one per statement. A
 period accumulates them: the regular run that billed it, every run that
@@ -374,15 +376,17 @@ does not parse is answered 400.
 
 The instant is `at`, and the page opens on it: a resource existed at it when
 it was created at or before it and not deleted at or before it; a resource
-whose history shows no create has no creation time and is taken to have
-existed all along. Without `at` the instant is now, so the page opens on what
-runs right now. The instant presets are now, which is no parameter at all, 24
-hours ago, 7 days ago, the start of this month and the start of last month.
-The instant input stays empty while nothing is pinned, so the page opens on
-now without claiming an instant was chosen.
+whose history starts without a create is taken to have existed from its first
+event, the `first_event_at` the API serves on every row, and only a row the API
+serves without one is taken to have existed all along. Without `at` the instant
+is now, so the page opens on what runs right now. The instant presets are now,
+which is no parameter at all, 24 hours ago, 7 days ago, the start of this month
+and the start of last month. The instant input stays empty while nothing is
+pinned, so the page opens on now without claiming an instant was chosen.
 
 The window is `from` and `to`, half-open: a resource existed in it when it was
-created before `to` and not deleted at or before `from`. Either bound may be
+created before `to`, or had its first event before `to` when its history starts
+without a create, and was not deleted at or before `from`. Either bound may be
 left out, which leaves the window open on that side, and a `to` that is not
 after `from` is answered 400. A window with neither bound holds every row of
 the page, whenever it lived. The window presets are the last 24 hours, the
@@ -399,14 +403,20 @@ kept for, and a page the filters emptied says so in place of the rows.
 
 Every row prints its lifetime in hours at two places: from its creation to
 its deletion, or to now for a resource still there, whatever the page is read
-at. A resource whose history starts without a create has no
-creation time, which the API leaves null and the fold reports as
-`history_starts_without_create`; the row prints `unknown` for its creation and
-its lifetime, and the line above the table counts such rows. The resource page
-names the event such a history starts with and counts the lifetime from it,
-which is where the fold starts the intervals a run bills. The last payload of
-a row is folded under a line that counts its keys, so the listing stays one
-line per row until a payload is opened.
+at. A resource whose history starts without a create has no creation time,
+which the API leaves null and the fold reports as
+`history_starts_without_create`. Its row prints the instant of its first event
+in the `created` column, followed by `, first event`, and counts its lifetime
+from that instant, which is where the fold starts the intervals a run bills;
+the line above the table counts such rows. The instant leads the cell, so
+sorting by `created` keeps such a row in time order among the creations, and
+filtering for `first event` finds such rows alone. A row the API serves
+without `first_event_at`, which only a Reporting API older than that field
+does, prints `unknown` for its creation and its lifetime and is counted on a
+line of its own. The resource page names the event such a history starts with
+and counts the lifetime from it. The last payload of a row is folded under a
+line that counts its keys, so the listing stays one line per row until a
+payload is opened.
 
 ## Theme
 

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -186,6 +186,23 @@ func lifetimeStart(resource httpapi.Resource) (start time.Time, ok bool) {
 	return resource.FirstEventAt, true
 }
 
+// firstEventMark follows the instant a created cell prints for a history that
+// starts without a create, so the cell says which instant it is.
+const firstEventMark = ", first event"
+
+// createdText is what a resource's created cell prints: its creation, the
+// instant of its first event marked as such, or unknown for a row carrying
+// neither.
+func createdText(resource httpapi.Resource) string {
+	if resource.CreatedAt != nil {
+		return stamp(*resource.CreatedAt)
+	}
+	if resource.FirstEventAt.IsZero() {
+		return unknown
+	}
+	return stamp(resource.FirstEventAt) + firstEventMark
+}
+
 // livedBetween reports whether a resource lived inside a half-open window: it
 // was created, or had its first event, before to and was not deleted at or
 // before from. A nil bound is a window open on that side, and a window with
@@ -279,17 +296,37 @@ func firstEvent(events []httpapi.StoredEvent) (httpapi.StoredEvent, bool) {
 	return first, true
 }
 
+// firstEventText is the line the resources page adds for the rows whose
+// history starts without a create and that show their first event instead,
+// and nothing when there is none.
+func firstEventText(rows int) string {
+	switch rows {
+	case 0:
+		return ""
+	case 1:
+		return "1 row has no creation, because its history starts without a create: " +
+			"it shows its first event instead, and its lifetime runs from that event"
+	default:
+		return fmt.Sprintf(
+			"%d rows have no creation, because their histories start without a create: "+
+				"they show their first event instead, and their lifetime runs from that event", rows)
+	}
+}
+
 // unknownText is the line the resources page adds for the rows whose history
-// starts without a create, and nothing when there is none.
+// starts without a create and that the API served no first event for either,
+// and nothing when there is none.
 func unknownText(rows int) string {
 	switch rows {
 	case 0:
 		return ""
 	case 1:
-		return "1 row has no creation and no lifetime, because its history starts without a create"
+		return "1 row has no creation and no lifetime, because its history starts without a create " +
+			"and the API served no first event for it"
 	default:
 		return fmt.Sprintf(
-			"%d rows have no creation and no lifetime, because their histories start without a create", rows)
+			"%d rows have no creation and no lifetime, because their histories start without a create "+
+				"and the API served no first event for them", rows)
 	}
 }
 
@@ -334,8 +371,11 @@ type fleetView struct {
 	// Empty is what the table says when the filters left nothing of a page
 	// that held rows; a page the API served empty says what it always said.
 	Empty string
-	// Unknown counts the rows kept whose history starts without a create,
-	// and is empty when there is none.
+	// FirstEvent counts the rows kept whose history starts without a create
+	// and that show their first event instead, and is empty when there is none.
+	FirstEvent string
+	// Unknown counts the rows kept whose history starts without a create and
+	// that the API served no first event for, and is empty when there is none.
 	Unknown string
 }
 
@@ -349,15 +389,16 @@ type fleetView struct {
 // nothing is pinned, so that the page opens on now without claiming an
 // instant was chosen.
 func buildFleetView(
-	r *http.Request, state fleetState, now time.Time, kept, total, unknown int, paged bool,
+	r *http.Request, state fleetState, now time.Time, kept, total, fromFirstEvent, unknown int, paged bool,
 ) fleetView {
 	values := r.URL.Query()
 	view := fleetView{
-		Path:     r.URL.Path,
-		Windowed: state.Window,
-		From:     inputValue(state.From),
-		To:       inputValue(state.To),
-		Unknown:  unknownText(unknown),
+		Path:       r.URL.Path,
+		Windowed:   state.Window,
+		From:       inputValue(state.From),
+		To:         inputValue(state.To),
+		FirstEvent: firstEventText(fromFirstEvent),
+		Unknown:    unknownText(unknown),
 	}
 	if state.Pinned {
 		view.At = state.At.UTC().Format(atLayout)

--- a/internal/console/httpui/fleet.go
+++ b/internal/console/httpui/fleet.go
@@ -31,7 +31,9 @@ import (
 // was created at or before it and not deleted at or before it. The window is
 // from and to, a half-open span: a resource existed in it when it was created
 // before to and not deleted at or before from. A window with neither bound is
-// every row the page holds, whenever it lived.
+// every row the page holds, whenever it lived. Every rule here reads a
+// resource whose history starts without a create from its first event, the
+// instant the fold starts billing it at.
 //
 // A deleted resource is only on the page when the status admits it, so
 // looking back starts with switching the status to all. Every row carries the
@@ -169,39 +171,58 @@ func keep(resource httpapi.Resource, state fleetState) bool {
 	return livedBetween(resource, state.From, state.To)
 }
 
+// lifetimeStart is the instant a resource's lifetime is counted from: its
+// creation, or for a history that starts without a create its first event,
+// which is where the fold starts the intervals a run bills. ok is false for a
+// row that carries neither, which is what a Reporting API older than
+// first_event_at serves.
+func lifetimeStart(resource httpapi.Resource) (start time.Time, ok bool) {
+	if resource.CreatedAt != nil {
+		return *resource.CreatedAt, true
+	}
+	if resource.FirstEventAt.IsZero() {
+		return time.Time{}, false
+	}
+	return resource.FirstEventAt, true
+}
+
 // livedBetween reports whether a resource lived inside a half-open window: it
-// was created before to and not deleted at or before from. A nil bound is a
-// window open on that side, and a window with neither bound holds every
-// resource, whenever it lived.
+// was created, or had its first event, before to and was not deleted at or
+// before from. A nil bound is a window open on that side, and a window with
+// neither bound holds every resource, whenever it lived.
 func livedBetween(resource httpapi.Resource, from, to *time.Time) bool {
 	if from != nil && resource.DeletedAt != nil && !resource.DeletedAt.After(*from) {
 		return false
 	}
-	if to != nil && resource.CreatedAt != nil && !resource.CreatedAt.Before(*to) {
-		return false
+	if to != nil {
+		if start, ok := lifetimeStart(resource); ok && !start.Before(*to) {
+			return false
+		}
 	}
 	return true
 }
 
 // existedAt reports whether a resource existed at an instant: created at or
 // before it, and not deleted at or before it. A resource whose history shows
-// no create has no created_at and is taken to have existed all along.
+// no create is read from its first event instead, and only a row carrying
+// neither is taken to have existed all along.
 func existedAt(resource httpapi.Resource, at time.Time) bool {
-	if resource.CreatedAt != nil && resource.CreatedAt.After(at) {
+	if start, ok := lifetimeStart(resource); ok && start.After(at) {
 		return false
 	}
 	return resource.DeletedAt == nil || resource.DeletedAt.After(at)
 }
 
-// lifetimeHours is how long a resource has lived, from its creation to its
-// deletion or to now for one still there, in hours at the two places the
-// bills carry hours at. A resource whose history shows no create has no
-// creation time, and reports that its lifetime is unknown.
+// lifetimeHours is how long a resource has lived, from its creation or, for a
+// history that shows no create, its first event, to its deletion or to now for
+// one still there, in hours at the two places the bills carry hours at. A row
+// carrying neither reports that its lifetime is unknown.
 func lifetimeHours(resource httpapi.Resource, now time.Time) (decimal.Decimal, bool) {
-	if resource.CreatedAt == nil {
+	start, ok := lifetimeStart(resource)
+	if !ok {
 		return decimal.Zero, false
 	}
-	return hoursBetween(*resource.CreatedAt, lifetimeEnd(resource, now)), true
+	return hoursBetween(start, lifetimeEnd(resource, now)), true
 }
 
 // lifetimeEnd is where a lifetime stops: the deletion, or now for a resource

--- a/internal/console/httpui/fleet_test.go
+++ b/internal/console/httpui/fleet_test.go
@@ -115,12 +115,41 @@ func TestExistedAt(t *testing.T) {
 		{"deleted after the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, between, true},
 		{"deleted at the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, deleted, false},
 		{"deleted before the instant", httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}, deleted.Add(time.Hour), false},
-		{"a history without a create", httpapi.Resource{}, before, true},
-		{"a history without a create that ended", httpapi.Resource{DeletedAt: &deleted}, deleted.Add(time.Hour), false},
+		{"a history without a create before its first event", httpapi.Resource{FirstEventAt: created}, before, false},
+		{"a history without a create at its first event", httpapi.Resource{FirstEventAt: created}, created, true},
+		{"a history without a create after its first event", httpapi.Resource{FirstEventAt: created}, between, true},
+		{"a history without a create that ended", httpapi.Resource{FirstEventAt: created, DeletedAt: &deleted}, deleted.Add(time.Hour), false},
+		{"a row with neither a creation nor a first event", httpapi.Resource{}, before, true},
+		{"a row with neither a creation nor a first event that ended", httpapi.Resource{DeletedAt: &deleted}, deleted.Add(time.Hour), false},
 	}
 	for _, tc := range cases {
 		if got := existedAt(tc.resource, tc.at); got != tc.want {
 			t.Errorf("%s: existedAt() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestLifetimeStart(t *testing.T) {
+	t.Parallel()
+
+	first := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	created := first.Add(24 * time.Hour)
+
+	cases := []struct {
+		name     string
+		resource httpapi.Resource
+		want     time.Time
+		ok       bool
+	}{
+		{"a creation", httpapi.Resource{CreatedAt: &first}, first, true},
+		{"a first event without a creation", httpapi.Resource{FirstEventAt: first}, first, true},
+		{"a creation after the first event", httpapi.Resource{CreatedAt: &created, FirstEventAt: first}, created, true},
+		{"neither", httpapi.Resource{}, time.Time{}, false},
+	}
+	for _, tc := range cases {
+		got, ok := lifetimeStart(tc.resource)
+		if !got.Equal(tc.want) || ok != tc.ok {
+			t.Errorf("%s: lifetimeStart() = %v, %v, want %v, %v", tc.name, got, ok, tc.want, tc.ok)
 		}
 	}
 }
@@ -162,8 +191,23 @@ func TestLifetimeHours(t *testing.T) {
 		t.Errorf("a resource still there = %s, %v, want 348 hours to now", hours, lived)
 	}
 
+	hours, lived = lifetimeHours(httpapi.Resource{FirstEventAt: created}, testNow)
+	if !lived || hours.String() != "348" {
+		t.Errorf("a history without a create = %s, %v, want 348 hours from its first event", hours, lived)
+	}
+
+	hours, lived = lifetimeHours(httpapi.Resource{FirstEventAt: created, DeletedAt: &deleted}, testNow)
+	if !lived || hours.String() != "1.5" {
+		t.Errorf("a deleted history without a create = %s, %v, want 1.5 hours", hours, lived)
+	}
+
+	hours, lived = lifetimeHours(httpapi.Resource{CreatedAt: &created, FirstEventAt: created.Add(-24 * time.Hour)}, testNow)
+	if !lived || hours.String() != "348" {
+		t.Errorf("a creation after the first event = %s, %v, want 348 hours from the creation", hours, lived)
+	}
+
 	if _, lived = lifetimeHours(httpapi.Resource{}, testNow); lived {
-		t.Error("a history without a create has a lifetime")
+		t.Error("a row with neither a creation nor a first event has a lifetime")
 	}
 
 	later := testNow.Add(time.Hour)
@@ -196,6 +240,10 @@ func TestKeep(t *testing.T) {
 	deleted := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
 	gone := httpapi.Resource{CreatedAt: &created, DeletedAt: &deleted}
 	alive := httpapi.Resource{CreatedAt: &created}
+	// orphan is gone's history without its create, and unplaced is one the API
+	// served no first event for either.
+	orphan := httpapi.Resource{FirstEventAt: created, DeletedAt: &deleted}
+	unplaced := httpapi.Resource{DeletedAt: &deleted}
 	at := func(day int) time.Time { return time.Date(2026, 3, day, 0, 0, 0, 0, time.UTC) }
 	window := func(from, to int) fleetState {
 		f, t := at(from), at(to)
@@ -221,6 +269,10 @@ func TestKeep(t *testing.T) {
 		{"a window without a bound keeps what is long gone", gone, fleetState{Window: true}, true},
 		{"an instant keeps what existed at it", gone, fleetState{At: at(5), Pinned: true}, true},
 		{"an instant drops what was gone by then", gone, fleetState{At: at(11), Pinned: true}, false},
+		{"a window drops a history without a create that began at its end", orphan, window(1, 3), false},
+		{"a window keeps a history without a create that began in it", orphan, window(1, 5), true},
+		{"a window open at the start drops a history without a create that began at the end", orphan, fleetState{Window: true, To: pointerTo(at(3))}, false},
+		{"a window keeps a row with neither a creation nor a first event", unplaced, window(1, 3), true},
 	}
 	for _, tc := range cases {
 		if got := keep(tc.resource, tc.state); got != tc.want {

--- a/internal/console/httpui/fleet_test.go
+++ b/internal/console/httpui/fleet_test.go
@@ -154,6 +154,65 @@ func TestLifetimeStart(t *testing.T) {
 	}
 }
 
+func TestCreatedText(t *testing.T) {
+	t.Parallel()
+
+	instant := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		resource httpapi.Resource
+		want     string
+	}{
+		{"a creation", httpapi.Resource{CreatedAt: &instant}, "2026-03-01T00:00:00Z"},
+		{"a first event without a creation", httpapi.Resource{FirstEventAt: instant}, "2026-03-01T00:00:00Z, first event"},
+		{"neither", httpapi.Resource{}, "unknown"},
+	}
+	for _, tc := range cases {
+		if got := createdText(tc.resource); got != tc.want {
+			t.Errorf("%s: createdText() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestWithoutCreateText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"no row with a first event", firstEventText(0), ""},
+		{
+			"one row with a first event", firstEventText(1),
+			"1 row has no creation, because its history starts without a create: " +
+				"it shows its first event instead, and its lifetime runs from that event",
+		},
+		{
+			"two rows with a first event", firstEventText(2),
+			"2 rows have no creation, because their histories start without a create: " +
+				"they show their first event instead, and their lifetime runs from that event",
+		},
+		{"no row without either", unknownText(0), ""},
+		{
+			"one row without either", unknownText(1),
+			"1 row has no creation and no lifetime, because its history starts without a create " +
+				"and the API served no first event for it",
+		},
+		{
+			"two rows without either", unknownText(2),
+			"2 rows have no creation and no lifetime, because their histories start without a create " +
+				"and the API served no first event for them",
+		},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
 func TestScale(t *testing.T) {
 	t.Parallel()
 

--- a/internal/console/httpui/funcs.go
+++ b/internal/console/httpui/funcs.go
@@ -15,8 +15,9 @@ import (
 // absent is what a template prints where a value is not there: a timestamp
 // that was never written, a payload nothing stored, a modifier map a catalog
 // entry left out. unknown is what it prints where a value exists but the
-// console cannot know it: the creation of a resource whose history starts
-// without a create, and the lifetime that would follow from it.
+// console cannot know it: the creation and the lifetime of a resource whose
+// history starts without a create when the API served no first event for it
+// either, and on a resource page the creation of such a history.
 const (
 	absent  = "none"
 	unknown = "unknown"
@@ -33,7 +34,6 @@ func funcMap() template.FuncMap {
 		"price":         price,
 		"stamp":         stamp,
 		"optStamp":      optStamp,
-		"unknownStamp":  unknownStamp,
 		"zeroStamp":     zeroStamp,
 		"idText":        idText,
 		"optString":     optString,
@@ -104,15 +104,6 @@ func stamp(t time.Time) string {
 func optStamp(t *time.Time) string {
 	if t == nil {
 		return absent
-	}
-	return stamp(*t)
-}
-
-// unknownStamp renders an instant the API leaves null because it does not
-// know it, the creation of a resource whose history starts without a create.
-func unknownStamp(t *time.Time) string {
-	if t == nil {
-		return unknown
 	}
 	return stamp(*t)
 }

--- a/internal/console/httpui/httpui_test.go
+++ b/internal/console/httpui/httpui_test.go
@@ -606,6 +606,7 @@ func fullAPI(t *testing.T) *fakeAPI {
 		State:         "active",
 		Size:          map[string]interface{}{"vcpus": 4},
 		CreatedAt:     &created,
+		FirstEventAt:  created,
 		LastEventAt:   created,
 		LastEventType: "instance.create.end",
 		LastPayload:   &map[string]interface{}{"state": "active"},
@@ -5043,35 +5044,217 @@ func TestHistoryWithoutCreate(t *testing.T) {
 	t.Parallel()
 
 	// orphan is the fixture's resource without a creation, the way the API
-	// serves a history that starts without a create.
+	// serves a history that starts without a create: no created_at, and the
+	// first event at the instant the history opens with.
 	orphan := func(t *testing.T) *fakeAPI {
 		t.Helper()
 
 		api := fullAPI(t)
 		api.resources.Items[0].CreatedAt = nil
+		api.resources.Items[0].FirstEventAt = testPeriod
 		api.lifecycle.Resource.CreatedAt = nil
 		api.lifecycle.Warnings = []string{"history_starts_without_create"}
 		return api
 	}
 
-	t.Run("the listing says the creation and the lifetime are unknown", func(t *testing.T) {
+	t.Run("the listing shows the first event and counts the lifetime from it", func(t *testing.T) {
 		t.Parallel()
 
 		handler, _ := serve(t, orphan(t), fullStore(t), testNow)
 
 		_, body, _ := get(t, handler, "/resources")
 		for _, want := range []string{
-			"<td>unknown</td>\n<td>none</td>\n<td class=\"number\">unknown</td>",
-			"1 row has no creation and no lifetime, because its history starts without a create</p>",
+			"<td>2026-03-01T00:00:00Z, first event</td>\n<td>none</td>\n<td class=\"number\">348.00</td>",
+			"; 1 row has no creation, because its history starts without a create: " +
+				"it shows its first event instead, and its lifetime runs from that event</p>",
 		} {
 			if !strings.Contains(body, want) {
 				t.Errorf("the listing lacks %q:\n%s", want, body)
 			}
 		}
+		if strings.Contains(body, "<td>unknown</td>") {
+			t.Errorf("the listing still calls the creation unknown:\n%s", body)
+		}
+	})
 
-		handler, _ = serve(t, fullAPI(t), fullStore(t), testNow)
-		if _, body, _ = get(t, handler, "/resources"); strings.Contains(body, "no creation") {
-			t.Error("a fleet with every creation known is told about unknown ones")
+	t.Run("a fleet with every creation known is told about neither", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, fullAPI(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources")
+		for _, unwanted := range []string{"no creation", ", first event"} {
+			if strings.Contains(body, unwanted) {
+				t.Errorf("a fleet with every creation known carries %q:\n%s", unwanted, body)
+			}
+		}
+	})
+
+	t.Run("an empty page counts nothing", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.Items = nil
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/resources")
+		if status != http.StatusOK || !strings.Contains(body, "no resource matched") {
+			t.Errorf("status = %d, body:\n%s", status, body)
+		}
+		for _, unwanted := range []string{"no creation", "first event"} {
+			if strings.Contains(body, unwanted) {
+				t.Errorf("an empty page carries %q:\n%s", unwanted, body)
+			}
+		}
+	})
+
+	t.Run("a row the API served without a first event stays unknown", func(t *testing.T) {
+		t.Parallel()
+
+		// A Reporting API older than first_event_at serves no such member,
+		// which the client decodes as the zero instant.
+		api := orphan(t)
+		api.resources.Items[0].FirstEventAt = time.Time{}
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources")
+		for _, want := range []string{
+			"<td>unknown</td>\n<td>none</td>\n<td class=\"number\">unknown</td>",
+			"; 1 row has no creation and no lifetime, because its history starts without a create " +
+				"and the API served no first event for it</p>",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the listing lacks %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, "first event</td>") {
+			t.Errorf("the listing names a first event it was not served:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, "/project?id="+testProjectID.String())
+		activity := section(t, body, "What this project ran", "Statements")
+		for _, want := range []string{"<td>unknown</td>", `<td class="number">unknown</td>`} {
+			if !strings.Contains(activity, want) {
+				t.Errorf("the fold lacks %q:\n%s", want, activity)
+			}
+		}
+	})
+
+	t.Run("the instant and the window place the row at its first event", func(t *testing.T) {
+		t.Parallel()
+
+		api := orphan(t)
+		api.resources.Items[0].FirstEventAt = testPeriod.Add(48 * time.Hour)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?at=2026-03-02T00:00:00Z")
+		if strings.Contains(body, ">vm-1</a>") || !strings.Contains(body, "0 of 1 row existed at 2026-03-02T00:00:00Z") {
+			t.Errorf("the row is on the page before its first event:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, "/resources?at=2026-03-03T00:00:00Z")
+		for _, want := range []string{
+			">vm-1</a>",
+			"1 of 1 row existed at 2026-03-03T00:00:00Z",
+			`<td class="number">300.00</td>`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("the page at the first event lacks %q:\n%s", want, body)
+			}
+		}
+
+		_, body, _ = get(t, handler, "/resources?from=2026-02-01T00:00:00Z&to=2026-03-03T00:00:00Z")
+		if !strings.Contains(body, "no resource of this page existed between 2026-02-01T00:00:00Z and 2026-03-03T00:00:00Z") {
+			t.Errorf("a window ending at the first event keeps the row:\n%s", body)
+		}
+	})
+
+	t.Run("sorting and filtering by the creation place the first event among the creations", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		second := api.resources.Items[0]
+		second.ResourceId, second.CreatedAt, second.FirstEventAt = "vm-2", nil, testPeriod.Add(-24*time.Hour)
+		api.resources.Items = append(api.resources.Items, second)
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/resources?resources.sort=created")
+		earlier, later := strings.Index(body, ">vm-2</a>"), strings.Index(body, ">vm-1</a>")
+		if earlier < 0 || later < 0 || earlier > later {
+			t.Errorf("sorting by the creation does not put the earlier first event first:\n%s", body)
+		}
+
+		_, body, _ = get(t, handler, "/resources?resources.q=first+event")
+		if !strings.Contains(body, ">vm-2</a>") || strings.Contains(body, ">vm-1</a>") {
+			t.Errorf("filtering for the first event keeps the wrong rows:\n%s", body)
+		}
+	})
+
+	t.Run("the project page folds the row open from its first event", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, orphan(t), fullStore(t), testNow)
+
+		_, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		activity := section(t, body, "What this project ran", "Statements")
+		for _, want := range []string{"<td>2026-03-01T00:00:00Z, first event</td>", `<td class="number">348.00</td>`} {
+			if !strings.Contains(activity, want) {
+				t.Errorf("the fold lacks %q:\n%s", want, activity)
+			}
+		}
+	})
+
+	t.Run("a project window before the first event folds nothing", func(t *testing.T) {
+		t.Parallel()
+
+		handler, _ := serve(t, orphan(t), fullStore(t), testNow)
+
+		// Taken to have existed all along, the row would be folded here.
+		_, body, _ := get(t, handler,
+			"/project?id="+testProjectID.String()+"&from=2026-02-01T00:00&to=2026-02-15T00:00")
+		activity := section(t, body, "What this project ran", "Statements")
+		if strings.Contains(activity, ">vm-1</a>") || !strings.Contains(activity, "<td>instance</td>") {
+			t.Errorf("a window before the first event folds the row open:\n%s", activity)
+		}
+	})
+
+	t.Run("a project without resources folds nothing", func(t *testing.T) {
+		t.Parallel()
+
+		api := fullAPI(t)
+		api.resources.Items = nil
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		status, body, _ := get(t, handler, "/project?id="+testProjectID.String())
+		activity := section(t, body, "What this project ran", "Statements")
+		if status != http.StatusOK || !strings.Contains(activity, "<td>instance</td>") {
+			t.Errorf("status = %d, the fold:\n%s", status, activity)
+		}
+		for _, unwanted := range []string{"first event", "unknown"} {
+			if strings.Contains(activity, unwanted) {
+				t.Errorf("an empty fold carries %q:\n%s", unwanted, activity)
+			}
+		}
+	})
+
+	t.Run("a first event the client could not decode fails both pages", func(t *testing.T) {
+		t.Parallel()
+
+		endpoint := "https://api.example/api/v1/resources"
+		api := fullAPI(t)
+		// What the client returns for a first_event_at that is not an instant.
+		api.resourcesErr = fmt.Errorf("decoding the answer of %s: %w", endpoint, errors.New(
+			`parsing time "yesterday" as "2006-01-02T15:04:05Z07:00": cannot parse "yesterday" as "2006"`))
+		handler, _ := serve(t, api, fullStore(t), testNow)
+
+		for _, path := range []string{"/resources", "/project?id=" + testProjectID.String()} {
+			status, body, _ := get(t, handler, path)
+			if status != http.StatusBadGateway || !strings.Contains(body, "the Reporting API call failed") {
+				t.Errorf("%s: status = %d, body:\n%s", path, status, body)
+			}
+			if !strings.Contains(body, endpoint) {
+				t.Errorf("%s: the page does not name the endpoint:\n%s", path, body)
+			}
 		}
 	})
 

--- a/internal/console/httpui/projects.go
+++ b/internal/console/httpui/projects.go
@@ -76,12 +76,14 @@ type activityRow struct {
 	Searched  string
 }
 
-// projectResourceRow is one resource under a type, its own page, and how long
-// it has lived. It is the resources page's row without the columns that only
-// make sense beside resources of other projects.
+// projectResourceRow is one resource under a type, its own page, what its
+// created cell prints, and how long it has lived. It is the resources page's
+// row without the columns that only make sense beside resources of other
+// projects.
 type projectResourceRow struct {
 	Resource httpapi.Resource
 	Link     string
+	Created  string
 	Lifetime decimal.Decimal
 	Lived    bool
 }
@@ -423,6 +425,7 @@ func activityRows(
 			Resource: resource,
 			Link: link("/resource",
 				"cloud", resource.Cloud, "type", resource.ResourceType, "id", resource.ResourceId),
+			Created:  createdText(resource),
 			Lifetime: lifetime,
 			Lived:    lived,
 		})

--- a/internal/console/httpui/resources.go
+++ b/internal/console/httpui/resources.go
@@ -28,20 +28,23 @@ var resourceColumns = []column[resourceRow]{
 	textCol("resource type", func(r resourceRow) string { return r.Resource.ResourceType }),
 	textCol("resource", func(r resourceRow) string { return r.Resource.ResourceId }),
 	textCol("state", func(r resourceRow) string { return r.Resource.State }),
-	textCol("created", func(r resourceRow) string { return unknownStamp(r.Resource.CreatedAt) }),
+	textCol("created", func(r resourceRow) string { return r.Created }),
 	textCol("deleted", func(r resourceRow) string { return optStamp(r.Resource.DeletedAt) }),
 	numberCol("lifetime hours", func(r resourceRow) decimal.Decimal { return r.Lifetime }),
 	textCol("last payload", func(r resourceRow) string { return pretty(r.Resource.LastPayload) }),
 }
 
-// resourceRow is one resource, its own page, the page of its project, how
-// long it has lived, and what its folded payload says.
+// resourceRow is one resource, its own page, the page of its project, what
+// its created cell prints, how long it has lived, and what its folded payload
+// says.
 type resourceRow struct {
 	Resource    httpapi.Resource
 	Link        string
 	ProjectLink string
-	// Lifetime is the resource's hours from creation to deletion or to now,
-	// and Lived is false for a resource whose history shows no create.
+	Created     string
+	// Lifetime is the resource's hours from its creation, or its first event
+	// for a history that shows no create, to deletion or to now, and Lived is
+	// false only for a row carrying neither.
 	Lifetime       decimal.Decimal
 	Lived          bool
 	PayloadSummary string
@@ -123,20 +126,26 @@ func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows := make([]resourceRow, 0, len(list.Items))
-	unknown := 0
+	// A row without a creation is counted by what it shows instead: its first
+	// event, or unknown when the API served none.
+	fromFirstEvent, unknown := 0, 0
 	for _, resource := range list.Items {
 		if !keep(resource, fleet) {
 			continue
 		}
 		lifetime, lived := lifetimeHours(resource, now)
-		if !lived {
+		switch {
+		case !lived:
 			unknown++
+		case resource.CreatedAt == nil:
+			fromFirstEvent++
 		}
 		rows = append(rows, resourceRow{
 			Resource: resource,
 			Link: link("/resource",
 				"cloud", resource.Cloud, "type", resource.ResourceType, "id", resource.ResourceId),
 			ProjectLink:    projectLink(resource.Cloud, resource.ProjectId),
+			Created:        createdText(resource),
 			Lifetime:       lifetime,
 			Lived:          lived,
 			PayloadSummary: payloadSummary(resource.LastPayload),
@@ -147,7 +156,7 @@ func (h *handlers) resources(w http.ResponseWriter, r *http.Request) {
 	// reached by a cursor: a fleet that fits one page is the whole fleet.
 	paged := list.NextCursor != nil || query.Cursor != ""
 	data := resourcesData{
-		Fleet: buildFleetView(r, fleet, now, len(rows), len(list.Items), unknown, paged),
+		Fleet: buildFleetView(r, fleet, now, len(rows), len(list.Items), fromFirstEvent, unknown, paged),
 		Items: tabulate(r, resourceTable, resourceColumns, rows),
 	}
 	if paged {

--- a/internal/console/httpui/templates/project.gohtml
+++ b/internal/console/httpui/templates/project.gohtml
@@ -78,7 +78,7 @@
 {{range .Resources}}<tr>
 <td><a href="{{.Link}}">{{.Resource.ResourceId}}</a></td>
 <td>{{.Resource.State}}</td>
-<td>{{unknownStamp .Resource.CreatedAt}}</td>
+<td>{{.Created}}</td>
 <td>{{optStamp .Resource.DeletedAt}}</td>
 <td class="number">{{if .Lived}}{{amount .Lifetime}}{{else}}unknown{{end}}</td>
 </tr>

--- a/internal/console/httpui/templates/resources.gohtml
+++ b/internal/console/httpui/templates/resources.gohtml
@@ -13,7 +13,7 @@
 {{end}}<button type="submit">apply</button>
 </form>
 <p class="presets">{{range .Fleet.Presets}}<a href="{{.Link}}"{{if .Current}} aria-current="true"{{end}}>{{.Label}}</a>{{end}}</p>
-<p class="axis">every instant is UTC; a lifetime runs from the creation to the deletion, or to now{{if .Fleet.Unknown}}; {{.Fleet.Unknown}}{{end}}</p>
+<p class="axis">every instant is UTC; a lifetime runs from the creation to the deletion, or to now{{if .Fleet.FirstEvent}}; {{.Fleet.FirstEvent}}{{end}}{{if .Fleet.Unknown}}; {{.Fleet.Unknown}}{{end}}</p>
 </div>
 {{template "tableTools" .Items.Table}}
 <table>
@@ -26,7 +26,7 @@
 <td>{{.Resource.ResourceType}}</td>
 <td><a href="{{.Link}}">{{.Resource.ResourceId}}</a></td>
 <td>{{.Resource.State}}</td>
-<td>{{unknownStamp .Resource.CreatedAt}}</td>
+<td>{{.Created}}</td>
 <td>{{optStamp .Resource.DeletedAt}}</td>
 <td class="number">{{if .Lived}}{{amount .Lifetime}}{{else}}unknown{{end}}</td>
 <td>{{if .PayloadSummary}}<details class="cell"><summary>{{.PayloadSummary}}</summary><pre>{{pretty .Resource.LastPayload}}</pre></details>{{else}}none{{end}}</td>


### PR DESCRIPTION
Closes #138

The demo console's resource list and the resource fold on a project page now read `first_event_at` where `created_at` is null. Such a row prints its first event in the created cell as `2026-03-01T00:00:00Z, first event`, counts its lifetime from that instant, and is placed at it by the instant and window filters. Before, it printed `unknown` twice and counted as having existed all along. A row whose `created_at` is set is unchanged. A row the API serves without `first_event_at`, which only a Reporting API older than #127 does, keeps the `unknown` path and is counted on a line of its own.

## Commits

1. `1596eeb` Place a resource without a create at its first event. `lifetimeStart` in `internal/console/httpui/fleet.go` returns the creation, else the first event, else nothing, and `existedAt`, `livedBetween` and `lifetimeHours` read it. Tests: `TestLifetimeStart`, plus first-event cases in `TestExistedAt`, `TestKeep` and `TestLifetimeHours`.
2. `b7850c2` Show a resource's first event in its created cell. `createdText` and `firstEventMark` feed a new `Created` field on `resourceRow` and `projectResourceRow`, which both templates print and the `created` column sorts and filters on. The axis line gains `firstEventText` beside the reworded `unknownText`, counted by `fromFirstEvent` and `unknown`. `unknownStamp` is deleted. Tests: `TestCreatedText`, `TestWithoutCreateText`, `FirstEventAt` on the `fullAPI` fixture, and `TestHistoryWithoutCreate` with ten new subtests.
3. `502ff7d` Document the first event in the console reference: five passages of `docs/reference/command-line/tally-console.md`.

## Verification

- `go build ./...` and `go vet ./...` pass.
- `go test -count=1 ./internal/console/... ./docs/` passes, including the store integration tests through Docker.
- `make lint` reports 0 issues, and `npm run docs:build` passes.
- The new page subtests were first run against unchanged `main`: six of them failed there. All 13 subtests of `TestHistoryWithoutCreate` pass on this branch.
- Not run: the two dev-cluster criteria (a month simulated with `SIM_FAULTS=missing-create`, compared against the API's own count and against the resource page). No dev cluster was up: there was no kube context, the API answered 000, and port 5432 was closed.

## Deviation from the plan

- The `orphan` test helper sets `FirstEventAt` itself, in addition to the fixture carrying it, so the helper does not depend on the fixture's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sSyZNhW5nEv1pU1yzmjdw
