### PR TITLE
Ship the OpenStack collector as a Debian package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,36 @@ jobs:
       - name: alerting
         run: make check-alerting
 
+      # go test ./packaging/ reads the package definition; only a build says
+      # whether nfpm accepts it and dpkg accepts the result, and only an install
+      # exercises the maintainer scripts. The runner is Debian-derived and
+      # carries dpkg, apt and systemd, so this is the one place that runs them.
+      - name: package
+        run: |
+          set -euo pipefail
+          make deb
+          deb=$(echo dist/*.deb)
+          sudo apt-get install -y "./${deb}"
+          dpkg-deb --contents "${deb}"
+          # The ownership dpkg could not resolve at unpack time, applied by
+          # postinstall.sh once the tally user existed.
+          getent passwd tally
+          test "$(stat -c '%U:%G:%a' /var/lib/tally/collector)" = 'tally:tally:750'
+          test "$(stat -c '%U:%G:%a' /etc/tally/ingest-token)" = 'root:tally:640'
+          # An install configures nothing, so it starts nothing. is-enabled
+          # answers 1 for a disabled unit, which set -e would read as a failure.
+          test "$(systemctl is-enabled tally-openstack-collector || true)" = 'disabled'
+          # Catches a hardening directive systemd would otherwise ignore.
+          systemd-analyze verify /lib/systemd/system/tally-openstack-collector.service
+          # A purge keeps the outbox and drops the credentials. Only tally may
+          # enter the outbox directory, so that check runs under sudo: the
+          # runner cannot stat through a 0750 directory it is not in the group
+          # of, and would read the file it kept as a file that is gone.
+          sudo touch /var/lib/tally/collector/outbox.db
+          sudo apt-get purge -y tally-openstack-collector
+          sudo test -e /var/lib/tally/collector/outbox.db
+          test ! -e /etc/tally/ingest-token
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ OAPI_CODEGEN_VERSION ?= v2.8.0
 SQLC_VERSION ?= v1.31.1
 GOLANGCI_LINT_VERSION ?= v2.13.2
 
+# The packager `deb` builds the collector's Debian package with, from the same
+# module cache as the three above.
+NFPM_VERSION ?= v2.47.0
+
+# What `deb` stamps into the package, and the architecture it builds for. The
+# repository carries no tags, so the default is a development version that
+# every release sorts above: dpkg reads 0.0.0+dev as lower than 0.1.0. A build
+# that is going somewhere passes its own, as `make deb DEB_VERSION=0.1.0`.
+DEB_VERSION ?= 0.0.0+dev
+DEB_GOARCH ?= amd64
+
 CLUSTER_NAME ?= tally
 NAMESPACE ?= tally
 DEV_OVERLAY := deploy/kubernetes/overlays/dev
@@ -198,7 +209,7 @@ VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' depl
 ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
 
 .PHONY: check-tools up down dev ca test lint fmt check-alerting migrate generate \
-	images simulator-up simulator-down console demo demo-drain demo-registry \
+	images deb simulator-up simulator-down console demo demo-drain demo-registry \
 	demo-bill demo-correct docs docs-build
 
 # What `check-tools` holds the Docker engine to. One kind node runs the whole
@@ -383,6 +394,23 @@ images:
 		echo "==> building $$service"; \
 		docker build --build-arg "CMD=$$service" -t "$$service:dev" .; \
 	done
+
+# The collector is the one binary that runs on a host rather than in a cluster,
+# so it is the one that is packaged. The build flags are the Dockerfile's, so
+# the packaged binary is the image's binary. nfpm reads VERSION and GOARCH out
+# of its environment, which is why they are exported here rather than written
+# into nfpm.yaml. Docker is not involved, and neither is a tool on the host:
+# this runs on macOS as well, where the .deb it writes can be read with
+# `ar x` and `tar tzvf data.tar.gz`.
+## deb: build the Debian package of the OpenStack collector into dist/
+deb:
+	GOOS=linux GOARCH=$(DEB_GOARCH) CGO_ENABLED=0 go build -trimpath \
+		-ldflags='-s -w' -o bin/tally-openstack-collector-linux-$(DEB_GOARCH) \
+		./cmd/tally-openstack-collector
+	mkdir -p dist
+	GOARCH=$(DEB_GOARCH) VERSION='$(DEB_VERSION)' \
+		go run github.com/goreleaser/nfpm/v2/cmd/nfpm@$(NFPM_VERSION) \
+		package --packager deb --target dist/
 
 ## down: delete the kind cluster
 down:

--- a/cmd/tally-reporting/main_test.go
+++ b/cmd/tally-reporting/main_test.go
@@ -209,12 +209,23 @@ func freePort(t *testing.T) int {
 	return addr.Port
 }
 
+// testClient is what every request in this file goes through. It reuses no
+// connection: the transport pools one it never sent a request on when a dial
+// and a freed idle connection race, and net/http holds Server.Shutdown for five
+// seconds over such a connection before it counts it as idle. That is longer
+// than the budget the shutdown assertions allow, so a pooled connection turns
+// them into a coin flip. Nothing here is hot enough to miss the reuse.
+var testClient = &http.Client{
+	Timeout:   startupTimeout,
+	Transport: &http.Transport{DisableKeepAlives: true},
+}
+
 // get reads one URL off the running server and returns the body and the status
 // it answered with.
 func get(t *testing.T, url string) (string, int) {
 	t.Helper()
 
-	resp, err := (&http.Client{Timeout: startupTimeout}).Get(url)
+	resp, err := testClient.Get(url)
 	if err != nil {
 		t.Fatalf("GET %s: %v", url, err)
 	}
@@ -233,7 +244,6 @@ func get(t *testing.T, url string) (string, int) {
 func waitForHealthz(t *testing.T, port int, done <-chan error) {
 	t.Helper()
 
-	client := &http.Client{Timeout: startupTimeout}
 	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
 
 	for deadline := time.Now().Add(startupTimeout); time.Now().Before(deadline); {
@@ -243,7 +253,7 @@ func waitForHealthz(t *testing.T, port int, done <-chan error) {
 		default:
 		}
 
-		resp, err := client.Get(url)
+		resp, err := testClient.Get(url)
 		if err != nil {
 			time.Sleep(10 * time.Millisecond)
 			continue

--- a/docs/.vitepress/proper-nouns.txt
+++ b/docs/.vitepress/proper-nouns.txt
@@ -4,6 +4,7 @@ Gardener
 Harbor
 Hetzner
 Ceilometer
+Debian
 Grafana
 Pushgateway
 Tally

--- a/docs/.vitepress/sidebar.json
+++ b/docs/.vitepress/sidebar.json
@@ -48,6 +48,7 @@
           "text": "OpenStack provider",
           "collapsed": true,
           "items": [
+            { "text": "Install the collector from the Debian package", "link": "/how-to/openstack/install-the-debian-package" },
             { "text": "Connect the collector to an OpenStack cloud", "link": "/how-to/openstack/connect-the-collector" },
             { "text": "Issue and revoke credentials", "link": "/how-to/openstack/issue-and-revoke-credentials" },
             { "text": "Verify a deployment with the dump", "link": "/how-to/openstack/verify-a-deployment-with-the-dump" },

--- a/docs/contributing/dev-stack.md
+++ b/docs/contributing/dev-stack.md
@@ -396,6 +396,13 @@ line, as in `make up WAIT_ATTEMPTS=12`.
   builds the server types with.
 - `SQLC_VERSION` (`v1.31.1`) is the sqlc release `generate` builds the query
   code with.
+- `NFPM_VERSION` (`v2.47.0`) is the nfpm release `deb` builds the Debian
+  package with, from the same module cache as the three above.
+- `DEB_VERSION` (`0.0.0+dev`) is the version `deb` stamps into that package.
+  The repository carries no tags, so the default is a development version every
+  release sorts above; a build that is going somewhere passes its own.
+- `DEB_GOARCH` (`amd64`) is the architecture `deb` cross-compiles and packages
+  for.
 - The `SIM_` set belongs to the simulator stack and is in the table above,
   and the `DEMO_` set belongs to `demo` and is in the table under
   [the demo](#the-demo).

--- a/docs/contributing/dev-stack.md
+++ b/docs/contributing/dev-stack.md
@@ -355,6 +355,7 @@ The table below is rendered from the `## target: description` comments of the
 | `check-tools` | check that the tools the dev stack and the tutorials need answer |
 | `up` | create the kind cluster, install the add-ons, and deploy the dev overlay |
 | `images` | build one container image per binary |
+| `deb` | build the Debian package of the OpenStack collector into dist/ |
 | `down` | delete the kind cluster |
 | `dev` | rebuild and redeploy on change |
 | `simulator-up` | run the simulator, the collector, and a broker against the dev cluster |

--- a/docs/contributing/toolchain.md
+++ b/docs/contributing/toolchain.md
@@ -99,6 +99,43 @@ broker rather than in the cluster.
 directories, `docs/.vitepress/dist/` and `docs/.vitepress/cache/`, out of the
 build context.
 
+## Debian package
+
+`make deb` builds `tally-openstack-collector` as a `.deb` into `dist/`. The
+collector is the one binary that runs on a host rather than in a cluster, next
+to the broker of an OpenStack control plane, so it is the one that is packaged;
+everything else ships as an image.
+
+The target cross-compiles `linux/$(DEB_GOARCH)` with the `Dockerfile`'s build
+flags, so the packaged binary is the image's binary, and then runs
+[nfpm](https://nfpm.goreleaser.com/) at `NFPM_VERSION` (`v2.47.0`) from the
+module cache. Nothing is installed on the host and Docker is not involved, so
+the target runs on macOS as well; reading the result there takes `ar x` and
+`tar tzvf data.tar.gz`, because macOS has no `dpkg-deb`.
+
+`nfpm.yaml` at the repository root is the package definition, and `packaging/`
+holds what it installs:
+
+| Path | Content |
+| --- | --- |
+| `/usr/bin/tally-openstack-collector` | the static binary |
+| `/lib/systemd/system/tally-openstack-collector.service` | the unit, running as the `tally` system user |
+| `/etc/default/tally-openstack-collector` | every variable with its default, a conffile |
+| `/etc/tally/amqp-url`, `/etc/tally/ingest-token` | the two secrets, `0640 root:tally`, conffiles shipped empty |
+| `/var/lib/tally/collector/` | the outbox directory, `0750 tally:tally` |
+
+`postinstall.sh` creates the `tally` user and group and applies the ownership
+dpkg cannot resolve at unpack time; `preremove.sh` stops and disables the unit;
+`postremove.sh` drops `/etc/tally` on purge and keeps the outbox, because
+between the acknowledgement on the bus and the delivery an event lives in that
+file and nowhere else.
+
+`packaging/packaging_test.go` pins all of it to `openstack.EnvNames` and to the
+paths the unit uses, and it reads files rather than building, so it needs
+neither Docker nor dpkg. The `package` step of `.github/workflows/ci.yaml` is
+what builds, installs, verifies and purges the package on a runner. Publishing
+it on a tagged release is not set up yet.
+
 ## Dependencies
 
 `go.mod` and `go.sum` pin every module the build resolves. Renovate proposes

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -23,6 +23,10 @@ Tally sit together.
 
 ### OpenStack provider
 
+- [Install the collector from the Debian package](/how-to/openstack/install-the-debian-package)
+  puts one collector on a control node as a systemd service, with its
+  credentials in files only it may read, and upgrades, removes or purges it
+  again.
 - [Connect the collector to an OpenStack cloud](/how-to/openstack/connect-the-collector)
   points one collector at one cloud, so its services publish the notifications
   the collector reads and that cloud's events arrive at the Reporting API.

--- a/docs/how-to/openstack/connect-the-collector.md
+++ b/docs/how-to/openstack/connect-the-collector.md
@@ -27,6 +27,11 @@ Reporting API. What the collector guarantees between those two ends is in
   has those steps.
 - The [collector settings](/reference/configuration/tally-openstack-collector)
   page, which lists every variable this guide sets with its default.
+- A collector to point at the cloud. This guide exports the variables into a
+  shell;
+  [install the collector from the Debian package](/how-to/openstack/install-the-debian-package)
+  puts the same settings into `/etc/default/tally-openstack-collector` and runs
+  it as a systemd service instead.
 
 ## Configure the OpenStack services
 

--- a/docs/how-to/openstack/install-the-debian-package.md
+++ b/docs/how-to/openstack/install-the-debian-package.md
@@ -1,0 +1,220 @@
+---
+title: Install the collector from the Debian package
+description: Install, configure and run one collector as a systemd service on a Debian or Ubuntu control node, and upgrade, remove or purge it again.
+quadrant: how-to
+audience: operator
+---
+
+# Install the collector from the Debian package
+
+This guide puts one `tally-openstack-collector` on an OpenStack control node as
+a service systemd starts, restarts and logs. At the end the collector runs as
+the unprivileged `tally` user, reads its credentials from files only that user
+may read, and buffers into a directory that survives an upgrade. Which
+notifications it then consumes, and what the cloud has to publish for it, is
+[connect the collector to an OpenStack cloud](/how-to/openstack/connect-the-collector).
+
+## Before you start
+
+- A Debian 12 or 13, or Ubuntu 24.04 or 26.04, host on `amd64`, with `sudo`.
+- The package file. Build it from a checkout with `make deb`, which writes
+  `dist/tally-openstack-collector_<version>_amd64.deb`, and copy that file to
+  the host. The build needs Go and nothing else, and it runs on macOS as well
+  as on Linux.
+- The broker's AMQP URL, the cloud name and the base URL of the Reporting API.
+- The ingest credential this cloud reports under.
+  [Issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
+  has those steps.
+- The [collector settings](/reference/configuration/tally-openstack-collector)
+  page, which lists every variable with its default.
+
+## Install the package
+
+1. Install the file. The leading `./` is what tells `apt` this is a path and
+   not a package name:
+
+   ```sh
+   sudo apt install ./tally-openstack-collector_<version>_amd64.deb
+   ```
+
+   ```text
+   Setting up tally-openstack-collector (<version>) ...
+   ```
+
+2. Read back what it installed. The `tally` user and group are created by the
+   package, and the state directory belongs to them:
+
+   ```sh
+   dpkg-query -W -f='${Status}\n' tally-openstack-collector
+   getent passwd tally
+   stat -c '%n %U:%G %a' /var/lib/tally/collector /etc/tally/ingest-token
+   ```
+
+   ```text
+   install ok installed
+   tally:x:998:998::/var/lib/tally/collector:/usr/sbin/nologin
+   /var/lib/tally/collector tally:tally 750
+   /etc/tally/ingest-token root:tally 640
+   ```
+
+   The service is installed stopped and disabled. It carries no credentials and
+   no cloud yet, and the collector refuses that configuration before it
+   listens, so nothing is started until you have configured it.
+
+## Put the credentials in place
+
+1. Write the broker URL and the ingest token into the two files the package
+   shipped empty. Writing into the existing file keeps its `0640 root:tally`
+   mode, which a new file created by a redirect would not have:
+
+   ```sh
+   printf '%s' 'amqp://tally:<password>@rabbitmq.example:5672/' | sudo tee /etc/tally/amqp-url > /dev/null
+   printf '%s' 'tly_i_<token>' | sudo tee /etc/tally/ingest-token > /dev/null
+   ```
+
+2. Check that both kept their mode and are no longer empty. One trailing
+   newline is trimmed when the file is read, so an `echo` here would have been
+   fine too; an empty file is refused:
+
+   ```sh
+   stat -c '%n %U:%G %a' /etc/tally/amqp-url /etc/tally/ingest-token
+   test -s /etc/tally/amqp-url && test -s /etc/tally/ingest-token && echo filled
+   ```
+
+   ```text
+   /etc/tally/amqp-url root:tally 640
+   /etc/tally/ingest-token root:tally 640
+   filled
+   ```
+
+## Configure the collector
+
+1. Open `/etc/default/tally-openstack-collector` and fill the two empty
+   settings. Every other variable is in that file, commented out with its
+   default beside it:
+
+   ```sh
+   sudoedit /etc/default/tally-openstack-collector
+   ```
+
+   ```sh
+   TALLY_OSC_CLOUD=os-prod-eu1
+   TALLY_OSC_REPORTING_URL=https://tally-reporting.internal
+   ```
+
+2. Where the cloud runs octavia, or renamed an exchange, uncomment the
+   exchanges line and list its own. The collector declares the exchanges
+   passively, so one the broker does not carry fails the connection:
+
+   ```sh
+   TALLY_OSC_EXCHANGES=nova,neutron,cinder,glance,octavia
+   ```
+
+3. Leave `TALLY_OSC_BUFFER_PATH` as it is. It points into
+   `/var/lib/tally/collector`, the directory the package owns and the unit
+   recreates; anywhere else the service may not write, because the unit runs
+   under `ProtectSystem=strict`.
+
+## Start the service
+
+1. Enable the unit and start it:
+
+   ```sh
+   sudo systemctl enable --now tally-openstack-collector
+   ```
+
+2. Check that it came up and read its first lines. The collector logs JSON to
+   the journal:
+
+   ```sh
+   systemctl is-active tally-openstack-collector
+   journalctl -u tally-openstack-collector -n 1 -o cat
+   ```
+
+   ```text
+   active
+   {"time":"2026-07-09T14:22:00.512Z","level":"INFO","msg":"listening","service":"tally-openstack-collector","port":8080}
+   ```
+
+   A start that ends in `failed` names the value to fix. An empty credential
+   file reports `TALLY_OSC_AMQP_URL_FILE: file /etc/tally/amqp-url is empty`,
+   an unset cloud reports `TALLY_OSC_CLOUD: must be set`, and a token set in
+   the environment file beside its `_FILE` companion reports
+   `set TALLY_OSC_TOKEN or TALLY_OSC_TOKEN_FILE, not both`.
+
+## Upgrade, remove and purge
+
+1. Upgrade by installing the newer file. Your edits to
+   `/etc/default/tally-openstack-collector` and to the two credential files are
+   kept, because all three are conffiles; a changed default arrives beside them
+   as `.dpkg-dist` for you to compare. The outbox is untouched, so events that
+   have not reached the Reporting API are delivered after the restart:
+
+   ```sh
+   sudo apt install ./tally-openstack-collector_<newer-version>_amd64.deb
+   ```
+
+2. Remove the package to stop and disable the service while keeping its
+   configuration and its outbox:
+
+   ```sh
+   sudo apt remove tally-openstack-collector
+   ```
+
+3. Purge it to drop the configuration and the credentials as well. The outbox
+   is deliberately kept: between the acknowledgement on the bus and the
+   delivery, an event lives in that file and nowhere else, so no purge destroys
+   usage that exists in no other copy. Delete it by hand once you know it is
+   empty:
+
+   ```sh
+   sudo apt purge tally-openstack-collector
+   ```
+
+   ```text
+   tally-openstack-collector: /var/lib/tally/collector/outbox.db was kept.
+     It may still hold events that never reached the Reporting API.
+     Delete it by hand once you know it is empty or no longer needed.
+   ```
+
+   The `tally` user and group stay as well: an orphaned system account is
+   harmless, and a later Tally package on this host uses the same one.
+
+## Check the result
+
+1. Ask the running service for readiness. It answers 200 while the consumer
+   holds the broker connection and the outbox answers:
+
+   ```sh
+   curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/readyz
+   ```
+
+   ```text
+   200
+   ```
+
+2. Read the two counters twice, a minute apart, while the cloud is in use. Both
+   rise:
+
+   ```sh
+   curl -sS http://127.0.0.1:8080/metrics | grep -E '^tally_collector_(consumed|delivered)_total'
+   ```
+
+   ```text
+   tally_collector_consumed_total{event_type="compute.instance.create.end"} 14
+   tally_collector_delivered_total 12
+   ```
+
+3. Confirm the service comes back on its own. Kill it and read the state again
+   a few seconds later; `Restart=on-failure` brings it back, and the outbox it
+   reopens is the one it was writing:
+
+   ```sh
+   sudo systemctl kill -s KILL tally-openstack-collector
+   sleep 10
+   systemctl is-active tally-openstack-collector
+   ```
+
+   ```text
+   active
+   ```

--- a/docs/reference/configuration/tally-openstack-collector.md
+++ b/docs/reference/configuration/tally-openstack-collector.md
@@ -83,3 +83,10 @@ nothing else: the mode maps nothing and posts nothing.
 
 [`cmd/tally-openstack-collector/.env.example`](https://github.com/B42Labs/tally/blob/main/cmd/tally-openstack-collector/.env.example)
 lists every variable with its default and a comment.
+
+The Debian package installs the same list as
+`/etc/default/tally-openstack-collector`, which the systemd unit reads. There
+the two secrets are left to their `_FILE` companions, which name
+`/etc/tally/amqp-url` and `/etc/tally/ingest-token`;
+[install the collector from the Debian package](/how-to/openstack/install-the-debian-package)
+has the steps.

--- a/internal/refdoc/maketargets_test.go
+++ b/internal/refdoc/maketargets_test.go
@@ -10,7 +10,7 @@ import (
 // noticed here.
 const (
 	realMakefile    = "../../Makefile"
-	realMakeTargets = 18
+	realMakeTargets = 19
 )
 
 func TestMakeTargets(t *testing.T) {

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,81 @@
+# The Debian package of the OpenStack collector, built by `make deb`.
+#
+# The collector is the one binary that runs beside a cloud rather than in the
+# cluster, on a control node that has no container runtime. Everything else
+# here ships as an image (Dockerfile).
+name: tally-openstack-collector
+arch: ${GOARCH}
+platform: linux
+version: ${VERSION}
+section: net
+priority: optional
+maintainer: B42Labs <info@b42labs.com>
+description: Collects OpenStack usage events and reports them to the Tally Reporting API.
+vendor: B42Labs
+homepage: https://github.com/B42Labs/tally
+license: Apache-2.0
+
+# The binary needs nothing: it is static (CGO_ENABLED=0, and the outbox runs on
+# the CGO-free modernc.org/sqlite). adduser is the one dependency, because
+# postinstall.sh calls addgroup and adduser, which a minimal image may not ship.
+depends:
+  - adduser
+
+contents:
+  - src: ./bin/tally-openstack-collector-linux-${GOARCH}
+    dst: /usr/bin/tally-openstack-collector
+    expand: true
+    file_info:
+      mode: 0755
+
+  - src: ./packaging/tally-openstack-collector.service
+    dst: /lib/systemd/system/tally-openstack-collector.service
+
+  # No credential lives in here, so it stays readable: the two secrets sit in
+  # /etc/tally below and reach the process through their *_FILE variables.
+  - src: ./packaging/tally-openstack-collector.default
+    dst: /etc/default/tally-openstack-collector
+    type: config|noreplace          # never clobber operator edits on upgrade
+    file_info:
+      mode: 0644
+
+  # The broker URL carries the broker password and the token authenticates
+  # every flush against the Reporting API. Both ship empty, which fails the
+  # first start with the name of the file to fill rather than with a missing
+  # variable. Shipping them is also what puts them at 0640: a file the operator
+  # creates with a shell redirect lands world-readable.
+  #
+  # systemd reads neither. The collector opens them itself, after systemd has
+  # dropped to the tally user, so the group bit is what it reads them through.
+  - src: ./packaging/secrets/amqp-url
+    dst: /etc/tally/amqp-url
+    type: config|noreplace
+    file_info:
+      mode: 0640
+      owner: root
+      group: tally
+
+  - src: ./packaging/secrets/ingest-token
+    dst: /etc/tally/ingest-token
+    type: config|noreplace
+    file_info:
+      mode: 0640
+      owner: root
+      group: tally
+
+  # The outbox lives here. The package owns the directory rather than leaving
+  # it to the unit's StateDirectory=, because OpenOutbox creates no directory
+  # and dpkg then tracks the one it fails without. The ownership below is not
+  # what lands on a fresh install: dpkg resolves these names at unpack time,
+  # before postinstall.sh has created the user, so that script applies it again.
+  - dst: /var/lib/tally/collector
+    type: dir
+    file_info:
+      mode: 0750
+      owner: tally
+      group: tally
+
+scripts:
+  postinstall: ./packaging/postinstall.sh
+  preremove:   ./packaging/preremove.sh
+  postremove:  ./packaging/postremove.sh

--- a/packaging/packaging_test.go
+++ b/packaging/packaging_test.go
@@ -1,0 +1,358 @@
+// This file pins the Debian package to what the collector reads and to where
+// the package puts it. Every mismatch it looks for fails quietly: a variable
+// the environment file does not carry leaves the service running on the default
+// it was meant to replace, a buffer path outside the state directory puts the
+// undelivered events somewhere ProtectSystem=strict makes read-only, a unit
+// pointing at a path the package does not ship fails only on the host that
+// installs it, and a postremove that deletes the outbox destroys usage that
+// reached no other copy. The test reads the four files from disk; it builds
+// nothing, needs neither Docker nor dpkg, and so runs on the macOS machines
+// this is developed on as well as in CI.
+package packaging_test
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/b42labs/tally/internal/providers/openstack"
+)
+
+const (
+	// The files this test reads. The spec sits at the repository root, beside
+	// the Dockerfile it is the host counterpart of; the rest sit here.
+	specPath       = "../nfpm.yaml"
+	makefilePath   = "../Makefile"
+	unitPath       = "tally-openstack-collector.service"
+	defaultPath    = "tally-openstack-collector.default"
+	postremovePath = "postremove.sh"
+
+	packageName = "tally-openstack-collector"
+
+	// Where the package puts what it ships. These are the paths an operator
+	// scripts against and the unit and the environment file refer to.
+	binaryDst      = "/usr/bin/tally-openstack-collector"
+	unitDst        = "/lib/systemd/system/tally-openstack-collector.service"
+	defaultDst     = "/etc/default/tally-openstack-collector"
+	amqpSecretDst  = "/etc/tally/amqp-url"
+	tokenSecretDst = "/etc/tally/ingest-token"
+	stateDst       = "/var/lib/tally/collector"
+
+	// The account the service runs under. It is the shared Tally name rather
+	// than the collector's, so a later package for another service uses it too.
+	serviceUser = "tally"
+
+	// The content type that keeps dpkg from overwriting a file the operator
+	// edited, and the one dependency the package declares.
+	conffile   = "config|noreplace"
+	dependency = "adduser"
+
+	// The two secrets the environment file names through their *_FILE
+	// companions and never sets itself: setting a secret beside its companion
+	// is an error the collector refuses to start on.
+	amqpVar  = "TALLY_OSC_AMQP_URL"
+	tokenVar = "TALLY_OSC_TOKEN"
+)
+
+// spec is the part of nfpm.yaml this file asserts over. yaml.v3 ignores every
+// field not named here.
+type spec struct {
+	Name     string
+	Arch     string
+	Platform string
+	Version  string
+	Depends  []string
+	Contents []content
+	Scripts  map[string]string
+}
+
+type content struct {
+	Src      string
+	Dst      string
+	Type     string
+	FileInfo fileInfo `yaml:"file_info"`
+}
+
+// fileInfo carries the mode as YAML resolves it: a leading zero makes the
+// literal octal, so 0750 arrives as 0o750 and compares against a Go octal
+// literal directly.
+type fileInfo struct {
+	Mode  int
+	Owner string
+	Group string
+}
+
+func TestPackageShipsWhatTheCollectorNeeds(t *testing.T) {
+	// The six entries are the installed surface. A dropped one leaves a service
+	// with no unit, no configuration or no directory to buffer into; a mode or
+	// an owner that drifts either puts the broker password where every account
+	// on the control node reads it, or leaves the collector unable to write its
+	// own outbox.
+	file := loadSpec(t)
+
+	if file.Name != packageName {
+		t.Errorf("name = %q, want %q, the name of the binary and of the unit", file.Name, packageName)
+	}
+	if !slices.Contains(file.Depends, dependency) {
+		t.Errorf("depends = %v, want it to hold %q, which postinstall.sh calls addgroup and adduser from",
+			file.Depends, dependency)
+	}
+
+	want := map[string]content{
+		binaryDst:      {Src: "./bin/tally-openstack-collector-linux-${GOARCH}", FileInfo: fileInfo{Mode: 0o755}},
+		unitDst:        {Src: "./packaging/" + unitPath},
+		defaultDst:     {Src: "./packaging/" + defaultPath, Type: conffile, FileInfo: fileInfo{Mode: 0o644}},
+		amqpSecretDst:  {Src: "./packaging/secrets/amqp-url", Type: conffile, FileInfo: fileInfo{Mode: 0o640, Owner: "root", Group: serviceUser}},
+		tokenSecretDst: {Src: "./packaging/secrets/ingest-token", Type: conffile, FileInfo: fileInfo{Mode: 0o640, Owner: "root", Group: serviceUser}},
+		stateDst:       {Type: "dir", FileInfo: fileInfo{Mode: 0o750, Owner: serviceUser, Group: serviceUser}},
+	}
+
+	shipped := make(map[string]content, len(file.Contents))
+	for _, entry := range file.Contents {
+		shipped[entry.Dst] = entry
+	}
+	if dsts, wantDsts := slices.Sorted(maps.Keys(shipped)), slices.Sorted(maps.Keys(want)); !slices.Equal(dsts, wantDsts) {
+		t.Fatalf("the package installs %v, want %v", dsts, wantDsts)
+	}
+
+	for dst, expected := range want {
+		entry := shipped[dst]
+		if entry.Src != expected.Src {
+			t.Errorf("%s is built from src %q, want %q", dst, entry.Src, expected.Src)
+		}
+		if entry.Type != expected.Type {
+			t.Errorf("%s has type %q, want %q", dst, entry.Type, expected.Type)
+		}
+		if entry.FileInfo.Mode != expected.FileInfo.Mode {
+			t.Errorf("%s has mode %#o, want %#o", dst, entry.FileInfo.Mode, expected.FileInfo.Mode)
+		}
+		if entry.FileInfo.Owner != expected.FileInfo.Owner || entry.FileInfo.Group != expected.FileInfo.Group {
+			t.Errorf("%s is owned %q:%q, want %q:%q",
+				dst, entry.FileInfo.Owner, entry.FileInfo.Group, expected.FileInfo.Owner, expected.FileInfo.Group)
+		}
+	}
+
+	// Every source but the binary is committed, so a renamed file fails here
+	// rather than in the middle of a release build.
+	for _, entry := range file.Contents {
+		if entry.Src == "" || strings.HasPrefix(entry.Src, "./bin/") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join("..", entry.Src)); err != nil {
+			t.Errorf("%s is built from %s, which is not there: %v", entry.Dst, entry.Src, err)
+		}
+	}
+	for action, script := range file.Scripts {
+		if _, err := os.Stat(filepath.Join("..", script)); err != nil {
+			t.Errorf("the %s script is %s, which is not there: %v", action, script, err)
+		}
+	}
+
+	// The binary is the one source `make deb` produces, so the two names have
+	// to agree. They disagree loudly at build time, and only there.
+	binary := strings.TrimPrefix(shipped[binaryDst].Src, "./")
+	if recipe := "-o " + strings.ReplaceAll(binary, "${GOARCH}", "$(DEB_GOARCH)"); !strings.Contains(read(t, makefilePath), recipe) {
+		t.Errorf("the Makefile does not build %q, which nfpm.yaml packages; the deb target writes a different name", recipe)
+	}
+}
+
+func TestDefaultFileListsEveryVariableAndNoOther(t *testing.T) {
+	// The collector ignores a variable it does not know, so a misspelled name in
+	// the environment file is a default in place of a setting. A variable the
+	// file omits is one an operator finds out about from a failure.
+	set, commented := settings(t)
+
+	for name := range set {
+		if !slices.Contains(openstack.EnvNames, name) {
+			t.Errorf("%s is set although the collector reads no variable of that name (openstack.EnvNames), so its value never arrives", name)
+		}
+	}
+	for name := range commented {
+		if !slices.Contains(openstack.EnvNames, name) {
+			t.Errorf("%s is offered as a commented default although the collector reads no variable of that name (openstack.EnvNames)", name)
+		}
+	}
+
+	for _, name := range openstack.EnvNames {
+		if name == amqpVar || name == tokenVar {
+			// Deliberately absent: both reach the process through their *_FILE
+			// companion, and setting a secret beside its companion is refused.
+			if _, ok := set[name]; ok {
+				t.Errorf("%s is set beside %s_FILE, which the collector refuses to start on", name, name)
+			}
+			if _, ok := commented[name]; ok {
+				t.Errorf("%s is offered as a commented default, which an operator who uncomments it is refused for", name)
+			}
+			continue
+		}
+		_, isSet := set[name]
+		_, isCommented := commented[name]
+		if !isSet && !isCommented {
+			t.Errorf("%s appears in neither form, so the file does not document it", name)
+		}
+	}
+}
+
+func TestDefaultFilePointsIntoThePackage(t *testing.T) {
+	// The three paths tie the running service to what the package installed. A
+	// secret path that drifts reads a file nothing ships, and a buffer path
+	// outside the state directory lands under ProtectSystem=strict, where the
+	// collector may not write.
+	set, _ := settings(t)
+
+	paths := map[string]string{
+		amqpVar + "_FILE":  amqpSecretDst,
+		tokenVar + "_FILE": tokenSecretDst,
+	}
+	for name, want := range paths {
+		if set[name] != want {
+			t.Errorf("%s = %q, want %q, the file the package ships at 0640", name, set[name], want)
+		}
+	}
+
+	if path := set["TALLY_OSC_BUFFER_PATH"]; !strings.HasPrefix(path, stateDst+"/") {
+		t.Errorf("TALLY_OSC_BUFFER_PATH = %q, want a path under %q, the directory the package owns and the unit recreates",
+			path, stateDst)
+	}
+
+	// Both are required and have no default, so an unset one is what the first
+	// start reports. A value here would book a customer's usage to whatever
+	// cloud this file happened to name.
+	for _, name := range []string{"TALLY_OSC_CLOUD", "TALLY_OSC_REPORTING_URL"} {
+		value, ok := set[name]
+		if !ok {
+			t.Errorf("%s is not in the file, so an operator is not told to fill it", name)
+			continue
+		}
+		if value != "" {
+			t.Errorf("%s = %q, want it shipped empty: no value here is right for a deployment", name, value)
+		}
+	}
+}
+
+func TestUnitRunsWhatThePackageInstalled(t *testing.T) {
+	// The unit is the only thing that starts the collector on a packaged host.
+	// A path here that the package does not ship fails on the host rather than
+	// in this repository, and a missing [Install] section leaves
+	// `systemctl enable` refusing the unit.
+	unit := read(t, unitPath)
+	directives := settingsFrom(unit)
+
+	want := map[string]string{
+		"User":            serviceUser,
+		"Group":           serviceUser,
+		"EnvironmentFile": defaultDst,
+		"ExecStart":       binaryDst,
+		"StateDirectory":  strings.TrimPrefix(stateDst, "/var/lib/"),
+		"WantedBy":        "multi-user.target",
+	}
+	for name, value := range want {
+		if directives[name] != value {
+			t.Errorf("%s = %q, want %q", name, directives[name], value)
+		}
+	}
+	if !strings.Contains(unit, "[Install]") {
+		t.Errorf("%s carries no [Install] section, so systemctl enable refuses it", unitPath)
+	}
+
+	// StartLimit* belong to [Unit]; systemd ignores them under [Service], which
+	// leaves a failing service restarting without a bound.
+	// Cut on the section header at the start of a line: the comment above those
+	// two directives names [Service] as the place they do not belong.
+	unitSection, _, ok := strings.Cut(unit, "\n[Service]")
+	if !ok {
+		t.Fatalf("%s carries no [Service] section", unitPath)
+	}
+	for _, directive := range []string{"StartLimitIntervalSec=", "StartLimitBurst="} {
+		if !strings.Contains(unitSection, directive) {
+			t.Errorf("%s is not in the [Unit] section, where systemd reads it", directive)
+		}
+	}
+}
+
+func TestPurgeKeepsTheOutbox(t *testing.T) {
+	// Between the acknowledgement on the bus and the delivery to the Reporting
+	// API, an event lives in the outbox and nowhere else. No path through the
+	// package manager may destroy it, so the script deletes nothing: it drops
+	// the emptied credential directory with rmdir and says what it kept.
+	script := read(t, postremovePath)
+
+	if regexp.MustCompile(`(^|[^\w-])rm\s`).MatchString(script) {
+		t.Errorf("%s runs rm, and the only state it could delete is the outbox, which holds events that reached no other copy",
+			postremovePath)
+	}
+	if !strings.Contains(script, "rmdir /etc/tally") {
+		t.Errorf("%s does not rmdir /etc/tally, so a purge leaves the credential directory behind", postremovePath)
+	}
+	if !strings.Contains(script, stateDst+"/outbox.db") {
+		t.Errorf("%s does not name %s/outbox.db, so a purge says nothing about the file it kept", postremovePath, stateDst)
+	}
+}
+
+// loadSpec decodes the package definition from disk.
+func loadSpec(t *testing.T) spec {
+	t.Helper()
+
+	var file spec
+	if err := yaml.Unmarshal([]byte(read(t, specPath)), &file); err != nil {
+		t.Fatalf("parsing %s, which nfpm refuses to package: %v", specPath, err)
+	}
+	return file
+}
+
+// settings reads the environment file: the variables it sets, and the ones it
+// offers as a commented default. A commented line counts as documentation, not
+// as configuration, so the two are kept apart.
+func settings(t *testing.T) (set, commented map[string]string) {
+	t.Helper()
+
+	content := read(t, defaultPath)
+	set = settingsFrom(content)
+
+	commented = make(map[string]string)
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimPrefix(strings.TrimSpace(line), "#")
+		name, value, ok := strings.Cut(trimmed, "=")
+		if !ok || !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if name = strings.TrimSpace(name); strings.HasPrefix(name, "TALLY_") && !strings.Contains(name, " ") {
+			commented[name] = strings.TrimSpace(value)
+		}
+	}
+	return set, commented
+}
+
+// settingsFrom reads the KEY=VALUE lines of a file, skipping comments, blank
+// lines and the section headers of a unit.
+func settingsFrom(content string) map[string]string {
+	values := make(map[string]string)
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "[") {
+			continue
+		}
+		if name, value, ok := strings.Cut(line, "="); ok {
+			values[strings.TrimSpace(name)] = strings.TrimSpace(value)
+		}
+	}
+	return values
+}
+
+// read returns a file's content, failing when it is missing rather than
+// asserting over an empty string.
+func read(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(content)
+}

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+if [ "$1" = "configure" ]; then
+    # The user and the group are named tally rather than after this package: a
+    # later package for another Tally service on the same host runs as the same
+    # account and reads the same /etc/tally.
+    #
+    # --quiet keeps dpkg's output clean. Without it adduser reports "Not
+    # creating home directory" for the --no-create-home it was just asked for.
+    # Warnings and errors still get through.
+    if ! getent group tally >/dev/null; then
+        addgroup --system --quiet tally
+    fi
+    if ! getent passwd tally >/dev/null; then
+        adduser --system --quiet --no-create-home --ingroup tally \
+            --home /var/lib/tally/collector --shell /usr/sbin/nologin tally
+    fi
+
+    # dpkg resolves the archive's user and group names at unpack time, before
+    # this script runs, so on a fresh install the shipped paths fall back to the
+    # numeric ids in the header and land root:root. Apply the intended ownership
+    # here. It is idempotent, so it also repairs an install made before the
+    # tally account existed.
+    for secret in /etc/tally/amqp-url /etc/tally/ingest-token; do
+        if [ -e "$secret" ]; then
+            chown root:tally "$secret"
+            chmod 0640 "$secret"
+        fi
+    done
+    if [ -d /var/lib/tally/collector ]; then
+        chown tally:tally /var/lib/tally/collector
+        chmod 0750 /var/lib/tally/collector
+    fi
+
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload
+    fi
+
+    # The service is left stopped and disabled. A fresh install carries no
+    # broker URL, no token and no cloud, and the collector refuses that
+    # configuration before it listens, so starting it here would only flap
+    # against Restart=on-failure until someone configured it.
+fi

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    if [ -d /run/systemd/system ]; then
+        systemctl daemon-reload || true
+    fi
+fi
+
+if [ "$1" = "purge" ]; then
+    # dpkg deletes the two credential conffiles itself on purge; this drops the
+    # directory they were the only content of. It fails while anything else is
+    # in there, which is what keeps a second Tally package's files.
+    rmdir /etc/tally 2>/dev/null || true
+
+    # The outbox stays, and this script deletes nothing under /var/lib/tally.
+    # Between the acknowledgement on the bus and the delivery to the Reporting
+    # API an event lives in that file and nowhere else, so a purge that removed
+    # it would destroy usage that exists in no other copy, including the usage
+    # of an operator who purges in order to reinstall.
+    if [ -e /var/lib/tally/collector/outbox.db ]; then
+        echo 'tally-openstack-collector: /var/lib/tally/collector/outbox.db was kept.' >&2
+        echo '  It may still hold events that never reached the Reporting API.' >&2
+        echo '  Delete it by hand once you know it is empty or no longer needed.' >&2
+    fi
+fi
+
+# The tally user and group are kept in every case: an orphaned system account
+# is harmless, it may still own files elsewhere, and a later Tally package on
+# this host uses the same one.

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+# Only on remove: an upgrade also runs this script, and stopping the service
+# there would take the sender away from an outbox it is draining.
+if [ "$1" = "remove" ]; then
+    systemctl stop tally-openstack-collector 2>/dev/null || true
+    systemctl disable tally-openstack-collector 2>/dev/null || true
+fi

--- a/packaging/tally-openstack-collector.default
+++ b/packaging/tally-openstack-collector.default
@@ -1,0 +1,91 @@
+# /etc/default/tally-openstack-collector: the environment of
+# tally-openstack-collector.service.
+#
+# Every variable the collector reads is here, the ones with a default commented
+# out beside it. systemd reads this file, so a line is KEY=VALUE: no export, no
+# shell quoting, and no expansion of another variable.
+#
+# The two secrets are not in this file. The broker URL and the ingest token
+# live in /etc/tally, which the tally group alone may read, and the two *_FILE
+# variables below name them. Setting a secret and its *_FILE companion at once
+# is an error the collector refuses to start on, so uncommenting
+# TALLY_OSC_AMQP_URL or TALLY_OSC_TOKEN means clearing the *_FILE line above it.
+
+# Required. The broker the notifications are consumed from. Put the whole URL,
+# password and all, into this file: amqp://user:password@rabbitmq.example:5672/
+TALLY_OSC_AMQP_URL_FILE=/etc/tally/amqp-url
+
+# Required. The token the sender authenticates with against the Reporting API.
+# Issue and revoke it with tally-reporting-admin.
+TALLY_OSC_TOKEN_FILE=/etc/tally/ingest-token
+
+# Required. The cloud every emitted event is attributed to. There is no
+# default, because a guessed cloud books usage to the wrong one.
+TALLY_OSC_CLOUD=
+
+# Required. Base URL of the Reporting API the buffered events are posted to. It
+# must be absolute and carry a host, with no trailing path: the ingest path is
+# appended to it. https unless TALLY_OSC_REPORTING_INSECURE says otherwise.
+TALLY_OSC_REPORTING_URL=
+
+# The SQLite file backing the outbox, in the state directory the package owns
+# and the unit's StateDirectory= recreates. Between the acknowledgement on the
+# bus and the delivery to the Reporting API, an event lives here and nowhere
+# else, so the file is worth backing up and worth watching the size of.
+TALLY_OSC_BUFFER_PATH=/var/lib/tally/collector/outbox.db
+
+# Log level: DEBUG, INFO, WARN, ERROR. The match is exact, so a lower-case
+# info is refused rather than read as INFO.
+#TALLY_LOG_LEVEL=INFO
+
+# Metrics switch. With the default true, GET /metrics serves the Prometheus
+# exposition; false makes the route answer 404 while the instruments keep
+# counting. The variable has no OSC infix by design.
+#TALLY_METRICS_ENABLED=true
+
+# Port the probes and the metrics route listen on. The collector serves no API
+# of its own.
+#TALLY_OSC_HTTP_PORT=8080
+
+# Service exchanges the collector binds its queue to, comma-separated. The
+# default covers nova, neutron, cinder and glance; a deployment that renamed
+# them through control_exchange lists its own, and one that runs octavia adds
+# it. The exchanges are declared passively, so the collector refuses to run
+# while one it lists is missing from the broker.
+#TALLY_OSC_EXCHANGES=nova,neutron,cinder,glance
+
+# Notification topics bound on each exchange, comma-separated. They are the
+# notification_topics of the services being collected.
+#TALLY_OSC_TOPICS=notifications.info
+
+# Allow a plaintext Reporting API. The ingest token travels in a header on
+# every flush, and the collector runs next to the OpenStack control plane, so
+# the link to Tally crosses a network the cluster's TLS does not cover. Set
+# this to true only where that link is trusted, or for development.
+#TALLY_OSC_REPORTING_INSECURE=false
+
+# How many buffered events one POST carries. Between 1 and 1000, which is the
+# array cap of the ingest API: it answers a longer batch with 413.
+#TALLY_OSC_BATCH_MAX=500
+
+# Seconds the sender waits before posting a batch that has not filled up.
+#TALLY_OSC_FLUSH_INTERVAL_S=5
+
+# Outbox depth at which the collector stops consuming. The notifications then
+# wait on the bus instead of being dropped, which is what keeps an unreachable
+# Reporting API from costing usage data. A buffered event runs a few hundred
+# bytes, so the default reaches roughly half a gigabyte on the disk this
+# directory lives on.
+#TALLY_OSC_BUFFER_MAX_EVENTS=1000000
+
+# AMQP QoS bound: how many unacknowledged messages the broker hands out. The
+# acks follow the outbox insert, so this also bounds how much work a crash
+# replays. Times the broker's max_message_size, it is what the process may hold
+# in memory.
+#TALLY_OSC_PREFETCH=100
+
+# How many seconds the outbox may stay unusable before liveness fails as well.
+# Readiness fails immediately, and on an unreachable broker too; liveness
+# weighs the outbox alone. Under systemd nothing acts on it: the probes are
+# read by an orchestrator or by a monitoring system, not by the unit.
+#TALLY_OSC_UNHEALTHY_THRESHOLD_S=600

--- a/packaging/tally-openstack-collector.service
+++ b/packaging/tally-openstack-collector.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Tally OpenStack event collector
+Documentation=https://b42labs.github.io/tally/how-to/openstack/install-the-debian-package
+After=network-online.target
+Wants=network-online.target
+# StartLimit* are [Unit] directives, ignored where they are put under [Service].
+StartLimitIntervalSec=120
+StartLimitBurst=10
+
+[Service]
+Type=simple
+User=tally
+Group=tally
+EnvironmentFile=/etc/default/tally-openstack-collector
+ExecStart=/usr/bin/tally-openstack-collector
+# The collector comes up while the broker or the Reporting API is unavailable
+# and reports that through its probes rather than by exiting, so a restart here
+# follows a real fault rather than a network outage.
+Restart=on-failure
+RestartSec=5
+
+# The outbox. The package ships and owns /var/lib/tally/collector; this keeps
+# it writable under ProtectSystem=strict and recreates it should it go missing.
+StateDirectory=tally/collector
+StateDirectoryMode=0750
+
+# Hardening: an AMQP client and an HTTPS client that serves probes and metrics
+# needs no privilege at all.
+NoNewPrivileges=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+[Install]
+WantedBy=multi-user.target

--- a/roadmap/00-conventions.md
+++ b/roadmap/00-conventions.md
@@ -68,6 +68,8 @@ tally/
 ├── Makefile                       # dev entry points: make up / dev / test / lint / migrate
 ├── Dockerfile                     # multi-stage, ARG CMD → builds ./cmd/${CMD}; one image per service
 ├── Tiltfile                       # dev loop: docker_build → kind load → redeploy on change
+├── nfpm.yaml                      # Debian package of the collector; `make deb` builds it
+├── packaging/                     # systemd unit, /etc/default file and maintainer scripts of that package
 ├── api/
 │   └── reporting/openapi.yaml     # Reporting API contract (oapi-codegen input)
 ├── cmd/


### PR DESCRIPTION
Closes #143

`tally-openstack-collector` can now be installed from a Debian package on an
OpenStack control node, where there is no Kubernetes and no container runtime.
`make deb` builds it from an [nfpm](https://nfpm.goreleaser.com/) spec at the
repository root; the package installs the static binary, a hardened systemd
unit running as the `tally` system user, `/etc/default/tally-openstack-collector`
with every variable and its default, the two credentials as conffiles at
`0640 root:tally` in `/etc/tally/`, and `/var/lib/tally/collector/` for the
outbox. Installing configures nothing and starts nothing: the collector refuses
a configuration without credentials and cloud before it listens, so the operator
fills the two files and the two empty settings and then enables the unit.

The user, the group and `/etc/tally` carry the shared `tally` name rather than
the collector's, so a later package for another Tally service slots in beside
this one. A purge drops the credentials and keeps the outbox, and says so:
between the acknowledgement on the bus and the delivery to the Reporting API an
event lives in that file and nowhere else, so no path through the package
manager destroys usage that exists in no other copy. Publishing the package on
a tagged release is #144 and is not part of this.

## Commits

1. `8c1e84d` Package the OpenStack collector for Debian. `nfpm.yaml` and
   `packaging/` with the unit, the environment file, the two empty credential
   files and the three maintainer scripts; the `deb` target with the
   `NFPM_VERSION`, `DEB_VERSION` and `DEB_GOARCH` pins. The regenerated
   `make-targets` row of `docs/contributing/dev-stack.md` and the target count
   in `internal/refdoc/maketargets_test.go` move with the target.
2. `215b5a4` Pin the package definition to what the collector reads.
   `packaging/packaging_test.go`, after the model of
   `deploy/compose/compose_test.go`: the installed paths with their modes and
   owners, every variable of `openstack.EnvNames` and no other, the three paths
   that tie the environment file to what the package installed, the unit's
   `User`, `ExecStart`, `EnvironmentFile` and `StateDirectory`, and a
   `postremove.sh` that runs no `rm`. It reads files, so it needs neither
   Docker nor dpkg.
3. `d0bd1ed` Build and verify the Debian package in CI. The `package` step of
   the `ci` job builds, installs, reads back the ownership `postinstall.sh`
   applied, runs `systemd-analyze verify` over the installed unit, and purges,
   asserting that the outbox survived and the credentials did not.
4. `bf608bd` Document installing the collector from the package.
   `docs/how-to/openstack/install-the-debian-package.md`, plus its sidebar
   entry, its bullet on the how-to index, `Debian` in the proper nouns, and a
   pointer each from the connect guide and the settings reference.
5. `8605ead` Record the package in the handbook and the conventions. A
   `Debian package` section in `docs/contributing/toolchain.md`, the three new
   variables in `docs/contributing/dev-stack.md`, and `nfpm.yaml` and
   `packaging/` in the binding repository tree of `roadmap/00-conventions.md`.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` and `make lint`
  (0 issues) pass; `npm run docs:build` builds with no dead link.
- `make deb` writes `dist/tally-openstack-collector_0.0.0+dev_amd64.deb`, and
  `make deb DEB_VERSION=1.2.3` the 1.2.3 name. Read back with `ar x` and
  `tar tzvf data.tar.gz`, because macOS carries no `dpkg-deb`: the six paths,
  the binary at 0755, `/var/lib/tally/collector` at `0750 tally:tally`, both
  secrets at `0640 root:tally`, `Depends: adduser`, and the three conffiles.
- The four startup paths were run against the built binary: an empty credential
  file reports `TALLY_OSC_AMQP_URL_FILE: file … is empty`, an unset cloud
  `TALLY_OSC_CLOUD: must be set`, a secret beside its companion `set
  TALLY_OSC_TOKEN or TALLY_OSC_TOKEN_FILE, not both`, and a buffer path in a
  directory that does not exist `creating the outbox table at …: unable to open
  database file (14)`. Against a dead broker the process stays up with
  `/readyz` at 503 and `/healthz` at 200.
- `packaging/packaging_test.go` was held against four deliberate breakages and
  reported every one: a variable the collector does not read, a variable added
  to `EnvNames` and not to the file, an `ExecStart` pointing elsewhere, and an
  `rm` in `postremove.sh`.
- Each of the five commits was checked out and run against
  `go test ./docs/ ./internal/refdoc/ ./packaging/...`; all five are green.

## Notes

- Not run here: install, upgrade, remove, purge, `StateDirectory=` recreating
  the state directory, `systemd-analyze` and the guide end to end. This was
  built on macOS, which has no dpkg, no apt and no systemd. The `package` step
  of this pull request's CI run is what exercises install, ownership, the
  disabled unit, `systemd-analyze verify` and purge.
- `TestRunServesTheProbes` in `cmd/tally-openstack-collector` is flaky under
  load, and was reproduced on unchanged `main` (three parallel runs fail with
  `run() did not return within 5s of the cancellation`; eight sequential runs
  pass). It is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UiUbZg1xzyGVb4kyA5mYq

