### PR TITLE
Publish signed release artifacts on a version tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,98 @@
+name: release
+
+# The tag is the trigger and the version source, so a release cannot disagree
+# with the artifacts attached to it. No pull request exercises this workflow:
+# the first tag pushed after it lands is what proves it, which is why the
+# version step refuses a malformed tag before anything is built, and why
+# packaging/release_test.go reads the file below.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # contents writes the release, id-token mints the OIDC token the Sigstore
+    # certificate is issued against, and attestations stores the attestation on
+    # the repository. artifact-metadata is not among them: that is what a
+    # registry storage record needs, and this pushes to no registry.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false # the publish step authenticates with GH_TOKEN
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # The raw tag reaches no shell as interpolated text: it is read from the
+      # runner's own GITHUB_REF_NAME here, and every later step takes the
+      # version this validated through a step output.
+      - name: version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(sh packaging/release-version.sh "${GITHUB_REF_NAME}")"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # The tilde the script wrote for the hyphen is what marks a prerelease.
+          case "${version}" in
+            *'~'*) echo 'prerelease=true' >> "${GITHUB_OUTPUT}" ;;
+            *) echo 'prerelease=false' >> "${GITHUB_OUTPUT}" ;;
+          esac
+
+      # sbom depends on deb, so this builds the binary, the package and the
+      # SBOM at one version.
+      - name: build
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: make sbom DEB_VERSION="${VERSION}"
+
+      - name: checksums
+        run: |
+          set -euo pipefail
+          # The names go in bare, so an operator checks the file in the
+          # directory they downloaded into. An empty dist/ leaves the globs
+          # unmatched, which fails here rather than publishing nothing.
+          cd dist
+          sha256sum *.deb *.spdx.json > SHA256SUMS
+
+      # No sbom-path and no predicate input puts the action in provenance mode.
+      # Several subjects produce one attestation referencing all of them.
+      - name: attest
+        id: attest
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/*.deb
+            dist/*.spdx.json
+            dist/SHA256SUMS
+
+      - name: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          # The bundle is the one artifact that cannot be a subject of itself.
+          # It rides along so that a host with no route to the attestations API
+          # can verify with gh attestation verify --bundle.
+          cp "${BUNDLE}" dist/attestation.sigstore.json
+          flags=()
+          if [ "${PRERELEASE}" = 'true' ]; then
+            flags+=(--prerelease)
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            "${flags[@]}" \
+            dist/*.deb dist/*.spdx.json dist/SHA256SUMS dist/attestation.sigstore.json

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ GOLANGCI_LINT_VERSION ?= v2.13.2
 # module cache as the three above.
 NFPM_VERSION ?= v2.47.0
 
+# The generator `sbom` catalogs the packaged binary with, from the same module
+# cache as the four above.
+SYFT_VERSION ?= v1.51.1
+
 # What `deb` stamps into the package, and the architecture it builds for. The
 # repository carries no tags, so the default is a development version that
 # every release sorts above: dpkg reads 0.0.0+dev as lower than 0.1.0. A build
@@ -209,7 +213,7 @@ VMALERT_IMAGE := $(shell grep -oE 'victoriametrics/vmalert:[A-Za-z0-9._-]+' depl
 ALERTMANAGER_IMAGE := $(shell grep -oE 'prom/alertmanager:[A-Za-z0-9._-]+' deploy/kubernetes/base/alertmanager/alertmanager.yaml | head -n1)
 
 .PHONY: check-tools up down dev ca test lint fmt check-alerting migrate generate \
-	images deb simulator-up simulator-down console demo demo-drain demo-registry \
+	images deb sbom simulator-up simulator-down console demo demo-drain demo-registry \
 	demo-bill demo-correct docs docs-build
 
 # What `check-tools` holds the Docker engine to. One kind node runs the whole
@@ -411,6 +415,17 @@ deb:
 	GOARCH=$(DEB_GOARCH) VERSION='$(DEB_VERSION)' \
 		go run github.com/goreleaser/nfpm/v2/cmd/nfpm@$(NFPM_VERSION) \
 		package --packager deb --target dist/
+
+# The SBOM is taken from the binary rather than from the .deb, because the
+# binary is the only thing in the package with dependencies: syft reads its
+# module list out of the Go build info, which the -ldflags='-s -w' above leaves
+# in place. The target depends on `deb`, so the binary it reads and the package
+# a release publishes come out of one build at one version.
+## sbom: write the SBOM of the packaged collector into dist/
+sbom: deb
+	go run github.com/anchore/syft/cmd/syft@$(SYFT_VERSION) scan \
+		file:bin/tally-openstack-collector-linux-$(DEB_GOARCH) \
+		-o spdx-json=dist/tally-openstack-collector_$(DEB_VERSION)_$(DEB_GOARCH).spdx.json
 
 ## down: delete the kind cluster
 down:

--- a/Makefile
+++ b/Makefile
@@ -421,11 +421,18 @@ deb:
 # module list out of the Go build info, which the -ldflags='-s -w' above leaves
 # in place. The target depends on `deb`, so the binary it reads and the package
 # a release publishes come out of one build at one version.
+#
+# syft truncates its output file before it resolves the source, so a run that
+# fails leaves an empty document behind. It writes to a temporary name here and
+# the move is a second recipe line, which make reaches only after the first one
+# succeeded: the artifact name then holds an SBOM or nothing.
 ## sbom: write the SBOM of the packaged collector into dist/
 sbom: deb
 	go run github.com/anchore/syft/cmd/syft@$(SYFT_VERSION) scan \
 		file:bin/tally-openstack-collector-linux-$(DEB_GOARCH) \
-		-o spdx-json=dist/tally-openstack-collector_$(DEB_VERSION)_$(DEB_GOARCH).spdx.json
+		-o spdx-json=dist/.sbom.tmp.json
+	mv dist/.sbom.tmp.json \
+		dist/tally-openstack-collector_$(DEB_VERSION)_$(DEB_GOARCH).spdx.json
 
 ## down: delete the kind cluster
 down:

--- a/docs/contributing/dev-stack.md
+++ b/docs/contributing/dev-stack.md
@@ -356,6 +356,7 @@ The table below is rendered from the `## target: description` comments of the
 | `up` | create the kind cluster, install the add-ons, and deploy the dev overlay |
 | `images` | build one container image per binary |
 | `deb` | build the Debian package of the OpenStack collector into dist/ |
+| `sbom` | write the SBOM of the packaged collector into dist/ |
 | `down` | delete the kind cluster |
 | `dev` | rebuild and redeploy on change |
 | `simulator-up` | run the simulator, the collector, and a broker against the dev cluster |
@@ -398,6 +399,8 @@ line, as in `make up WAIT_ATTEMPTS=12`.
   code with.
 - `NFPM_VERSION` (`v2.47.0`) is the nfpm release `deb` builds the Debian
   package with, from the same module cache as the three above.
+- `SYFT_VERSION` (`v1.51.1`) is the syft release `sbom` catalogs the packaged
+  binary with, from the same module cache as the four above.
 - `DEB_VERSION` (`0.0.0+dev`) is the version `deb` stamps into that package.
   The repository carries no tags, so the default is a development version every
   release sorts above; a build that is going somewhere passes its own.

--- a/docs/contributing/toolchain.md
+++ b/docs/contributing/toolchain.md
@@ -130,11 +130,18 @@ dpkg cannot resolve at unpack time; `preremove.sh` stops and disables the unit;
 between the acknowledgement on the bus and the delivery an event lives in that
 file and nowhere else.
 
+`make sbom` builds the package and then writes the SPDX SBOM of the binary it
+installs into `dist/`, with [syft](https://github.com/anchore/syft) at
+`SYFT_VERSION` (`v1.51.1`) from the module cache. It catalogs the binary rather
+than the `.deb`, because the binary is the only thing in the package with
+dependencies: syft reads its module list out of the Go build info, which
+`-ldflags="-s -w"` leaves in place.
+
 `packaging/packaging_test.go` pins all of it to `openstack.EnvNames` and to the
 paths the unit uses, and it reads files rather than building, so it needs
 neither Docker nor dpkg. The `package` step of `.github/workflows/ci.yaml` is
-what builds, installs, verifies and purges the package on a runner. Publishing
-it on a tagged release is not set up yet.
+what builds, installs, verifies and purges the package on a runner, and
+[Releases](#releases) below is what publishes it.
 
 ## Dependencies
 
@@ -166,3 +173,34 @@ that step is the link check of the site.
 `deploy-docs.yaml` publishes `main` to GitHub Pages. It runs when a push
 touches `docs/`, `package.json`, `package-lock.json`, `.nvmrc` or the workflow
 itself.
+
+## Releases
+
+`.github/workflows/release.yaml` runs on a push of a tag matching `v*` and
+publishes a GitHub release from it. The tag is both the trigger and the version
+source, so a release cannot disagree with what is attached to it.
+`packaging/release-version.sh` is the one place the mapping is written: `v1.2.3`
+becomes `1.2.3`, and the prerelease tag `v1.2.3-rc.1` becomes `1.2.3~rc.1`,
+because dpkg reads everything after a hyphen as the package revision and would
+sort `1.2.3-rc.1` above `1.2.3`, while a tilde sorts below every other
+character. A tag the script refuses fails the run before anything is built, and
+a version carrying a tilde marks the release as a prerelease.
+
+The run builds with `make sbom`, writes `SHA256SUMS` over the package and the
+SBOM, and attests all three with `actions/attest`. That action signs with a
+short-lived Sigstore certificate minted from the workflow's OIDC token and
+stores the attestation on the repository, so the project holds no key. Several
+subjects produce one attestation, whose bundle is attached as
+`attestation.sigstore.json`;
+[Install the collector from the Debian package](/how-to/openstack/install-the-debian-package)
+is the operator's side of it. The job holds `contents: write`,
+`id-token: write` and `attestations: write`, and the workflow holds
+`contents: read`.
+
+The run repeats none of the `ci` job's checks. What judges a commit is the `ci`
+run on it, so a tag belongs on a commit whose run is green.
+
+No pull request exercises this workflow, which is why
+`packaging/release_test.go` reads it: the tag mapping and its refusals, the
+trigger, the three permissions, the version source, and that every file the
+release attaches is a subject of the attestation.

--- a/docs/how-to/openstack/install-the-debian-package.md
+++ b/docs/how-to/openstack/install-the-debian-package.md
@@ -17,16 +17,62 @@ notifications it then consumes, and what the cloud has to publish for it, is
 ## Before you start
 
 - A Debian 12 or 13, or Ubuntu 24.04 or 26.04, host on `amd64`, with `sudo`.
-- The package file. Build it from a checkout with `make deb`, which writes
-  `dist/tally-openstack-collector_<version>_amd64.deb`, and copy that file to
-  the host. The build needs Go and nothing else, and it runs on macOS as well
-  as on Linux.
+- The package file, the `SHA256SUMS` beside it and the attestation bundle
+  `attestation.sigstore.json`, all three from the
+  [releases page](https://github.com/B42Labs/tally/releases). Copy them to the
+  host, or to the machine you check them on.
+- The [GitHub CLI](https://cli.github.com/) wherever you check them, for
+  `gh attestation verify`.
+- For a version that has no release yet, a build from a checkout with
+  `make deb`, which writes
+  `dist/tally-openstack-collector_<version>_amd64.deb`. The build needs Go and
+  nothing else and runs on macOS as well as on Linux, but it produces no
+  checksum file and no attestation, so the next section does not apply to it.
 - The broker's AMQP URL, the cloud name and the base URL of the Reporting API.
 - The ingest credential this cloud reports under.
   [Issue and revoke credentials](/how-to/openstack/issue-and-revoke-credentials)
   has those steps.
 - The [collector settings](/reference/configuration/tally-openstack-collector)
   page, which lists every variable with its default.
+
+## Verify the download
+
+1. Check the package against the checksum file. `--ignore-missing` is what lets
+   you check the package alone against a `SHA256SUMS` that also lists the SBOM:
+
+   ```sh
+   sha256sum -c --ignore-missing SHA256SUMS
+   ```
+
+   ```text
+   tally-openstack-collector_<version>_amd64.deb: OK
+   ```
+
+2. Check that the file came out of this repository's release workflow. That run
+   signs what it publishes with a short-lived Sigstore certificate and stores
+   the attestation on GitHub, so there is no key to fetch and none to import:
+
+   ```sh
+   gh attestation verify tally-openstack-collector_<version>_amd64.deb --repo B42Labs/tally
+   ```
+
+   ```text
+   ✓ Verification succeeded!
+   ```
+
+   The lines above that one name the digest that was read and how many
+   attestations were loaded.
+
+3. On a host with no route to the attestations API, check against the bundle
+   you downloaded beside the package instead:
+
+   ```sh
+   gh attestation verify tally-openstack-collector_<version>_amd64.deb \
+     --repo B42Labs/tally --bundle attestation.sigstore.json
+   ```
+
+   A file that did not come out of a release of this repository fails both
+   forms, and a file that fails here is one you do not install.
 
 ## Install the package
 

--- a/internal/refdoc/maketargets_test.go
+++ b/internal/refdoc/maketargets_test.go
@@ -10,7 +10,7 @@ import (
 // noticed here.
 const (
 	realMakefile    = "../../Makefile"
-	realMakeTargets = 19
+	realMakeTargets = 20
 )
 
 func TestMakeTargets(t *testing.T) {

--- a/packaging/release-version.sh
+++ b/packaging/release-version.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Maps a release tag to the version the Debian package carries. The release
+# workflow reads it as `sh packaging/release-version.sh "${GITHUB_REF_NAME}"`,
+# and it is the one place the mapping is written: a second copy in YAML would
+# drift from the one packaging/release_test.go covers.
+#
+# The hyphen of a prerelease tag becomes a tilde, because dpkg reads everything
+# after a hyphen as the package revision and would sort 1.2.3-rc.1 above 1.2.3,
+# while a tilde sorts below every other character. The accepted prerelease part
+# carries no hyphen of its own, so exactly one can be present and the
+# substitution is unambiguous.
+set -e
+
+if [ $# -ne 1 ]; then
+    printf 'release-version: usage: release-version.sh <tag>\n' >&2
+    exit 1
+fi
+
+tag=$1
+version=${tag#v}
+
+# A tag without the leading v leaves $version equal to $tag, which is the first
+# test; the second is the shape of what is left.
+if [ "$version" = "$tag" ] || ! printf '%s' "$version" | grep -Eq \
+    '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.]+)?$'; then
+    printf "release-version: '%s' is not a release tag; expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-PRERELEASE\n" "$tag" >&2
+    exit 1
+fi
+
+printf '%s\n' "$version" | tr '-' '~'

--- a/packaging/release_test.go
+++ b/packaging/release_test.go
@@ -1,21 +1,44 @@
-// This file pins the release to the tag that triggers it. The version a
-// release publishes is read off that tag by release-version.sh and by nothing
-// else, so the mapping is covered here rather than left to the one run that
-// would exercise it: a tag is pushed once, and a version it stamped wrongly is
-// in a package operators already downloaded. The test runs the script the way
-// the workflow does, through sh, and needs neither dpkg nor a runner.
+// This file pins the release to the tag that triggers it, and the workflow to
+// what the Makefile builds. Nothing else covers either: no pull request runs
+// the release workflow, so a target renamed out from under it, a permission
+// dropped, or an artifact attached without being signed would surface on the
+// one run that publishes, after a tag was pushed and cannot be pushed again.
+// The test runs the script the way the workflow does, through sh, and reads
+// the workflow as a file; it needs neither dpkg nor a runner.
 package packaging_test
 
 import (
 	"errors"
 	"os/exec"
+	"path"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
-// The script the release workflow reads the package version from. It is run
-// through sh, so the mode the file carries in the repository never matters.
-const releaseVersionScript = "release-version.sh"
+const (
+	// The script the release workflow reads the package version from. It is run
+	// through sh, so the mode the file carries in the repository never matters.
+	// This test runs beside it; the workflow runs from the repository root, so
+	// it names the second path.
+	releaseVersionScript   = "release-version.sh"
+	releaseVersionFromRoot = "packaging/" + releaseVersionScript
+
+	// The workflow that publishes a release, read from here.
+	releaseWorkflowPath = "../.github/workflows/release.yaml"
+
+	// The tag pattern that triggers it, and the job that does the work.
+	releaseTagPattern = "v*"
+	releaseJob        = "release"
+
+	// The bundle the attestation is written to. It is the one file a release
+	// carries that is not among the attestation's subjects, because an
+	// attestation cannot be a subject of itself.
+	attestationBundle = "dist/attestation.sigstore.json"
+)
 
 // acceptedTags are the tags the script maps rather than refuses, with the
 // version each one puts into the package. A prerelease arrives with a tilde:
@@ -96,6 +119,169 @@ func TestReleaseVersionRefusesAMissingArgument(t *testing.T) {
 	if want := "usage: release-version.sh <tag>"; !strings.Contains(stderr, want) {
 		t.Errorf("%s with no argument wrote %q to stderr, which does not carry %q", releaseVersionScript, stderr, want)
 	}
+}
+
+func TestReleaseWorkflowTriggersOnAVersionTag(t *testing.T) {
+	got := releaseWorkflow(t).On.Push.Tags
+
+	if want := []string{releaseTagPattern}; !slices.Equal(got, want) {
+		t.Fatalf("the workflow triggers on %v, want %v", got, want)
+	}
+
+	// A tag the script maps that the trigger does not match is a release
+	// nobody gets, and the run that would have said so never starts.
+	for _, tc := range acceptedTags {
+		matched, err := path.Match(releaseTagPattern, tc.tag)
+		if err != nil {
+			t.Fatalf("matching %q against %q: %v", tc.tag, releaseTagPattern, err)
+		}
+		if !matched {
+			t.Errorf("%s is a tag release-version.sh maps, but %q does not match it", tc.tag, releaseTagPattern)
+		}
+	}
+}
+
+func TestReleaseWorkflowHoldsThePermissionsTheAttestationNeeds(t *testing.T) {
+	// Dropping one of these fails the one run that publishes, and only after
+	// the package was built: contents creates the release, id-token mints the
+	// OIDC token the Sigstore certificate is issued against, and attestations
+	// stores the attestation on the repository.
+	want := map[string]string{
+		"contents":     "write",
+		"id-token":     "write",
+		"attestations": "write",
+	}
+
+	got := releaseJobOf(t).Permissions
+	if len(got) != len(want) {
+		t.Fatalf("the %s job holds %v, want exactly %v", releaseJob, got, want)
+	}
+	for name, access := range want {
+		if got[name] != access {
+			t.Errorf("the %s job holds %s: %q, want %q", releaseJob, name, got[name], access)
+		}
+	}
+}
+
+func TestReleaseWorkflowStampsTheTagIntoThePackage(t *testing.T) {
+	// The mapping lives in the script and nowhere else, and the version it
+	// produces reaches the package through the Makefile. A second copy in YAML
+	// would drift from the one the tests above cover.
+	if run := releaseStep(t, "version").Run; !strings.Contains(run, "sh "+releaseVersionFromRoot) {
+		t.Errorf("the version step does not run %s:\n%s", releaseVersionFromRoot, run)
+	}
+
+	build := releaseStep(t, "build").Run
+	for _, want := range []string{"make sbom", "DEB_VERSION="} {
+		if !strings.Contains(build, want) {
+			t.Errorf("the build step does not carry %q:\n%s", want, build)
+		}
+	}
+	if target := "\nsbom:"; !strings.Contains(read(t, makefilePath), target) {
+		t.Errorf("the Makefile has no %q target, which the build step calls", strings.TrimSpace(target))
+	}
+}
+
+func TestReleaseWorkflowAttestsEveryFileItPublishes(t *testing.T) {
+	// A file attached to a release without being a subject of the attestation
+	// is a file an operator cannot check the provenance of, and nothing else
+	// would report it.
+	attest := releaseStep(t, "attest")
+	if action := "actions/attest@"; !strings.HasPrefix(attest.Uses, action) {
+		t.Fatalf("the attest step uses %q rather than %s, so its subjects are named but not signed", attest.Uses, action)
+	}
+
+	attested := distPaths(attest.With["subject-path"])
+	published := distPaths(releaseStep(t, "publish").Run)
+
+	for _, file := range published {
+		if file == attestationBundle {
+			continue
+		}
+		if !slices.Contains(attested, file) {
+			t.Errorf("the release publishes %s, which the attest step does not name as a subject", file)
+		}
+	}
+	for _, file := range attested {
+		if !slices.Contains(published, file) {
+			t.Errorf("the attest step signs %s, which the release does not publish", file)
+		}
+	}
+	if !slices.Contains(published, attestationBundle) {
+		t.Errorf("the release does not publish %s, so a host that cannot reach the attestations API has nothing to verify against", attestationBundle)
+	}
+}
+
+// releaseWorkflow reads the release workflow. The `on` key survives yaml.v3 as
+// the string it is written as, rather than being resolved to the boolean true.
+func releaseWorkflow(t *testing.T) releaseSpec {
+	t.Helper()
+
+	var spec releaseSpec
+	if err := yaml.Unmarshal([]byte(read(t, releaseWorkflowPath)), &spec); err != nil {
+		t.Fatalf("parsing %s: %v", releaseWorkflowPath, err)
+	}
+	return spec
+}
+
+// releaseJobOf returns the job that builds and publishes the release.
+func releaseJobOf(t *testing.T) releaseJobSpec {
+	t.Helper()
+
+	job, ok := releaseWorkflow(t).Jobs[releaseJob]
+	if !ok {
+		t.Fatalf("%s carries no %s job", releaseWorkflowPath, releaseJob)
+	}
+	return job
+}
+
+// releaseStep returns one named step of that job. The steps are addressed by
+// name, so a renamed step fails here rather than silently dropping a check.
+func releaseStep(t *testing.T, name string) releaseStepSpec {
+	t.Helper()
+
+	for _, step := range releaseJobOf(t).Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("the %s job carries no step named %q", releaseJob, name)
+	return releaseStepSpec{}
+}
+
+// distPathRe matches a path into dist/ as a workflow writes one: a step's
+// subject list or the argument list of gh release create.
+var distPathRe = regexp.MustCompile(`dist/[A-Za-z0-9_.*-]+`)
+
+// distPaths returns the dist/ paths a step names, deduplicated and sorted, so
+// two lists written in different orders compare equal.
+func distPaths(step string) []string {
+	found := distPathRe.FindAllString(step, -1)
+	slices.Sort(found)
+	return slices.Compact(found)
+}
+
+// releaseSpec is the part of the workflow this file asserts over. yaml.v3
+// ignores every key not named here.
+type releaseSpec struct {
+	On struct {
+		Push struct {
+			Tags []string
+		}
+	}
+	Jobs map[string]releaseJobSpec
+}
+
+type releaseJobSpec struct {
+	Permissions map[string]string
+	Steps       []releaseStepSpec
+}
+
+type releaseStepSpec struct {
+	Name string
+	Uses string
+	With map[string]string
+	Run  string
 }
 
 // releaseVersion runs the script over the given arguments and returns what it

--- a/packaging/release_test.go
+++ b/packaging/release_test.go
@@ -1,0 +1,121 @@
+// This file pins the release to the tag that triggers it. The version a
+// release publishes is read off that tag by release-version.sh and by nothing
+// else, so the mapping is covered here rather than left to the one run that
+// would exercise it: a tag is pushed once, and a version it stamped wrongly is
+// in a package operators already downloaded. The test runs the script the way
+// the workflow does, through sh, and needs neither dpkg nor a runner.
+package packaging_test
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The script the release workflow reads the package version from. It is run
+// through sh, so the mode the file carries in the repository never matters.
+const releaseVersionScript = "release-version.sh"
+
+// acceptedTags are the tags the script maps rather than refuses, with the
+// version each one puts into the package. A prerelease arrives with a tilde:
+// dpkg reads everything after a hyphen as the package revision and sorts
+// 1.2.3-rc.1 above 1.2.3, while a tilde sorts below every other character.
+var acceptedTags = []struct{ tag, want string }{
+	{"v0.0.0", "0.0.0"},
+	{"v0.1.0", "0.1.0"},
+	{"v1.2.3", "1.2.3"},
+	{"v1.2.3-rc.1", "1.2.3~rc.1"},
+	{"v10.20.30-beta.2", "10.20.30~beta.2"},
+}
+
+func TestReleaseVersionMapsATagToAPackageVersion(t *testing.T) {
+	for _, tc := range acceptedTags {
+		t.Run(tc.tag, func(t *testing.T) {
+			stdout, stderr, code := releaseVersion(t, tc.tag)
+
+			if code != 0 {
+				t.Fatalf("%s %s exited %d, want 0: %s", releaseVersionScript, tc.tag, code, stderr)
+			}
+			if got := strings.TrimSuffix(stdout, "\n"); got != tc.want {
+				t.Errorf("%s %s printed %q, want %q", releaseVersionScript, tc.tag, got, tc.want)
+			}
+			if stderr != "" {
+				t.Errorf("%s %s wrote %q to stderr, want nothing", releaseVersionScript, tc.tag, stderr)
+			}
+		})
+	}
+}
+
+func TestReleaseVersionRefusesWhatIsNotAReleaseTag(t *testing.T) {
+	// Each of these would otherwise reach dpkg as a version: a tag with no
+	// leading v, one that is not three numbers, a leading zero, an empty or
+	// hyphenated prerelease part, build metadata, a name, and the empty string
+	// a caller passes when it read no tag at all.
+	for _, tag := range []string{
+		"1.2.3",
+		"v1.2",
+		"v1.2.3.4",
+		"v01.2.3",
+		"v1.2.3-",
+		"v1.2.3+build.5",
+		"v1.2.3-rc-1",
+		"vlatest",
+		"",
+	} {
+		t.Run(tag, func(t *testing.T) {
+			stdout, stderr, code := releaseVersion(t, tag)
+
+			if code != 1 {
+				t.Errorf("%s %q exited %d, want 1", releaseVersionScript, tag, code)
+			}
+			// Nothing on stdout, so a caller that captures the output stamps an
+			// empty version into the package rather than this message.
+			if stdout != "" {
+				t.Errorf("%s %q printed %q, want nothing", releaseVersionScript, tag, stdout)
+			}
+			if want := "'" + tag + "' is not a release tag"; !strings.Contains(stderr, want) {
+				t.Errorf("%s %q wrote %q to stderr, which does not carry %q", releaseVersionScript, tag, stderr, want)
+			}
+		})
+	}
+}
+
+func TestReleaseVersionRefusesAMissingArgument(t *testing.T) {
+	// An absent argument is not an empty tag: a workflow step whose variable
+	// went missing is a different fault from a tag that is malformed, and the
+	// message says so.
+	stdout, stderr, code := releaseVersion(t)
+
+	if code != 1 {
+		t.Errorf("%s with no argument exited %d, want 1", releaseVersionScript, code)
+	}
+	if stdout != "" {
+		t.Errorf("%s with no argument printed %q, want nothing", releaseVersionScript, stdout)
+	}
+	if want := "usage: release-version.sh <tag>"; !strings.Contains(stderr, want) {
+		t.Errorf("%s with no argument wrote %q to stderr, which does not carry %q", releaseVersionScript, stderr, want)
+	}
+}
+
+// releaseVersion runs the script over the given arguments and returns what it
+// wrote to stdout and stderr and the status it exited with. A failure to start
+// the script at all fails the run rather than being reported as a refusal.
+func releaseVersion(t *testing.T, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+
+	var out, errOut strings.Builder
+	cmd := exec.Command("sh", append([]string{releaseVersionScript}, args...)...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	var exit *exec.ExitError
+	switch err := cmd.Run(); {
+	case err == nil:
+	case errors.As(err, &exit):
+		code = exit.ExitCode()
+	default:
+		t.Fatalf("running %s: %v", releaseVersionScript, err)
+	}
+	return out.String(), errOut.String(), code
+}

--- a/roadmap/00-conventions.md
+++ b/roadmap/00-conventions.md
@@ -69,7 +69,7 @@ tally/
 ├── Dockerfile                     # multi-stage, ARG CMD → builds ./cmd/${CMD}; one image per service
 ├── Tiltfile                       # dev loop: docker_build → kind load → redeploy on change
 ├── nfpm.yaml                      # Debian package of the collector; `make deb` builds it
-├── packaging/                     # systemd unit, /etc/default file and maintainer scripts of that package
+├── packaging/                     # systemd unit, /etc/default file, maintainer scripts, release version script
 ├── api/
 │   └── reporting/openapi.yaml     # Reporting API contract (oapi-codegen input)
 ├── cmd/
@@ -120,7 +120,7 @@ tally/
 │       └── overlays/
 │           ├── dev/               # kind: namespace tally, nip.io hostnames, self-signed CA, replicas: 1
 │           └── prod/              # real hostnames + issuer; added when first deployed to a real cluster
-└── .github/workflows/ci.yaml
+└── .github/workflows/             # ci.yaml, deploy-docs.yaml, release.yaml (tag → signed release)
 ```
 
 Naming rules:


### PR DESCRIPTION
A push of a tag matching `v*` now publishes a GitHub release carrying the
collector's Debian package for `amd64`, an SPDX SBOM of the binary it installs,
a `SHA256SUMS` over both, and one Sigstore attestation whose subjects are all
three. The tag is the trigger and the version source, so a release cannot
disagree with what is attached to it. The project holds no signing key: the
attestation is signed with a short-lived certificate minted from the workflow's
OIDC token.

## The commits, in order

1. `Write the collector's SBOM with make sbom` — `SYFT_VERSION` beside
   `NFPM_VERSION`, a `sbom` target that depends on `deb` so the binary it reads
   and the package a release publishes come out of one build at one version,
   and the handbook row `make generate` renders from its help comment.
2. `Map a release tag to the package version` — `packaging/release-version.sh`
   turns `v1.2.3` into `1.2.3` and `v1.2.3-rc.1` into `1.2.3~rc.1`. dpkg reads
   everything after a hyphen as the package revision and sorts `1.2.3-rc.1`
   above `1.2.3`, while a tilde sorts below every other character. Every other
   tag is refused with exit 1 and nothing on stdout.
3. `Publish signed release artifacts on a version tag` — the workflow, and the
   tests that read it back: the trigger, the three job permissions, the version
   source, and that every file the release attaches is a subject of the
   attestation.
4. `Document the release and how to verify a download` — the install guide takes
   the package from the release page and checks it before installing; the
   toolchain page gains `make sbom` and a `Releases` section.
5. `Move the SBOM into place only after syft succeeded` — syft truncates its
   output file before it resolves the source, so a failed run left an empty
   document under the artifact name.

## What was verified

`go vet ./...`, `make lint` and `go test ./...` (64 packages) pass, and
`make docs-build` builds the site.

The tag mapping was checked against dpkg itself in a `debian:13-slim`
container: `1.2.3~rc.1` sorts below `1.2.3`, and `1.2.3-rc.1` sorts above it,
which is the ordering bug the tilde avoids. `make sbom` was run at both a
release and a prerelease version; `dpkg-deb -f … Version` reads back `1.2.3`
and `1.2.3~rc.1`, and the SBOM is SPDX-2.3 with 22 packages including
`github.com/b42labs/tally`. The two assertions that carry the most weight were
mutation-checked: dropping `dist/SHA256SUMS` from the attestation's subjects,
and swapping the attest action for another one, each fail the test.

Three things only a real tag can prove, and none of them can run in a pull
request: `gh attestation verify` against a published package, the behavior of
`gh release create`, and that a failed attestation publishes nothing. The step
order is what guarantees the last one, and `packaging/release_test.go` is what
guards the rest of the workflow in the meantime.

## Decisions recorded in the issue

Signing uses GitHub artifact attestations rather than cosign. The release run
repeats none of the `ci` job's checks, so a tag belongs on a commit whose `ci`
run is green. Prerelease tags are accepted and mark the release as a
prerelease.

Closes #144
